### PR TITLE
Set unicode literals everywhere

### DIFF
--- a/lint.py
+++ b/lint.py
@@ -67,7 +67,7 @@ def run_isort():
     print('Running isort check')
     return subprocess.call([
         'isort', '--recursive', '--check-only', '--diff',
-        '-a', 'from __future__ import absolute_import, print_function, division',
+        '-a', 'from __future__ import absolute_import, print_function, division, unicode_literals',
     ] + [x for x in CODE_PATHS if x != 'tests'])
 
 

--- a/pyticketswitch/__init__.py
+++ b/pyticketswitch/__init__.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
 
 from .interface_objects import *  # NOQA
 from .util import auto_date_to_slug, slug_to_auto_date  # NOQA

--- a/pyticketswitch/api_exceptions.py
+++ b/pyticketswitch/api_exceptions.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
 
 from pyticketswitch.util import resolve_boolean
 

--- a/pyticketswitch/core_objects.py
+++ b/pyticketswitch/core_objects.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
 
 
 class CoreObject(object):

--- a/pyticketswitch/interface.py
+++ b/pyticketswitch/interface.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
 
 import logging
 from datetime import datetime
@@ -150,10 +152,9 @@ class CoreAPI(object):
         return response_string
 
     def _create_xml_and_post(self, method_name, arg_dict, url=None):
-
         data = xml.tostring(
             create_xml_from_dict(method_name, arg_dict),
-            encoding='UTF-8'
+            encoding=b'UTF-8'
         )
 
         if not url:

--- a/pyticketswitch/interface_objects/__init__.py
+++ b/pyticketswitch/interface_objects/__init__.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
 
 from .availability import AvailDetail, Concession, DespatchMethod, TicketType
 from .base import Address, Card, Commission, Currency, Customer, Seat
@@ -12,8 +14,8 @@ from .reservation import Reservation
 from .trolley import Trolley
 
 __all__ = (
-    'Core', 'Category', 'Event', 'Review', 'Performance',
-    'TicketType', 'Concession', 'DespatchMethod', 'AvailDetail',
-    'Order', 'Trolley', 'Reservation', 'Customer', 'Commission',
-    'Card', 'Address', 'Seat', 'Video', 'Bundle', 'Currency',
+    b'Core', b'Category', b'Event', b'Review', b'Performance',
+    b'TicketType', b'Concession', b'DespatchMethod', b'AvailDetail',
+    b'Order', b'Trolley', b'Reservation', b'Customer', b'Commission',
+    b'Card', b'Address', b'Seat', b'Video', b'Bundle', b'Currency',
 )

--- a/pyticketswitch/interface_objects/availability.py
+++ b/pyticketswitch/interface_objects/availability.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
 
 from copy import deepcopy
 from operator import attrgetter
@@ -8,6 +10,7 @@ from pyticketswitch.util import (
     day_mask_to_bool_list, format_price_with_symbol, resolve_boolean,
     to_float_or_none, to_float_summed, to_int_or_none, yyyymmdd_to_date
 )
+
 from six.moves import zip
 
 from .base import Commission, Currency, InterfaceObject, Seat, SeatBlock

--- a/pyticketswitch/interface_objects/base.py
+++ b/pyticketswitch/interface_objects/base.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
 
 import logging
 
 import six
