### PR TITLE
remove misleading logging on api error

### DIFF
--- a/pyticketswitch/interface.py
+++ b/pyticketswitch/interface.py
@@ -209,20 +209,12 @@ class CoreAPI(object):
         )
 
     def parse_response(self, parse_function, xml_elem):
-        """ Calls the specified parse function
-
-        Calls the specified parse function and logs
-        any errors that are raised.
-
         """
-        try:
-            result = parse_function(
-                parse.script_error(xml_elem)
-            )
-        except Exception as e:
-            logger.error(e)
-            raise e
-
+        Calls the specified parse function
+        """
+        result = parse_function(
+            parse.script_error(xml_elem)
+        )
         return result
 
     def start_session_resolve_user(


### PR DESCRIPTION
Whenever there is an error returned by ticketswitch, pyticketswitch logs the error and then raises an exception. This feels wrong and its cluttering up our log monitoring.

https://docs.python.org/2/howto/logging.html

![2016-04-28-174132_1386x847_scrot](https://cloud.githubusercontent.com/assets/794070/14893844/d750543a-0d68-11e6-932c-973bb9356246.png)

@tolomea @adamchainz: you guys don't rely on this or anything do you?