### PR TITLE
Linting - add isort

### DIFF
--- a/pyticketswitch/__init__.py
+++ b/pyticketswitch/__init__.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
-__version__ = '1.10.0'
-
 from .interface_objects import *  # NOQA
-
 from .util import auto_date_to_slug, slug_to_auto_date  # NOQA
+
+__version__ = '1.10.0'

--- a/pyticketswitch/interface.py
+++ b/pyticketswitch/interface.py
@@ -1,18 +1,20 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
+import logging
+from datetime import datetime
+
 import requests
+
+from . import parse, settings
+from .api_exceptions import CommsException, InvalidResponse
+from .util import create_xml_from_dict, dict_ignore_nones
+
 try:
     import xml.etree.cElementTree as xml
 except ImportError:
     import xml.etree.ElementTree as xml
-from datetime import datetime
-import logging
 
-from .util import create_xml_from_dict, dict_ignore_nones
-from .api_exceptions import CommsException, InvalidResponse
-from . import parse
-from . import settings
 
 logger = logging.getLogger(__name__)
 filelog = logging.getLogger('filelog.' + __name__)

--- a/pyticketswitch/interface_objects/__init__.py
+++ b/pyticketswitch/interface_objects/__init__.py
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
+from .availability import AvailDetail, Concession, DespatchMethod, TicketType
+from .base import Address, Card, Commission, Currency, Customer, Seat
+from .bundle import Bundle
 from .core import Core
 from .event import Category, Event, Review, Video
-from .performance import Performance
-from .availability import TicketType, Concession, DespatchMethod, AvailDetail
-from .trolley import Trolley
-from .reservation import Reservation
-from .base import Customer, Seat, Card, Address, Commission, Currency
-from .bundle import Bundle
 from .order import Order
