### PR TITLE
Add modernize linter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python: 2.7
 env:
   - TOX_ENV=py27,coveralls
-  - TOX_ENV=lint
+  - TOX_ENV=py27-lint
 install:
   - pip install -r requirements/test.txt
   - pip install coveralls

--- a/lint.py
+++ b/lint.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
+
+import subprocess
+import sys
+
+import six
+from flake8.main import main as flake8_main
+from libmodernize.main import main as libmodernize_main
+
+
+CODE_PATHS = [
+    'lint.py',
+    'pyticketswitch',
+    'tests',
+]
+
+
+def main():
+    exit_on_failure(run_flake8())
+    exit_on_failure(run_modernize())
+    exit_on_failure(run_isort())
+
+
+def run_flake8():
+    print('Running flake8 code linting')
+    try:
+        original_argv = sys.argv
+        sys.argv = ['flake8'] + CODE_PATHS
+        did_fail = False
+        flake8_main()
+    except SystemExit:
+        did_fail = True
+    finally:
+        sys.argv = original_argv
+
+    if did_fail:
+        print('flake8 failed')
+    else:
+        print('flake8 passed')
+    return did_fail
+
+
+def run_modernize():
+    print('Running modernize checks')
+    try:
+        orig_stdout = getattr(sys, 'stdout')
+        out = six.StringIO()
+        setattr(sys, 'stdout', out)
+        libmodernize_main(CODE_PATHS)
+    finally:
+        sys.stdout = orig_stdout
+    output = out.getvalue()
+    print(output)
+    ret = len(output)
+    if ret:
+        print('modernize failed')
+    else:
+        print('modernize passed')
+    return ret
+
+
+def run_isort():
+    print('Running isort check')
+    return subprocess.call([
+        'isort', '--recursive', '--check-only', '--diff',
+        '-a', 'from __future__ import absolute_import, print_function, division',
+    ] + [x for x in CODE_PATHS if x != 'tests'])
+
+
+def exit_on_failure(ret):
+    if ret:
+        sys.exit(ret)
+
+
+if __name__ == '__main__':
+    main()

--- a/pyticketswitch/interface.py
+++ b/pyticketswitch/interface.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime
 
 import requests
+import six
 
 from . import parse, settings
 from .api_exceptions import CommsException, InvalidResponse
@@ -60,7 +61,7 @@ class CoreAPI(object):
 
         filelog.debug(
             u'URL=%s; API_REQUEST=%s',
-            url, unicode(data, 'UTF-8')
+            url, six.text_type(data, 'UTF-8')
         )
 
         response_string = None
@@ -127,7 +128,7 @@ class CoreAPI(object):
 
             filelog.debug(
                 u'API_RESPONSE=%s',
-                unicode(response_string, 'UTF-8')
+                six.text_type(response_string, 'UTF-8')
             )
 
         finally:

--- a/pyticketswitch/interface_objects/availability.py
+++ b/pyticketswitch/interface_objects/availability.py
@@ -8,6 +8,7 @@ from pyticketswitch.util import (
     day_mask_to_bool_list, format_price_with_symbol, resolve_boolean,
     to_float_or_none, to_float_summed, to_int_or_none, yyyymmdd_to_date
 )
+from six.moves import zip
 
 from .base import Commission, Currency, InterfaceObject, Seat, SeatBlock
 

