### PR TITLE
From the future

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 #
 # pyticketswitch documentation build configuration file, created by
 # sphinx-quickstart on Tue Sep  2 16:32:25 2014.

--- a/example_usage.py
+++ b/example_usage.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 # EXAMPLE USAGE
 
 from pyticketswitch import (
@@ -22,7 +25,7 @@ events = core.search_events(keyword='nutcracker')
 
 # select an Event object from the list
 for e in events:
-    print e.event_id, e.description
+    print(e.event_id, e.description)
     if e.event_id == '6IF':
         event = e
 
@@ -33,7 +36,7 @@ performances = event.performances
 
 # select a performance
 for p in performances:
-    print p.date_desc, p.time_desc
+    print(p.date_desc, p.time_desc)
     if (
         p.date_desc == 'Mon, 6th October 2014' and
         p.time_desc == '7.30 PM'
@@ -47,7 +50,7 @@ ticket_types = performance.ticket_types
 
 # select a TicketType
 for tt in ticket_types:
-    print tt.description, tt.price_combined_float, tt.number_available
+    print(tt.description, tt.price_combined_float, tt.number_available)
     if (
         tt.description == 'Upper circle'and
         tt.price_combined_float == 34.0
@@ -62,7 +65,7 @@ concession_sets = ticket_type.get_concessions(no_of_tickets=2)
 selected_concessions = []
 for concession_list in concession_sets:
     for c in concession_list:
-        print c.description, c.ticket_price_float
+        print(c.description, c.ticket_price_float)
         if c.description == 'Adult standard':
             selected_concessions.append(c)
 
@@ -70,7 +73,7 @@ for concession_list in concession_sets:
 despatch_methods = performance.despatch_methods
 
 for dm in despatch_methods:
-    print dm.description, dm.cost_float
+    print(dm.description, dm.cost_float)
 
 # select a despatch method
 despatch_method = despatch_methods[0]

--- a/pyticketswitch/__init__.py
+++ b/pyticketswitch/__init__.py
@@ -1,5 +1,8 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 __version__ = '1.9.1'
 
-from interface_objects import *  # NOQA
+from .interface_objects import *  # NOQA
 
-from util import auto_date_to_slug, slug_to_auto_date  # NOQA
+from .util import auto_date_to_slug, slug_to_auto_date  # NOQA

--- a/pyticketswitch/api_exceptions.py
+++ b/pyticketswitch/api_exceptions.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 from pyticketswitch.util import resolve_boolean
 
 

--- a/pyticketswitch/core_objects.py
+++ b/pyticketswitch/core_objects.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 
 class CoreObject(object):
     pass

--- a/pyticketswitch/interface.py
+++ b/pyticketswitch/interface.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 import requests
 try:
     import xml.etree.cElementTree as xml
@@ -6,10 +9,10 @@ except ImportError:
 from datetime import datetime
 import logging
 
-from util import create_xml_from_dict, dict_ignore_nones
-from api_exceptions import CommsException, InvalidResponse
-import parse
-import settings
+from .util import create_xml_from_dict, dict_ignore_nones
+from .api_exceptions import CommsException, InvalidResponse
+from . import parse
+from . import settings
 
 logger = logging.getLogger(__name__)
 filelog = logging.getLogger('filelog.' + __name__)

--- a/pyticketswitch/interface_objects/__init__.py
+++ b/pyticketswitch/interface_objects/__init__.py
@@ -1,12 +1,15 @@
-from core import Core
-from event import Category, Event, Review, Video
-from performance import Performance
-from availability import TicketType, Concession, DespatchMethod, AvailDetail
-from trolley import Trolley
-from reservation import Reservation
-from base import Customer, Seat, Card, Address, Commission, Currency
-from bundle import Bundle
-from order import Order
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
+from .core import Core
+from .event import Category, Event, Review, Video
+from .performance import Performance
+from .availability import TicketType, Concession, DespatchMethod, AvailDetail
+from .trolley import Trolley
+from .reservation import Reservation
+from .base import Customer, Seat, Card, Address, Commission, Currency
+from .bundle import Bundle
+from .order import Order
 
 __all__ = (
     'Core', 'Category', 'Event', 'Review', 'Performance',

--- a/pyticketswitch/interface_objects/availability.py
+++ b/pyticketswitch/interface_objects/availability.py
@@ -1,7 +1,10 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 from operator import attrgetter
 from copy import deepcopy
 
-from base import InterfaceObject, Seat, SeatBlock, Currency, Commission
+from .base import InterfaceObject, Seat, SeatBlock, Currency, Commission
 from pyticketswitch.util import (
     format_price_with_symbol, to_float_or_none, to_float_summed,
     to_int_or_none, resolve_boolean, day_mask_to_bool_list, yyyymmdd_to_date,

--- a/pyticketswitch/interface_objects/base.py
+++ b/pyticketswitch/interface_objects/base.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 import logging
 
 from pyticketswitch import settings as default_settings

--- a/pyticketswitch/interface_objects/bundle.py
+++ b/pyticketswitch/interface_objects/bundle.py
@@ -1,10 +1,13 @@
-import order as order_objs
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
+from . import order as order_objs
 from pyticketswitch.util import (
     to_int_or_none, format_price_with_symbol,
     to_float_or_none, resolve_boolean,
     to_int_or_return
 )
-from base import InterfaceObject
+from .base import InterfaceObject
 
 
 class Bundle(InterfaceObject):

--- a/pyticketswitch/interface_objects/core.py
+++ b/pyticketswitch/interface_objects/core.py
@@ -1,8 +1,11 @@
-from base import InterfaceObject
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
+from .base import InterfaceObject
 from pyticketswitch import settings
-import event as event_objs
-import order as order_objs
-import reservation as res_objs
+from . import event as event_objs
+from . import order as order_objs
+from . import reservation as res_objs
 from pyticketswitch.util import date_to_yyyymmdd
 
 

--- a/pyticketswitch/interface_objects/event.py
+++ b/pyticketswitch/interface_objects/event.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 from operator import itemgetter, attrgetter
 import datetime
 from copy import deepcopy
@@ -6,12 +9,10 @@ from pyticketswitch.util import (
     resolve_boolean, to_int_or_none, yyyymmdd_to_date,
     dates_in_range, hhmmss_to_time, date_to_yyyymmdd_or_none
 )
-from base import InterfaceObject, CostRangeMixin
+from .base import InterfaceObject, CostRangeMixin
 from pyticketswitch.api_exceptions import InvalidId
 from pyticketswitch import settings
-import core as core_objs
-import performance as perf_objs
-import availability as avail_objs
+from . import availability as avail_objs
 
 
 class Category(object):
@@ -643,6 +644,7 @@ class Event(InterfaceObject, CostRangeMixin):
         if required (could reduce the number of API calls
         in some circumstances).
         """
+        from . import core as core_objs
 
         if request_media is None:
             request_media = settings.REQUEST_MEDIA
@@ -766,6 +768,7 @@ class Event(InterfaceObject, CostRangeMixin):
         return self._performance_calendar
 
     def _get_search_crypto(self):
+        from . import core as core_objs
 
         crypto_block = self.get_crypto_block(
             method_name='event_search',
@@ -979,6 +982,8 @@ class Event(InterfaceObject, CostRangeMixin):
         Returns:
             list: List of Performance objects
         """
+        from . import performance as perf_objs
+
         crypto_block = self._get_search_crypto()
 
         resp_dict = self.get_core_api().date_time_options(
@@ -1059,6 +1064,7 @@ class Event(InterfaceObject, CostRangeMixin):
     def _build_performances_from_usage(
         self, usage_date_dict, need_departure_date, latest_date
     ):
+        from . import performance as perf_objs
 
         inv_dates = []
 

--- a/pyticketswitch/interface_objects/order.py
+++ b/pyticketswitch/interface_objects/order.py
@@ -1,11 +1,14 @@
-from base import InterfaceObject, Seat, Currency, Commission
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
+from .base import InterfaceObject, Seat, Currency, Commission
 from pyticketswitch.util import (
     to_int_or_return, to_float_or_none,
     to_float_summed, format_price_with_symbol
 )
-import performance as perf_objs
-import event as event_objs
-import availability
+from . import performance as perf_objs
+from . import event as event_objs
+from . import availability as availability
 
 
 class Order(InterfaceObject):

--- a/pyticketswitch/interface_objects/performance.py
+++ b/pyticketswitch/interface_objects/performance.py
@@ -1,14 +1,17 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 from operator import attrgetter
 import datetime
 
-from base import InterfaceObject, CostRangeMixin
+from .base import InterfaceObject, CostRangeMixin
 from pyticketswitch.util import (
     yyyymmdd_to_date, hhmmss_to_time,
     date_to_yyyymmdd_or_none, time_to_hhmmss,
     date_to_yyyymmdd, resolve_boolean, to_int_or_none
 )
-import event as event_objs
-import availability
+from . import event as event_objs
+from . import availability as availability
 
 
 class Performance(InterfaceObject, CostRangeMixin):

--- a/pyticketswitch/interface_objects/reservation.py
+++ b/pyticketswitch/interface_objects/reservation.py
@@ -1,10 +1,13 @@
-import trolley as trolley_objs
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
+from . import trolley as trolley_objs
 from pyticketswitch.util import (
     to_float_or_zero, resolve_boolean, dict_ignore_nones,
     boolean_to_yes_no
 )
-from base import Customer
-import bundle as bundle_objs
+from .base import Customer
+from . import bundle as bundle_objs
 
 
 class Reservation(trolley_objs.Trolley):

--- a/pyticketswitch/interface_objects/trolley.py
+++ b/pyticketswitch/interface_objects/trolley.py
@@ -1,10 +1,12 @@
-from base import InterfaceObject
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
+from .base import InterfaceObject
 from pyticketswitch.util import (
     to_int_or_none, resolve_boolean
 )
-import order as order_objs
-import bundle as bundle_objs
-import reservation as res_objs
+from . import order as order_objs
+from . import bundle as bundle_objs
 
 
 class Trolley(InterfaceObject):
@@ -178,6 +180,8 @@ class Trolley(InterfaceObject):
         Returns:
             Reservation: Reservation object for this Trolley.
         """
+        from . import reservation as res_objs
+
         crypto_block = self.get_crypto_block(
             method_name='start_session'
         )

--- a/pyticketswitch/parse.py
+++ b/pyticketswitch/parse.py
@@ -1,6 +1,9 @@
-import core_objects as objects
-from util import create_dict_from_xml_element
-import api_exceptions as aex
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
+from . import core_objects as objects
+from .util import create_dict_from_xml_element
+from . import api_exceptions as aex
 
 
 def script_error(root):

--- a/pyticketswitch/settings.py
+++ b/pyticketswitch/settings.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 API_URL = 'https://www.tsd-aff.com/cgi-bin/xml_core.exe'
 EXT_START_SESSION_URL = 'https://www.tsd-aff.com/cgi-bin/xml_start_session.exe'
 

--- a/pyticketswitch/util.py
+++ b/pyticketswitch/util.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 try:
     import xml.etree.cElementTree as xml
 except ImportError:
@@ -6,7 +9,7 @@ import random
 import string
 import datetime
 
-import settings
+from . import settings
 
 __all__ = (
     'create_xml_from_dict', 'create_dict_from_xml',

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 from setuptools import setup
 import re
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function

--- a/tests/interface_objects/__init__.py
+++ b/tests/interface_objects/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function

--- a/tests/interface_objects/common.py
+++ b/tests/interface_objects/common.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 try:
     import xml.etree.cElementTree as xml
 except ImportError:

--- a/tests/interface_objects/test_concessions.py
+++ b/tests/interface_objects/test_concessions.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 import datetime
 
 from pyticketswitch.interface_objects import Event

--- a/tests/interface_objects/test_core.py
+++ b/tests/interface_objects/test_core.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 from pyticketswitch.interface_objects import Core, Event
 
 from .. import settings_test as settings

--- a/tests/interface_objects/test_event.py
+++ b/tests/interface_objects/test_event.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 import datetime
 from copy import deepcopy
 

--- a/tests/interface_objects/test_order.py
+++ b/tests/interface_objects/test_order.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 import datetime
 
 from pyticketswitch.interface_objects import (

--- a/tests/interface_objects/test_performance.py
+++ b/tests/interface_objects/test_performance.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 import datetime
 
 from pyticketswitch.interface_objects import Event, TicketType, DespatchMethod

--- a/tests/interface_objects/test_purchase.py
+++ b/tests/interface_objects/test_purchase.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 import datetime
 
 from pyticketswitch.interface_objects import (

--- a/tests/interface_objects/test_reservation.py
+++ b/tests/interface_objects/test_reservation.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 import datetime
 
 from pyticketswitch.interface_objects import Core, Event, Reservation, Trolley

--- a/tests/interface_objects/test_ticket_types.py
+++ b/tests/interface_objects/test_ticket_types.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 import datetime
 
 from pyticketswitch.interface_objects import Event, Seat, Concession

--- a/tests/interface_objects/test_trolley.py
+++ b/tests/interface_objects/test_trolley.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 import datetime
 
 from pyticketswitch.interface_objects import (

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 from pyticketswitch.settings import *
 
 API_URL = 'https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe'


### PR DESCRIPTION
Enable the future Python features absolute_import, division and print_function in all py files.
Also specify a character encoding for all py files.
This is necessary preparatory work for making the project Py2/3 compatible.

Enabling absolute_import required changing most of the imports.
All implicit relative imports were converted to explicit relative imports.
Additionally the project has a lot of circular import structures and explict relative imports are much less tolerant of these so several of them (in event.py and trolley.py) had to be converted to function scope imports to break import loops.
This is also why the implicit relative imports were not converted to absolute imports.

I grepped the code base for divides and only found one which from context should be using floats anyway.

The Tox tests pass.