-
 from pyticketswitch import settings as default_settings
 from pyticketswitch.interface import CoreAPI
 from pyticketswitch.util import (

--- a/pyticketswitch/interface_objects/bundle.py
+++ b/pyticketswitch/interface_objects/bundle.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
 
 from pyticketswitch.util import (
     format_price_with_symbol, resolve_boolean, to_float_or_none,

--- a/pyticketswitch/interface_objects/core.py
+++ b/pyticketswitch/interface_objects/core.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
 
 from pyticketswitch import settings
 from pyticketswitch.util import date_to_yyyymmdd

--- a/pyticketswitch/interface_objects/event.py
+++ b/pyticketswitch/interface_objects/event.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
 
 import datetime
 from copy import deepcopy
@@ -11,6 +13,7 @@ from pyticketswitch.util import (
     date_to_yyyymmdd_or_none, dates_in_range, hhmmss_to_time, resolve_boolean,
     to_int_or_none, yyyymmdd_to_date
 )
+
 from six.moves import range
 
 from . import availability as avail_objs

--- a/pyticketswitch/interface_objects/order.py
+++ b/pyticketswitch/interface_objects/order.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
 
 from pyticketswitch.util import (
     format_price_with_symbol, to_float_or_none, to_float_summed,

--- a/pyticketswitch/interface_objects/performance.py
+++ b/pyticketswitch/interface_objects/performance.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
 
 import datetime
 from operator import attrgetter

--- a/pyticketswitch/interface_objects/reservation.py
+++ b/pyticketswitch/interface_objects/reservation.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
 
 from pyticketswitch.util import (
     boolean_to_yes_no, dict_ignore_nones, resolve_boolean, to_float_or_zero

--- a/pyticketswitch/interface_objects/trolley.py
+++ b/pyticketswitch/interface_objects/trolley.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
 
 from pyticketswitch.util import resolve_boolean, to_int_or_none
 

--- a/pyticketswitch/parse.py
+++ b/pyticketswitch/parse.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
 
 from . import api_exceptions as aex
 from . import core_objects as objects

--- a/pyticketswitch/settings.py
+++ b/pyticketswitch/settings.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
 
 API_URL = 'https://www.tsd-aff.com/cgi-bin/xml_core.exe'
 EXT_START_SESSION_URL = 'https://www.tsd-aff.com/cgi-bin/xml_start_session.exe'

--- a/pyticketswitch/util.py
+++ b/pyticketswitch/util.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
 
 import datetime
 import random
@@ -18,17 +20,17 @@ except ImportError:
 
 
 __all__ = (
-    'create_xml_from_dict', 'create_dict_from_xml',
-    'create_dict_from_xml_element',
-    'random_string_generator',
-    'format_price', 'format_price_with_symbol',
-    'yyyymmdd_to_date', 'hhmmss_to_time',
-    'date_to_yyyymmdd', 'time_to_hhmmss',
-    'dates_in_range', 'auto_date_to_slug',
-    'slug_to_auto_date', 'resolve_boolean',
-    'to_int_or_none', 'to_int_or_return',
-    'to_float_or_none', 'to_float_summed',
-    'to_float_or_zero'
+    b'create_xml_from_dict', b'create_dict_from_xml',
+    b'create_dict_from_xml_element',
+    b'random_string_generator',
+    b'format_price', b'format_price_with_symbol',
+    b'yyyymmdd_to_date', b'hhmmss_to_time',
+    b'date_to_yyyymmdd', b'time_to_hhmmss',
+    b'dates_in_range', b'auto_date_to_slug',
+    b'slug_to_auto_date', b'resolve_boolean',
+    b'to_int_or_none', b'to_int_or_return',
+    b'to_float_or_none', b'to_float_summed',
+    b'to_float_or_zero'
 )
 
 

--- a/tests/interface_objects/test_concessions.py
+++ b/tests/interface_objects/test_concessions.py
@@ -51,7 +51,7 @@ class ConcessionTests(InterfaceObjectTestCase):
         for prop_name in (
             'concession_id', 'description',
         ):
-            self.assertIsInstance(getattr(self.concession, prop_name), str)
+            self.assertIsInstance(getattr(self.concession, prop_name), six.string_types)
 
     def test_unicode_properties(self):
 

--- a/tests/interface_objects/test_core.py
+++ b/tests/interface_objects/test_core.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
+import six
+
 from pyticketswitch.interface_objects import Core, Event
 
 from .. import settings_test as settings
@@ -83,7 +85,7 @@ class CoreTests(InterfaceObjectTestCase):
         self.assertIsInstance(self.core.event_cities, dict)
         self.assertIn('london-uk', self.core.event_cities)
         for city, info in self.core.event_cities.items():
-            self.assertIsInstance(city, str)
+            self.assertIsInstance(city, six.string_types)
             self.assertIsInstance(info, dict)
 
             self.assertIn('count', info)
@@ -96,7 +98,7 @@ class CoreTests(InterfaceObjectTestCase):
         self.assertIsInstance(self.core.event_categories, dict)
         self.assertIn('theatre/', self.core.event_categories)
         for cat, info in self.core.event_categories.items():
-            self.assertIsInstance(cat, str)
+            self.assertIsInstance(cat, six.string_types)
             self.assertIsInstance(info, dict)
             self.assertIn('count', info)
             self.assertIn('category', info)
@@ -109,7 +111,7 @@ class CoreTests(InterfaceObjectTestCase):
         self.assertIsInstance(self.core.event_countries, dict)
         self.assertIn('uk', self.core.event_countries)
         for country, info in self.core.event_countries.items():
-            self.assertIsInstance(country, str)
+            self.assertIsInstance(country, six.string_types)
             self.assertIsInstance(info, dict)
 
             self.assertIn('count', info)

--- a/tests/interface_objects/test_event.py
+++ b/tests/interface_objects/test_event.py
@@ -55,7 +55,7 @@ class ValidEventTests(InterfaceObjectTestCase):
             'country_desc', 'latitude', 'longitude',
             'event_id', 'event_type'
         ):
-            self.assertIsInstance(getattr(self.event, prop_name), str)
+            self.assertIsInstance(getattr(self.event, prop_name), six.string_types)
 
     def test_categories(self):
 
@@ -168,7 +168,7 @@ class EventReviewsTests(InterfaceObjectTestCase):
             event_id='6IF', session=session, **self.api_settings)
 
     def test_critic_review_percent(self):
-        self.assertIsInstance(self.event.critic_review_percent, str)
+        self.assertIsInstance(self.event.critic_review_percent, six.string_types)
 
     def test_critic_reviews(self):
         self.assertTrue(self.event.critic_reviews)
@@ -197,7 +197,7 @@ class ReviewTests(InterfaceObjectTestCase):
         for prop_name in (
             'title', 'author', 'date_desc', 'time_desc', 'body',
         ):
-            self.assertIsInstance(getattr(self.review, prop_name), str)
+            self.assertIsInstance(getattr(self.review, prop_name), six.string_types)
 
     def test_date_is_datetime_date(self):
         self.assertIsInstance(self.review.date, datetime.date)
@@ -225,7 +225,7 @@ class AvailDetailTests(InterfaceObjectTestCase):
         ):
             prop = getattr(self.avail_detail, prop_name)
             if prop is not None:
-                self.assertIsInstance(prop, str)
+                self.assertIsInstance(prop, six.string_types)
 
     def test_unicode_properties(self):
 

--- a/tests/interface_objects/test_order.py
+++ b/tests/interface_objects/test_order.py
@@ -66,7 +66,7 @@ class OrderTests(InterfaceObjectTestCase):
             'ticket_type_desc', 'order_id',
         ):
             self.assertIsInstance(
-                getattr(self.order, prop_name), str
+                getattr(self.order, prop_name), six.string_types
             )
 
     def test_int_properties(self):