--- a/pyticketswitch/interface_objects/base.py
+++ b/pyticketswitch/interface_objects/base.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 
+import six
+
 from pyticketswitch import settings as default_settings
 from pyticketswitch.interface import CoreAPI
 from pyticketswitch.util import (
@@ -801,7 +803,7 @@ class Customer(object):
         else:
             if isinstance(self._user_can_use_data, bool):
                 return self._user_can_use_data
-            elif isinstance(self._user_can_use_data, basestring):
+            elif isinstance(self._user_can_use_data, six.string_types):
                 return resolve_boolean(
                     self._user_can_use_data
                 )
@@ -815,7 +817,7 @@ class Customer(object):
         else:
             if isinstance(self._supplier_can_use_data, bool):
                 return self._supplier_can_use_data
-            elif isinstance(self._supplier_can_use_data, basestring):
+            elif isinstance(self._supplier_can_use_data, six.string_types):
                 return resolve_boolean(
                     self._supplier_can_use_data
                 )
@@ -829,7 +831,7 @@ class Customer(object):
         else:
             if isinstance(self._world_can_use_data, bool):
                 return self._world_can_use_data
-            elif isinstance(self._world_can_use_data, basestring):
+            elif isinstance(self._world_can_use_data, six.string_types):
                 return resolve_boolean(
                     self._world_can_use_data
                 )

--- a/pyticketswitch/interface_objects/core.py
+++ b/pyticketswitch/interface_objects/core.py
@@ -144,14 +144,14 @@ class Core(InterfaceObject):
             ):
 
                 if page_length is None:
-                    resp_dict['event'] = events.values()
+                    resp_dict['event'] = list(events.values())
 
                 else:
 
                     start = (page_number or 0) * page_length
                     end = ((page_number or 0) + 1) * page_length
 
-                    resp_dict['event'] = events.values()[start:end]
+                    resp_dict['event'] = list(events.values())[start:end]
 
                 return resp_dict
 

--- a/pyticketswitch/interface_objects/event.py
+++ b/pyticketswitch/interface_objects/event.py
@@ -11,6 +11,7 @@ from pyticketswitch.util import (
     date_to_yyyymmdd_or_none, dates_in_range, hhmmss_to_time, resolve_boolean,
     to_int_or_none, yyyymmdd_to_date
 )
+from six.moves import range
 
 from . import availability as avail_objs
 from .base import CostRangeMixin, InterfaceObject

--- a/pyticketswitch/util.py
+++ b/pyticketswitch/util.py
@@ -5,6 +5,10 @@ import datetime
 import random
 import string
 
+import six
+
+from six.moves import range
+
 from . import settings
 
 try:
@@ -54,14 +58,14 @@ def _recur_xml_list(root, key, arg_list):
         else:
             tmp = xml.SubElement(root, key)
             try:
-                tmp.text = unicode(value)
+                tmp.text = six.text_type(value)
             except:
                 tmp.text = value
     return root
 
 
 def _recur_xml_dict(root, arg_dict):
-    for (key, value) in arg_dict.iteritems():
+    for (key, value) in six.iteritems(arg_dict):
         if type(value) is dict:
             tmp = xml.SubElement(root, key)
             _recur_xml_dict(tmp, value)
@@ -73,7 +77,7 @@ def _recur_xml_dict(root, arg_dict):
         else:
             tmp = xml.SubElement(root, key)
             try:
-                tmp.text = unicode(value)
+                tmp.text = six.text_type(value)
             except:
                 tmp.text = value
     return root

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'requests>=2.0.0',
+        'six',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/tests/interface_objects/test_concessions.py
+++ b/tests/interface_objects/test_concessions.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, division, print_function
 
 import datetime
 
+import six
+
 from pyticketswitch.interface_objects import Event
 
 from .common import InterfaceObjectTestCase
@@ -56,7 +58,7 @@ class ConcessionTests(InterfaceObjectTestCase):
         for prop_name in (
             'ticket_price', 'surcharge', 'seatprice'
         ):
-            self.assertIsInstance(getattr(self.concession, prop_name), unicode)
+            self.assertIsInstance(getattr(self.concession, prop_name), six.text_type)
 
     def test_float_properties(self):
 

--- a/tests/interface_objects/test_event.py
+++ b/tests/interface_objects/test_event.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import, division, print_function
 import datetime
 from copy import deepcopy
 
+import six
+
 from pyticketswitch.api_exceptions import InvalidId
 from pyticketswitch.interface_objects import Event, Performance, Review
 
