### PR TITLE
Raise BackendCallFailure when there's a backend_call_failed element

### DIFF
--- a/pyticketswitch/api_exceptions.py
+++ b/pyticketswitch/api_exceptions.py
@@ -52,7 +52,7 @@ class BackendCallFailure(APIException):
         code = "N/A"
         description = "The call to the backend system failed."
 
-        super(InvalidToken, self).__init__(
+        super(BackendCallFailure, self).__init__(
             call=call, code=code, description=description
         )
 

--- a/pyticketswitch/parse.py
+++ b/pyticketswitch/parse.py
@@ -551,7 +551,7 @@ def availability_options_result(root):
 
     backend_call_failed = root.find('backend_call_failed')
 
-    if backend_call_failed:
+    if backend_call_failed is not None:
         raise aex.BackendCallFailure(call=root.tag)
 
     ret_dict = {
@@ -666,7 +666,7 @@ def discount_options_result(root):
 
     backend_call_failed = root.find('backend_call_failed')
 
-    if backend_call_failed:
+    if backend_call_failed is not None:
         raise aex.BackendCallFailure(call=root.tag)
 
     ret_dict = {

--- a/pyticketswitch/test/test_parse.py
+++ b/pyticketswitch/test/test_parse.py
@@ -1,0 +1,25 @@
+import unittest
+try:
+    import xml.etree.cElementTree as xml
+except ImportError:
+    import xml.etree.ElementTree as xml
+
+from pyticketswitch.api_exceptions import BackendCallFailure
+from pyticketswitch.parse import availability_options_result, discount_options_result
+
+
+class BackendCallFailureTestCase(unittest.TestCase):
+
+    def test_availability_options_result(self):
+        content = """<?xml version="1.0" encoding="UTF-8"?>
+        <availability_options_result><backend_call_failed/></availability_options_result>
+        """
+        with self.assertRaises(BackendCallFailure):
+            availability_options_result(xml.fromstring(content))
+
+    def test_discount_options_result(self):
+        content = """<?xml version="1.0" encoding="UTF-8"?>
+        <discount_options_result><backend_call_failed/></discount_options_result>
+        """
+        with self.assertRaises(BackendCallFailure):
+            discount_options_result(xml.fromstring(content))


### PR DESCRIPTION
This was silently failing because the backend_call_failed element is empty (when it's present), and bool() of it is False. Also fixed a copy-paste error in the super call in `BackendCallFailure.__init__`.