--- a/tests/interface_objects/test_performance.py
+++ b/tests/interface_objects/test_performance.py
@@ -35,7 +35,7 @@ class PerformanceTests(InterfaceObjectTestCase):
         for prop_name in (
             'date_desc', 'time_desc', 'perf_id'
         ):
-            self.assertIsInstance(getattr(self.performance, prop_name), str)
+            self.assertIsInstance(getattr(self.performance, prop_name), six.string_types)
 
     def test_date_is_datetime_date(self):
         self.assertIsInstance(self.performance.date, datetime.date)
@@ -47,7 +47,7 @@ class PerformanceTests(InterfaceObjectTestCase):
 
         for perf in self.performances:
             if perf.date.weekday() == 1:
-                self.assertIsInstance(perf.required_info, str)
+                self.assertIsInstance(perf.required_info, six.string_types)
 
 
 class PerformanceAvailabilityTests(InterfaceObjectTestCase):
@@ -171,7 +171,7 @@ class DespatchMethodTests(InterfaceObjectTestCase):
             'description', 'despatch_id',
         ):
             self.assertIsInstance(
-                getattr(self.despatch_method, prop_name), str
+                getattr(self.despatch_method, prop_name), six.string_types
             )
 
     def test_unicode_properties(self):

--- a/tests/interface_objects/test_reservation.py
+++ b/tests/interface_objects/test_reservation.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, division, print_function
 
 import datetime
 
+import six
+
 from pyticketswitch.interface_objects import Core, Event, Reservation, Trolley
 
 from .common import InterfaceObjectTestCase
@@ -19,7 +21,7 @@ class ReservationTests(object):
             'transaction_id',
         ):
             self.assertIsInstance(
-                getattr(self.reservation, prop_name), str
+                getattr(self.reservation, prop_name), six.string_types
             )
 
     def test_bool_properties(self):

--- a/tests/interface_objects/test_ticket_types.py
+++ b/tests/interface_objects/test_ticket_types.py
@@ -46,14 +46,14 @@ class TicketTypeTests(InterfaceObjectTestCase):
             self.assertIsInstance(option, tuple)
 
             for item in option:
-                self.assertIsInstance(item, str)
+                self.assertIsInstance(item, six.string_types)
 
     def test_string_properties(self):
 
         for prop_name in (
             'description', 'ticket_type_id',
         ):
-            self.assertIsInstance(getattr(self.ticket_type, prop_name), str)
+            self.assertIsInstance(getattr(self.ticket_type, prop_name), six.string_types)
 
     def test_float_properties(self):
 
@@ -135,7 +135,7 @@ class TicketTypeConcessionTests(InterfaceObjectTestCase):
         )
 
     def test_blanket_discount_only(self):
-        self.assertIsInstance(self.ticket_type.blanket_discount_only, str)
+        self.assertIsInstance(self.ticket_type.blanket_discount_only, six.string_types)
 
     def test_ticket_concessions(self):
         self.assertIsInstance(self.ticket_type.ticket_concessions, list)

--- a/tests/interface_objects/test_trolley.py
+++ b/tests/interface_objects/test_trolley.py
@@ -69,7 +69,7 @@ class TrolleyTests(InterfaceObjectTestCase):
             'trolley_id',
         ):
             self.assertIsInstance(
-                getattr(self.trolley, prop_name), str
+                getattr(self.trolley, prop_name), six.string_types
             )
 
     def test_int_properties(self):
@@ -165,7 +165,7 @@ class BundleTests(InterfaceObjectTestCase):
             'source_description', 'source_code',
         ):
             self.assertIsInstance(
-                getattr(self.trolley.bundles[0], prop_name), str
+                getattr(self.trolley.bundles[0], prop_name), six.string_types
             )
 
     def test_unicode_properties(self):


### PR DESCRIPTION
This is further work toward Python3 suppot.
Replace isinstance(..., str) with isinstance(..., six.string_types) in a bunch of places, mostly in tests.
Strings in `__all__` in Py2 must be bytestrings so explicitly declare them as such.
The odd change in interface.py is due to element tree incorrectly returning a unicode string when the encoding string is itself unicode.
Tests and lint pass.