@@ -80,7 +82,7 @@ class ValidEventTests(InterfaceObjectTestCase):
         for prop_name in (
             'min_seatprice', 'min_combined_price',
         ):
-            self.assertIsInstance(getattr(self.event, prop_name), unicode)
+            self.assertIsInstance(getattr(self.event, prop_name), six.text_type)
 
     def test_boolean_properties(self):
 
@@ -234,7 +236,7 @@ class AvailDetailTests(InterfaceObjectTestCase):
         ):
             prop = getattr(self.avail_detail, prop_name)
             if prop is not None:
-                self.assertIsInstance(prop, unicode)
+                self.assertIsInstance(prop, six.text_type)
 
     def test_weekday_available(self):
         self.assertIsInstance(self.avail_detail.weekdays_available, list)

--- a/tests/interface_objects/test_order.py
+++ b/tests/interface_objects/test_order.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, division, print_function
 
 import datetime
 
+import six
+
 from pyticketswitch.interface_objects import (
     Concession, Core, DespatchMethod, Event, Performance
 )
@@ -82,7 +84,7 @@ class OrderTests(InterfaceObjectTestCase):
             'total_combined',
         ):
             self.assertIsInstance(
-                getattr(self.order, prop_name), unicode
+                getattr(self.order, prop_name), six.text_type
             )
 
     def test_performance(self):

--- a/tests/interface_objects/test_performance.py
+++ b/tests/interface_objects/test_performance.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, division, print_function
 
 import datetime
 
+import six
+
 from pyticketswitch.interface_objects import DespatchMethod, Event, TicketType
 
 from .common import InterfaceObjectTestCase
@@ -178,5 +180,5 @@ class DespatchMethodTests(InterfaceObjectTestCase):
             'cost',
         ):
             self.assertIsInstance(
-                getattr(self.despatch_method, prop_name), unicode
+                getattr(self.despatch_method, prop_name), six.text_type
             )

--- a/tests/interface_objects/test_ticket_types.py
+++ b/tests/interface_objects/test_ticket_types.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, division, print_function
 
 import datetime
 
+import six
+
 from pyticketswitch.interface_objects import Concession, Event, Seat
 
 from .common import InterfaceObjectTestCase
@@ -69,7 +71,7 @@ class TicketTypeTests(InterfaceObjectTestCase):
             'non_offer_combined', 'non_offer_surcharge', 'non_offer_seatprice',
         ):
             self.assertIsInstance(
-                getattr(self.ticket_type, prop_name), unicode
+                getattr(self.ticket_type, prop_name), six.text_type
             )
 
     def test_int_properties(self):

--- a/tests/interface_objects/test_trolley.py
+++ b/tests/interface_objects/test_trolley.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, division, print_function
 
 import datetime
 
+import six
+
 from pyticketswitch.interface_objects import (
     Bundle, Core, Event, Order, Trolley
 )
@@ -173,7 +175,7 @@ class BundleTests(InterfaceObjectTestCase):
             'total_despatch', 'total_cost',
         ):
             self.assertIsInstance(
-                getattr(self.trolley.bundles[0], prop_name), unicode
+                getattr(self.trolley.bundles[0], prop_name), six.text_type
             )
 
     def test_int_properties(self):

--- a/tox.ini
+++ b/tox.ini
@@ -17,9 +17,8 @@ deps =
 deps =
     flake8==2.5.0
     isort==4.2.5
-commands =
-    flake8 pyticketswitch
-    isort --recursive --check-only --diff -a 'from __future__ import absolute_import, division, print_function' pyticketswitch tests
+    modernize==0.5
+commands = ./lint.py
 
 [testenv:py27-docs]
 changedir=docs


### PR DESCRIPTION
'modernize' is a layer on top of 2to3 for producing Python 2 + 3 compatible code via `six`.

Read more at https://python-modernize.readthedocs.org/en/latest/

This runs it during linting and automatically applies the differences - it's not ideal since it won't fail the tests if something needs changing, but it's not easy to do that without a wrapper script.