+from .performance import Performance
+from .reservation import Reservation
+from .trolley import Trolley
 
 __all__ = (
     'Core', 'Category', 'Event', 'Review', 'Performance',

--- a/pyticketswitch/interface_objects/availability.py
+++ b/pyticketswitch/interface_objects/availability.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
-from operator import attrgetter
 from copy import deepcopy
+from operator import attrgetter
 
-from .base import InterfaceObject, Seat, SeatBlock, Currency, Commission
 from pyticketswitch.util import (
-    format_price_with_symbol, to_float_or_none, to_float_summed,
-    to_int_or_none, resolve_boolean, day_mask_to_bool_list, yyyymmdd_to_date,
+    day_mask_to_bool_list, format_price_with_symbol, resolve_boolean,
+    to_float_or_none, to_float_summed, to_int_or_none, yyyymmdd_to_date
 )
+
+from .base import Commission, Currency, InterfaceObject, Seat, SeatBlock
 
 
 class TicketType(InterfaceObject):

--- a/pyticketswitch/interface_objects/base.py
+++ b/pyticketswitch/interface_objects/base.py
@@ -6,8 +6,8 @@ import logging
 from pyticketswitch import settings as default_settings
 from pyticketswitch.interface import CoreAPI
 from pyticketswitch.util import (
-    resolve_boolean, format_price_with_symbol,
-    to_float_or_none, to_int_or_none,
+    format_price_with_symbol, resolve_boolean, to_float_or_none,
+    to_int_or_none
 )
 
 logger = logging.getLogger(__name__)

--- a/pyticketswitch/interface_objects/bundle.py
+++ b/pyticketswitch/interface_objects/bundle.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
-from . import order as order_objs
 from pyticketswitch.util import (
-    to_int_or_none, format_price_with_symbol,
-    to_float_or_none, resolve_boolean,
-    to_int_or_return
+    format_price_with_symbol, resolve_boolean, to_float_or_none,
+    to_int_or_none, to_int_or_return
 )
+
+from . import order as order_objs
 from .base import InterfaceObject
 
 

--- a/pyticketswitch/interface_objects/core.py
+++ b/pyticketswitch/interface_objects/core.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
-from .base import InterfaceObject
 from pyticketswitch import settings
+from pyticketswitch.util import date_to_yyyymmdd
+
 from . import event as event_objs
 from . import order as order_objs
 from . import reservation as res_objs
-from pyticketswitch.util import date_to_yyyymmdd
+from .base import InterfaceObject
 
 
 class Core(InterfaceObject):

--- a/pyticketswitch/interface_objects/event.py
+++ b/pyticketswitch/interface_objects/event.py
@@ -1,18 +1,19 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
-from operator import itemgetter, attrgetter
 import datetime
 from copy import deepcopy
+from operator import attrgetter, itemgetter
 
-from pyticketswitch.util import (
-    resolve_boolean, to_int_or_none, yyyymmdd_to_date,
-    dates_in_range, hhmmss_to_time, date_to_yyyymmdd_or_none
-)
-from .base import InterfaceObject, CostRangeMixin
-from pyticketswitch.api_exceptions import InvalidId
 from pyticketswitch import settings
+from pyticketswitch.api_exceptions import InvalidId
+from pyticketswitch.util import (
+    date_to_yyyymmdd_or_none, dates_in_range, hhmmss_to_time, resolve_boolean,
+    to_int_or_none, yyyymmdd_to_date
+)
+
 from . import availability as avail_objs
+from .base import CostRangeMixin, InterfaceObject
 
 
 class Category(object):

--- a/pyticketswitch/interface_objects/order.py
+++ b/pyticketswitch/interface_objects/order.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
-from .base import InterfaceObject, Seat, Currency, Commission
 from pyticketswitch.util import (
-    to_int_or_return, to_float_or_none,
-    to_float_summed, format_price_with_symbol
+    format_price_with_symbol, to_float_or_none, to_float_summed,
+    to_int_or_return
 )
-from . import performance as perf_objs
-from . import event as event_objs
+
 from . import availability as availability
+from . import event as event_objs
+from . import performance as perf_objs
+from .base import Commission, Currency, InterfaceObject, Seat
 
 
 class Order(InterfaceObject):

--- a/pyticketswitch/interface_objects/performance.py
+++ b/pyticketswitch/interface_objects/performance.py
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
-from operator import attrgetter
 import datetime
+from operator import attrgetter
 
-from .base import InterfaceObject, CostRangeMixin
 from pyticketswitch.util import (
-    yyyymmdd_to_date, hhmmss_to_time,
-    date_to_yyyymmdd_or_none, time_to_hhmmss,
-    date_to_yyyymmdd, resolve_boolean, to_int_or_none
+    date_to_yyyymmdd, date_to_yyyymmdd_or_none, hhmmss_to_time,
+    resolve_boolean, time_to_hhmmss, to_int_or_none, yyyymmdd_to_date
 )
-from . import event as event_objs
+
 from . import availability as availability
+from . import event as event_objs
+from .base import CostRangeMixin, InterfaceObject
 
 
 class Performance(InterfaceObject, CostRangeMixin):

--- a/pyticketswitch/interface_objects/reservation.py
+++ b/pyticketswitch/interface_objects/reservation.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
-from . import trolley as trolley_objs
 from pyticketswitch.util import (
-    to_float_or_zero, resolve_boolean, dict_ignore_nones,
-    boolean_to_yes_no
+    boolean_to_yes_no, dict_ignore_nones, resolve_boolean, to_float_or_zero
 )
-from .base import Customer
+
 from . import bundle as bundle_objs
+from . import trolley as trolley_objs
+from .base import Customer
 
 
 class Reservation(trolley_objs.Trolley):

--- a/pyticketswitch/interface_objects/trolley.py
+++ b/pyticketswitch/interface_objects/trolley.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
-from .base import InterfaceObject
-from pyticketswitch.util import (
-    to_int_or_none, resolve_boolean
-)
-from . import order as order_objs
+from pyticketswitch.util import resolve_boolean, to_int_or_none
+
 from . import bundle as bundle_objs
+from . import order as order_objs
+from .base import InterfaceObject
 
 
 class Trolley(InterfaceObject):

--- a/pyticketswitch/parse.py
+++ b/pyticketswitch/parse.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
+from . import api_exceptions as aex
 from . import core_objects as objects
 from .util import create_dict_from_xml_element
-from . import api_exceptions as aex
 
 
 def script_error(root):

--- a/pyticketswitch/util.py
+++ b/pyticketswitch/util.py
@@ -1,15 +1,17 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
+import datetime
+import random
+import string
+
+from . import settings
+
 try:
     import xml.etree.cElementTree as xml
 except ImportError:
     import xml.etree.ElementTree as xml
-import random
-import string
-import datetime
 
-from . import settings
 
 __all__ = (
     'create_xml_from_dict', 'create_dict_from_xml',

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,5 +8,9 @@ exclude = .svn,CVS,.bzr,.hg,.git,__pycache,dependencies,node_modules,tests,test,
 max-complexity = 99
 filename = *.py
 
+[isort]
+multi_line_output = 5
+not_skip = __init__.py
+
 [bdist_wheel]
 universal=1

--- a/tests/interface_objects/common.py
+++ b/tests/interface_objects/common.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
+from vcr_unittest import VCRTestCase
+
+from .. import settings_test as settings
+
 try:
     import xml.etree.cElementTree as xml
 except ImportError:
     import xml.etree.ElementTree as xml
 
-from vcr_unittest import VCRTestCase
 
-from .. import settings_test as settings
 
 
 def xml_matcher(r1, r2):

--- a/tests/interface_objects/test_event.py
+++ b/tests/interface_objects/test_event.py
@@ -4,8 +4,8 @@ from __future__ import absolute_import, division, print_function
 import datetime
 from copy import deepcopy
 
-from pyticketswitch.interface_objects import Event, Performance, Review
 from pyticketswitch.api_exceptions import InvalidId
+from pyticketswitch.interface_objects import Event, Performance, Review
 
 from .common import InterfaceObjectTestCase
 

--- a/tests/interface_objects/test_order.py
+++ b/tests/interface_objects/test_order.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function
 import datetime
 
 from pyticketswitch.interface_objects import (
-    Core, Event, Performance, Concession, DespatchMethod,
+    Concession, Core, DespatchMethod, Event, Performance
 )
 
 from .common import InterfaceObjectTestCase

--- a/tests/interface_objects/test_performance.py
+++ b/tests/interface_objects/test_performance.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 
 import datetime
 
-from pyticketswitch.interface_objects import Event, TicketType, DespatchMethod
+from pyticketswitch.interface_objects import DespatchMethod, Event, TicketType
 
 from .common import InterfaceObjectTestCase
 

--- a/tests/interface_objects/test_purchase.py
+++ b/tests/interface_objects/test_purchase.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function
 import datetime
 
 from pyticketswitch.interface_objects import (
-    Core, Event, Trolley, Address, Customer,
+    Address, Core, Customer, Event, Trolley
 )
 
 from .common import InterfaceObjectCreditUserTestCase

--- a/tests/interface_objects/test_ticket_types.py
+++ b/tests/interface_objects/test_ticket_types.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 
 import datetime
 
-from pyticketswitch.interface_objects import Event, Seat, Concession
+from pyticketswitch.interface_objects import Concession, Event, Seat
 
 from .common import InterfaceObjectTestCase
 

--- a/tests/interface_objects/test_trolley.py
+++ b/tests/interface_objects/test_trolley.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function
 import datetime
 
 from pyticketswitch.interface_objects import (
-    Core, Event, Trolley, Bundle, Order,
+    Bundle, Core, Event, Order, Trolley
 )
 
 from .common import InterfaceObjectTestCase

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27}, lint, docs
+envlist = py{27}, py27-lint, py27-docs
 
 [testenv]
 commands =
@@ -13,12 +13,15 @@ commands =
 deps =
     coveralls
 
-[testenv:lint]
+[testenv:py27-lint]
 deps =
     flake8==2.5.0
-commands=flake8 pyticketswitch
+    isort==4.2.5
+commands =
+    flake8 pyticketswitch
+    isort --recursive --check-only --diff -a 'from __future__ import absolute_import, division, print_function' pyticketswitch tests
 
-[testenv:docs]
+[testenv:py27-docs]
 changedir=docs
 deps =
     sphinx==1.3.1


### PR DESCRIPTION
isort does do two things here:

1. Ensures imports are in alphabetical order
2. Ensures the __future__ lines are at the top of every file

I also fixed tox.ini to do the linting and docs under python 2.7; before it would use whichever python tox was installed with, which might not be 2.7 !

N.B. this builds on top of #16 so probably won't merge nicely. I'll rebase on top of master after #16 is merged.