### PR TITLE
Remove deprecated internal api call

### DIFF
--- a/.projections.json
+++ b/.projections.json
@@ -1,0 +1,4 @@
+{
+  "pyticketswitch/*.py": { "alternate": "tests/{dirname}/test_{basename}.py" },
+  "tests/**/test_*.py": { "alternate": "pyticketswitch/{dirname}/{basename}.py" }
+}

--- a/pyticketswitch/interface.py
+++ b/pyticketswitch/interface.py
@@ -26,10 +26,10 @@ class CoreAPI(object):
     def __init__(
             self, username, password, url,
             remote_ip, remote_site, accept_language,
-            ext_start_session_url, api_request_timeout,
+            api_request_timeout,
             sub_id=None,
             additional_elements=None,
-            requests_session=None):
+            requests_session=None, custom_start_session=None):
 
         self.username = username
         self.password = password
@@ -39,9 +39,9 @@ class CoreAPI(object):
         self.remote_ip = remote_ip
         self.remote_site = remote_site
         self.accept_language = accept_language
-        self.ext_start_session_url = ext_start_session_url
         self.content_language = None
         self.running_user = None
+        self.custom_start_session = custom_start_session
 
         if api_request_timeout:
             self.api_request_timeout = api_request_timeout
@@ -199,6 +199,7 @@ class CoreAPI(object):
             'sub_id': self.sub_id,
             'remote_ip': self.remote_ip,
             'remote_site': self.remote_site,
+            'puzzled': 'yes',
         }
 
         args.update(self.additional_elements)
@@ -220,36 +221,24 @@ class CoreAPI(object):
         )
         return result
 
-    def start_session_resolve_user(
-            self, user_id=None, remote_site=None, remote_ip=None):
-
-        resp = self._create_xml_and_post(
-            method_name='start_session',
-            arg_dict=dict_ignore_nones(
-                user_id=user_id,
-                remote_site=remote_site,
-                remote_ip=remote_ip
-            ),
-            url=self.ext_start_session_url
-        )
-
-        return self.parse_response(
-            parse.start_session_resolve_user_result, resp
-        )
-
     def start_session(self):
+        """
+        Attempts to start a new user session with the creditials provided.
+        If a custom start session method is provided then it will use that
+        instead.
+        the expected result from a custom_start_session method is a dictionary
+        containing a crypto_block, user_id, and running_user
+        (pyticketswitch.core_objects.RunningUser)
+        """
 
-        if not self.password or not self.username:
-            resp = self.start_session_resolve_user(
-                user_id=self.username,
+        if self.custom_start_session:
+            resp = self.custom_start_session(
                 remote_ip=self.remote_ip,
                 remote_site=self.remote_site,
             )
-
             crypto_block = resp['crypto_block']
-            self.username = resp['running_user'].user_id
+            self.username = resp['user_id']
             self.running_user = resp['running_user']
-
         else:
             arg_dict={
                 'user_id': self.username,

--- a/pyticketswitch/interface.py
+++ b/pyticketswitch/interface.py
@@ -199,7 +199,6 @@ class CoreAPI(object):
             'sub_id': self.sub_id,
             'remote_ip': self.remote_ip,
             'remote_site': self.remote_site,
-            'puzzled': 'yes',
         }
 
         args.update(self.additional_elements)

--- a/pyticketswitch/interface.py
+++ b/pyticketswitch/interface.py
@@ -226,8 +226,8 @@ class CoreAPI(object):
         Attempts to start a new user session with the creditials provided.
         If a custom start session method is provided then it will use that
         instead.
-        the expected result from a custom_start_session method is a dictionary
-        containing a crypto_block, user_id, and running_user
+        The expected result from a custom_start_session method is a dictionary
+        containing a crypto_block, and a running_user
         (pyticketswitch.core_objects.RunningUser)
         """
 
@@ -237,8 +237,8 @@ class CoreAPI(object):
                 remote_site=self.remote_site,
             )
             crypto_block = resp['crypto_block']
-            self.username = resp['user_id']
             self.running_user = resp['running_user']
+            self.username = resp['running_user'].user_id
         else:
             arg_dict={
                 'user_id': self.username,

--- a/pyticketswitch/interface_objects/base.py
+++ b/pyticketswitch/interface_objects/base.py
@@ -37,7 +37,6 @@ class InterfaceObject(object):
             is returned by the API for a concession
         remote_ip (string): user's IP address (internal use)
         remote_site (string): domain of the user request (internal use)
-        ext_start_session_url (string): URL for start_session (internal user)
         additional_elements (dict): An optional dictionary of key/values to
             include in the XML passed to the API.
         upfront_data_token (string): upfront data token is required by the API
@@ -77,9 +76,8 @@ class InterfaceObject(object):
             no_time_descr=None, api_request_timeout=None,
             default_concession_descr=None, remote_ip=None,
             remote_site=None, accept_language=None,
-            ext_start_session_url=None,
             additional_elements=None, upfront_data_token=None,
-            requests_session=None):
+            requests_session=None, custom_start_session=None):
 
         return {
             'username': username,
@@ -89,22 +87,22 @@ class InterfaceObject(object):
             'remote_site': remote_site,
             'accept_language': accept_language,
             'url': url,
-            'ext_start_session_url': ext_start_session_url,
             'api_request_timeout': api_request_timeout,
             'no_time_descr': no_time_descr,
             'default_concession_descr': default_concession_descr,
             'additional_elements': additional_elements,
             'upfront_data_token': upfront_data_token,
             'requests_session': requests_session,
+            'custom_start_session': custom_start_session,
         }
 
     def _configure(
             self, username=None, password=None, sub_id=None, url=None,
             no_time_descr=None, api_request_timeout=None,
             default_concession_descr=None, remote_ip=None,
-            remote_site=None, accept_language=None, ext_start_session_url=None,
+            remote_site=None, accept_language=None,
             additional_elements=None, upfront_data_token=None,
-            requests_session=None):
+            requests_session=None, custom_start_session=None):
 
         if (not username) and remote_ip and remote_site:
             username = self._get_cached_username(
@@ -134,9 +132,6 @@ class InterfaceObject(object):
         if not url:
             url = default_settings.API_URL
 
-        if not ext_start_session_url:
-            ext_start_session_url = default_settings.EXT_START_SESSION_URL
-
         if not api_request_timeout:
             api_request_timeout = default_settings.API_REQUEST_TIMEOUT
 
@@ -156,10 +151,10 @@ class InterfaceObject(object):
             remote_ip=remote_ip,
             remote_site=remote_site,
             accept_language=accept_language,
-            ext_start_session_url=ext_start_session_url,
             additional_elements=additional_elements,
             upfront_data_token=upfront_data_token,
             requests_session=requests_session,
+            custom_start_session=custom_start_session,
         )
 
         self._core_api = CoreAPI(
@@ -170,10 +165,10 @@ class InterfaceObject(object):
             remote_ip=remote_ip,
             remote_site=remote_site,
             accept_language=accept_language,
-            ext_start_session_url=ext_start_session_url,
             api_request_timeout=api_request_timeout,
             additional_elements=additional_elements,
             requests_session=requests_session,
+            custom_start_session=custom_start_session,
         )
 
     def get_core_api(self):

--- a/pyticketswitch/settings.py
+++ b/pyticketswitch/settings.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, division, print_function
 
 API_URL = 'https://www.tsd-aff.com/cgi-bin/xml_core.exe'
-EXT_START_SESSION_URL = 'https://www.tsd-aff.com/cgi-bin/xml_start_session.exe'
 
 DATE_SLUG_MAP = (
     {

--- a/tests/interface_objects/cassettes/AvailDetailTests.test_bool_properties.yaml
+++ b/tests/interface_objects/cassettes/AvailDetailTests.test_bool_properties.yaml
@@ -1,146 +1,119 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF92aWRlb19pZnJhbWUgLz48
+      cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNj
+      YXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21l
+      ZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9m
+      b3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlh
+      PnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVx
+      dWVzdF9tZWRpYT48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHJlcXVlc3RfYXZhaWxfZGV0YWlscyAv
+      PjxyZXF1ZXN0X2N1c3RvbV9maWVsZHMgLz48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxtaW1lX3Rl
+      eHRfdHlwZT5odG1sPC9taW1lX3RleHRfdHlwZT48cmVxdWVzdF9tZXRhX2NvbXBvbmVudHMgLz48
+      cmVxdWVzdF9leHRyYV9pbmZvIC8+PHJlcXVlc3Rfc291cmNlX2luZm8gLz48cmVxdWVzdF9jb3N0
+      X3JhbmdlIC8+PHJlcXVlc3RfcmV2aWV3cyAvPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['784']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+087XbbOK7/+xTs3HOme8/GtmRL/mi1mpukabdfaTdxp7v7R4eSKEu1JLoiFcfz
+        OvfPPsfeF7sAKdmS4yROP/Z0OpnjmZFAkABBAAQJKM4vl1lKLlghEp7/5Seza/xEWB7wMMlnf/np
+        /fRZZ/zTL+4Dh12wXHqC0SKIvYKJMpWuI0o/5BlNcq8UrPAS4fk0dHPu9Ha3OEGxWkju+SkP5m7g
+        dTrDji8+fnj7MT2bFawjnvovzyZvj4JoHL8aXn46P42ey9Pzd0fv/KGZGqvDxF88m87kkf/J/0cw
+        HB+X9uujdzR+f/7ubOIdi7//+s9L8Zs4L58Op/2F1c/9hX+2fPm3o5cnL/95+dxaHc/juE+TaJIO
+        Qjta+fEb+2/2m9PUWBxZnX84vRZ/TpgISfOACY8WzLugaaIntwuuBeQ6AKEeiI+5Jx+c3uZNN4RM
+        BO4JSHu1jFnBKgQFdegFTVJ4lvA/4ToyCeZMenK1gM6LIgkYiDAP23j1W1AWBazaCiRcPWmqM38B
+        k2qBNhgRDSQvXNMwGjgVcIOVl5nPCnfcHzawKuAGa5FSkIfbb+BUoAYOF6BBq8znaa8JBhlqqPvv
+        /23238BBTlvTVO/UT5kXUolUoqSA0VfwT5aFods3zKFhG7bT22pwUnoFbzwACbThFcUmhZCuvIyK
+        uTscgArUL86nkuYykSuPLySYECAqhfBquGs6vS3INkb/VozBrRjWrRj2rRjDqxi9q9MDHyCVPrrW
+        qAuC27yDPwDvQIsZc23Vsn6tF7DW2o0+a6U8dHrboCYOGgioTK9pBg370B2ODl8fvz0FI77S0sJV
+        xnZE04DnqzauNsNey/DurfDeCr9zKxzY11qh9c2t8N4k7k3iOzQJ42uZxNG9SdybxI9gEv2vtksc
+        f4VY7fjF2fHrk71CtfeLBStIkBRByu7jtXtL/P1bonmtJQ7u47V7k/hPm8SNymqOv5ayfkYkdWV3
+        OJ8evn59vte2cS5pmorbN4wW16hkKAg1ZsrzkOedcg6qtAbqdjXQa9VeNeqhA1h7Uf1P49NCAhMN
+        QNWo8A+hkfxMs8WT/xqMn5DjMpUlXgo2UJxEeOoaVQ+9YjBaG+RUd7JztlLUemq5aghe0VZ4dbc1
+        pDXYBm97vBCvOncPqqdUI7SAG5z6wiVlUk+WPN3qUK3LhoVeLUg09ILmqF4ZvYSRMz/JWejafVS+
+        FkghbN9NtWEapX1H1QY5Gcq1HlJ76hZIIWybRxumUdpm0gY5OfdEks9ShsL6Maf4h9vg1Rr++Pvn
+        9jR71+jy/fr/Qda/uegBL3NZVPNTG2cTsG7W57o8kSwkr0B3Qp5tUKudtEhgm/YKdpGwpQcnwACz
+        a1pCO5scDK40Hx7D4EG9q8GmcXlATCHJOVtIhvIiGK1h7FWjaOxSBh6PIsGkOxgiqW3oBk2wALZ/
+        4ZrWqD+yrTZ23ajR2yHixDArzE2ImAg+Hhqmig89DIZkkjGF3jEmHcOcmpPHA+OxYfzZMB8jpd0d
+        qnG3ZaDfhYTN/IpUbBmTN3T1NeUx7FujgbG3PFRofQd52PD7HHlU89dpbKWOp++nx2eHx69Ozpxe
+        A1yhKDG8oVLGbEmOeFnk7JEgpzCdgkL4WJDpyfm07qhlpp+T0B2+eFa3rDPDXpJH3P05lU/C5OLn
+        mXyCjwt8uEJEyDLPwSzIouBhGaB/ITxq0H5ICgaRYi5IksPSGWMiOTmnYcoK6P6BQeBLYnqBQ/gF
+        n7OcQPRFfH4Jw0Swf0P3gBehIGFZIBKeWMgK4jskDr07vJTwQAXPu8hmT/H5YM3xNE4EiZiQyQUj
+        soCwgCCgBCLAJzbKgoYso8UcJrNKGYKXiTwgCypjLggsEYE5UwnRBE1JRmdJ0G1NMOJpypeCHKe0
+        oMDWRyWcFYkKnhFK4DRF5+Q4LhIh4fREToAR4OJp0X1acCEekbfFIqY5nbEDIFTwchZDLxEnWcbU
+        lEEKHTGnEp+XoJysSJEpxRhH3ohYsEDSoAQGSADwFfI0x5mcLxmTCcMOO8XzNgW5FIQuaRF2lole
+        S1CRZJYD+DAHEeQr8gFaFb0phEzJnF+I+QommpVB3En5BbhGAYvESB2XoQBjIpLffktxvCCGRj4r
+        6CJekVkJUsolg9WIQQw3qO1DXCkKYmQiPiBpsuiIDBpgxANY8ULpDEwR1y9BxYPV2Ug5ogXbOeM2
+        QdA9oBHECcNZ+BzYBtuDMZJATRhmBKsQJDC2KAPYmoSeGypOgrqQU6VZOYxYFaYIZEodCpTC+Oo0
+        Ibrkda25qvO7FFzZBxgK9feD0vAM9BAWrlBLesZX0PmUVhObKg0EDQFzYAnyKpec4OoluE64fFpV
+        YWgB4pbpCpXDR/u5QPyGLNRTZdkPlGBiC5+floUip9o16MEuJ3BInvM0TLDuRJml6kQ6JOdwaAIk
+        liGW5FwNpN8InFBh2W5EUXwfkI8lyAlFUCSzWBKa4WarFhoc5R7T+BCDEzmmOXkBfP5y62TyFY5L
+        VrwEFZuzh+RQKGYJKIbEwpdHQpkjXxJwMd39GABbCDkwMLudgekVd4jqA8op2MN9aFFZnconTwR5
+        kQdpGbLwVqqqrkfGaEI485ztpSHPOQcfwMmrnC9vowA+A53JQ/IGlgN8PxKEJcQlVf8Ve9A7LxOJ
+        t1HkGVjFcZykIURytxE+L9FOlBaB+qNnUz4dNYqCdbEMdjhQWDShffk4xkuANNWK/o6nSbC6hotT
+        DgYXlRBBEGCZXYK/hB0dNKi+WAMeJFjsQp0+RaXPNcn1Toz7b7UXowflrt6BWI2ggRVGxsKEQhhK
+        VXgPUTJsW9INzeWltRzYpZ+FyWU3SHkZwo6Uy27OpNNTOE6SQ7wD8sIT9QLcFMRARerGUi7E417v
+        xiF6Ak7PLOw1eIBwl2MGpDcZwC8wLD8ywr7FokFo2Gwcscjy6WhkTMLIsAYWo+Yg6H5czCAo2smH
+        k1MIjXDvEjA5mLx6d3Bjdr8qeTWi832IYqcgRLlYgHMUHvJTFS02IW2E6rpsC+b0WuryverOiMHP
+        sMbB0Laj0SQ0KTNMy5wEk77VN8ZDM4xMe+iPB9EeugNh3aeS7a85dyb+DTXnzrz8AJrzBfLyFGav
+        P4HfyGL2eDQZUTC6iTmy+/5oENLBxKBsGI0jOmTWeNi/XX3wFhE8Ld5K5Pvq0Ofy8e006XM52kOf
+        rmrLd6ZQX2SBNoOfYVhR3/ZtSv1hZA36QThiw/Fg4oPztvrhmNqROfL30KVPcPDZ3xPdmfY39ER3
+        5uUP6onYpfQkE9Lo/VmshGSZt4HgRFI4q+2hKBXmraqyP7lvoBv7E//Du5FoAj9KIeKDONAajYKB
+        MQhHYz+wTWMUBMbItsJobA1pML5dO2SRIMiL4FC/tzO5Mwff0JncmZcfwJl8h+rDy9sdzL36fB/q
+        8+Wxn8Hg17ft0IomQz80+j6lIz8K+334N6D+xAjG0TBg4cDaX4d4vrcH+lw2vnlQfGeOfoTd7MvF
+        FgCA9kPLHk/oeGKNDdu04EQBkWHAgjGdjPtDu98fG8ZksL8+ySW/oz7dmY1vrk935ug/rE9asMMX
+        zzqZzoN0fJUH6YhOvk68dDCM69X9tcyqb2ollaVwUxV8tEA1QumHVNJe/S4xpddMMmpA3YplbSLB
+        qXu60m2Npgre9HO5wESflyZCthKXJzsSl6H75q9GE97bMcaMcUy/UqyLlIksQ+baZtfuT4amORhh
+        VWQFdTARoB87Rtc0hoZpD/uAsAY7vc1gMRVezjHLHwm1p7QAWNOG9wksXBezVa+qDqrQeVSdDTb7
+        VSlUC6oqmXbgbUMdvM33QragBdboqUyz4mcXvEKusjgNtBqiEXAOvMjwHlyzfwXqYKWG/pj42Dwj
+        1vQUzK0GOboCQtQPShrqa+vqHelugSpUj5Yy5oU7jRmZwvSAdruhxvN5uHKPaY45JkwaZxlTqVud
+        EVsSlmNq9eG6u8KvOzdqDUp2QMyRjMkpv1hXYNjrbo3CgyakWSlgm6Y5anfYFAxU0JTmM5flayz1
+        XjfyIsHMYoreoLeG4uJqyqbRNQxy+Gbde9PUQo7jLBMCS1FUkcOOpg26TJn7Ps8SITBN8bCBjS0O
+        1iR4hboOwzKk5muNeu3i1vp+w+piVpYcpumiYOLmFcaMV5WQe4hpUQIssw7LOyL4v3/lDBOgKkdP
+        0wOV82kln6FRZ9CjsmoWkherqlOeYMVBLqucPxesThF1uyTJA3D9CcimS148whoFRvxyhRk07bpE
+        lbut9Y3OaJKrodTTrXqHNS79MejdYTnD5BUoknUXrbOMcX/8e9Q6sNlHksyYvGKid9G93trFVNW/
+        9V8+8OaZW39jtw13cKWUG9OuU++jbZgjYIcMquLt9SUHoDXANY7+mwmXkhUqaQ+I5Ai3VFCCTQ8t
+        scaLh5UiMFAeJbO9erc61COx/FOZFAkTHsuwql1fy4j/ATGhUfFuwLtY53YNej0M+mzQARqGhYv5
+        V0ZG9gH5NcEKv4Ri3UIADhIz1UvMBp/LgjF5QI5YGmGBw9HU7BP72d/XdJrj1TSqGyNdOV2LdN2j
+        1Vp3kapWKnAxEwx+RGXnUUC49RKep6vuA3AG2FAworcAkKHa/HVhBM1XBJwMyxYAkHydgSUJSkkX
+        62jjrW6vyDLRVh7o7G9V1oL1GjA+OIrumuOaOdDUogxwcw2rHG7QyByDKDBzXEW9O3LKdfR7QdOS
+        4QcGO3s3dmbErqs2Wp3d761YQ5WllqrObc3+DPQH4kFvnvNlNZlmgcE1E7pLXcGGapsWbOyF9hqK
+        xNvq9RqK90Vv90Vv90Vvv/Oit40r2Bg/fiCCp6bqg6rKZSsf8E43kaqJYBMcdG5wtEecz4m/IgMD
+        QzgYOlXTahyRqk3GNMjLEjjt4FMV6+EkFiCbHLiHcZByBMoCfmUdT+6ayu4JiKpqygPCXlBVTVXz
+        2llRdc2MvqCQasPiNcwswQyQX12uVjF3XTHbNfzdXMO2YWGb1jJmuQcew0u8GV+TbhYNXreXfn6t
+        YJObFnX1t7W8kG8x0yggvIaZ/eoGW3SbhHpXQpXG6az9EcOuBgcCq5LpqO4MDkpwTIZt+FBBkbpf
+        kJ5yQS8EekOpq0rXUP09Ygv0/hXwuhm0IqA/pTx8+vrk7PzDifqgstFQIemPKFvCqNF0rK2f1TSn
+        Z4e/nrxuUW69nIKvwrjyPW45M9iY8vAxbAkzlpI/nYKLASnmsPg5++/bxzgDo3ysvhqBfRK3va0h
+        0FmpoW8Yi5BpiegsgrCqVKGV5gbv3TDwUA5bDa7CME5D3GjVyRehCNAn03NJXvI4ryL2LtleNvSi
+        yuHUwZzy+fhaFR8S6iMHoBMkY/AO4Qlf5q0+3VruWqUukpCBwkWFVuDGm7e50W6BY4bDuAO8cNnV
+        sIWNF93L5bILFilLn8ERJ9vup+7CWyB9B4pXO2HvuflycfLX58lvc2uro772bIGuZo1uaL6ha3Vf
+        exNCuzccyD3lN+pr9PV19dbkb53V1ZGuofS16OykskxCEK6Ft5c74G1gfYW7vspt/13H/wd2F8fQ
+        FFIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:35 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['4165']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:43 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_extra_info /><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><request_avail_details
-      /><request_video_iframe /><request_source_info /><request_reviews /><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><mime_text_type>html</mime_text_type><event_token_list>6IF</event_token_list></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['928']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+097XbbtpL/8xRI95z2R22JlKivlmXXsZ1c37hJajubzf7hAUlQZEQSMgFaUV/n
-        vsl9sp0BSImUZFv22hs7VY5OTA4Gg8FgPgAMINm/f00TcsVyEfPstx/MlvEDYZnPgzgb//bDx4vX
-        +8Mffnde2OyKZdIVjOZ+5OZMFIl0bFF4AU9pnLmFYLkbC9ejgTNnwm5vLrL9fD6V3PUS7k+cj+7+
-        /tVkGo4mh6Ppx957b3+c8zAw5ZuZ/+7D5y9d5osv3aPPZv/Ln5P3xudP2dFVevE2Egfdqfv14+Xg
-        7PT1/Mjv7Z8FZth/exkWn08uxwevxfuzbDa/pMaF2X9v5e5R2j09Of5zfpkff7kcjpK88+EkG3WP
-        JrNx8tluN3iyg1hImvlMuDRn7hVN4sDJuN3eBNdScWyAUBdkxpzjT3Z7+aYLAiZ85xhEPJ9FLGcl
-        goLa9IrGCTxL+CMcW8b+hElXzqdQeZrHPgOxZUETD948wZNCMlfQKxgnx+y0DCC7Ai0r+UWew4jO
-        Qfjlk2Zu7E2h7w3QEiOkvuS5YxpGDacELrGyIvVY7gw7/RpWCVxiTRMKYnM6NZwSVMPhArRrnno8
-        adfBIGoNdf79r3r9JRz6vdJN9U69hLkBldhKGOdAfQ7/0jQInI5h9o2eAfysFNgJXcMbdE273YSX
-        LdZbCOjcTamYOP0uaEr1YodFkqDNSDWUjjXAYVoBlkgF2BXNx8wxljgLmD1luQ+aRseLwUWRr0Pt
-        y4JmMpZzl08lGDSwpjTVreAO9GYFsorRuRWjeyuGdStG71aM/jpGe717S0F2eyi5mmBXZFoTZ3vF
-        nG42ru7OuO5oXFbH3Mq4hqb1/2tcvS2Nq7czrq2Ny7rZuJZRTJvBAYh2BVTHwbAIStquB79aVNQV
-        Xh2cHr5/B6F7raSBq0LsK5r4PJs3cXXwbTfC7T1j72jnHZ5B6O32dqH38bxDp/9IodfYGdczCL1b
-        GZe1M64HN67uo4feG+Lgzgi/bYT7G5tE13igeLPT4W8bSHY6/AArqlcP6tZXJlv93QzsKTr/lclW
-        5yGXN9ZuBtY0VXP0OMubwc62nmJQuo9tbbu62dnW9rZ1x9XN4QNsLB6enB2eHm+1r/hxCgNJ/Dj3
-        E/Zom4u9nYd4DtHX3EXfR/QQj7S5uJvZPovou41tdXdpvQe3rc5ub/FJGuG2Aa6PfXtu+zI3K+tw
-        t+v36NqF84+Hnz5h4HjO2tWzdur1bGYQz0297rjOfdTtXms3KX6K8Xhl/quV6YEWnJ0nNSm+2Yis
-        x1kKWsrB79T+qU0U7qf2OJbPbqPlm+j9bnvxSU5g7qP2226BfB9af8fNiYdIDZxfHJyenm+VGjiX
-        NEnE7UmBBtfQdS8eF1O8WlQwbUJ1gO2jmFSLCc8Cnu0XE1DtBVCXq2ZOVXlZqBv2QRdF+UfjywgE
-        i7eRarCyXFW5aJZrMrFw1Z0uTU5d9GqC7PKG2ITNqxbaagwrIN4ZK1GrmgtIg94SbwPJSRyIzWR1
-        R8ryBmyJovrymqZxMq8hlSO0bLddCQ2dTE4zVDSPwbMaEJeHIfqrLa+LKNP0eerFGQucXmdhrgvY
-        w11oUJwtCXdVim0FWCKtHuJchVZozUTnKnD7vdb2ugBT+nWV1wZIIej6O5nfS+brAlSQFTaaMI3S
-        ZKEJslO0+qpv2lk3QCUCjPc1w7Z5sdkcoVrwu3bU7r8cWhkg09pm1OpYN4yase2obV6AtVelh++r
-        TDRhGqXJQBNkZ9wVQD5hwt25tZ1be9Yy37m1nVsrm//bpXCV3/7+1+ir3ZR86upV2s5l3sdlrsmv
-        fc2EYGdQO4PaGdR9DKpuRT4vMpmXCqO2a+qARbE+T5rFkgXkLdANeLpELfdv8ljGvpuzq5jN3JKT
-        UuU2Ftm4xaj5cBluaKn3cmen2CPmUEbkoBgXQhLcscT9xwpB4xbSx04JJp1uHxtahS7RBPN5FgiI
-        3gOzZ/WMBnZVqNFXt0mHJeZymzQWfNg3TLVH6uL2nIxTptD3jeG+ObwwR790jV8M42fD/AVb2lyh
-        pLsqAf0uJM3lmkw6JgjjAIYzeUiR9M1Ov2ttLRJLp0C2Fom13zHvI5JSBPp7nZQ+vvt4cXh2cPj2
-        +Mxu18AlihLDH1TKiM3IK17kGftJkHfQnZz6E5a/rCppeennOHD6J6+rksU3JrlxFnLnx0T+GsRX
-        P47lr026P9J0+ut/dEe/CiJkkWVgEmSa86Dw0VkTHtabJTmTUEmQOINRM4ZEcnJOg4TlNTKfWJII
-        EimrJV7OJywjNEmIx78CuRDsF8j4PA8ECYockXDvnswZrVMRQGWfFxIeqOBZCzvg5aSNPXjReLmI
-        YkFCWBPGV4zIHPwPQQA4NuQeC2VOA5bSfAJdnCcMwbNY7pEplREXBMaM6M3O2KcJSek49luNboc8
-        SfhMkMOE5rTG5BclwjkJc54SSryE0Qk5jPJYyJQKcgwMATdHeeso50IsKpL3+TSiGTi3PWg458U4
-        gtoiitOUKYGAjPbFhEp8noH2sjxBJhWjHHklYsp8Sf0CGCI+wOfI4wR7dj5jTMYMK9wgtPcJSCsn
-        dEbzYH8W63EHbYrHGYAPMhBMNiefoFS1egHeOp7wKzGZ17qfFn60n/ArcKUCBpSRKkSgeCMi4r/+
-        SpCuH0EhH+d0Gs3JuAAZZpLBWEUgnGu1sS5/GEMKQmYi2iNJPN0XKRQA5T3QjlzpGXQcRzlGpYUx
-        XI5BSHN2gxyazYPWQkt+FDPsk8ehE2C4QCn2lRigfzBCfgwtiMKHmYLQPUUli1FvMqq0MAOK5de8
-        CWRNbW4r5fLAEpgULXJa6byq/CGhIG0ghRr/SdlGCjoLg5qr4T7jc6j8jpbdK/MFe2hILEZe5YwT
-        HNMYRw8HVas1kBYgfJnMUXE8tLwrxFcSaZcO4YUSSWTh86cIrPWQZuSEvOG/Kyxd8KLmQQ6yOfo4
-        MucFDMeEvSQHgiQchgHEJ/F712rjiIrNZwRMuHVTq6A9R/zGVvFxig8XldP5qXI2KGIYQMFeqrrT
-        Cn1zW1TW2DvJ/KQIWHBdq+q75GSEOobdzdgNwnvDOZgKJ28zPruGHFgUmtpL8gfIGbwoUicyHkdS
-        /y+uJX5exBLzmeQ16MRhFCcBTCuvaeW8QOX4gvMNGHM0cuX0UJMoqBRLIS6AJqHebGh0EUIwcJRB
-        BO2YL/NYdWCJkbIgpjB5omqWD5NlcK3SUdCWzsQJsBU/avk441KFdpxBdAZecW45BbuAiJ0nTiTl
-        VPzSbm+u2xYwcWRBu9YqTMs43hBqj7rw8Q3LC42gY7GwGxg9NgxZaHl0MDBGQWhYXYtRs+u3vkzH
-        ELs3MmBnFCI4elAB3YHuqncbw4XzoM0rivY3lsFGCYhiOgW/IVxkRH0nYxPSRBDV91A2YHa7oRlP
-        R00GDD6GNfT7vV44GAUmZYZpmSN/1LE6xrBvBqHZ63vDbriFmsC84rJg2yvJnRt/DCW5MxN/PyXp
-        MfgYhhV2el6PUq8fWt2OHwxYf9gdeWBIVicY0l5oDrzblURcwqxnex25c9uPoSN3ZuIp6Ehgzr5a
-        s26v8NIg/tryE14EMDvPZCtj8nZVAUHdSGGTvNhX6UpYfhjtn8VcSJa6Swh2JIE52RYaUmLeqiPb
-        N3e7UjxiX7dQhvWhft4eIxzBh1IItBB+rcHA7xrdYDD0/J5pDHzfGPSsIBxafeoPb9cHWIwiyA1h
-        ur6137gzB4/hN+7MxFPwG9+DpsAKaKcp32OEKeXlKsz2qAcfb+R7Fh0NQzrweqblWVbfMkYDagwH
-        oecNvIFp+j7dXnlgMbit7tyXjUcIR/9Hjp5EjPrm+tTpwcfo94KR3w9ox+/3B2Z3BO+DAbUCy+r2
-        R33f7I2C7h30SUb59mui+zLy6Bp1Z46ehEZ9B7FMzvgulD1gKBOSykI4iZpMNkAVQuEFVNJ29S4x
-        bVPPJ2lAVYpH6kWMrLtaSgs0ddhePxdTTOK4SSxkI0d1vCFHdV3uCuBvP9bh7Q20x4xj9o3i7RAZ
-        yyJgTs9s9fBSSPlq4+60ftw3WiYWLQB2e1k/osLNOCZ2Q6Hk3wDgKXrMb7NgcXy+fFVH3XKdPtP5
-        P7NTnnZrQNXxqg14q1Ab95ndgE1pLlFNMJeo+NkEL5GLXKUHamgVRCNgH3ie4u+qaPbXoDaedtA/
-        rXJonhHr4h0YSwWyddJbVA9KGur3Zsp3bHcFVKK6tJARz/GaA7mA7kHbzYIKz+PB3DmkWcalyhGm
-        KVO5OZ3GmBGWYa7s5aK6wq8q1xLMBdsj5kBG5B2/YnjqA3PMvUW1Wqq5DqnnhnumaQ6aFZYp4hKa
-        0GzssGyBpd6rQp7HmA5K0LDbCygOrm651+qMyIc/FpWXJQ3cKEpTIRxz0BlhknxD0RJdJsz5mKWx
-        EJgneFnDxhIbk9BurpKKeJKn/lqhLh6WN0Gqn+JxJ6lTfYvmKtzGwVGapLVXu6UmzBawPAF0Gko8
-        /0HxEBRL8QaRXwjJU5arVJ7PxH8CRzkTgoPPbeFBjmtrVjSVfi42IhYVypso+kUrBpSTc7VxQf6H
-        5XyBqgVfe3ExpQsUsjAe31ytgVmRYNllEefxnfu4Wq+iF2fQ96xM/7kh/er8bFmg1F1idgcDy+ws
-        KKxjbqYxjWDK36TSMa6honErOgn3S8rGJgaWxc0KmoixqbU6QlUJ/Q4AaRDkDqa+GBn09sh/xXjS
-        K6aYMPXByDH9N8Os27mE+abcI69YEmJm9dWF2SG91/+9aKNOr2qj3MLSV48q/VnUaJRWVaQ64eE7
-        mIQDT6cSnqgdGD4Iz5J56wV4OSzIGdFujCZExSydkaXZnFAJhKcAkJxM1UkoqABdTIU+SaAdXrmd
-        RmYxHp5gmOb3obtldh0TxUAflKm14LhiDkw9L3wMEEGZxMNuM+yGmlMd6LdqhqXvvC3Sq2dcMA/T
-        kgfANXrSE4GJPsmzPaJvuy2TrOq4X6Gu11UtjGE4YLbgTjI+K9ur50UbjeJFwCY++OtceyKF9r58
-        Xau1xMMTYRg3y5t9ZYcV+gddRMoigkUQ6lCr1whuJiPKpKsLFV2/TLqW1DcmZNfoXkNhFlGJjejk
-        c0nxutT0GtHV2rOIZS7ohxu7Y74gVs/kbyDRqKJ+Lc0N+AqFWlb+Gm3ZLhm/1JOVhtprqqqUTtvp
-        puT/XbRzJatdo1y2oi+bHhydHp+dfzpWV05rBSWSvmba6GOFpsOGfl4cs1JNk5IqUWTJyTk5IB9O
-        Dw6PGzJZVrSv4gBmoXGYayHX3tzl8q4Bjhjm7p0uTmw2Faxg4+JvNpu15uA5Co/pJeE6SrOWXnzh
-        FCpovzH/OT3+x5v4r4m1UlEvqBqg9ZXMDcU3VC3XODchNGvDdMtVul0tMxeLupXO39qrdUrXtPRQ
-        7WxsZRYHIFwVLTfAm8BqdbRYJTV/QvJ/AXM6VYN/cgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['4080']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:35 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/AvailDetailTests.test_comparison.yaml
+++ b/tests/interface_objects/cassettes/AvailDetailTests.test_comparison.yaml
@@ -1,146 +1,119 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF92aWRlb19pZnJhbWUgLz48
+      cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNj
+      YXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21l
+      ZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9m
+      b3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlh
+      PnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVx
+      dWVzdF9tZWRpYT48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHJlcXVlc3RfYXZhaWxfZGV0YWlscyAv
+      PjxyZXF1ZXN0X2N1c3RvbV9maWVsZHMgLz48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxtaW1lX3Rl
+      eHRfdHlwZT5odG1sPC9taW1lX3RleHRfdHlwZT48cmVxdWVzdF9tZXRhX2NvbXBvbmVudHMgLz48
+      cmVxdWVzdF9leHRyYV9pbmZvIC8+PHJlcXVlc3Rfc291cmNlX2luZm8gLz48cmVxdWVzdF9jb3N0
+      X3JhbmdlIC8+PHJlcXVlc3RfcmV2aWV3cyAvPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['784']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+087XbbOK7/+xTs3HOme8/GtmRL/mi1mpukabdfaTdxp7v7R4eSKEu1JLoiFcfz
+        OvfPPsfeF7sAKdmS4yROP/Z0OpnjmZFAkABBAAQJKM4vl1lKLlghEp7/5Seza/xEWB7wMMlnf/np
+        /fRZZ/zTL+4Dh12wXHqC0SKIvYKJMpWuI0o/5BlNcq8UrPAS4fk0dHPu9Ha3OEGxWkju+SkP5m7g
+        dTrDji8+fnj7MT2bFawjnvovzyZvj4JoHL8aXn46P42ey9Pzd0fv/KGZGqvDxF88m87kkf/J/0cw
+        HB+X9uujdzR+f/7ubOIdi7//+s9L8Zs4L58Op/2F1c/9hX+2fPm3o5cnL/95+dxaHc/juE+TaJIO
+        Qjta+fEb+2/2m9PUWBxZnX84vRZ/TpgISfOACY8WzLugaaIntwuuBeQ6AKEeiI+5Jx+c3uZNN4RM
+        BO4JSHu1jFnBKgQFdegFTVJ4lvA/4ToyCeZMenK1gM6LIgkYiDAP23j1W1AWBazaCiRcPWmqM38B
+        k2qBNhgRDSQvXNMwGjgVcIOVl5nPCnfcHzawKuAGa5FSkIfbb+BUoAYOF6BBq8znaa8JBhlqqPvv
+        /23238BBTlvTVO/UT5kXUolUoqSA0VfwT5aFods3zKFhG7bT22pwUnoFbzwACbThFcUmhZCuvIyK
+        uTscgArUL86nkuYykSuPLySYECAqhfBquGs6vS3INkb/VozBrRjWrRj2rRjDqxi9q9MDHyCVPrrW
+        qAuC27yDPwDvQIsZc23Vsn6tF7DW2o0+a6U8dHrboCYOGgioTK9pBg370B2ODl8fvz0FI77S0sJV
+        xnZE04DnqzauNsNey/DurfDeCr9zKxzY11qh9c2t8N4k7k3iOzQJ42uZxNG9SdybxI9gEv2vtksc
+        f4VY7fjF2fHrk71CtfeLBStIkBRByu7jtXtL/P1bonmtJQ7u47V7k/hPm8SNymqOv5ayfkYkdWV3
+        OJ8evn59vte2cS5pmorbN4wW16hkKAg1ZsrzkOedcg6qtAbqdjXQa9VeNeqhA1h7Uf1P49NCAhMN
+        QNWo8A+hkfxMs8WT/xqMn5DjMpUlXgo2UJxEeOoaVQ+9YjBaG+RUd7JztlLUemq5aghe0VZ4dbc1
+        pDXYBm97vBCvOncPqqdUI7SAG5z6wiVlUk+WPN3qUK3LhoVeLUg09ILmqF4ZvYSRMz/JWejafVS+
+        FkghbN9NtWEapX1H1QY5Gcq1HlJ76hZIIWybRxumUdpm0gY5OfdEks9ShsL6Maf4h9vg1Rr++Pvn
+        9jR71+jy/fr/Qda/uegBL3NZVPNTG2cTsG7W57o8kSwkr0B3Qp5tUKudtEhgm/YKdpGwpQcnwACz
+        a1pCO5scDK40Hx7D4EG9q8GmcXlATCHJOVtIhvIiGK1h7FWjaOxSBh6PIsGkOxgiqW3oBk2wALZ/
+        4ZrWqD+yrTZ23ajR2yHixDArzE2ImAg+Hhqmig89DIZkkjGF3jEmHcOcmpPHA+OxYfzZMB8jpd0d
+        qnG3ZaDfhYTN/IpUbBmTN3T1NeUx7FujgbG3PFRofQd52PD7HHlU89dpbKWOp++nx2eHx69Ozpxe
+        A1yhKDG8oVLGbEmOeFnk7JEgpzCdgkL4WJDpyfm07qhlpp+T0B2+eFa3rDPDXpJH3P05lU/C5OLn
+        mXyCjwt8uEJEyDLPwSzIouBhGaB/ITxq0H5ICgaRYi5IksPSGWMiOTmnYcoK6P6BQeBLYnqBQ/gF
+        n7OcQPRFfH4Jw0Swf0P3gBehIGFZIBKeWMgK4jskDr07vJTwQAXPu8hmT/H5YM3xNE4EiZiQyQUj
+        soCwgCCgBCLAJzbKgoYso8UcJrNKGYKXiTwgCypjLggsEYE5UwnRBE1JRmdJ0G1NMOJpypeCHKe0
+        oMDWRyWcFYkKnhFK4DRF5+Q4LhIh4fREToAR4OJp0X1acCEekbfFIqY5nbEDIFTwchZDLxEnWcbU
+        lEEKHTGnEp+XoJysSJEpxRhH3ohYsEDSoAQGSADwFfI0x5mcLxmTCcMOO8XzNgW5FIQuaRF2lole
+        S1CRZJYD+DAHEeQr8gFaFb0phEzJnF+I+QommpVB3En5BbhGAYvESB2XoQBjIpLffktxvCCGRj4r
+        6CJekVkJUsolg9WIQQw3qO1DXCkKYmQiPiBpsuiIDBpgxANY8ULpDEwR1y9BxYPV2Ug5ogXbOeM2
+        QdA9oBHECcNZ+BzYBtuDMZJATRhmBKsQJDC2KAPYmoSeGypOgrqQU6VZOYxYFaYIZEodCpTC+Oo0
+        Ibrkda25qvO7FFzZBxgK9feD0vAM9BAWrlBLesZX0PmUVhObKg0EDQFzYAnyKpec4OoluE64fFpV
+        YWgB4pbpCpXDR/u5QPyGLNRTZdkPlGBiC5+floUip9o16MEuJ3BInvM0TLDuRJml6kQ6JOdwaAIk
+        liGW5FwNpN8InFBh2W5EUXwfkI8lyAlFUCSzWBKa4WarFhoc5R7T+BCDEzmmOXkBfP5y62TyFY5L
+        VrwEFZuzh+RQKGYJKIbEwpdHQpkjXxJwMd39GABbCDkwMLudgekVd4jqA8op2MN9aFFZnconTwR5
+        kQdpGbLwVqqqrkfGaEI485ztpSHPOQcfwMmrnC9vowA+A53JQ/IGlgN8PxKEJcQlVf8Ve9A7LxOJ
+        t1HkGVjFcZykIURytxE+L9FOlBaB+qNnUz4dNYqCdbEMdjhQWDShffk4xkuANNWK/o6nSbC6hotT
+        DgYXlRBBEGCZXYK/hB0dNKi+WAMeJFjsQp0+RaXPNcn1Toz7b7UXowflrt6BWI2ggRVGxsKEQhhK
+        VXgPUTJsW9INzeWltRzYpZ+FyWU3SHkZwo6Uy27OpNNTOE6SQ7wD8sIT9QLcFMRARerGUi7E417v
+        xiF6Ak7PLOw1eIBwl2MGpDcZwC8wLD8ywr7FokFo2Gwcscjy6WhkTMLIsAYWo+Yg6H5czCAo2smH
+        k1MIjXDvEjA5mLx6d3Bjdr8qeTWi832IYqcgRLlYgHMUHvJTFS02IW2E6rpsC+b0WuryverOiMHP
+        sMbB0Laj0SQ0KTNMy5wEk77VN8ZDM4xMe+iPB9EeugNh3aeS7a85dyb+DTXnzrz8AJrzBfLyFGav
+        P4HfyGL2eDQZUTC6iTmy+/5oENLBxKBsGI0jOmTWeNi/XX3wFhE8Ld5K5Pvq0Ofy8e006XM52kOf
+        rmrLd6ZQX2SBNoOfYVhR3/ZtSv1hZA36QThiw/Fg4oPztvrhmNqROfL30KVPcPDZ3xPdmfY39ER3
+        5uUP6onYpfQkE9Lo/VmshGSZt4HgRFI4q+2hKBXmraqyP7lvoBv7E//Du5FoAj9KIeKDONAajYKB
+        MQhHYz+wTWMUBMbItsJobA1pML5dO2SRIMiL4FC/tzO5Mwff0JncmZcfwJl8h+rDy9sdzL36fB/q
+        8+Wxn8Hg17ft0IomQz80+j6lIz8K+334N6D+xAjG0TBg4cDaX4d4vrcH+lw2vnlQfGeOfoTd7MvF
+        FgCA9kPLHk/oeGKNDdu04EQBkWHAgjGdjPtDu98fG8ZksL8+ySW/oz7dmY1vrk935ug/rE9asMMX
+        zzqZzoN0fJUH6YhOvk68dDCM69X9tcyqb2ollaVwUxV8tEA1QumHVNJe/S4xpddMMmpA3YplbSLB
+        qXu60m2Npgre9HO5wESflyZCthKXJzsSl6H75q9GE97bMcaMcUy/UqyLlIksQ+baZtfuT4amORhh
+        VWQFdTARoB87Rtc0hoZpD/uAsAY7vc1gMRVezjHLHwm1p7QAWNOG9wksXBezVa+qDqrQeVSdDTb7
+        VSlUC6oqmXbgbUMdvM33QragBdboqUyz4mcXvEKusjgNtBqiEXAOvMjwHlyzfwXqYKWG/pj42Dwj
+        1vQUzK0GOboCQtQPShrqa+vqHelugSpUj5Yy5oU7jRmZwvSAdruhxvN5uHKPaY45JkwaZxlTqVud
+        EVsSlmNq9eG6u8KvOzdqDUp2QMyRjMkpv1hXYNjrbo3CgyakWSlgm6Y5anfYFAxU0JTmM5flayz1
+        XjfyIsHMYoreoLeG4uJqyqbRNQxy+Gbde9PUQo7jLBMCS1FUkcOOpg26TJn7Ps8SITBN8bCBjS0O
+        1iR4hboOwzKk5muNeu3i1vp+w+piVpYcpumiYOLmFcaMV5WQe4hpUQIssw7LOyL4v3/lDBOgKkdP
+        0wOV82kln6FRZ9CjsmoWkherqlOeYMVBLqucPxesThF1uyTJA3D9CcimS148whoFRvxyhRk07bpE
+        lbut9Y3OaJKrodTTrXqHNS79MejdYTnD5BUoknUXrbOMcX/8e9Q6sNlHksyYvGKid9G93trFVNW/
+        9V8+8OaZW39jtw13cKWUG9OuU++jbZgjYIcMquLt9SUHoDXANY7+mwmXkhUqaQ+I5Ai3VFCCTQ8t
+        scaLh5UiMFAeJbO9erc61COx/FOZFAkTHsuwql1fy4j/ATGhUfFuwLtY53YNej0M+mzQARqGhYv5
+        V0ZG9gH5NcEKv4Ri3UIADhIz1UvMBp/LgjF5QI5YGmGBw9HU7BP72d/XdJrj1TSqGyNdOV2LdN2j
+        1Vp3kapWKnAxEwx+RGXnUUC49RKep6vuA3AG2FAworcAkKHa/HVhBM1XBJwMyxYAkHydgSUJSkkX
+        62jjrW6vyDLRVh7o7G9V1oL1GjA+OIrumuOaOdDUogxwcw2rHG7QyByDKDBzXEW9O3LKdfR7QdOS
+        4QcGO3s3dmbErqs2Wp3d761YQ5WllqrObc3+DPQH4kFvnvNlNZlmgcE1E7pLXcGGapsWbOyF9hqK
+        xNvq9RqK90Vv90Vv90Vvv/Oit40r2Bg/fiCCp6bqg6rKZSsf8E43kaqJYBMcdG5wtEecz4m/IgMD
+        QzgYOlXTahyRqk3GNMjLEjjt4FMV6+EkFiCbHLiHcZByBMoCfmUdT+6ayu4JiKpqygPCXlBVTVXz
+        2llRdc2MvqCQasPiNcwswQyQX12uVjF3XTHbNfzdXMO2YWGb1jJmuQcew0u8GV+TbhYNXreXfn6t
+        YJObFnX1t7W8kG8x0yggvIaZ/eoGW3SbhHpXQpXG6az9EcOuBgcCq5LpqO4MDkpwTIZt+FBBkbpf
+        kJ5yQS8EekOpq0rXUP09Ygv0/hXwuhm0IqA/pTx8+vrk7PzDifqgstFQIemPKFvCqNF0rK2f1TSn
+        Z4e/nrxuUW69nIKvwrjyPW45M9iY8vAxbAkzlpI/nYKLASnmsPg5++/bxzgDo3ysvhqBfRK3va0h
+        0FmpoW8Yi5BpiegsgrCqVKGV5gbv3TDwUA5bDa7CME5D3GjVyRehCNAn03NJXvI4ryL2LtleNvSi
+        yuHUwZzy+fhaFR8S6iMHoBMkY/AO4Qlf5q0+3VruWqUukpCBwkWFVuDGm7e50W6BY4bDuAO8cNnV
+        sIWNF93L5bILFilLn8ERJ9vup+7CWyB9B4pXO2HvuflycfLX58lvc2uro772bIGuZo1uaL6ha3Vf
+        exNCuzccyD3lN+pr9PV19dbkb53V1ZGuofS16OykskxCEK6Ft5c74G1gfYW7vspt/13H/wd2F8fQ
+        FFIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:35 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['4165']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:43 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_extra_info /><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><request_avail_details
-      /><request_video_iframe /><request_source_info /><request_reviews /><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><mime_text_type>html</mime_text_type><event_token_list>6IF</event_token_list></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['928']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+097XbbtpL/8xRI95z2R22JlKivlmXXsZ1c37hJajubzf7hAUlQZEQSMgFaUV/n
-        vsl9sp0BSImUZFv22hs7VY5OTA4Gg8FgPgAMINm/f00TcsVyEfPstx/MlvEDYZnPgzgb//bDx4vX
-        +8Mffnde2OyKZdIVjOZ+5OZMFIl0bFF4AU9pnLmFYLkbC9ejgTNnwm5vLrL9fD6V3PUS7k+cj+7+
-        /tVkGo4mh6Ppx957b3+c8zAw5ZuZ/+7D5y9d5osv3aPPZv/Ln5P3xudP2dFVevE2Egfdqfv14+Xg
-        7PT1/Mjv7Z8FZth/exkWn08uxwevxfuzbDa/pMaF2X9v5e5R2j09Of5zfpkff7kcjpK88+EkG3WP
-        JrNx8tluN3iyg1hImvlMuDRn7hVN4sDJuN3eBNdScWyAUBdkxpzjT3Z7+aYLAiZ85xhEPJ9FLGcl
-        goLa9IrGCTxL+CMcW8b+hElXzqdQeZrHPgOxZUETD948wZNCMlfQKxgnx+y0DCC7Ai0r+UWew4jO
-        Qfjlk2Zu7E2h7w3QEiOkvuS5YxpGDacELrGyIvVY7gw7/RpWCVxiTRMKYnM6NZwSVMPhArRrnno8
-        adfBIGoNdf79r3r9JRz6vdJN9U69hLkBldhKGOdAfQ7/0jQInI5h9o2eAfysFNgJXcMbdE273YSX
-        LdZbCOjcTamYOP0uaEr1YodFkqDNSDWUjjXAYVoBlkgF2BXNx8wxljgLmD1luQ+aRseLwUWRr0Pt
-        y4JmMpZzl08lGDSwpjTVreAO9GYFsorRuRWjeyuGdStG71aM/jpGe717S0F2eyi5mmBXZFoTZ3vF
-        nG42ru7OuO5oXFbH3Mq4hqb1/2tcvS2Nq7czrq2Ny7rZuJZRTJvBAYh2BVTHwbAIStquB79aVNQV
-        Xh2cHr5/B6F7raSBq0LsK5r4PJs3cXXwbTfC7T1j72jnHZ5B6O32dqH38bxDp/9IodfYGdczCL1b
-        GZe1M64HN67uo4feG+Lgzgi/bYT7G5tE13igeLPT4W8bSHY6/AArqlcP6tZXJlv93QzsKTr/lclW
-        5yGXN9ZuBtY0VXP0OMubwc62nmJQuo9tbbu62dnW9rZ1x9XN4QNsLB6enB2eHm+1r/hxCgNJ/Dj3
-        E/Zom4u9nYd4DtHX3EXfR/QQj7S5uJvZPovou41tdXdpvQe3rc5ub/FJGuG2Aa6PfXtu+zI3K+tw
-        t+v36NqF84+Hnz5h4HjO2tWzdur1bGYQz0297rjOfdTtXms3KX6K8Xhl/quV6YEWnJ0nNSm+2Yis
-        x1kKWsrB79T+qU0U7qf2OJbPbqPlm+j9bnvxSU5g7qP2226BfB9af8fNiYdIDZxfHJyenm+VGjiX
-        NEnE7UmBBtfQdS8eF1O8WlQwbUJ1gO2jmFSLCc8Cnu0XE1DtBVCXq2ZOVXlZqBv2QRdF+UfjywgE
-        i7eRarCyXFW5aJZrMrFw1Z0uTU5d9GqC7PKG2ITNqxbaagwrIN4ZK1GrmgtIg94SbwPJSRyIzWR1
-        R8ryBmyJovrymqZxMq8hlSO0bLddCQ2dTE4zVDSPwbMaEJeHIfqrLa+LKNP0eerFGQucXmdhrgvY
-        w11oUJwtCXdVim0FWCKtHuJchVZozUTnKnD7vdb2ugBT+nWV1wZIIej6O5nfS+brAlSQFTaaMI3S
-        ZKEJslO0+qpv2lk3QCUCjPc1w7Z5sdkcoVrwu3bU7r8cWhkg09pm1OpYN4yase2obV6AtVelh++r
-        TDRhGqXJQBNkZ9wVQD5hwt25tZ1be9Yy37m1nVsrm//bpXCV3/7+1+ir3ZR86upV2s5l3sdlrsmv
-        fc2EYGdQO4PaGdR9DKpuRT4vMpmXCqO2a+qARbE+T5rFkgXkLdANeLpELfdv8ljGvpuzq5jN3JKT
-        UuU2Ftm4xaj5cBluaKn3cmen2CPmUEbkoBgXQhLcscT9xwpB4xbSx04JJp1uHxtahS7RBPN5FgiI
-        3gOzZ/WMBnZVqNFXt0mHJeZymzQWfNg3TLVH6uL2nIxTptD3jeG+ObwwR790jV8M42fD/AVb2lyh
-        pLsqAf0uJM3lmkw6JgjjAIYzeUiR9M1Ov2ttLRJLp0C2Fom13zHvI5JSBPp7nZQ+vvt4cXh2cPj2
-        +Mxu18AlihLDH1TKiM3IK17kGftJkHfQnZz6E5a/rCppeennOHD6J6+rksU3JrlxFnLnx0T+GsRX
-        P47lr026P9J0+ut/dEe/CiJkkWVgEmSa86Dw0VkTHtabJTmTUEmQOINRM4ZEcnJOg4TlNTKfWJII
-        EimrJV7OJywjNEmIx78CuRDsF8j4PA8ECYockXDvnswZrVMRQGWfFxIeqOBZCzvg5aSNPXjReLmI
-        YkFCWBPGV4zIHPwPQQA4NuQeC2VOA5bSfAJdnCcMwbNY7pEplREXBMaM6M3O2KcJSek49luNboc8
-        SfhMkMOE5rTG5BclwjkJc54SSryE0Qk5jPJYyJQKcgwMATdHeeso50IsKpL3+TSiGTi3PWg458U4
-        gtoiitOUKYGAjPbFhEp8noH2sjxBJhWjHHklYsp8Sf0CGCI+wOfI4wR7dj5jTMYMK9wgtPcJSCsn
-        dEbzYH8W63EHbYrHGYAPMhBMNiefoFS1egHeOp7wKzGZ17qfFn60n/ArcKUCBpSRKkSgeCMi4r/+
-        SpCuH0EhH+d0Gs3JuAAZZpLBWEUgnGu1sS5/GEMKQmYi2iNJPN0XKRQA5T3QjlzpGXQcRzlGpYUx
-        XI5BSHN2gxyazYPWQkt+FDPsk8ehE2C4QCn2lRigfzBCfgwtiMKHmYLQPUUli1FvMqq0MAOK5de8
-        CWRNbW4r5fLAEpgULXJa6byq/CGhIG0ghRr/SdlGCjoLg5qr4T7jc6j8jpbdK/MFe2hILEZe5YwT
-        HNMYRw8HVas1kBYgfJnMUXE8tLwrxFcSaZcO4YUSSWTh86cIrPWQZuSEvOG/Kyxd8KLmQQ6yOfo4
-        MucFDMeEvSQHgiQchgHEJ/F712rjiIrNZwRMuHVTq6A9R/zGVvFxig8XldP5qXI2KGIYQMFeqrrT
-        Cn1zW1TW2DvJ/KQIWHBdq+q75GSEOobdzdgNwnvDOZgKJ28zPruGHFgUmtpL8gfIGbwoUicyHkdS
-        /y+uJX5exBLzmeQ16MRhFCcBTCuvaeW8QOX4gvMNGHM0cuX0UJMoqBRLIS6AJqHebGh0EUIwcJRB
-        BO2YL/NYdWCJkbIgpjB5omqWD5NlcK3SUdCWzsQJsBU/avk441KFdpxBdAZecW45BbuAiJ0nTiTl
-        VPzSbm+u2xYwcWRBu9YqTMs43hBqj7rw8Q3LC42gY7GwGxg9NgxZaHl0MDBGQWhYXYtRs+u3vkzH
-        ELs3MmBnFCI4elAB3YHuqncbw4XzoM0rivY3lsFGCYhiOgW/IVxkRH0nYxPSRBDV91A2YHa7oRlP
-        R00GDD6GNfT7vV44GAUmZYZpmSN/1LE6xrBvBqHZ63vDbriFmsC84rJg2yvJnRt/DCW5MxN/PyXp
-        MfgYhhV2el6PUq8fWt2OHwxYf9gdeWBIVicY0l5oDrzblURcwqxnex25c9uPoSN3ZuIp6Ehgzr5a
-        s26v8NIg/tryE14EMDvPZCtj8nZVAUHdSGGTvNhX6UpYfhjtn8VcSJa6Swh2JIE52RYaUmLeqiPb
-        N3e7UjxiX7dQhvWhft4eIxzBh1IItBB+rcHA7xrdYDD0/J5pDHzfGPSsIBxafeoPb9cHWIwiyA1h
-        ur6137gzB4/hN+7MxFPwG9+DpsAKaKcp32OEKeXlKsz2qAcfb+R7Fh0NQzrweqblWVbfMkYDagwH
-        oecNvIFp+j7dXnlgMbit7tyXjUcIR/9Hjp5EjPrm+tTpwcfo94KR3w9ox+/3B2Z3BO+DAbUCy+r2
-        R33f7I2C7h30SUb59mui+zLy6Bp1Z46ehEZ9B7FMzvgulD1gKBOSykI4iZpMNkAVQuEFVNJ29S4x
-        bVPPJ2lAVYpH6kWMrLtaSgs0ddhePxdTTOK4SSxkI0d1vCFHdV3uCuBvP9bh7Q20x4xj9o3i7RAZ
-        yyJgTs9s9fBSSPlq4+60ftw3WiYWLQB2e1k/osLNOCZ2Q6Hk3wDgKXrMb7NgcXy+fFVH3XKdPtP5
-        P7NTnnZrQNXxqg14q1Ab95ndgE1pLlFNMJeo+NkEL5GLXKUHamgVRCNgH3ie4u+qaPbXoDaedtA/
-        rXJonhHr4h0YSwWyddJbVA9KGur3Zsp3bHcFVKK6tJARz/GaA7mA7kHbzYIKz+PB3DmkWcalyhGm
-        KVO5OZ3GmBGWYa7s5aK6wq8q1xLMBdsj5kBG5B2/YnjqA3PMvUW1Wqq5DqnnhnumaQ6aFZYp4hKa
-        0GzssGyBpd6rQp7HmA5K0LDbCygOrm651+qMyIc/FpWXJQ3cKEpTIRxz0BlhknxD0RJdJsz5mKWx
-        EJgneFnDxhIbk9BurpKKeJKn/lqhLh6WN0Gqn+JxJ6lTfYvmKtzGwVGapLVXu6UmzBawPAF0Gko8
-        /0HxEBRL8QaRXwjJU5arVJ7PxH8CRzkTgoPPbeFBjmtrVjSVfi42IhYVypso+kUrBpSTc7VxQf6H
-        5XyBqgVfe3ExpQsUsjAe31ytgVmRYNllEefxnfu4Wq+iF2fQ96xM/7kh/er8bFmg1F1idgcDy+ws
-        KKxjbqYxjWDK36TSMa6honErOgn3S8rGJgaWxc0KmoixqbU6QlUJ/Q4AaRDkDqa+GBn09sh/xXjS
-        K6aYMPXByDH9N8Os27mE+abcI69YEmJm9dWF2SG91/+9aKNOr2qj3MLSV48q/VnUaJRWVaQ64eE7
-        mIQDT6cSnqgdGD4Iz5J56wV4OSzIGdFujCZExSydkaXZnFAJhKcAkJxM1UkoqABdTIU+SaAdXrmd
-        RmYxHp5gmOb3obtldh0TxUAflKm14LhiDkw9L3wMEEGZxMNuM+yGmlMd6LdqhqXvvC3Sq2dcMA/T
-        kgfANXrSE4GJPsmzPaJvuy2TrOq4X6Gu11UtjGE4YLbgTjI+K9ur50UbjeJFwCY++OtceyKF9r58
-        Xau1xMMTYRg3y5t9ZYcV+gddRMoigkUQ6lCr1whuJiPKpKsLFV2/TLqW1DcmZNfoXkNhFlGJjejk
-        c0nxutT0GtHV2rOIZS7ohxu7Y74gVs/kbyDRqKJ+Lc0N+AqFWlb+Gm3ZLhm/1JOVhtprqqqUTtvp
-        puT/XbRzJatdo1y2oi+bHhydHp+dfzpWV05rBSWSvmba6GOFpsOGfl4cs1JNk5IqUWTJyTk5IB9O
-        Dw6PGzJZVrSv4gBmoXGYayHX3tzl8q4Bjhjm7p0uTmw2Faxg4+JvNpu15uA5Co/pJeE6SrOWXnzh
-        FCpovzH/OT3+x5v4r4m1UlEvqBqg9ZXMDcU3VC3XODchNGvDdMtVul0tMxeLupXO39qrdUrXtPRQ
-        7WxsZRYHIFwVLTfAm8BqdbRYJTV/QvJ/AXM6VYN/cgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['4080']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:36 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/AvailDetailTests.test_date_properties.yaml
+++ b/tests/interface_objects/cassettes/AvailDetailTests.test_date_properties.yaml
@@ -1,146 +1,119 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF92aWRlb19pZnJhbWUgLz48
+      cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNj
+      YXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21l
+      ZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9m
+      b3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlh
+      PnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVx
+      dWVzdF9tZWRpYT48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHJlcXVlc3RfYXZhaWxfZGV0YWlscyAv
+      PjxyZXF1ZXN0X2N1c3RvbV9maWVsZHMgLz48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxtaW1lX3Rl
+      eHRfdHlwZT5odG1sPC9taW1lX3RleHRfdHlwZT48cmVxdWVzdF9tZXRhX2NvbXBvbmVudHMgLz48
+      cmVxdWVzdF9leHRyYV9pbmZvIC8+PHJlcXVlc3Rfc291cmNlX2luZm8gLz48cmVxdWVzdF9jb3N0
+      X3JhbmdlIC8+PHJlcXVlc3RfcmV2aWV3cyAvPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['784']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+087XbbOK7/+xTs3HOme8/GtmRL/mi1mpukabdfaTdxp7v7R4eSKEu1JLoiFcfz
+        OvfPPsfeF7sAKdmS4yROP/Z0OpnjmZFAkABBAAQJKM4vl1lKLlghEp7/5Seza/xEWB7wMMlnf/np
+        /fRZZ/zTL+4Dh12wXHqC0SKIvYKJMpWuI0o/5BlNcq8UrPAS4fk0dHPu9Ha3OEGxWkju+SkP5m7g
+        dTrDji8+fnj7MT2bFawjnvovzyZvj4JoHL8aXn46P42ey9Pzd0fv/KGZGqvDxF88m87kkf/J/0cw
+        HB+X9uujdzR+f/7ubOIdi7//+s9L8Zs4L58Op/2F1c/9hX+2fPm3o5cnL/95+dxaHc/juE+TaJIO
+        Qjta+fEb+2/2m9PUWBxZnX84vRZ/TpgISfOACY8WzLugaaIntwuuBeQ6AKEeiI+5Jx+c3uZNN4RM
+        BO4JSHu1jFnBKgQFdegFTVJ4lvA/4ToyCeZMenK1gM6LIgkYiDAP23j1W1AWBazaCiRcPWmqM38B
+        k2qBNhgRDSQvXNMwGjgVcIOVl5nPCnfcHzawKuAGa5FSkIfbb+BUoAYOF6BBq8znaa8JBhlqqPvv
+        /23238BBTlvTVO/UT5kXUolUoqSA0VfwT5aFods3zKFhG7bT22pwUnoFbzwACbThFcUmhZCuvIyK
+        uTscgArUL86nkuYykSuPLySYECAqhfBquGs6vS3INkb/VozBrRjWrRj2rRjDqxi9q9MDHyCVPrrW
+        qAuC27yDPwDvQIsZc23Vsn6tF7DW2o0+a6U8dHrboCYOGgioTK9pBg370B2ODl8fvz0FI77S0sJV
+        xnZE04DnqzauNsNey/DurfDeCr9zKxzY11qh9c2t8N4k7k3iOzQJ42uZxNG9SdybxI9gEv2vtksc
+        f4VY7fjF2fHrk71CtfeLBStIkBRByu7jtXtL/P1bonmtJQ7u47V7k/hPm8SNymqOv5ayfkYkdWV3
+        OJ8evn59vte2cS5pmorbN4wW16hkKAg1ZsrzkOedcg6qtAbqdjXQa9VeNeqhA1h7Uf1P49NCAhMN
+        QNWo8A+hkfxMs8WT/xqMn5DjMpUlXgo2UJxEeOoaVQ+9YjBaG+RUd7JztlLUemq5aghe0VZ4dbc1
+        pDXYBm97vBCvOncPqqdUI7SAG5z6wiVlUk+WPN3qUK3LhoVeLUg09ILmqF4ZvYSRMz/JWejafVS+
+        FkghbN9NtWEapX1H1QY5Gcq1HlJ76hZIIWybRxumUdpm0gY5OfdEks9ShsL6Maf4h9vg1Rr++Pvn
+        9jR71+jy/fr/Qda/uegBL3NZVPNTG2cTsG7W57o8kSwkr0B3Qp5tUKudtEhgm/YKdpGwpQcnwACz
+        a1pCO5scDK40Hx7D4EG9q8GmcXlATCHJOVtIhvIiGK1h7FWjaOxSBh6PIsGkOxgiqW3oBk2wALZ/
+        4ZrWqD+yrTZ23ajR2yHixDArzE2ImAg+Hhqmig89DIZkkjGF3jEmHcOcmpPHA+OxYfzZMB8jpd0d
+        qnG3ZaDfhYTN/IpUbBmTN3T1NeUx7FujgbG3PFRofQd52PD7HHlU89dpbKWOp++nx2eHx69Ozpxe
+        A1yhKDG8oVLGbEmOeFnk7JEgpzCdgkL4WJDpyfm07qhlpp+T0B2+eFa3rDPDXpJH3P05lU/C5OLn
+        mXyCjwt8uEJEyDLPwSzIouBhGaB/ITxq0H5ICgaRYi5IksPSGWMiOTmnYcoK6P6BQeBLYnqBQ/gF
+        n7OcQPRFfH4Jw0Swf0P3gBehIGFZIBKeWMgK4jskDr07vJTwQAXPu8hmT/H5YM3xNE4EiZiQyQUj
+        soCwgCCgBCLAJzbKgoYso8UcJrNKGYKXiTwgCypjLggsEYE5UwnRBE1JRmdJ0G1NMOJpypeCHKe0
+        oMDWRyWcFYkKnhFK4DRF5+Q4LhIh4fREToAR4OJp0X1acCEekbfFIqY5nbEDIFTwchZDLxEnWcbU
+        lEEKHTGnEp+XoJysSJEpxRhH3ohYsEDSoAQGSADwFfI0x5mcLxmTCcMOO8XzNgW5FIQuaRF2lole
+        S1CRZJYD+DAHEeQr8gFaFb0phEzJnF+I+QommpVB3En5BbhGAYvESB2XoQBjIpLffktxvCCGRj4r
+        6CJekVkJUsolg9WIQQw3qO1DXCkKYmQiPiBpsuiIDBpgxANY8ULpDEwR1y9BxYPV2Ug5ogXbOeM2
+        QdA9oBHECcNZ+BzYBtuDMZJATRhmBKsQJDC2KAPYmoSeGypOgrqQU6VZOYxYFaYIZEodCpTC+Oo0
+        Ibrkda25qvO7FFzZBxgK9feD0vAM9BAWrlBLesZX0PmUVhObKg0EDQFzYAnyKpec4OoluE64fFpV
+        YWgB4pbpCpXDR/u5QPyGLNRTZdkPlGBiC5+floUip9o16MEuJ3BInvM0TLDuRJml6kQ6JOdwaAIk
+        liGW5FwNpN8InFBh2W5EUXwfkI8lyAlFUCSzWBKa4WarFhoc5R7T+BCDEzmmOXkBfP5y62TyFY5L
+        VrwEFZuzh+RQKGYJKIbEwpdHQpkjXxJwMd39GABbCDkwMLudgekVd4jqA8op2MN9aFFZnconTwR5
+        kQdpGbLwVqqqrkfGaEI485ztpSHPOQcfwMmrnC9vowA+A53JQ/IGlgN8PxKEJcQlVf8Ve9A7LxOJ
+        t1HkGVjFcZykIURytxE+L9FOlBaB+qNnUz4dNYqCdbEMdjhQWDShffk4xkuANNWK/o6nSbC6hotT
+        DgYXlRBBEGCZXYK/hB0dNKi+WAMeJFjsQp0+RaXPNcn1Toz7b7UXowflrt6BWI2ggRVGxsKEQhhK
+        VXgPUTJsW9INzeWltRzYpZ+FyWU3SHkZwo6Uy27OpNNTOE6SQ7wD8sIT9QLcFMRARerGUi7E417v
+        xiF6Ak7PLOw1eIBwl2MGpDcZwC8wLD8ywr7FokFo2Gwcscjy6WhkTMLIsAYWo+Yg6H5czCAo2smH
+        k1MIjXDvEjA5mLx6d3Bjdr8qeTWi832IYqcgRLlYgHMUHvJTFS02IW2E6rpsC+b0WuryverOiMHP
+        sMbB0Laj0SQ0KTNMy5wEk77VN8ZDM4xMe+iPB9EeugNh3aeS7a85dyb+DTXnzrz8AJrzBfLyFGav
+        P4HfyGL2eDQZUTC6iTmy+/5oENLBxKBsGI0jOmTWeNi/XX3wFhE8Ld5K5Pvq0Ofy8e006XM52kOf
+        rmrLd6ZQX2SBNoOfYVhR3/ZtSv1hZA36QThiw/Fg4oPztvrhmNqROfL30KVPcPDZ3xPdmfY39ER3
+        5uUP6onYpfQkE9Lo/VmshGSZt4HgRFI4q+2hKBXmraqyP7lvoBv7E//Du5FoAj9KIeKDONAajYKB
+        MQhHYz+wTWMUBMbItsJobA1pML5dO2SRIMiL4FC/tzO5Mwff0JncmZcfwJl8h+rDy9sdzL36fB/q
+        8+Wxn8Hg17ft0IomQz80+j6lIz8K+334N6D+xAjG0TBg4cDaX4d4vrcH+lw2vnlQfGeOfoTd7MvF
+        FgCA9kPLHk/oeGKNDdu04EQBkWHAgjGdjPtDu98fG8ZksL8+ySW/oz7dmY1vrk935ug/rE9asMMX
+        zzqZzoN0fJUH6YhOvk68dDCM69X9tcyqb2ollaVwUxV8tEA1QumHVNJe/S4xpddMMmpA3YplbSLB
+        qXu60m2Npgre9HO5wESflyZCthKXJzsSl6H75q9GE97bMcaMcUy/UqyLlIksQ+baZtfuT4amORhh
+        VWQFdTARoB87Rtc0hoZpD/uAsAY7vc1gMRVezjHLHwm1p7QAWNOG9wksXBezVa+qDqrQeVSdDTb7
+        VSlUC6oqmXbgbUMdvM33QragBdboqUyz4mcXvEKusjgNtBqiEXAOvMjwHlyzfwXqYKWG/pj42Dwj
+        1vQUzK0GOboCQtQPShrqa+vqHelugSpUj5Yy5oU7jRmZwvSAdruhxvN5uHKPaY45JkwaZxlTqVud
+        EVsSlmNq9eG6u8KvOzdqDUp2QMyRjMkpv1hXYNjrbo3CgyakWSlgm6Y5anfYFAxU0JTmM5flayz1
+        XjfyIsHMYoreoLeG4uJqyqbRNQxy+Gbde9PUQo7jLBMCS1FUkcOOpg26TJn7Ps8SITBN8bCBjS0O
+        1iR4hboOwzKk5muNeu3i1vp+w+piVpYcpumiYOLmFcaMV5WQe4hpUQIssw7LOyL4v3/lDBOgKkdP
+        0wOV82kln6FRZ9CjsmoWkherqlOeYMVBLqucPxesThF1uyTJA3D9CcimS148whoFRvxyhRk07bpE
+        lbut9Y3OaJKrodTTrXqHNS79MejdYTnD5BUoknUXrbOMcX/8e9Q6sNlHksyYvGKid9G93trFVNW/
+        9V8+8OaZW39jtw13cKWUG9OuU++jbZgjYIcMquLt9SUHoDXANY7+mwmXkhUqaQ+I5Ai3VFCCTQ8t
+        scaLh5UiMFAeJbO9erc61COx/FOZFAkTHsuwql1fy4j/ATGhUfFuwLtY53YNej0M+mzQARqGhYv5
+        V0ZG9gH5NcEKv4Ri3UIADhIz1UvMBp/LgjF5QI5YGmGBw9HU7BP72d/XdJrj1TSqGyNdOV2LdN2j
+        1Vp3kapWKnAxEwx+RGXnUUC49RKep6vuA3AG2FAworcAkKHa/HVhBM1XBJwMyxYAkHydgSUJSkkX
+        62jjrW6vyDLRVh7o7G9V1oL1GjA+OIrumuOaOdDUogxwcw2rHG7QyByDKDBzXEW9O3LKdfR7QdOS
+        4QcGO3s3dmbErqs2Wp3d761YQ5WllqrObc3+DPQH4kFvnvNlNZlmgcE1E7pLXcGGapsWbOyF9hqK
+        xNvq9RqK90Vv90Vv90Vvv/Oit40r2Bg/fiCCp6bqg6rKZSsf8E43kaqJYBMcdG5wtEecz4m/IgMD
+        QzgYOlXTahyRqk3GNMjLEjjt4FMV6+EkFiCbHLiHcZByBMoCfmUdT+6ayu4JiKpqygPCXlBVTVXz
+        2llRdc2MvqCQasPiNcwswQyQX12uVjF3XTHbNfzdXMO2YWGb1jJmuQcew0u8GV+TbhYNXreXfn6t
+        YJObFnX1t7W8kG8x0yggvIaZ/eoGW3SbhHpXQpXG6az9EcOuBgcCq5LpqO4MDkpwTIZt+FBBkbpf
+        kJ5yQS8EekOpq0rXUP09Ygv0/hXwuhm0IqA/pTx8+vrk7PzDifqgstFQIemPKFvCqNF0rK2f1TSn
+        Z4e/nrxuUW69nIKvwrjyPW45M9iY8vAxbAkzlpI/nYKLASnmsPg5++/bxzgDo3ysvhqBfRK3va0h
+        0FmpoW8Yi5BpiegsgrCqVKGV5gbv3TDwUA5bDa7CME5D3GjVyRehCNAn03NJXvI4ryL2LtleNvSi
+        yuHUwZzy+fhaFR8S6iMHoBMkY/AO4Qlf5q0+3VruWqUukpCBwkWFVuDGm7e50W6BY4bDuAO8cNnV
+        sIWNF93L5bILFilLn8ERJ9vup+7CWyB9B4pXO2HvuflycfLX58lvc2uro772bIGuZo1uaL6ha3Vf
+        exNCuzccyD3lN+pr9PV19dbkb53V1ZGuofS16OykskxCEK6Ft5c74G1gfYW7vspt/13H/wd2F8fQ
+        FFIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:36 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['4165']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:44 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_extra_info /><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><request_avail_details
-      /><request_video_iframe /><request_source_info /><request_reviews /><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><mime_text_type>html</mime_text_type><event_token_list>6IF</event_token_list></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['928']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+097XbbtpL/8xRI95z2R22JlKivlmXXsZ1c37hJajubzf7hAUlQZEQSMgFaUV/n
-        vsl9sp0BSImUZFv22hs7VY5OTA4Gg8FgPgAMINm/f00TcsVyEfPstx/MlvEDYZnPgzgb//bDx4vX
-        +8Mffnde2OyKZdIVjOZ+5OZMFIl0bFF4AU9pnLmFYLkbC9ejgTNnwm5vLrL9fD6V3PUS7k+cj+7+
-        /tVkGo4mh6Ppx957b3+c8zAw5ZuZ/+7D5y9d5osv3aPPZv/Ln5P3xudP2dFVevE2Egfdqfv14+Xg
-        7PT1/Mjv7Z8FZth/exkWn08uxwevxfuzbDa/pMaF2X9v5e5R2j09Of5zfpkff7kcjpK88+EkG3WP
-        JrNx8tluN3iyg1hImvlMuDRn7hVN4sDJuN3eBNdScWyAUBdkxpzjT3Z7+aYLAiZ85xhEPJ9FLGcl
-        goLa9IrGCTxL+CMcW8b+hElXzqdQeZrHPgOxZUETD948wZNCMlfQKxgnx+y0DCC7Ai0r+UWew4jO
-        Qfjlk2Zu7E2h7w3QEiOkvuS5YxpGDacELrGyIvVY7gw7/RpWCVxiTRMKYnM6NZwSVMPhArRrnno8
-        adfBIGoNdf79r3r9JRz6vdJN9U69hLkBldhKGOdAfQ7/0jQInI5h9o2eAfysFNgJXcMbdE273YSX
-        LdZbCOjcTamYOP0uaEr1YodFkqDNSDWUjjXAYVoBlkgF2BXNx8wxljgLmD1luQ+aRseLwUWRr0Pt
-        y4JmMpZzl08lGDSwpjTVreAO9GYFsorRuRWjeyuGdStG71aM/jpGe717S0F2eyi5mmBXZFoTZ3vF
-        nG42ru7OuO5oXFbH3Mq4hqb1/2tcvS2Nq7czrq2Ny7rZuJZRTJvBAYh2BVTHwbAIStquB79aVNQV
-        Xh2cHr5/B6F7raSBq0LsK5r4PJs3cXXwbTfC7T1j72jnHZ5B6O32dqH38bxDp/9IodfYGdczCL1b
-        GZe1M64HN67uo4feG+Lgzgi/bYT7G5tE13igeLPT4W8bSHY6/AArqlcP6tZXJlv93QzsKTr/lclW
-        5yGXN9ZuBtY0VXP0OMubwc62nmJQuo9tbbu62dnW9rZ1x9XN4QNsLB6enB2eHm+1r/hxCgNJ/Dj3
-        E/Zom4u9nYd4DtHX3EXfR/QQj7S5uJvZPovou41tdXdpvQe3rc5ub/FJGuG2Aa6PfXtu+zI3K+tw
-        t+v36NqF84+Hnz5h4HjO2tWzdur1bGYQz0297rjOfdTtXms3KX6K8Xhl/quV6YEWnJ0nNSm+2Yis
-        x1kKWsrB79T+qU0U7qf2OJbPbqPlm+j9bnvxSU5g7qP2226BfB9af8fNiYdIDZxfHJyenm+VGjiX
-        NEnE7UmBBtfQdS8eF1O8WlQwbUJ1gO2jmFSLCc8Cnu0XE1DtBVCXq2ZOVXlZqBv2QRdF+UfjywgE
-        i7eRarCyXFW5aJZrMrFw1Z0uTU5d9GqC7PKG2ITNqxbaagwrIN4ZK1GrmgtIg94SbwPJSRyIzWR1
-        R8ryBmyJovrymqZxMq8hlSO0bLddCQ2dTE4zVDSPwbMaEJeHIfqrLa+LKNP0eerFGQucXmdhrgvY
-        w11oUJwtCXdVim0FWCKtHuJchVZozUTnKnD7vdb2ugBT+nWV1wZIIej6O5nfS+brAlSQFTaaMI3S
-        ZKEJslO0+qpv2lk3QCUCjPc1w7Z5sdkcoVrwu3bU7r8cWhkg09pm1OpYN4yase2obV6AtVelh++r
-        TDRhGqXJQBNkZ9wVQD5hwt25tZ1be9Yy37m1nVsrm//bpXCV3/7+1+ir3ZR86upV2s5l3sdlrsmv
-        fc2EYGdQO4PaGdR9DKpuRT4vMpmXCqO2a+qARbE+T5rFkgXkLdANeLpELfdv8ljGvpuzq5jN3JKT
-        UuU2Ftm4xaj5cBluaKn3cmen2CPmUEbkoBgXQhLcscT9xwpB4xbSx04JJp1uHxtahS7RBPN5FgiI
-        3gOzZ/WMBnZVqNFXt0mHJeZymzQWfNg3TLVH6uL2nIxTptD3jeG+ObwwR790jV8M42fD/AVb2lyh
-        pLsqAf0uJM3lmkw6JgjjAIYzeUiR9M1Ov2ttLRJLp0C2Fom13zHvI5JSBPp7nZQ+vvt4cXh2cPj2
-        +Mxu18AlihLDH1TKiM3IK17kGftJkHfQnZz6E5a/rCppeennOHD6J6+rksU3JrlxFnLnx0T+GsRX
-        P47lr026P9J0+ut/dEe/CiJkkWVgEmSa86Dw0VkTHtabJTmTUEmQOINRM4ZEcnJOg4TlNTKfWJII
-        EimrJV7OJywjNEmIx78CuRDsF8j4PA8ECYockXDvnswZrVMRQGWfFxIeqOBZCzvg5aSNPXjReLmI
-        YkFCWBPGV4zIHPwPQQA4NuQeC2VOA5bSfAJdnCcMwbNY7pEplREXBMaM6M3O2KcJSek49luNboc8
-        SfhMkMOE5rTG5BclwjkJc54SSryE0Qk5jPJYyJQKcgwMATdHeeso50IsKpL3+TSiGTi3PWg458U4
-        gtoiitOUKYGAjPbFhEp8noH2sjxBJhWjHHklYsp8Sf0CGCI+wOfI4wR7dj5jTMYMK9wgtPcJSCsn
-        dEbzYH8W63EHbYrHGYAPMhBMNiefoFS1egHeOp7wKzGZ17qfFn60n/ArcKUCBpSRKkSgeCMi4r/+
-        SpCuH0EhH+d0Gs3JuAAZZpLBWEUgnGu1sS5/GEMKQmYi2iNJPN0XKRQA5T3QjlzpGXQcRzlGpYUx
-        XI5BSHN2gxyazYPWQkt+FDPsk8ehE2C4QCn2lRigfzBCfgwtiMKHmYLQPUUli1FvMqq0MAOK5de8
-        CWRNbW4r5fLAEpgULXJa6byq/CGhIG0ghRr/SdlGCjoLg5qr4T7jc6j8jpbdK/MFe2hILEZe5YwT
-        HNMYRw8HVas1kBYgfJnMUXE8tLwrxFcSaZcO4YUSSWTh86cIrPWQZuSEvOG/Kyxd8KLmQQ6yOfo4
-        MucFDMeEvSQHgiQchgHEJ/F712rjiIrNZwRMuHVTq6A9R/zGVvFxig8XldP5qXI2KGIYQMFeqrrT
-        Cn1zW1TW2DvJ/KQIWHBdq+q75GSEOobdzdgNwnvDOZgKJ28zPruGHFgUmtpL8gfIGbwoUicyHkdS
-        /y+uJX5exBLzmeQ16MRhFCcBTCuvaeW8QOX4gvMNGHM0cuX0UJMoqBRLIS6AJqHebGh0EUIwcJRB
-        BO2YL/NYdWCJkbIgpjB5omqWD5NlcK3SUdCWzsQJsBU/avk441KFdpxBdAZecW45BbuAiJ0nTiTl
-        VPzSbm+u2xYwcWRBu9YqTMs43hBqj7rw8Q3LC42gY7GwGxg9NgxZaHl0MDBGQWhYXYtRs+u3vkzH
-        ELs3MmBnFCI4elAB3YHuqncbw4XzoM0rivY3lsFGCYhiOgW/IVxkRH0nYxPSRBDV91A2YHa7oRlP
-        R00GDD6GNfT7vV44GAUmZYZpmSN/1LE6xrBvBqHZ63vDbriFmsC84rJg2yvJnRt/DCW5MxN/PyXp
-        MfgYhhV2el6PUq8fWt2OHwxYf9gdeWBIVicY0l5oDrzblURcwqxnex25c9uPoSN3ZuIp6Ehgzr5a
-        s26v8NIg/tryE14EMDvPZCtj8nZVAUHdSGGTvNhX6UpYfhjtn8VcSJa6Swh2JIE52RYaUmLeqiPb
-        N3e7UjxiX7dQhvWhft4eIxzBh1IItBB+rcHA7xrdYDD0/J5pDHzfGPSsIBxafeoPb9cHWIwiyA1h
-        ur6137gzB4/hN+7MxFPwG9+DpsAKaKcp32OEKeXlKsz2qAcfb+R7Fh0NQzrweqblWVbfMkYDagwH
-        oecNvIFp+j7dXnlgMbit7tyXjUcIR/9Hjp5EjPrm+tTpwcfo94KR3w9ox+/3B2Z3BO+DAbUCy+r2
-        R33f7I2C7h30SUb59mui+zLy6Bp1Z46ehEZ9B7FMzvgulD1gKBOSykI4iZpMNkAVQuEFVNJ29S4x
-        bVPPJ2lAVYpH6kWMrLtaSgs0ddhePxdTTOK4SSxkI0d1vCFHdV3uCuBvP9bh7Q20x4xj9o3i7RAZ
-        yyJgTs9s9fBSSPlq4+60ftw3WiYWLQB2e1k/osLNOCZ2Q6Hk3wDgKXrMb7NgcXy+fFVH3XKdPtP5
-        P7NTnnZrQNXxqg14q1Ab95ndgE1pLlFNMJeo+NkEL5GLXKUHamgVRCNgH3ie4u+qaPbXoDaedtA/
-        rXJonhHr4h0YSwWyddJbVA9KGur3Zsp3bHcFVKK6tJARz/GaA7mA7kHbzYIKz+PB3DmkWcalyhGm
-        KVO5OZ3GmBGWYa7s5aK6wq8q1xLMBdsj5kBG5B2/YnjqA3PMvUW1Wqq5DqnnhnumaQ6aFZYp4hKa
-        0GzssGyBpd6rQp7HmA5K0LDbCygOrm651+qMyIc/FpWXJQ3cKEpTIRxz0BlhknxD0RJdJsz5mKWx
-        EJgneFnDxhIbk9BurpKKeJKn/lqhLh6WN0Gqn+JxJ6lTfYvmKtzGwVGapLVXu6UmzBawPAF0Gko8
-        /0HxEBRL8QaRXwjJU5arVJ7PxH8CRzkTgoPPbeFBjmtrVjSVfi42IhYVypso+kUrBpSTc7VxQf6H
-        5XyBqgVfe3ExpQsUsjAe31ytgVmRYNllEefxnfu4Wq+iF2fQ96xM/7kh/er8bFmg1F1idgcDy+ws
-        KKxjbqYxjWDK36TSMa6honErOgn3S8rGJgaWxc0KmoixqbU6QlUJ/Q4AaRDkDqa+GBn09sh/xXjS
-        K6aYMPXByDH9N8Os27mE+abcI69YEmJm9dWF2SG91/+9aKNOr2qj3MLSV48q/VnUaJRWVaQ64eE7
-        mIQDT6cSnqgdGD4Iz5J56wV4OSzIGdFujCZExSydkaXZnFAJhKcAkJxM1UkoqABdTIU+SaAdXrmd
-        RmYxHp5gmOb3obtldh0TxUAflKm14LhiDkw9L3wMEEGZxMNuM+yGmlMd6LdqhqXvvC3Sq2dcMA/T
-        kgfANXrSE4GJPsmzPaJvuy2TrOq4X6Gu11UtjGE4YLbgTjI+K9ur50UbjeJFwCY++OtceyKF9r58
-        Xau1xMMTYRg3y5t9ZYcV+gddRMoigkUQ6lCr1whuJiPKpKsLFV2/TLqW1DcmZNfoXkNhFlGJjejk
-        c0nxutT0GtHV2rOIZS7ohxu7Y74gVs/kbyDRqKJ+Lc0N+AqFWlb+Gm3ZLhm/1JOVhtprqqqUTtvp
-        puT/XbRzJatdo1y2oi+bHhydHp+dfzpWV05rBSWSvmba6GOFpsOGfl4cs1JNk5IqUWTJyTk5IB9O
-        Dw6PGzJZVrSv4gBmoXGYayHX3tzl8q4Bjhjm7p0uTmw2Faxg4+JvNpu15uA5Co/pJeE6SrOWXnzh
-        FCpovzH/OT3+x5v4r4m1UlEvqBqg9ZXMDcU3VC3XODchNGvDdMtVul0tMxeLupXO39qrdUrXtPRQ
-        7WxsZRYHIFwVLTfAm8BqdbRYJTV/QvJ/AXM6VYN/cgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['4080']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:36 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/AvailDetailTests.test_float_properties.yaml
+++ b/tests/interface_objects/cassettes/AvailDetailTests.test_float_properties.yaml
@@ -1,146 +1,119 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF92aWRlb19pZnJhbWUgLz48
+      cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNj
+      YXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21l
+      ZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9m
+      b3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlh
+      PnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVx
+      dWVzdF9tZWRpYT48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHJlcXVlc3RfYXZhaWxfZGV0YWlscyAv
+      PjxyZXF1ZXN0X2N1c3RvbV9maWVsZHMgLz48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxtaW1lX3Rl
+      eHRfdHlwZT5odG1sPC9taW1lX3RleHRfdHlwZT48cmVxdWVzdF9tZXRhX2NvbXBvbmVudHMgLz48
+      cmVxdWVzdF9leHRyYV9pbmZvIC8+PHJlcXVlc3Rfc291cmNlX2luZm8gLz48cmVxdWVzdF9jb3N0
+      X3JhbmdlIC8+PHJlcXVlc3RfcmV2aWV3cyAvPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['784']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+087XbbOK7/+xTs3HOme8/GtmRL/mi1mpukabdfaTdxp7v7R4eSKEu1JLoiFcfz
+        OvfPPsfeF7sAKdmS4yROP/Z0OpnjmZFAkABBAAQJKM4vl1lKLlghEp7/5Seza/xEWB7wMMlnf/np
+        /fRZZ/zTL+4Dh12wXHqC0SKIvYKJMpWuI0o/5BlNcq8UrPAS4fk0dHPu9Ha3OEGxWkju+SkP5m7g
+        dTrDji8+fnj7MT2bFawjnvovzyZvj4JoHL8aXn46P42ey9Pzd0fv/KGZGqvDxF88m87kkf/J/0cw
+        HB+X9uujdzR+f/7ubOIdi7//+s9L8Zs4L58Op/2F1c/9hX+2fPm3o5cnL/95+dxaHc/juE+TaJIO
+        Qjta+fEb+2/2m9PUWBxZnX84vRZ/TpgISfOACY8WzLugaaIntwuuBeQ6AKEeiI+5Jx+c3uZNN4RM
+        BO4JSHu1jFnBKgQFdegFTVJ4lvA/4ToyCeZMenK1gM6LIgkYiDAP23j1W1AWBazaCiRcPWmqM38B
+        k2qBNhgRDSQvXNMwGjgVcIOVl5nPCnfcHzawKuAGa5FSkIfbb+BUoAYOF6BBq8znaa8JBhlqqPvv
+        /23238BBTlvTVO/UT5kXUolUoqSA0VfwT5aFods3zKFhG7bT22pwUnoFbzwACbThFcUmhZCuvIyK
+        uTscgArUL86nkuYykSuPLySYECAqhfBquGs6vS3INkb/VozBrRjWrRj2rRjDqxi9q9MDHyCVPrrW
+        qAuC27yDPwDvQIsZc23Vsn6tF7DW2o0+a6U8dHrboCYOGgioTK9pBg370B2ODl8fvz0FI77S0sJV
+        xnZE04DnqzauNsNey/DurfDeCr9zKxzY11qh9c2t8N4k7k3iOzQJ42uZxNG9SdybxI9gEv2vtksc
+        f4VY7fjF2fHrk71CtfeLBStIkBRByu7jtXtL/P1bonmtJQ7u47V7k/hPm8SNymqOv5ayfkYkdWV3
+        OJ8evn59vte2cS5pmorbN4wW16hkKAg1ZsrzkOedcg6qtAbqdjXQa9VeNeqhA1h7Uf1P49NCAhMN
+        QNWo8A+hkfxMs8WT/xqMn5DjMpUlXgo2UJxEeOoaVQ+9YjBaG+RUd7JztlLUemq5aghe0VZ4dbc1
+        pDXYBm97vBCvOncPqqdUI7SAG5z6wiVlUk+WPN3qUK3LhoVeLUg09ILmqF4ZvYSRMz/JWejafVS+
+        FkghbN9NtWEapX1H1QY5Gcq1HlJ76hZIIWybRxumUdpm0gY5OfdEks9ShsL6Maf4h9vg1Rr++Pvn
+        9jR71+jy/fr/Qda/uegBL3NZVPNTG2cTsG7W57o8kSwkr0B3Qp5tUKudtEhgm/YKdpGwpQcnwACz
+        a1pCO5scDK40Hx7D4EG9q8GmcXlATCHJOVtIhvIiGK1h7FWjaOxSBh6PIsGkOxgiqW3oBk2wALZ/
+        4ZrWqD+yrTZ23ajR2yHixDArzE2ImAg+Hhqmig89DIZkkjGF3jEmHcOcmpPHA+OxYfzZMB8jpd0d
+        qnG3ZaDfhYTN/IpUbBmTN3T1NeUx7FujgbG3PFRofQd52PD7HHlU89dpbKWOp++nx2eHx69Ozpxe
+        A1yhKDG8oVLGbEmOeFnk7JEgpzCdgkL4WJDpyfm07qhlpp+T0B2+eFa3rDPDXpJH3P05lU/C5OLn
+        mXyCjwt8uEJEyDLPwSzIouBhGaB/ITxq0H5ICgaRYi5IksPSGWMiOTmnYcoK6P6BQeBLYnqBQ/gF
+        n7OcQPRFfH4Jw0Swf0P3gBehIGFZIBKeWMgK4jskDr07vJTwQAXPu8hmT/H5YM3xNE4EiZiQyQUj
+        soCwgCCgBCLAJzbKgoYso8UcJrNKGYKXiTwgCypjLggsEYE5UwnRBE1JRmdJ0G1NMOJpypeCHKe0
+        oMDWRyWcFYkKnhFK4DRF5+Q4LhIh4fREToAR4OJp0X1acCEekbfFIqY5nbEDIFTwchZDLxEnWcbU
+        lEEKHTGnEp+XoJysSJEpxRhH3ohYsEDSoAQGSADwFfI0x5mcLxmTCcMOO8XzNgW5FIQuaRF2lole
+        S1CRZJYD+DAHEeQr8gFaFb0phEzJnF+I+QommpVB3En5BbhGAYvESB2XoQBjIpLffktxvCCGRj4r
+        6CJekVkJUsolg9WIQQw3qO1DXCkKYmQiPiBpsuiIDBpgxANY8ULpDEwR1y9BxYPV2Ug5ogXbOeM2
+        QdA9oBHECcNZ+BzYBtuDMZJATRhmBKsQJDC2KAPYmoSeGypOgrqQU6VZOYxYFaYIZEodCpTC+Oo0
+        Ibrkda25qvO7FFzZBxgK9feD0vAM9BAWrlBLesZX0PmUVhObKg0EDQFzYAnyKpec4OoluE64fFpV
+        YWgB4pbpCpXDR/u5QPyGLNRTZdkPlGBiC5+floUip9o16MEuJ3BInvM0TLDuRJml6kQ6JOdwaAIk
+        liGW5FwNpN8InFBh2W5EUXwfkI8lyAlFUCSzWBKa4WarFhoc5R7T+BCDEzmmOXkBfP5y62TyFY5L
+        VrwEFZuzh+RQKGYJKIbEwpdHQpkjXxJwMd39GABbCDkwMLudgekVd4jqA8op2MN9aFFZnconTwR5
+        kQdpGbLwVqqqrkfGaEI485ztpSHPOQcfwMmrnC9vowA+A53JQ/IGlgN8PxKEJcQlVf8Ve9A7LxOJ
+        t1HkGVjFcZykIURytxE+L9FOlBaB+qNnUz4dNYqCdbEMdjhQWDShffk4xkuANNWK/o6nSbC6hotT
+        DgYXlRBBEGCZXYK/hB0dNKi+WAMeJFjsQp0+RaXPNcn1Toz7b7UXowflrt6BWI2ggRVGxsKEQhhK
+        VXgPUTJsW9INzeWltRzYpZ+FyWU3SHkZwo6Uy27OpNNTOE6SQ7wD8sIT9QLcFMRARerGUi7E417v
+        xiF6Ak7PLOw1eIBwl2MGpDcZwC8wLD8ywr7FokFo2Gwcscjy6WhkTMLIsAYWo+Yg6H5czCAo2smH
+        k1MIjXDvEjA5mLx6d3Bjdr8qeTWi832IYqcgRLlYgHMUHvJTFS02IW2E6rpsC+b0WuryverOiMHP
+        sMbB0Laj0SQ0KTNMy5wEk77VN8ZDM4xMe+iPB9EeugNh3aeS7a85dyb+DTXnzrz8AJrzBfLyFGav
+        P4HfyGL2eDQZUTC6iTmy+/5oENLBxKBsGI0jOmTWeNi/XX3wFhE8Ld5K5Pvq0Ofy8e006XM52kOf
+        rmrLd6ZQX2SBNoOfYVhR3/ZtSv1hZA36QThiw/Fg4oPztvrhmNqROfL30KVPcPDZ3xPdmfY39ER3
+        5uUP6onYpfQkE9Lo/VmshGSZt4HgRFI4q+2hKBXmraqyP7lvoBv7E//Du5FoAj9KIeKDONAajYKB
+        MQhHYz+wTWMUBMbItsJobA1pML5dO2SRIMiL4FC/tzO5Mwff0JncmZcfwJl8h+rDy9sdzL36fB/q
+        8+Wxn8Hg17ft0IomQz80+j6lIz8K+334N6D+xAjG0TBg4cDaX4d4vrcH+lw2vnlQfGeOfoTd7MvF
+        FgCA9kPLHk/oeGKNDdu04EQBkWHAgjGdjPtDu98fG8ZksL8+ySW/oz7dmY1vrk935ug/rE9asMMX
+        zzqZzoN0fJUH6YhOvk68dDCM69X9tcyqb2ollaVwUxV8tEA1QumHVNJe/S4xpddMMmpA3YplbSLB
+        qXu60m2Npgre9HO5wESflyZCthKXJzsSl6H75q9GE97bMcaMcUy/UqyLlIksQ+baZtfuT4amORhh
+        VWQFdTARoB87Rtc0hoZpD/uAsAY7vc1gMRVezjHLHwm1p7QAWNOG9wksXBezVa+qDqrQeVSdDTb7
+        VSlUC6oqmXbgbUMdvM33QragBdboqUyz4mcXvEKusjgNtBqiEXAOvMjwHlyzfwXqYKWG/pj42Dwj
+        1vQUzK0GOboCQtQPShrqa+vqHelugSpUj5Yy5oU7jRmZwvSAdruhxvN5uHKPaY45JkwaZxlTqVud
+        EVsSlmNq9eG6u8KvOzdqDUp2QMyRjMkpv1hXYNjrbo3CgyakWSlgm6Y5anfYFAxU0JTmM5flayz1
+        XjfyIsHMYoreoLeG4uJqyqbRNQxy+Gbde9PUQo7jLBMCS1FUkcOOpg26TJn7Ps8SITBN8bCBjS0O
+        1iR4hboOwzKk5muNeu3i1vp+w+piVpYcpumiYOLmFcaMV5WQe4hpUQIssw7LOyL4v3/lDBOgKkdP
+        0wOV82kln6FRZ9CjsmoWkherqlOeYMVBLqucPxesThF1uyTJA3D9CcimS148whoFRvxyhRk07bpE
+        lbut9Y3OaJKrodTTrXqHNS79MejdYTnD5BUoknUXrbOMcX/8e9Q6sNlHksyYvGKid9G93trFVNW/
+        9V8+8OaZW39jtw13cKWUG9OuU++jbZgjYIcMquLt9SUHoDXANY7+mwmXkhUqaQ+I5Ai3VFCCTQ8t
+        scaLh5UiMFAeJbO9erc61COx/FOZFAkTHsuwql1fy4j/ATGhUfFuwLtY53YNej0M+mzQARqGhYv5
+        V0ZG9gH5NcEKv4Ri3UIADhIz1UvMBp/LgjF5QI5YGmGBw9HU7BP72d/XdJrj1TSqGyNdOV2LdN2j
+        1Vp3kapWKnAxEwx+RGXnUUC49RKep6vuA3AG2FAworcAkKHa/HVhBM1XBJwMyxYAkHydgSUJSkkX
+        62jjrW6vyDLRVh7o7G9V1oL1GjA+OIrumuOaOdDUogxwcw2rHG7QyByDKDBzXEW9O3LKdfR7QdOS
+        4QcGO3s3dmbErqs2Wp3d761YQ5WllqrObc3+DPQH4kFvnvNlNZlmgcE1E7pLXcGGapsWbOyF9hqK
+        xNvq9RqK90Vv90Vv90Vvv/Oit40r2Bg/fiCCp6bqg6rKZSsf8E43kaqJYBMcdG5wtEecz4m/IgMD
+        QzgYOlXTahyRqk3GNMjLEjjt4FMV6+EkFiCbHLiHcZByBMoCfmUdT+6ayu4JiKpqygPCXlBVTVXz
+        2llRdc2MvqCQasPiNcwswQyQX12uVjF3XTHbNfzdXMO2YWGb1jJmuQcew0u8GV+TbhYNXreXfn6t
+        YJObFnX1t7W8kG8x0yggvIaZ/eoGW3SbhHpXQpXG6az9EcOuBgcCq5LpqO4MDkpwTIZt+FBBkbpf
+        kJ5yQS8EekOpq0rXUP09Ygv0/hXwuhm0IqA/pTx8+vrk7PzDifqgstFQIemPKFvCqNF0rK2f1TSn
+        Z4e/nrxuUW69nIKvwrjyPW45M9iY8vAxbAkzlpI/nYKLASnmsPg5++/bxzgDo3ysvhqBfRK3va0h
+        0FmpoW8Yi5BpiegsgrCqVKGV5gbv3TDwUA5bDa7CME5D3GjVyRehCNAn03NJXvI4ryL2LtleNvSi
+        yuHUwZzy+fhaFR8S6iMHoBMkY/AO4Qlf5q0+3VruWqUukpCBwkWFVuDGm7e50W6BY4bDuAO8cNnV
+        sIWNF93L5bILFilLn8ERJ9vup+7CWyB9B4pXO2HvuflycfLX58lvc2uro772bIGuZo1uaL6ha3Vf
+        exNCuzccyD3lN+pr9PV19dbkb53V1ZGuofS16OykskxCEK6Ft5c74G1gfYW7vspt/13H/wd2F8fQ
+        FFIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:37 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['4165']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:44 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_extra_info /><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><request_avail_details
-      /><request_video_iframe /><request_source_info /><request_reviews /><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><mime_text_type>html</mime_text_type><event_token_list>6IF</event_token_list></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['928']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+097XbbtpL/8xRI95z2R22JlKivlmXXsZ1c37hJajubzf7hAUlQZEQSMgFaUV/n
-        vsl9sp0BSImUZFv22hs7VY5OTA4Gg8FgPgAMINm/f00TcsVyEfPstx/MlvEDYZnPgzgb//bDx4vX
-        +8Mffnde2OyKZdIVjOZ+5OZMFIl0bFF4AU9pnLmFYLkbC9ejgTNnwm5vLrL9fD6V3PUS7k+cj+7+
-        /tVkGo4mh6Ppx957b3+c8zAw5ZuZ/+7D5y9d5osv3aPPZv/Ln5P3xudP2dFVevE2Egfdqfv14+Xg
-        7PT1/Mjv7Z8FZth/exkWn08uxwevxfuzbDa/pMaF2X9v5e5R2j09Of5zfpkff7kcjpK88+EkG3WP
-        JrNx8tluN3iyg1hImvlMuDRn7hVN4sDJuN3eBNdScWyAUBdkxpzjT3Z7+aYLAiZ85xhEPJ9FLGcl
-        goLa9IrGCTxL+CMcW8b+hElXzqdQeZrHPgOxZUETD948wZNCMlfQKxgnx+y0DCC7Ai0r+UWew4jO
-        Qfjlk2Zu7E2h7w3QEiOkvuS5YxpGDacELrGyIvVY7gw7/RpWCVxiTRMKYnM6NZwSVMPhArRrnno8
-        adfBIGoNdf79r3r9JRz6vdJN9U69hLkBldhKGOdAfQ7/0jQInI5h9o2eAfysFNgJXcMbdE273YSX
-        LdZbCOjcTamYOP0uaEr1YodFkqDNSDWUjjXAYVoBlkgF2BXNx8wxljgLmD1luQ+aRseLwUWRr0Pt
-        y4JmMpZzl08lGDSwpjTVreAO9GYFsorRuRWjeyuGdStG71aM/jpGe717S0F2eyi5mmBXZFoTZ3vF
-        nG42ru7OuO5oXFbH3Mq4hqb1/2tcvS2Nq7czrq2Ny7rZuJZRTJvBAYh2BVTHwbAIStquB79aVNQV
-        Xh2cHr5/B6F7raSBq0LsK5r4PJs3cXXwbTfC7T1j72jnHZ5B6O32dqH38bxDp/9IodfYGdczCL1b
-        GZe1M64HN67uo4feG+Lgzgi/bYT7G5tE13igeLPT4W8bSHY6/AArqlcP6tZXJlv93QzsKTr/lclW
-        5yGXN9ZuBtY0VXP0OMubwc62nmJQuo9tbbu62dnW9rZ1x9XN4QNsLB6enB2eHm+1r/hxCgNJ/Dj3
-        E/Zom4u9nYd4DtHX3EXfR/QQj7S5uJvZPovou41tdXdpvQe3rc5ub/FJGuG2Aa6PfXtu+zI3K+tw
-        t+v36NqF84+Hnz5h4HjO2tWzdur1bGYQz0297rjOfdTtXms3KX6K8Xhl/quV6YEWnJ0nNSm+2Yis
-        x1kKWsrB79T+qU0U7qf2OJbPbqPlm+j9bnvxSU5g7qP2226BfB9af8fNiYdIDZxfHJyenm+VGjiX
-        NEnE7UmBBtfQdS8eF1O8WlQwbUJ1gO2jmFSLCc8Cnu0XE1DtBVCXq2ZOVXlZqBv2QRdF+UfjywgE
-        i7eRarCyXFW5aJZrMrFw1Z0uTU5d9GqC7PKG2ITNqxbaagwrIN4ZK1GrmgtIg94SbwPJSRyIzWR1
-        R8ryBmyJovrymqZxMq8hlSO0bLddCQ2dTE4zVDSPwbMaEJeHIfqrLa+LKNP0eerFGQucXmdhrgvY
-        w11oUJwtCXdVim0FWCKtHuJchVZozUTnKnD7vdb2ugBT+nWV1wZIIej6O5nfS+brAlSQFTaaMI3S
-        ZKEJslO0+qpv2lk3QCUCjPc1w7Z5sdkcoVrwu3bU7r8cWhkg09pm1OpYN4yase2obV6AtVelh++r
-        TDRhGqXJQBNkZ9wVQD5hwt25tZ1be9Yy37m1nVsrm//bpXCV3/7+1+ir3ZR86upV2s5l3sdlrsmv
-        fc2EYGdQO4PaGdR9DKpuRT4vMpmXCqO2a+qARbE+T5rFkgXkLdANeLpELfdv8ljGvpuzq5jN3JKT
-        UuU2Ftm4xaj5cBluaKn3cmen2CPmUEbkoBgXQhLcscT9xwpB4xbSx04JJp1uHxtahS7RBPN5FgiI
-        3gOzZ/WMBnZVqNFXt0mHJeZymzQWfNg3TLVH6uL2nIxTptD3jeG+ObwwR790jV8M42fD/AVb2lyh
-        pLsqAf0uJM3lmkw6JgjjAIYzeUiR9M1Ov2ttLRJLp0C2Fom13zHvI5JSBPp7nZQ+vvt4cXh2cPj2
-        +Mxu18AlihLDH1TKiM3IK17kGftJkHfQnZz6E5a/rCppeennOHD6J6+rksU3JrlxFnLnx0T+GsRX
-        P47lr026P9J0+ut/dEe/CiJkkWVgEmSa86Dw0VkTHtabJTmTUEmQOINRM4ZEcnJOg4TlNTKfWJII
-        EimrJV7OJywjNEmIx78CuRDsF8j4PA8ECYockXDvnswZrVMRQGWfFxIeqOBZCzvg5aSNPXjReLmI
-        YkFCWBPGV4zIHPwPQQA4NuQeC2VOA5bSfAJdnCcMwbNY7pEplREXBMaM6M3O2KcJSek49luNboc8
-        SfhMkMOE5rTG5BclwjkJc54SSryE0Qk5jPJYyJQKcgwMATdHeeso50IsKpL3+TSiGTi3PWg458U4
-        gtoiitOUKYGAjPbFhEp8noH2sjxBJhWjHHklYsp8Sf0CGCI+wOfI4wR7dj5jTMYMK9wgtPcJSCsn
-        dEbzYH8W63EHbYrHGYAPMhBMNiefoFS1egHeOp7wKzGZ17qfFn60n/ArcKUCBpSRKkSgeCMi4r/+
-        SpCuH0EhH+d0Gs3JuAAZZpLBWEUgnGu1sS5/GEMKQmYi2iNJPN0XKRQA5T3QjlzpGXQcRzlGpYUx
-        XI5BSHN2gxyazYPWQkt+FDPsk8ehE2C4QCn2lRigfzBCfgwtiMKHmYLQPUUli1FvMqq0MAOK5de8
-        CWRNbW4r5fLAEpgULXJa6byq/CGhIG0ghRr/SdlGCjoLg5qr4T7jc6j8jpbdK/MFe2hILEZe5YwT
-        HNMYRw8HVas1kBYgfJnMUXE8tLwrxFcSaZcO4YUSSWTh86cIrPWQZuSEvOG/Kyxd8KLmQQ6yOfo4
-        MucFDMeEvSQHgiQchgHEJ/F712rjiIrNZwRMuHVTq6A9R/zGVvFxig8XldP5qXI2KGIYQMFeqrrT
-        Cn1zW1TW2DvJ/KQIWHBdq+q75GSEOobdzdgNwnvDOZgKJ28zPruGHFgUmtpL8gfIGbwoUicyHkdS
-        /y+uJX5exBLzmeQ16MRhFCcBTCuvaeW8QOX4gvMNGHM0cuX0UJMoqBRLIS6AJqHebGh0EUIwcJRB
-        BO2YL/NYdWCJkbIgpjB5omqWD5NlcK3SUdCWzsQJsBU/avk441KFdpxBdAZecW45BbuAiJ0nTiTl
-        VPzSbm+u2xYwcWRBu9YqTMs43hBqj7rw8Q3LC42gY7GwGxg9NgxZaHl0MDBGQWhYXYtRs+u3vkzH
-        ELs3MmBnFCI4elAB3YHuqncbw4XzoM0rivY3lsFGCYhiOgW/IVxkRH0nYxPSRBDV91A2YHa7oRlP
-        R00GDD6GNfT7vV44GAUmZYZpmSN/1LE6xrBvBqHZ63vDbriFmsC84rJg2yvJnRt/DCW5MxN/PyXp
-        MfgYhhV2el6PUq8fWt2OHwxYf9gdeWBIVicY0l5oDrzblURcwqxnex25c9uPoSN3ZuIp6Ehgzr5a
-        s26v8NIg/tryE14EMDvPZCtj8nZVAUHdSGGTvNhX6UpYfhjtn8VcSJa6Swh2JIE52RYaUmLeqiPb
-        N3e7UjxiX7dQhvWhft4eIxzBh1IItBB+rcHA7xrdYDD0/J5pDHzfGPSsIBxafeoPb9cHWIwiyA1h
-        ur6137gzB4/hN+7MxFPwG9+DpsAKaKcp32OEKeXlKsz2qAcfb+R7Fh0NQzrweqblWVbfMkYDagwH
-        oecNvIFp+j7dXnlgMbit7tyXjUcIR/9Hjp5EjPrm+tTpwcfo94KR3w9ox+/3B2Z3BO+DAbUCy+r2
-        R33f7I2C7h30SUb59mui+zLy6Bp1Z46ehEZ9B7FMzvgulD1gKBOSykI4iZpMNkAVQuEFVNJ29S4x
-        bVPPJ2lAVYpH6kWMrLtaSgs0ddhePxdTTOK4SSxkI0d1vCFHdV3uCuBvP9bh7Q20x4xj9o3i7RAZ
-        yyJgTs9s9fBSSPlq4+60ftw3WiYWLQB2e1k/osLNOCZ2Q6Hk3wDgKXrMb7NgcXy+fFVH3XKdPtP5
-        P7NTnnZrQNXxqg14q1Ab95ndgE1pLlFNMJeo+NkEL5GLXKUHamgVRCNgH3ie4u+qaPbXoDaedtA/
-        rXJonhHr4h0YSwWyddJbVA9KGur3Zsp3bHcFVKK6tJARz/GaA7mA7kHbzYIKz+PB3DmkWcalyhGm
-        KVO5OZ3GmBGWYa7s5aK6wq8q1xLMBdsj5kBG5B2/YnjqA3PMvUW1Wqq5DqnnhnumaQ6aFZYp4hKa
-        0GzssGyBpd6rQp7HmA5K0LDbCygOrm651+qMyIc/FpWXJQ3cKEpTIRxz0BlhknxD0RJdJsz5mKWx
-        EJgneFnDxhIbk9BurpKKeJKn/lqhLh6WN0Gqn+JxJ6lTfYvmKtzGwVGapLVXu6UmzBawPAF0Gko8
-        /0HxEBRL8QaRXwjJU5arVJ7PxH8CRzkTgoPPbeFBjmtrVjSVfi42IhYVypso+kUrBpSTc7VxQf6H
-        5XyBqgVfe3ExpQsUsjAe31ytgVmRYNllEefxnfu4Wq+iF2fQ96xM/7kh/er8bFmg1F1idgcDy+ws
-        KKxjbqYxjWDK36TSMa6honErOgn3S8rGJgaWxc0KmoixqbU6QlUJ/Q4AaRDkDqa+GBn09sh/xXjS
-        K6aYMPXByDH9N8Os27mE+abcI69YEmJm9dWF2SG91/+9aKNOr2qj3MLSV48q/VnUaJRWVaQ64eE7
-        mIQDT6cSnqgdGD4Iz5J56wV4OSzIGdFujCZExSydkaXZnFAJhKcAkJxM1UkoqABdTIU+SaAdXrmd
-        RmYxHp5gmOb3obtldh0TxUAflKm14LhiDkw9L3wMEEGZxMNuM+yGmlMd6LdqhqXvvC3Sq2dcMA/T
-        kgfANXrSE4GJPsmzPaJvuy2TrOq4X6Gu11UtjGE4YLbgTjI+K9ur50UbjeJFwCY++OtceyKF9r58
-        Xau1xMMTYRg3y5t9ZYcV+gddRMoigkUQ6lCr1whuJiPKpKsLFV2/TLqW1DcmZNfoXkNhFlGJjejk
-        c0nxutT0GtHV2rOIZS7ohxu7Y74gVs/kbyDRqKJ+Lc0N+AqFWlb+Gm3ZLhm/1JOVhtprqqqUTtvp
-        puT/XbRzJatdo1y2oi+bHhydHp+dfzpWV05rBSWSvmba6GOFpsOGfl4cs1JNk5IqUWTJyTk5IB9O
-        Dw6PGzJZVrSv4gBmoXGYayHX3tzl8q4Bjhjm7p0uTmw2Faxg4+JvNpu15uA5Co/pJeE6SrOWXnzh
-        FCpovzH/OT3+x5v4r4m1UlEvqBqg9ZXMDcU3VC3XODchNGvDdMtVul0tMxeLupXO39qrdUrXtPRQ
-        7WxsZRYHIFwVLTfAm8BqdbRYJTV/QvJ/AXM6VYN/cgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['4080']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:37 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/AvailDetailTests.test_int_properties.yaml
+++ b/tests/interface_objects/cassettes/AvailDetailTests.test_int_properties.yaml
@@ -1,146 +1,119 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF92aWRlb19pZnJhbWUgLz48
+      cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNj
+      YXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21l
+      ZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9m
+      b3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlh
+      PnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVx
+      dWVzdF9tZWRpYT48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHJlcXVlc3RfYXZhaWxfZGV0YWlscyAv
+      PjxyZXF1ZXN0X2N1c3RvbV9maWVsZHMgLz48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxtaW1lX3Rl
+      eHRfdHlwZT5odG1sPC9taW1lX3RleHRfdHlwZT48cmVxdWVzdF9tZXRhX2NvbXBvbmVudHMgLz48
+      cmVxdWVzdF9leHRyYV9pbmZvIC8+PHJlcXVlc3Rfc291cmNlX2luZm8gLz48cmVxdWVzdF9jb3N0
+      X3JhbmdlIC8+PHJlcXVlc3RfcmV2aWV3cyAvPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['784']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+087XbbOK7/+xTs3HOme8/GtmRL/mi1mpukabdfaTdxp7v7R4eSKEu1JLoiFcfz
+        OvfPPsfeF7sAKdmS4yROP/Z0OpnjmZFAkABBAAQJKM4vl1lKLlghEp7/5Seza/xEWB7wMMlnf/np
+        /fRZZ/zTL+4Dh12wXHqC0SKIvYKJMpWuI0o/5BlNcq8UrPAS4fk0dHPu9Ha3OEGxWkju+SkP5m7g
+        dTrDji8+fnj7MT2bFawjnvovzyZvj4JoHL8aXn46P42ey9Pzd0fv/KGZGqvDxF88m87kkf/J/0cw
+        HB+X9uujdzR+f/7ubOIdi7//+s9L8Zs4L58Op/2F1c/9hX+2fPm3o5cnL/95+dxaHc/juE+TaJIO
+        Qjta+fEb+2/2m9PUWBxZnX84vRZ/TpgISfOACY8WzLugaaIntwuuBeQ6AKEeiI+5Jx+c3uZNN4RM
+        BO4JSHu1jFnBKgQFdegFTVJ4lvA/4ToyCeZMenK1gM6LIgkYiDAP23j1W1AWBazaCiRcPWmqM38B
+        k2qBNhgRDSQvXNMwGjgVcIOVl5nPCnfcHzawKuAGa5FSkIfbb+BUoAYOF6BBq8znaa8JBhlqqPvv
+        /23238BBTlvTVO/UT5kXUolUoqSA0VfwT5aFods3zKFhG7bT22pwUnoFbzwACbThFcUmhZCuvIyK
+        uTscgArUL86nkuYykSuPLySYECAqhfBquGs6vS3INkb/VozBrRjWrRj2rRjDqxi9q9MDHyCVPrrW
+        qAuC27yDPwDvQIsZc23Vsn6tF7DW2o0+a6U8dHrboCYOGgioTK9pBg370B2ODl8fvz0FI77S0sJV
+        xnZE04DnqzauNsNey/DurfDeCr9zKxzY11qh9c2t8N4k7k3iOzQJ42uZxNG9SdybxI9gEv2vtksc
+        f4VY7fjF2fHrk71CtfeLBStIkBRByu7jtXtL/P1bonmtJQ7u47V7k/hPm8SNymqOv5ayfkYkdWV3
+        OJ8evn59vte2cS5pmorbN4wW16hkKAg1ZsrzkOedcg6qtAbqdjXQa9VeNeqhA1h7Uf1P49NCAhMN
+        QNWo8A+hkfxMs8WT/xqMn5DjMpUlXgo2UJxEeOoaVQ+9YjBaG+RUd7JztlLUemq5aghe0VZ4dbc1
+        pDXYBm97vBCvOncPqqdUI7SAG5z6wiVlUk+WPN3qUK3LhoVeLUg09ILmqF4ZvYSRMz/JWejafVS+
+        FkghbN9NtWEapX1H1QY5Gcq1HlJ76hZIIWybRxumUdpm0gY5OfdEks9ShsL6Maf4h9vg1Rr++Pvn
+        9jR71+jy/fr/Qda/uegBL3NZVPNTG2cTsG7W57o8kSwkr0B3Qp5tUKudtEhgm/YKdpGwpQcnwACz
+        a1pCO5scDK40Hx7D4EG9q8GmcXlATCHJOVtIhvIiGK1h7FWjaOxSBh6PIsGkOxgiqW3oBk2wALZ/
+        4ZrWqD+yrTZ23ajR2yHixDArzE2ImAg+Hhqmig89DIZkkjGF3jEmHcOcmpPHA+OxYfzZMB8jpd0d
+        qnG3ZaDfhYTN/IpUbBmTN3T1NeUx7FujgbG3PFRofQd52PD7HHlU89dpbKWOp++nx2eHx69Ozpxe
+        A1yhKDG8oVLGbEmOeFnk7JEgpzCdgkL4WJDpyfm07qhlpp+T0B2+eFa3rDPDXpJH3P05lU/C5OLn
+        mXyCjwt8uEJEyDLPwSzIouBhGaB/ITxq0H5ICgaRYi5IksPSGWMiOTmnYcoK6P6BQeBLYnqBQ/gF
+        n7OcQPRFfH4Jw0Swf0P3gBehIGFZIBKeWMgK4jskDr07vJTwQAXPu8hmT/H5YM3xNE4EiZiQyQUj
+        soCwgCCgBCLAJzbKgoYso8UcJrNKGYKXiTwgCypjLggsEYE5UwnRBE1JRmdJ0G1NMOJpypeCHKe0
+        oMDWRyWcFYkKnhFK4DRF5+Q4LhIh4fREToAR4OJp0X1acCEekbfFIqY5nbEDIFTwchZDLxEnWcbU
+        lEEKHTGnEp+XoJysSJEpxRhH3ohYsEDSoAQGSADwFfI0x5mcLxmTCcMOO8XzNgW5FIQuaRF2lole
+        S1CRZJYD+DAHEeQr8gFaFb0phEzJnF+I+QommpVB3En5BbhGAYvESB2XoQBjIpLffktxvCCGRj4r
+        6CJekVkJUsolg9WIQQw3qO1DXCkKYmQiPiBpsuiIDBpgxANY8ULpDEwR1y9BxYPV2Ug5ogXbOeM2
+        QdA9oBHECcNZ+BzYBtuDMZJATRhmBKsQJDC2KAPYmoSeGypOgrqQU6VZOYxYFaYIZEodCpTC+Oo0
+        Ibrkda25qvO7FFzZBxgK9feD0vAM9BAWrlBLesZX0PmUVhObKg0EDQFzYAnyKpec4OoluE64fFpV
+        YWgB4pbpCpXDR/u5QPyGLNRTZdkPlGBiC5+floUip9o16MEuJ3BInvM0TLDuRJml6kQ6JOdwaAIk
+        liGW5FwNpN8InFBh2W5EUXwfkI8lyAlFUCSzWBKa4WarFhoc5R7T+BCDEzmmOXkBfP5y62TyFY5L
+        VrwEFZuzh+RQKGYJKIbEwpdHQpkjXxJwMd39GABbCDkwMLudgekVd4jqA8op2MN9aFFZnconTwR5
+        kQdpGbLwVqqqrkfGaEI485ztpSHPOQcfwMmrnC9vowA+A53JQ/IGlgN8PxKEJcQlVf8Ve9A7LxOJ
+        t1HkGVjFcZykIURytxE+L9FOlBaB+qNnUz4dNYqCdbEMdjhQWDShffk4xkuANNWK/o6nSbC6hotT
+        DgYXlRBBEGCZXYK/hB0dNKi+WAMeJFjsQp0+RaXPNcn1Toz7b7UXowflrt6BWI2ggRVGxsKEQhhK
+        VXgPUTJsW9INzeWltRzYpZ+FyWU3SHkZwo6Uy27OpNNTOE6SQ7wD8sIT9QLcFMRARerGUi7E417v
+        xiF6Ak7PLOw1eIBwl2MGpDcZwC8wLD8ywr7FokFo2Gwcscjy6WhkTMLIsAYWo+Yg6H5czCAo2smH
+        k1MIjXDvEjA5mLx6d3Bjdr8qeTWi832IYqcgRLlYgHMUHvJTFS02IW2E6rpsC+b0WuryverOiMHP
+        sMbB0Laj0SQ0KTNMy5wEk77VN8ZDM4xMe+iPB9EeugNh3aeS7a85dyb+DTXnzrz8AJrzBfLyFGav
+        P4HfyGL2eDQZUTC6iTmy+/5oENLBxKBsGI0jOmTWeNi/XX3wFhE8Ld5K5Pvq0Ofy8e006XM52kOf
+        rmrLd6ZQX2SBNoOfYVhR3/ZtSv1hZA36QThiw/Fg4oPztvrhmNqROfL30KVPcPDZ3xPdmfY39ER3
+        5uUP6onYpfQkE9Lo/VmshGSZt4HgRFI4q+2hKBXmraqyP7lvoBv7E//Du5FoAj9KIeKDONAajYKB
+        MQhHYz+wTWMUBMbItsJobA1pML5dO2SRIMiL4FC/tzO5Mwff0JncmZcfwJl8h+rDy9sdzL36fB/q
+        8+Wxn8Hg17ft0IomQz80+j6lIz8K+334N6D+xAjG0TBg4cDaX4d4vrcH+lw2vnlQfGeOfoTd7MvF
+        FgCA9kPLHk/oeGKNDdu04EQBkWHAgjGdjPtDu98fG8ZksL8+ySW/oz7dmY1vrk935ug/rE9asMMX
+        zzqZzoN0fJUH6YhOvk68dDCM69X9tcyqb2ollaVwUxV8tEA1QumHVNJe/S4xpddMMmpA3YplbSLB
+        qXu60m2Npgre9HO5wESflyZCthKXJzsSl6H75q9GE97bMcaMcUy/UqyLlIksQ+baZtfuT4amORhh
+        VWQFdTARoB87Rtc0hoZpD/uAsAY7vc1gMRVezjHLHwm1p7QAWNOG9wksXBezVa+qDqrQeVSdDTb7
+        VSlUC6oqmXbgbUMdvM33QragBdboqUyz4mcXvEKusjgNtBqiEXAOvMjwHlyzfwXqYKWG/pj42Dwj
+        1vQUzK0GOboCQtQPShrqa+vqHelugSpUj5Yy5oU7jRmZwvSAdruhxvN5uHKPaY45JkwaZxlTqVud
+        EVsSlmNq9eG6u8KvOzdqDUp2QMyRjMkpv1hXYNjrbo3CgyakWSlgm6Y5anfYFAxU0JTmM5flayz1
+        XjfyIsHMYoreoLeG4uJqyqbRNQxy+Gbde9PUQo7jLBMCS1FUkcOOpg26TJn7Ps8SITBN8bCBjS0O
+        1iR4hboOwzKk5muNeu3i1vp+w+piVpYcpumiYOLmFcaMV5WQe4hpUQIssw7LOyL4v3/lDBOgKkdP
+        0wOV82kln6FRZ9CjsmoWkherqlOeYMVBLqucPxesThF1uyTJA3D9CcimS148whoFRvxyhRk07bpE
+        lbut9Y3OaJKrodTTrXqHNS79MejdYTnD5BUoknUXrbOMcX/8e9Q6sNlHksyYvGKid9G93trFVNW/
+        9V8+8OaZW39jtw13cKWUG9OuU++jbZgjYIcMquLt9SUHoDXANY7+mwmXkhUqaQ+I5Ai3VFCCTQ8t
+        scaLh5UiMFAeJbO9erc61COx/FOZFAkTHsuwql1fy4j/ATGhUfFuwLtY53YNej0M+mzQARqGhYv5
+        V0ZG9gH5NcEKv4Ri3UIADhIz1UvMBp/LgjF5QI5YGmGBw9HU7BP72d/XdJrj1TSqGyNdOV2LdN2j
+        1Vp3kapWKnAxEwx+RGXnUUC49RKep6vuA3AG2FAworcAkKHa/HVhBM1XBJwMyxYAkHydgSUJSkkX
+        62jjrW6vyDLRVh7o7G9V1oL1GjA+OIrumuOaOdDUogxwcw2rHG7QyByDKDBzXEW9O3LKdfR7QdOS
+        4QcGO3s3dmbErqs2Wp3d761YQ5WllqrObc3+DPQH4kFvnvNlNZlmgcE1E7pLXcGGapsWbOyF9hqK
+        xNvq9RqK90Vv90Vv90Vvv/Oit40r2Bg/fiCCp6bqg6rKZSsf8E43kaqJYBMcdG5wtEecz4m/IgMD
+        QzgYOlXTahyRqk3GNMjLEjjt4FMV6+EkFiCbHLiHcZByBMoCfmUdT+6ayu4JiKpqygPCXlBVTVXz
+        2llRdc2MvqCQasPiNcwswQyQX12uVjF3XTHbNfzdXMO2YWGb1jJmuQcew0u8GV+TbhYNXreXfn6t
+        YJObFnX1t7W8kG8x0yggvIaZ/eoGW3SbhHpXQpXG6az9EcOuBgcCq5LpqO4MDkpwTIZt+FBBkbpf
+        kJ5yQS8EekOpq0rXUP09Ygv0/hXwuhm0IqA/pTx8+vrk7PzDifqgstFQIemPKFvCqNF0rK2f1TSn
+        Z4e/nrxuUW69nIKvwrjyPW45M9iY8vAxbAkzlpI/nYKLASnmsPg5++/bxzgDo3ysvhqBfRK3va0h
+        0FmpoW8Yi5BpiegsgrCqVKGV5gbv3TDwUA5bDa7CME5D3GjVyRehCNAn03NJXvI4ryL2LtleNvSi
+        yuHUwZzy+fhaFR8S6iMHoBMkY/AO4Qlf5q0+3VruWqUukpCBwkWFVuDGm7e50W6BY4bDuAO8cNnV
+        sIWNF93L5bILFilLn8ERJ9vup+7CWyB9B4pXO2HvuflycfLX58lvc2uro772bIGuZo1uaL6ha3Vf
+        exNCuzccyD3lN+pr9PV19dbkb53V1ZGuofS16OykskxCEK6Ft5c74G1gfYW7vspt/13H/wd2F8fQ
+        FFIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:37 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['4165']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:45 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_extra_info /><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><request_avail_details
-      /><request_video_iframe /><request_source_info /><request_reviews /><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><mime_text_type>html</mime_text_type><event_token_list>6IF</event_token_list></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['928']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+097XbbtpL/8xRI95z2R22JlKivlmXXsZ1c37hJajubzf7hAUlQZEQSMgFaUV/n
-        vsl9sp0BSImUZFv22hs7VY5OTA4Gg8FgPgAMINm/f00TcsVyEfPstx/MlvEDYZnPgzgb//bDx4vX
-        +8Mffnde2OyKZdIVjOZ+5OZMFIl0bFF4AU9pnLmFYLkbC9ejgTNnwm5vLrL9fD6V3PUS7k+cj+7+
-        /tVkGo4mh6Ppx957b3+c8zAw5ZuZ/+7D5y9d5osv3aPPZv/Ln5P3xudP2dFVevE2Egfdqfv14+Xg
-        7PT1/Mjv7Z8FZth/exkWn08uxwevxfuzbDa/pMaF2X9v5e5R2j09Of5zfpkff7kcjpK88+EkG3WP
-        JrNx8tluN3iyg1hImvlMuDRn7hVN4sDJuN3eBNdScWyAUBdkxpzjT3Z7+aYLAiZ85xhEPJ9FLGcl
-        goLa9IrGCTxL+CMcW8b+hElXzqdQeZrHPgOxZUETD948wZNCMlfQKxgnx+y0DCC7Ai0r+UWew4jO
-        Qfjlk2Zu7E2h7w3QEiOkvuS5YxpGDacELrGyIvVY7gw7/RpWCVxiTRMKYnM6NZwSVMPhArRrnno8
-        adfBIGoNdf79r3r9JRz6vdJN9U69hLkBldhKGOdAfQ7/0jQInI5h9o2eAfysFNgJXcMbdE273YSX
-        LdZbCOjcTamYOP0uaEr1YodFkqDNSDWUjjXAYVoBlkgF2BXNx8wxljgLmD1luQ+aRseLwUWRr0Pt
-        y4JmMpZzl08lGDSwpjTVreAO9GYFsorRuRWjeyuGdStG71aM/jpGe717S0F2eyi5mmBXZFoTZ3vF
-        nG42ru7OuO5oXFbH3Mq4hqb1/2tcvS2Nq7czrq2Ny7rZuJZRTJvBAYh2BVTHwbAIStquB79aVNQV
-        Xh2cHr5/B6F7raSBq0LsK5r4PJs3cXXwbTfC7T1j72jnHZ5B6O32dqH38bxDp/9IodfYGdczCL1b
-        GZe1M64HN67uo4feG+Lgzgi/bYT7G5tE13igeLPT4W8bSHY6/AArqlcP6tZXJlv93QzsKTr/lclW
-        5yGXN9ZuBtY0VXP0OMubwc62nmJQuo9tbbu62dnW9rZ1x9XN4QNsLB6enB2eHm+1r/hxCgNJ/Dj3
-        E/Zom4u9nYd4DtHX3EXfR/QQj7S5uJvZPovou41tdXdpvQe3rc5ub/FJGuG2Aa6PfXtu+zI3K+tw
-        t+v36NqF84+Hnz5h4HjO2tWzdur1bGYQz0297rjOfdTtXms3KX6K8Xhl/quV6YEWnJ0nNSm+2Yis
-        x1kKWsrB79T+qU0U7qf2OJbPbqPlm+j9bnvxSU5g7qP2226BfB9af8fNiYdIDZxfHJyenm+VGjiX
-        NEnE7UmBBtfQdS8eF1O8WlQwbUJ1gO2jmFSLCc8Cnu0XE1DtBVCXq2ZOVXlZqBv2QRdF+UfjywgE
-        i7eRarCyXFW5aJZrMrFw1Z0uTU5d9GqC7PKG2ITNqxbaagwrIN4ZK1GrmgtIg94SbwPJSRyIzWR1
-        R8ryBmyJovrymqZxMq8hlSO0bLddCQ2dTE4zVDSPwbMaEJeHIfqrLa+LKNP0eerFGQucXmdhrgvY
-        w11oUJwtCXdVim0FWCKtHuJchVZozUTnKnD7vdb2ugBT+nWV1wZIIej6O5nfS+brAlSQFTaaMI3S
-        ZKEJslO0+qpv2lk3QCUCjPc1w7Z5sdkcoVrwu3bU7r8cWhkg09pm1OpYN4yase2obV6AtVelh++r
-        TDRhGqXJQBNkZ9wVQD5hwt25tZ1be9Yy37m1nVsrm//bpXCV3/7+1+ir3ZR86upV2s5l3sdlrsmv
-        fc2EYGdQO4PaGdR9DKpuRT4vMpmXCqO2a+qARbE+T5rFkgXkLdANeLpELfdv8ljGvpuzq5jN3JKT
-        UuU2Ftm4xaj5cBluaKn3cmen2CPmUEbkoBgXQhLcscT9xwpB4xbSx04JJp1uHxtahS7RBPN5FgiI
-        3gOzZ/WMBnZVqNFXt0mHJeZymzQWfNg3TLVH6uL2nIxTptD3jeG+ObwwR790jV8M42fD/AVb2lyh
-        pLsqAf0uJM3lmkw6JgjjAIYzeUiR9M1Ov2ttLRJLp0C2Fom13zHvI5JSBPp7nZQ+vvt4cXh2cPj2
-        +Mxu18AlihLDH1TKiM3IK17kGftJkHfQnZz6E5a/rCppeennOHD6J6+rksU3JrlxFnLnx0T+GsRX
-        P47lr026P9J0+ut/dEe/CiJkkWVgEmSa86Dw0VkTHtabJTmTUEmQOINRM4ZEcnJOg4TlNTKfWJII
-        EimrJV7OJywjNEmIx78CuRDsF8j4PA8ECYockXDvnswZrVMRQGWfFxIeqOBZCzvg5aSNPXjReLmI
-        YkFCWBPGV4zIHPwPQQA4NuQeC2VOA5bSfAJdnCcMwbNY7pEplREXBMaM6M3O2KcJSek49luNboc8
-        SfhMkMOE5rTG5BclwjkJc54SSryE0Qk5jPJYyJQKcgwMATdHeeso50IsKpL3+TSiGTi3PWg458U4
-        gtoiitOUKYGAjPbFhEp8noH2sjxBJhWjHHklYsp8Sf0CGCI+wOfI4wR7dj5jTMYMK9wgtPcJSCsn
-        dEbzYH8W63EHbYrHGYAPMhBMNiefoFS1egHeOp7wKzGZ17qfFn60n/ArcKUCBpSRKkSgeCMi4r/+
-        SpCuH0EhH+d0Gs3JuAAZZpLBWEUgnGu1sS5/GEMKQmYi2iNJPN0XKRQA5T3QjlzpGXQcRzlGpYUx
-        XI5BSHN2gxyazYPWQkt+FDPsk8ehE2C4QCn2lRigfzBCfgwtiMKHmYLQPUUli1FvMqq0MAOK5de8
-        CWRNbW4r5fLAEpgULXJa6byq/CGhIG0ghRr/SdlGCjoLg5qr4T7jc6j8jpbdK/MFe2hILEZe5YwT
-        HNMYRw8HVas1kBYgfJnMUXE8tLwrxFcSaZcO4YUSSWTh86cIrPWQZuSEvOG/Kyxd8KLmQQ6yOfo4
-        MucFDMeEvSQHgiQchgHEJ/F712rjiIrNZwRMuHVTq6A9R/zGVvFxig8XldP5qXI2KGIYQMFeqrrT
-        Cn1zW1TW2DvJ/KQIWHBdq+q75GSEOobdzdgNwnvDOZgKJ28zPruGHFgUmtpL8gfIGbwoUicyHkdS
-        /y+uJX5exBLzmeQ16MRhFCcBTCuvaeW8QOX4gvMNGHM0cuX0UJMoqBRLIS6AJqHebGh0EUIwcJRB
-        BO2YL/NYdWCJkbIgpjB5omqWD5NlcK3SUdCWzsQJsBU/avk441KFdpxBdAZecW45BbuAiJ0nTiTl
-        VPzSbm+u2xYwcWRBu9YqTMs43hBqj7rw8Q3LC42gY7GwGxg9NgxZaHl0MDBGQWhYXYtRs+u3vkzH
-        ELs3MmBnFCI4elAB3YHuqncbw4XzoM0rivY3lsFGCYhiOgW/IVxkRH0nYxPSRBDV91A2YHa7oRlP
-        R00GDD6GNfT7vV44GAUmZYZpmSN/1LE6xrBvBqHZ63vDbriFmsC84rJg2yvJnRt/DCW5MxN/PyXp
-        MfgYhhV2el6PUq8fWt2OHwxYf9gdeWBIVicY0l5oDrzblURcwqxnex25c9uPoSN3ZuIp6Ehgzr5a
-        s26v8NIg/tryE14EMDvPZCtj8nZVAUHdSGGTvNhX6UpYfhjtn8VcSJa6Swh2JIE52RYaUmLeqiPb
-        N3e7UjxiX7dQhvWhft4eIxzBh1IItBB+rcHA7xrdYDD0/J5pDHzfGPSsIBxafeoPb9cHWIwiyA1h
-        ur6137gzB4/hN+7MxFPwG9+DpsAKaKcp32OEKeXlKsz2qAcfb+R7Fh0NQzrweqblWVbfMkYDagwH
-        oecNvIFp+j7dXnlgMbit7tyXjUcIR/9Hjp5EjPrm+tTpwcfo94KR3w9ox+/3B2Z3BO+DAbUCy+r2
-        R33f7I2C7h30SUb59mui+zLy6Bp1Z46ehEZ9B7FMzvgulD1gKBOSykI4iZpMNkAVQuEFVNJ29S4x
-        bVPPJ2lAVYpH6kWMrLtaSgs0ddhePxdTTOK4SSxkI0d1vCFHdV3uCuBvP9bh7Q20x4xj9o3i7RAZ
-        yyJgTs9s9fBSSPlq4+60ftw3WiYWLQB2e1k/osLNOCZ2Q6Hk3wDgKXrMb7NgcXy+fFVH3XKdPtP5
-        P7NTnnZrQNXxqg14q1Ab95ndgE1pLlFNMJeo+NkEL5GLXKUHamgVRCNgH3ie4u+qaPbXoDaedtA/
-        rXJonhHr4h0YSwWyddJbVA9KGur3Zsp3bHcFVKK6tJARz/GaA7mA7kHbzYIKz+PB3DmkWcalyhGm
-        KVO5OZ3GmBGWYa7s5aK6wq8q1xLMBdsj5kBG5B2/YnjqA3PMvUW1Wqq5DqnnhnumaQ6aFZYp4hKa
-        0GzssGyBpd6rQp7HmA5K0LDbCygOrm651+qMyIc/FpWXJQ3cKEpTIRxz0BlhknxD0RJdJsz5mKWx
-        EJgneFnDxhIbk9BurpKKeJKn/lqhLh6WN0Gqn+JxJ6lTfYvmKtzGwVGapLVXu6UmzBawPAF0Gko8
-        /0HxEBRL8QaRXwjJU5arVJ7PxH8CRzkTgoPPbeFBjmtrVjSVfi42IhYVypso+kUrBpSTc7VxQf6H
-        5XyBqgVfe3ExpQsUsjAe31ytgVmRYNllEefxnfu4Wq+iF2fQ96xM/7kh/er8bFmg1F1idgcDy+ws
-        KKxjbqYxjWDK36TSMa6honErOgn3S8rGJgaWxc0KmoixqbU6QlUJ/Q4AaRDkDqa+GBn09sh/xXjS
-        K6aYMPXByDH9N8Os27mE+abcI69YEmJm9dWF2SG91/+9aKNOr2qj3MLSV48q/VnUaJRWVaQ64eE7
-        mIQDT6cSnqgdGD4Iz5J56wV4OSzIGdFujCZExSydkaXZnFAJhKcAkJxM1UkoqABdTIU+SaAdXrmd
-        RmYxHp5gmOb3obtldh0TxUAflKm14LhiDkw9L3wMEEGZxMNuM+yGmlMd6LdqhqXvvC3Sq2dcMA/T
-        kgfANXrSE4GJPsmzPaJvuy2TrOq4X6Gu11UtjGE4YLbgTjI+K9ur50UbjeJFwCY++OtceyKF9r58
-        Xau1xMMTYRg3y5t9ZYcV+gddRMoigkUQ6lCr1whuJiPKpKsLFV2/TLqW1DcmZNfoXkNhFlGJjejk
-        c0nxutT0GtHV2rOIZS7ohxu7Y74gVs/kbyDRqKJ+Lc0N+AqFWlb+Gm3ZLhm/1JOVhtprqqqUTtvp
-        puT/XbRzJatdo1y2oi+bHhydHp+dfzpWV05rBSWSvmba6GOFpsOGfl4cs1JNk5IqUWTJyTk5IB9O
-        Dw6PGzJZVrSv4gBmoXGYayHX3tzl8q4Bjhjm7p0uTmw2Faxg4+JvNpu15uA5Co/pJeE6SrOWXnzh
-        FCpovzH/OT3+x5v4r4m1UlEvqBqg9ZXMDcU3VC3XODchNGvDdMtVul0tMxeLupXO39qrdUrXtPRQ
-        7WxsZRYHIFwVLTfAm8BqdbRYJTV/QvJ/AXM6VYN/cgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['4080']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:38 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/AvailDetailTests.test_string_properties.yaml
+++ b/tests/interface_objects/cassettes/AvailDetailTests.test_string_properties.yaml
@@ -1,146 +1,119 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF92aWRlb19pZnJhbWUgLz48
+      cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNj
+      YXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21l
+      ZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9m
+      b3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlh
+      PnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVx
+      dWVzdF9tZWRpYT48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHJlcXVlc3RfYXZhaWxfZGV0YWlscyAv
+      PjxyZXF1ZXN0X2N1c3RvbV9maWVsZHMgLz48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxtaW1lX3Rl
+      eHRfdHlwZT5odG1sPC9taW1lX3RleHRfdHlwZT48cmVxdWVzdF9tZXRhX2NvbXBvbmVudHMgLz48
+      cmVxdWVzdF9leHRyYV9pbmZvIC8+PHJlcXVlc3Rfc291cmNlX2luZm8gLz48cmVxdWVzdF9jb3N0
+      X3JhbmdlIC8+PHJlcXVlc3RfcmV2aWV3cyAvPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['784']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+087XbbOK7/+xTs3HOme8/GtmRL/mi1mpukabdfaTdxp7v7R4eSKEu1JLoiFcfz
+        OvfPPsfeF7sAKdmS4yROP/Z0OpnjmZFAkABBAAQJKM4vl1lKLlghEp7/5Seza/xEWB7wMMlnf/np
+        /fRZZ/zTL+4Dh12wXHqC0SKIvYKJMpWuI0o/5BlNcq8UrPAS4fk0dHPu9Ha3OEGxWkju+SkP5m7g
+        dTrDji8+fnj7MT2bFawjnvovzyZvj4JoHL8aXn46P42ey9Pzd0fv/KGZGqvDxF88m87kkf/J/0cw
+        HB+X9uujdzR+f/7ubOIdi7//+s9L8Zs4L58Op/2F1c/9hX+2fPm3o5cnL/95+dxaHc/juE+TaJIO
+        Qjta+fEb+2/2m9PUWBxZnX84vRZ/TpgISfOACY8WzLugaaIntwuuBeQ6AKEeiI+5Jx+c3uZNN4RM
+        BO4JSHu1jFnBKgQFdegFTVJ4lvA/4ToyCeZMenK1gM6LIgkYiDAP23j1W1AWBazaCiRcPWmqM38B
+        k2qBNhgRDSQvXNMwGjgVcIOVl5nPCnfcHzawKuAGa5FSkIfbb+BUoAYOF6BBq8znaa8JBhlqqPvv
+        /23238BBTlvTVO/UT5kXUolUoqSA0VfwT5aFods3zKFhG7bT22pwUnoFbzwACbThFcUmhZCuvIyK
+        uTscgArUL86nkuYykSuPLySYECAqhfBquGs6vS3INkb/VozBrRjWrRj2rRjDqxi9q9MDHyCVPrrW
+        qAuC27yDPwDvQIsZc23Vsn6tF7DW2o0+a6U8dHrboCYOGgioTK9pBg370B2ODl8fvz0FI77S0sJV
+        xnZE04DnqzauNsNey/DurfDeCr9zKxzY11qh9c2t8N4k7k3iOzQJ42uZxNG9SdybxI9gEv2vtksc
+        f4VY7fjF2fHrk71CtfeLBStIkBRByu7jtXtL/P1bonmtJQ7u47V7k/hPm8SNymqOv5ayfkYkdWV3
+        OJ8evn59vte2cS5pmorbN4wW16hkKAg1ZsrzkOedcg6qtAbqdjXQa9VeNeqhA1h7Uf1P49NCAhMN
+        QNWo8A+hkfxMs8WT/xqMn5DjMpUlXgo2UJxEeOoaVQ+9YjBaG+RUd7JztlLUemq5aghe0VZ4dbc1
+        pDXYBm97vBCvOncPqqdUI7SAG5z6wiVlUk+WPN3qUK3LhoVeLUg09ILmqF4ZvYSRMz/JWejafVS+
+        FkghbN9NtWEapX1H1QY5Gcq1HlJ76hZIIWybRxumUdpm0gY5OfdEks9ShsL6Maf4h9vg1Rr++Pvn
+        9jR71+jy/fr/Qda/uegBL3NZVPNTG2cTsG7W57o8kSwkr0B3Qp5tUKudtEhgm/YKdpGwpQcnwACz
+        a1pCO5scDK40Hx7D4EG9q8GmcXlATCHJOVtIhvIiGK1h7FWjaOxSBh6PIsGkOxgiqW3oBk2wALZ/
+        4ZrWqD+yrTZ23ajR2yHixDArzE2ImAg+Hhqmig89DIZkkjGF3jEmHcOcmpPHA+OxYfzZMB8jpd0d
+        qnG3ZaDfhYTN/IpUbBmTN3T1NeUx7FujgbG3PFRofQd52PD7HHlU89dpbKWOp++nx2eHx69Ozpxe
+        A1yhKDG8oVLGbEmOeFnk7JEgpzCdgkL4WJDpyfm07qhlpp+T0B2+eFa3rDPDXpJH3P05lU/C5OLn
+        mXyCjwt8uEJEyDLPwSzIouBhGaB/ITxq0H5ICgaRYi5IksPSGWMiOTmnYcoK6P6BQeBLYnqBQ/gF
+        n7OcQPRFfH4Jw0Swf0P3gBehIGFZIBKeWMgK4jskDr07vJTwQAXPu8hmT/H5YM3xNE4EiZiQyQUj
+        soCwgCCgBCLAJzbKgoYso8UcJrNKGYKXiTwgCypjLggsEYE5UwnRBE1JRmdJ0G1NMOJpypeCHKe0
+        oMDWRyWcFYkKnhFK4DRF5+Q4LhIh4fREToAR4OJp0X1acCEekbfFIqY5nbEDIFTwchZDLxEnWcbU
+        lEEKHTGnEp+XoJysSJEpxRhH3ohYsEDSoAQGSADwFfI0x5mcLxmTCcMOO8XzNgW5FIQuaRF2lole
+        S1CRZJYD+DAHEeQr8gFaFb0phEzJnF+I+QommpVB3En5BbhGAYvESB2XoQBjIpLffktxvCCGRj4r
+        6CJekVkJUsolg9WIQQw3qO1DXCkKYmQiPiBpsuiIDBpgxANY8ULpDEwR1y9BxYPV2Ug5ogXbOeM2
+        QdA9oBHECcNZ+BzYBtuDMZJATRhmBKsQJDC2KAPYmoSeGypOgrqQU6VZOYxYFaYIZEodCpTC+Oo0
+        Ibrkda25qvO7FFzZBxgK9feD0vAM9BAWrlBLesZX0PmUVhObKg0EDQFzYAnyKpec4OoluE64fFpV
+        YWgB4pbpCpXDR/u5QPyGLNRTZdkPlGBiC5+floUip9o16MEuJ3BInvM0TLDuRJml6kQ6JOdwaAIk
+        liGW5FwNpN8InFBh2W5EUXwfkI8lyAlFUCSzWBKa4WarFhoc5R7T+BCDEzmmOXkBfP5y62TyFY5L
+        VrwEFZuzh+RQKGYJKIbEwpdHQpkjXxJwMd39GABbCDkwMLudgekVd4jqA8op2MN9aFFZnconTwR5
+        kQdpGbLwVqqqrkfGaEI485ztpSHPOQcfwMmrnC9vowA+A53JQ/IGlgN8PxKEJcQlVf8Ve9A7LxOJ
+        t1HkGVjFcZykIURytxE+L9FOlBaB+qNnUz4dNYqCdbEMdjhQWDShffk4xkuANNWK/o6nSbC6hotT
+        DgYXlRBBEGCZXYK/hB0dNKi+WAMeJFjsQp0+RaXPNcn1Toz7b7UXowflrt6BWI2ggRVGxsKEQhhK
+        VXgPUTJsW9INzeWltRzYpZ+FyWU3SHkZwo6Uy27OpNNTOE6SQ7wD8sIT9QLcFMRARerGUi7E417v
+        xiF6Ak7PLOw1eIBwl2MGpDcZwC8wLD8ywr7FokFo2Gwcscjy6WhkTMLIsAYWo+Yg6H5czCAo2smH
+        k1MIjXDvEjA5mLx6d3Bjdr8qeTWi832IYqcgRLlYgHMUHvJTFS02IW2E6rpsC+b0WuryverOiMHP
+        sMbB0Laj0SQ0KTNMy5wEk77VN8ZDM4xMe+iPB9EeugNh3aeS7a85dyb+DTXnzrz8AJrzBfLyFGav
+        P4HfyGL2eDQZUTC6iTmy+/5oENLBxKBsGI0jOmTWeNi/XX3wFhE8Ld5K5Pvq0Ofy8e006XM52kOf
+        rmrLd6ZQX2SBNoOfYVhR3/ZtSv1hZA36QThiw/Fg4oPztvrhmNqROfL30KVPcPDZ3xPdmfY39ER3
+        5uUP6onYpfQkE9Lo/VmshGSZt4HgRFI4q+2hKBXmraqyP7lvoBv7E//Du5FoAj9KIeKDONAajYKB
+        MQhHYz+wTWMUBMbItsJobA1pML5dO2SRIMiL4FC/tzO5Mwff0JncmZcfwJl8h+rDy9sdzL36fB/q
+        8+Wxn8Hg17ft0IomQz80+j6lIz8K+334N6D+xAjG0TBg4cDaX4d4vrcH+lw2vnlQfGeOfoTd7MvF
+        FgCA9kPLHk/oeGKNDdu04EQBkWHAgjGdjPtDu98fG8ZksL8+ySW/oz7dmY1vrk935ug/rE9asMMX
+        zzqZzoN0fJUH6YhOvk68dDCM69X9tcyqb2ollaVwUxV8tEA1QumHVNJe/S4xpddMMmpA3YplbSLB
+        qXu60m2Npgre9HO5wESflyZCthKXJzsSl6H75q9GE97bMcaMcUy/UqyLlIksQ+baZtfuT4amORhh
+        VWQFdTARoB87Rtc0hoZpD/uAsAY7vc1gMRVezjHLHwm1p7QAWNOG9wksXBezVa+qDqrQeVSdDTb7
+        VSlUC6oqmXbgbUMdvM33QragBdboqUyz4mcXvEKusjgNtBqiEXAOvMjwHlyzfwXqYKWG/pj42Dwj
+        1vQUzK0GOboCQtQPShrqa+vqHelugSpUj5Yy5oU7jRmZwvSAdruhxvN5uHKPaY45JkwaZxlTqVud
+        EVsSlmNq9eG6u8KvOzdqDUp2QMyRjMkpv1hXYNjrbo3CgyakWSlgm6Y5anfYFAxU0JTmM5flayz1
+        XjfyIsHMYoreoLeG4uJqyqbRNQxy+Gbde9PUQo7jLBMCS1FUkcOOpg26TJn7Ps8SITBN8bCBjS0O
+        1iR4hboOwzKk5muNeu3i1vp+w+piVpYcpumiYOLmFcaMV5WQe4hpUQIssw7LOyL4v3/lDBOgKkdP
+        0wOV82kln6FRZ9CjsmoWkherqlOeYMVBLqucPxesThF1uyTJA3D9CcimS148whoFRvxyhRk07bpE
+        lbut9Y3OaJKrodTTrXqHNS79MejdYTnD5BUoknUXrbOMcX/8e9Q6sNlHksyYvGKid9G93trFVNW/
+        9V8+8OaZW39jtw13cKWUG9OuU++jbZgjYIcMquLt9SUHoDXANY7+mwmXkhUqaQ+I5Ai3VFCCTQ8t
+        scaLh5UiMFAeJbO9erc61COx/FOZFAkTHsuwql1fy4j/ATGhUfFuwLtY53YNej0M+mzQARqGhYv5
+        V0ZG9gH5NcEKv4Ri3UIADhIz1UvMBp/LgjF5QI5YGmGBw9HU7BP72d/XdJrj1TSqGyNdOV2LdN2j
+        1Vp3kapWKnAxEwx+RGXnUUC49RKep6vuA3AG2FAworcAkKHa/HVhBM1XBJwMyxYAkHydgSUJSkkX
+        62jjrW6vyDLRVh7o7G9V1oL1GjA+OIrumuOaOdDUogxwcw2rHG7QyByDKDBzXEW9O3LKdfR7QdOS
+        4QcGO3s3dmbErqs2Wp3d761YQ5WllqrObc3+DPQH4kFvnvNlNZlmgcE1E7pLXcGGapsWbOyF9hqK
+        xNvq9RqK90Vv90Vv90Vvv/Oit40r2Bg/fiCCp6bqg6rKZSsf8E43kaqJYBMcdG5wtEecz4m/IgMD
+        QzgYOlXTahyRqk3GNMjLEjjt4FMV6+EkFiCbHLiHcZByBMoCfmUdT+6ayu4JiKpqygPCXlBVTVXz
+        2llRdc2MvqCQasPiNcwswQyQX12uVjF3XTHbNfzdXMO2YWGb1jJmuQcew0u8GV+TbhYNXreXfn6t
+        YJObFnX1t7W8kG8x0yggvIaZ/eoGW3SbhHpXQpXG6az9EcOuBgcCq5LpqO4MDkpwTIZt+FBBkbpf
+        kJ5yQS8EekOpq0rXUP09Ygv0/hXwuhm0IqA/pTx8+vrk7PzDifqgstFQIemPKFvCqNF0rK2f1TSn
+        Z4e/nrxuUW69nIKvwrjyPW45M9iY8vAxbAkzlpI/nYKLASnmsPg5++/bxzgDo3ysvhqBfRK3va0h
+        0FmpoW8Yi5BpiegsgrCqVKGV5gbv3TDwUA5bDa7CME5D3GjVyRehCNAn03NJXvI4ryL2LtleNvSi
+        yuHUwZzy+fhaFR8S6iMHoBMkY/AO4Qlf5q0+3VruWqUukpCBwkWFVuDGm7e50W6BY4bDuAO8cNnV
+        sIWNF93L5bILFilLn8ERJ9vup+7CWyB9B4pXO2HvuflycfLX58lvc2uro772bIGuZo1uaL6ha3Vf
+        exNCuzccyD3lN+pr9PV19dbkb53V1ZGuofS16OykskxCEK6Ft5c74G1gfYW7vspt/13H/wd2F8fQ
+        FFIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:38 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['4165']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:45 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_extra_info /><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><request_avail_details
-      /><request_video_iframe /><request_source_info /><request_reviews /><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><mime_text_type>html</mime_text_type><event_token_list>6IF</event_token_list></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['928']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+097XbbtpL/8xRI95z2R22JlKivlmXXsZ1c37hJajubzf7hAUlQZEQSMgFaUV/n
-        vsl9sp0BSImUZFv22hs7VY5OTA4Gg8FgPgAMINm/f00TcsVyEfPstx/MlvEDYZnPgzgb//bDx4vX
-        +8Mffnde2OyKZdIVjOZ+5OZMFIl0bFF4AU9pnLmFYLkbC9ejgTNnwm5vLrL9fD6V3PUS7k+cj+7+
-        /tVkGo4mh6Ppx957b3+c8zAw5ZuZ/+7D5y9d5osv3aPPZv/Ln5P3xudP2dFVevE2Egfdqfv14+Xg
-        7PT1/Mjv7Z8FZth/exkWn08uxwevxfuzbDa/pMaF2X9v5e5R2j09Of5zfpkff7kcjpK88+EkG3WP
-        JrNx8tluN3iyg1hImvlMuDRn7hVN4sDJuN3eBNdScWyAUBdkxpzjT3Z7+aYLAiZ85xhEPJ9FLGcl
-        goLa9IrGCTxL+CMcW8b+hElXzqdQeZrHPgOxZUETD948wZNCMlfQKxgnx+y0DCC7Ai0r+UWew4jO
-        Qfjlk2Zu7E2h7w3QEiOkvuS5YxpGDacELrGyIvVY7gw7/RpWCVxiTRMKYnM6NZwSVMPhArRrnno8
-        adfBIGoNdf79r3r9JRz6vdJN9U69hLkBldhKGOdAfQ7/0jQInI5h9o2eAfysFNgJXcMbdE273YSX
-        LdZbCOjcTamYOP0uaEr1YodFkqDNSDWUjjXAYVoBlkgF2BXNx8wxljgLmD1luQ+aRseLwUWRr0Pt
-        y4JmMpZzl08lGDSwpjTVreAO9GYFsorRuRWjeyuGdStG71aM/jpGe717S0F2eyi5mmBXZFoTZ3vF
-        nG42ru7OuO5oXFbH3Mq4hqb1/2tcvS2Nq7czrq2Ny7rZuJZRTJvBAYh2BVTHwbAIStquB79aVNQV
-        Xh2cHr5/B6F7raSBq0LsK5r4PJs3cXXwbTfC7T1j72jnHZ5B6O32dqH38bxDp/9IodfYGdczCL1b
-        GZe1M64HN67uo4feG+Lgzgi/bYT7G5tE13igeLPT4W8bSHY6/AArqlcP6tZXJlv93QzsKTr/lclW
-        5yGXN9ZuBtY0VXP0OMubwc62nmJQuo9tbbu62dnW9rZ1x9XN4QNsLB6enB2eHm+1r/hxCgNJ/Dj3
-        E/Zom4u9nYd4DtHX3EXfR/QQj7S5uJvZPovou41tdXdpvQe3rc5ub/FJGuG2Aa6PfXtu+zI3K+tw
-        t+v36NqF84+Hnz5h4HjO2tWzdur1bGYQz0297rjOfdTtXms3KX6K8Xhl/quV6YEWnJ0nNSm+2Yis
-        x1kKWsrB79T+qU0U7qf2OJbPbqPlm+j9bnvxSU5g7qP2226BfB9af8fNiYdIDZxfHJyenm+VGjiX
-        NEnE7UmBBtfQdS8eF1O8WlQwbUJ1gO2jmFSLCc8Cnu0XE1DtBVCXq2ZOVXlZqBv2QRdF+UfjywgE
-        i7eRarCyXFW5aJZrMrFw1Z0uTU5d9GqC7PKG2ITNqxbaagwrIN4ZK1GrmgtIg94SbwPJSRyIzWR1
-        R8ryBmyJovrymqZxMq8hlSO0bLddCQ2dTE4zVDSPwbMaEJeHIfqrLa+LKNP0eerFGQucXmdhrgvY
-        w11oUJwtCXdVim0FWCKtHuJchVZozUTnKnD7vdb2ugBT+nWV1wZIIej6O5nfS+brAlSQFTaaMI3S
-        ZKEJslO0+qpv2lk3QCUCjPc1w7Z5sdkcoVrwu3bU7r8cWhkg09pm1OpYN4yase2obV6AtVelh++r
-        TDRhGqXJQBNkZ9wVQD5hwt25tZ1be9Yy37m1nVsrm//bpXCV3/7+1+ir3ZR86upV2s5l3sdlrsmv
-        fc2EYGdQO4PaGdR9DKpuRT4vMpmXCqO2a+qARbE+T5rFkgXkLdANeLpELfdv8ljGvpuzq5jN3JKT
-        UuU2Ftm4xaj5cBluaKn3cmen2CPmUEbkoBgXQhLcscT9xwpB4xbSx04JJp1uHxtahS7RBPN5FgiI
-        3gOzZ/WMBnZVqNFXt0mHJeZymzQWfNg3TLVH6uL2nIxTptD3jeG+ObwwR790jV8M42fD/AVb2lyh
-        pLsqAf0uJM3lmkw6JgjjAIYzeUiR9M1Ov2ttLRJLp0C2Fom13zHvI5JSBPp7nZQ+vvt4cXh2cPj2
-        +Mxu18AlihLDH1TKiM3IK17kGftJkHfQnZz6E5a/rCppeennOHD6J6+rksU3JrlxFnLnx0T+GsRX
-        P47lr026P9J0+ut/dEe/CiJkkWVgEmSa86Dw0VkTHtabJTmTUEmQOINRM4ZEcnJOg4TlNTKfWJII
-        EimrJV7OJywjNEmIx78CuRDsF8j4PA8ECYockXDvnswZrVMRQGWfFxIeqOBZCzvg5aSNPXjReLmI
-        YkFCWBPGV4zIHPwPQQA4NuQeC2VOA5bSfAJdnCcMwbNY7pEplREXBMaM6M3O2KcJSek49luNboc8
-        SfhMkMOE5rTG5BclwjkJc54SSryE0Qk5jPJYyJQKcgwMATdHeeso50IsKpL3+TSiGTi3PWg458U4
-        gtoiitOUKYGAjPbFhEp8noH2sjxBJhWjHHklYsp8Sf0CGCI+wOfI4wR7dj5jTMYMK9wgtPcJSCsn
-        dEbzYH8W63EHbYrHGYAPMhBMNiefoFS1egHeOp7wKzGZ17qfFn60n/ArcKUCBpSRKkSgeCMi4r/+
-        SpCuH0EhH+d0Gs3JuAAZZpLBWEUgnGu1sS5/GEMKQmYi2iNJPN0XKRQA5T3QjlzpGXQcRzlGpYUx
-        XI5BSHN2gxyazYPWQkt+FDPsk8ehE2C4QCn2lRigfzBCfgwtiMKHmYLQPUUli1FvMqq0MAOK5de8
-        CWRNbW4r5fLAEpgULXJa6byq/CGhIG0ghRr/SdlGCjoLg5qr4T7jc6j8jpbdK/MFe2hILEZe5YwT
-        HNMYRw8HVas1kBYgfJnMUXE8tLwrxFcSaZcO4YUSSWTh86cIrPWQZuSEvOG/Kyxd8KLmQQ6yOfo4
-        MucFDMeEvSQHgiQchgHEJ/F712rjiIrNZwRMuHVTq6A9R/zGVvFxig8XldP5qXI2KGIYQMFeqrrT
-        Cn1zW1TW2DvJ/KQIWHBdq+q75GSEOobdzdgNwnvDOZgKJ28zPruGHFgUmtpL8gfIGbwoUicyHkdS
-        /y+uJX5exBLzmeQ16MRhFCcBTCuvaeW8QOX4gvMNGHM0cuX0UJMoqBRLIS6AJqHebGh0EUIwcJRB
-        BO2YL/NYdWCJkbIgpjB5omqWD5NlcK3SUdCWzsQJsBU/avk441KFdpxBdAZecW45BbuAiJ0nTiTl
-        VPzSbm+u2xYwcWRBu9YqTMs43hBqj7rw8Q3LC42gY7GwGxg9NgxZaHl0MDBGQWhYXYtRs+u3vkzH
-        ELs3MmBnFCI4elAB3YHuqncbw4XzoM0rivY3lsFGCYhiOgW/IVxkRH0nYxPSRBDV91A2YHa7oRlP
-        R00GDD6GNfT7vV44GAUmZYZpmSN/1LE6xrBvBqHZ63vDbriFmsC84rJg2yvJnRt/DCW5MxN/PyXp
-        MfgYhhV2el6PUq8fWt2OHwxYf9gdeWBIVicY0l5oDrzblURcwqxnex25c9uPoSN3ZuIp6Ehgzr5a
-        s26v8NIg/tryE14EMDvPZCtj8nZVAUHdSGGTvNhX6UpYfhjtn8VcSJa6Swh2JIE52RYaUmLeqiPb
-        N3e7UjxiX7dQhvWhft4eIxzBh1IItBB+rcHA7xrdYDD0/J5pDHzfGPSsIBxafeoPb9cHWIwiyA1h
-        ur6137gzB4/hN+7MxFPwG9+DpsAKaKcp32OEKeXlKsz2qAcfb+R7Fh0NQzrweqblWVbfMkYDagwH
-        oecNvIFp+j7dXnlgMbit7tyXjUcIR/9Hjp5EjPrm+tTpwcfo94KR3w9ox+/3B2Z3BO+DAbUCy+r2
-        R33f7I2C7h30SUb59mui+zLy6Bp1Z46ehEZ9B7FMzvgulD1gKBOSykI4iZpMNkAVQuEFVNJ29S4x
-        bVPPJ2lAVYpH6kWMrLtaSgs0ddhePxdTTOK4SSxkI0d1vCFHdV3uCuBvP9bh7Q20x4xj9o3i7RAZ
-        yyJgTs9s9fBSSPlq4+60ftw3WiYWLQB2e1k/osLNOCZ2Q6Hk3wDgKXrMb7NgcXy+fFVH3XKdPtP5
-        P7NTnnZrQNXxqg14q1Ab95ndgE1pLlFNMJeo+NkEL5GLXKUHamgVRCNgH3ie4u+qaPbXoDaedtA/
-        rXJonhHr4h0YSwWyddJbVA9KGur3Zsp3bHcFVKK6tJARz/GaA7mA7kHbzYIKz+PB3DmkWcalyhGm
-        KVO5OZ3GmBGWYa7s5aK6wq8q1xLMBdsj5kBG5B2/YnjqA3PMvUW1Wqq5DqnnhnumaQ6aFZYp4hKa
-        0GzssGyBpd6rQp7HmA5K0LDbCygOrm651+qMyIc/FpWXJQ3cKEpTIRxz0BlhknxD0RJdJsz5mKWx
-        EJgneFnDxhIbk9BurpKKeJKn/lqhLh6WN0Gqn+JxJ6lTfYvmKtzGwVGapLVXu6UmzBawPAF0Gko8
-        /0HxEBRL8QaRXwjJU5arVJ7PxH8CRzkTgoPPbeFBjmtrVjSVfi42IhYVypso+kUrBpSTc7VxQf6H
-        5XyBqgVfe3ExpQsUsjAe31ytgVmRYNllEefxnfu4Wq+iF2fQ96xM/7kh/er8bFmg1F1idgcDy+ws
-        KKxjbqYxjWDK36TSMa6honErOgn3S8rGJgaWxc0KmoixqbU6QlUJ/Q4AaRDkDqa+GBn09sh/xXjS
-        K6aYMPXByDH9N8Os27mE+abcI69YEmJm9dWF2SG91/+9aKNOr2qj3MLSV48q/VnUaJRWVaQ64eE7
-        mIQDT6cSnqgdGD4Iz5J56wV4OSzIGdFujCZExSydkaXZnFAJhKcAkJxM1UkoqABdTIU+SaAdXrmd
-        RmYxHp5gmOb3obtldh0TxUAflKm14LhiDkw9L3wMEEGZxMNuM+yGmlMd6LdqhqXvvC3Sq2dcMA/T
-        kgfANXrSE4GJPsmzPaJvuy2TrOq4X6Gu11UtjGE4YLbgTjI+K9ur50UbjeJFwCY++OtceyKF9r58
-        Xau1xMMTYRg3y5t9ZYcV+gddRMoigkUQ6lCr1whuJiPKpKsLFV2/TLqW1DcmZNfoXkNhFlGJjejk
-        c0nxutT0GtHV2rOIZS7ohxu7Y74gVs/kbyDRqKJ+Lc0N+AqFWlb+Gm3ZLhm/1JOVhtprqqqUTtvp
-        puT/XbRzJatdo1y2oi+bHhydHp+dfzpWV05rBSWSvmba6GOFpsOGfl4cs1JNk5IqUWTJyTk5IB9O
-        Dw6PGzJZVrSv4gBmoXGYayHX3tzl8q4Bjhjm7p0uTmw2Faxg4+JvNpu15uA5Co/pJeE6SrOWXnzh
-        FCpovzH/OT3+x5v4r4m1UlEvqBqg9ZXMDcU3VC3XODchNGvDdMtVul0tMxeLupXO39qrdUrXtPRQ
-        7WxsZRYHIFwVLTfAm8BqdbRYJTV/QvJ/AXM6VYN/cgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['4080']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:38 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/AvailDetailTests.test_unicode_properties.yaml
+++ b/tests/interface_objects/cassettes/AvailDetailTests.test_unicode_properties.yaml
@@ -1,146 +1,119 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF92aWRlb19pZnJhbWUgLz48
+      cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNj
+      YXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21l
+      ZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9m
+      b3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlh
+      PnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVx
+      dWVzdF9tZWRpYT48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHJlcXVlc3RfYXZhaWxfZGV0YWlscyAv
+      PjxyZXF1ZXN0X2N1c3RvbV9maWVsZHMgLz48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxtaW1lX3Rl
+      eHRfdHlwZT5odG1sPC9taW1lX3RleHRfdHlwZT48cmVxdWVzdF9tZXRhX2NvbXBvbmVudHMgLz48
+      cmVxdWVzdF9leHRyYV9pbmZvIC8+PHJlcXVlc3Rfc291cmNlX2luZm8gLz48cmVxdWVzdF9jb3N0
+      X3JhbmdlIC8+PHJlcXVlc3RfcmV2aWV3cyAvPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['784']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+087XbbOK7/+xTs3HOme8/GtmRL/mi1mpukabdfaTdxp7v7R4eSKEu1JLoiFcfz
+        OvfPPsfeF7sAKdmS4yROP/Z0OpnjmZFAkABBAAQJKM4vl1lKLlghEp7/5Seza/xEWB7wMMlnf/np
+        /fRZZ/zTL+4Dh12wXHqC0SKIvYKJMpWuI0o/5BlNcq8UrPAS4fk0dHPu9Ha3OEGxWkju+SkP5m7g
+        dTrDji8+fnj7MT2bFawjnvovzyZvj4JoHL8aXn46P42ey9Pzd0fv/KGZGqvDxF88m87kkf/J/0cw
+        HB+X9uujdzR+f/7ubOIdi7//+s9L8Zs4L58Op/2F1c/9hX+2fPm3o5cnL/95+dxaHc/juE+TaJIO
+        Qjta+fEb+2/2m9PUWBxZnX84vRZ/TpgISfOACY8WzLugaaIntwuuBeQ6AKEeiI+5Jx+c3uZNN4RM
+        BO4JSHu1jFnBKgQFdegFTVJ4lvA/4ToyCeZMenK1gM6LIgkYiDAP23j1W1AWBazaCiRcPWmqM38B
+        k2qBNhgRDSQvXNMwGjgVcIOVl5nPCnfcHzawKuAGa5FSkIfbb+BUoAYOF6BBq8znaa8JBhlqqPvv
+        /23238BBTlvTVO/UT5kXUolUoqSA0VfwT5aFods3zKFhG7bT22pwUnoFbzwACbThFcUmhZCuvIyK
+        uTscgArUL86nkuYykSuPLySYECAqhfBquGs6vS3INkb/VozBrRjWrRj2rRjDqxi9q9MDHyCVPrrW
+        qAuC27yDPwDvQIsZc23Vsn6tF7DW2o0+a6U8dHrboCYOGgioTK9pBg370B2ODl8fvz0FI77S0sJV
+        xnZE04DnqzauNsNey/DurfDeCr9zKxzY11qh9c2t8N4k7k3iOzQJ42uZxNG9SdybxI9gEv2vtksc
+        f4VY7fjF2fHrk71CtfeLBStIkBRByu7jtXtL/P1bonmtJQ7u47V7k/hPm8SNymqOv5ayfkYkdWV3
+        OJ8evn59vte2cS5pmorbN4wW16hkKAg1ZsrzkOedcg6qtAbqdjXQa9VeNeqhA1h7Uf1P49NCAhMN
+        QNWo8A+hkfxMs8WT/xqMn5DjMpUlXgo2UJxEeOoaVQ+9YjBaG+RUd7JztlLUemq5aghe0VZ4dbc1
+        pDXYBm97vBCvOncPqqdUI7SAG5z6wiVlUk+WPN3qUK3LhoVeLUg09ILmqF4ZvYSRMz/JWejafVS+
+        FkghbN9NtWEapX1H1QY5Gcq1HlJ76hZIIWybRxumUdpm0gY5OfdEks9ShsL6Maf4h9vg1Rr++Pvn
+        9jR71+jy/fr/Qda/uegBL3NZVPNTG2cTsG7W57o8kSwkr0B3Qp5tUKudtEhgm/YKdpGwpQcnwACz
+        a1pCO5scDK40Hx7D4EG9q8GmcXlATCHJOVtIhvIiGK1h7FWjaOxSBh6PIsGkOxgiqW3oBk2wALZ/
+        4ZrWqD+yrTZ23ajR2yHixDArzE2ImAg+Hhqmig89DIZkkjGF3jEmHcOcmpPHA+OxYfzZMB8jpd0d
+        qnG3ZaDfhYTN/IpUbBmTN3T1NeUx7FujgbG3PFRofQd52PD7HHlU89dpbKWOp++nx2eHx69Ozpxe
+        A1yhKDG8oVLGbEmOeFnk7JEgpzCdgkL4WJDpyfm07qhlpp+T0B2+eFa3rDPDXpJH3P05lU/C5OLn
+        mXyCjwt8uEJEyDLPwSzIouBhGaB/ITxq0H5ICgaRYi5IksPSGWMiOTmnYcoK6P6BQeBLYnqBQ/gF
+        n7OcQPRFfH4Jw0Swf0P3gBehIGFZIBKeWMgK4jskDr07vJTwQAXPu8hmT/H5YM3xNE4EiZiQyQUj
+        soCwgCCgBCLAJzbKgoYso8UcJrNKGYKXiTwgCypjLggsEYE5UwnRBE1JRmdJ0G1NMOJpypeCHKe0
+        oMDWRyWcFYkKnhFK4DRF5+Q4LhIh4fREToAR4OJp0X1acCEekbfFIqY5nbEDIFTwchZDLxEnWcbU
+        lEEKHTGnEp+XoJysSJEpxRhH3ohYsEDSoAQGSADwFfI0x5mcLxmTCcMOO8XzNgW5FIQuaRF2lole
+        S1CRZJYD+DAHEeQr8gFaFb0phEzJnF+I+QommpVB3En5BbhGAYvESB2XoQBjIpLffktxvCCGRj4r
+        6CJekVkJUsolg9WIQQw3qO1DXCkKYmQiPiBpsuiIDBpgxANY8ULpDEwR1y9BxYPV2Ug5ogXbOeM2
+        QdA9oBHECcNZ+BzYBtuDMZJATRhmBKsQJDC2KAPYmoSeGypOgrqQU6VZOYxYFaYIZEodCpTC+Oo0
+        Ibrkda25qvO7FFzZBxgK9feD0vAM9BAWrlBLesZX0PmUVhObKg0EDQFzYAnyKpec4OoluE64fFpV
+        YWgB4pbpCpXDR/u5QPyGLNRTZdkPlGBiC5+floUip9o16MEuJ3BInvM0TLDuRJml6kQ6JOdwaAIk
+        liGW5FwNpN8InFBh2W5EUXwfkI8lyAlFUCSzWBKa4WarFhoc5R7T+BCDEzmmOXkBfP5y62TyFY5L
+        VrwEFZuzh+RQKGYJKIbEwpdHQpkjXxJwMd39GABbCDkwMLudgekVd4jqA8op2MN9aFFZnconTwR5
+        kQdpGbLwVqqqrkfGaEI485ztpSHPOQcfwMmrnC9vowA+A53JQ/IGlgN8PxKEJcQlVf8Ve9A7LxOJ
+        t1HkGVjFcZykIURytxE+L9FOlBaB+qNnUz4dNYqCdbEMdjhQWDShffk4xkuANNWK/o6nSbC6hotT
+        DgYXlRBBEGCZXYK/hB0dNKi+WAMeJFjsQp0+RaXPNcn1Toz7b7UXowflrt6BWI2ggRVGxsKEQhhK
+        VXgPUTJsW9INzeWltRzYpZ+FyWU3SHkZwo6Uy27OpNNTOE6SQ7wD8sIT9QLcFMRARerGUi7E417v
+        xiF6Ak7PLOw1eIBwl2MGpDcZwC8wLD8ywr7FokFo2Gwcscjy6WhkTMLIsAYWo+Yg6H5czCAo2smH
+        k1MIjXDvEjA5mLx6d3Bjdr8qeTWi832IYqcgRLlYgHMUHvJTFS02IW2E6rpsC+b0WuryverOiMHP
+        sMbB0Laj0SQ0KTNMy5wEk77VN8ZDM4xMe+iPB9EeugNh3aeS7a85dyb+DTXnzrz8AJrzBfLyFGav
+        P4HfyGL2eDQZUTC6iTmy+/5oENLBxKBsGI0jOmTWeNi/XX3wFhE8Ld5K5Pvq0Ofy8e006XM52kOf
+        rmrLd6ZQX2SBNoOfYVhR3/ZtSv1hZA36QThiw/Fg4oPztvrhmNqROfL30KVPcPDZ3xPdmfY39ER3
+        5uUP6onYpfQkE9Lo/VmshGSZt4HgRFI4q+2hKBXmraqyP7lvoBv7E//Du5FoAj9KIeKDONAajYKB
+        MQhHYz+wTWMUBMbItsJobA1pML5dO2SRIMiL4FC/tzO5Mwff0JncmZcfwJl8h+rDy9sdzL36fB/q
+        8+Wxn8Hg17ft0IomQz80+j6lIz8K+334N6D+xAjG0TBg4cDaX4d4vrcH+lw2vnlQfGeOfoTd7MvF
+        FgCA9kPLHk/oeGKNDdu04EQBkWHAgjGdjPtDu98fG8ZksL8+ySW/oz7dmY1vrk935ug/rE9asMMX
+        zzqZzoN0fJUH6YhOvk68dDCM69X9tcyqb2ollaVwUxV8tEA1QumHVNJe/S4xpddMMmpA3YplbSLB
+        qXu60m2Npgre9HO5wESflyZCthKXJzsSl6H75q9GE97bMcaMcUy/UqyLlIksQ+baZtfuT4amORhh
+        VWQFdTARoB87Rtc0hoZpD/uAsAY7vc1gMRVezjHLHwm1p7QAWNOG9wksXBezVa+qDqrQeVSdDTb7
+        VSlUC6oqmXbgbUMdvM33QragBdboqUyz4mcXvEKusjgNtBqiEXAOvMjwHlyzfwXqYKWG/pj42Dwj
+        1vQUzK0GOboCQtQPShrqa+vqHelugSpUj5Yy5oU7jRmZwvSAdruhxvN5uHKPaY45JkwaZxlTqVud
+        EVsSlmNq9eG6u8KvOzdqDUp2QMyRjMkpv1hXYNjrbo3CgyakWSlgm6Y5anfYFAxU0JTmM5flayz1
+        XjfyIsHMYoreoLeG4uJqyqbRNQxy+Gbde9PUQo7jLBMCS1FUkcOOpg26TJn7Ps8SITBN8bCBjS0O
+        1iR4hboOwzKk5muNeu3i1vp+w+piVpYcpumiYOLmFcaMV5WQe4hpUQIssw7LOyL4v3/lDBOgKkdP
+        0wOV82kln6FRZ9CjsmoWkherqlOeYMVBLqucPxesThF1uyTJA3D9CcimS148whoFRvxyhRk07bpE
+        lbut9Y3OaJKrodTTrXqHNS79MejdYTnD5BUoknUXrbOMcX/8e9Q6sNlHksyYvGKid9G93trFVNW/
+        9V8+8OaZW39jtw13cKWUG9OuU++jbZgjYIcMquLt9SUHoDXANY7+mwmXkhUqaQ+I5Ai3VFCCTQ8t
+        scaLh5UiMFAeJbO9erc61COx/FOZFAkTHsuwql1fy4j/ATGhUfFuwLtY53YNej0M+mzQARqGhYv5
+        V0ZG9gH5NcEKv4Ri3UIADhIz1UvMBp/LgjF5QI5YGmGBw9HU7BP72d/XdJrj1TSqGyNdOV2LdN2j
+        1Vp3kapWKnAxEwx+RGXnUUC49RKep6vuA3AG2FAworcAkKHa/HVhBM1XBJwMyxYAkHydgSUJSkkX
+        62jjrW6vyDLRVh7o7G9V1oL1GjA+OIrumuOaOdDUogxwcw2rHG7QyByDKDBzXEW9O3LKdfR7QdOS
+        4QcGO3s3dmbErqs2Wp3d761YQ5WllqrObc3+DPQH4kFvnvNlNZlmgcE1E7pLXcGGapsWbOyF9hqK
+        xNvq9RqK90Vv90Vv90Vvv/Oit40r2Bg/fiCCp6bqg6rKZSsf8E43kaqJYBMcdG5wtEecz4m/IgMD
+        QzgYOlXTahyRqk3GNMjLEjjt4FMV6+EkFiCbHLiHcZByBMoCfmUdT+6ayu4JiKpqygPCXlBVTVXz
+        2llRdc2MvqCQasPiNcwswQyQX12uVjF3XTHbNfzdXMO2YWGb1jJmuQcew0u8GV+TbhYNXreXfn6t
+        YJObFnX1t7W8kG8x0yggvIaZ/eoGW3SbhHpXQpXG6az9EcOuBgcCq5LpqO4MDkpwTIZt+FBBkbpf
+        kJ5yQS8EekOpq0rXUP09Ygv0/hXwuhm0IqA/pTx8+vrk7PzDifqgstFQIemPKFvCqNF0rK2f1TSn
+        Z4e/nrxuUW69nIKvwrjyPW45M9iY8vAxbAkzlpI/nYKLASnmsPg5++/bxzgDo3ysvhqBfRK3va0h
+        0FmpoW8Yi5BpiegsgrCqVKGV5gbv3TDwUA5bDa7CME5D3GjVyRehCNAn03NJXvI4ryL2LtleNvSi
+        yuHUwZzy+fhaFR8S6iMHoBMkY/AO4Qlf5q0+3VruWqUukpCBwkWFVuDGm7e50W6BY4bDuAO8cNnV
+        sIWNF93L5bILFilLn8ERJ9vup+7CWyB9B4pXO2HvuflycfLX58lvc2uro772bIGuZo1uaL6ha3Vf
+        exNCuzccyD3lN+pr9PV19dbkb53V1ZGuofS16OykskxCEK6Ft5c74G1gfYW7vspt/13H/wd2F8fQ
+        FFIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:39 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['4165']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:46 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_extra_info /><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><request_avail_details
-      /><request_video_iframe /><request_source_info /><request_reviews /><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><mime_text_type>html</mime_text_type><event_token_list>6IF</event_token_list></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['928']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+097XbbtpL/8xRI95z2R22JlKivlmXXsZ1c37hJajubzf7hAUlQZEQSMgFaUV/n
-        vsl9sp0BSImUZFv22hs7VY5OTA4Gg8FgPgAMINm/f00TcsVyEfPstx/MlvEDYZnPgzgb//bDx4vX
-        +8Mffnde2OyKZdIVjOZ+5OZMFIl0bFF4AU9pnLmFYLkbC9ejgTNnwm5vLrL9fD6V3PUS7k+cj+7+
-        /tVkGo4mh6Ppx957b3+c8zAw5ZuZ/+7D5y9d5osv3aPPZv/Ln5P3xudP2dFVevE2Egfdqfv14+Xg
-        7PT1/Mjv7Z8FZth/exkWn08uxwevxfuzbDa/pMaF2X9v5e5R2j09Of5zfpkff7kcjpK88+EkG3WP
-        JrNx8tluN3iyg1hImvlMuDRn7hVN4sDJuN3eBNdScWyAUBdkxpzjT3Z7+aYLAiZ85xhEPJ9FLGcl
-        goLa9IrGCTxL+CMcW8b+hElXzqdQeZrHPgOxZUETD948wZNCMlfQKxgnx+y0DCC7Ai0r+UWew4jO
-        Qfjlk2Zu7E2h7w3QEiOkvuS5YxpGDacELrGyIvVY7gw7/RpWCVxiTRMKYnM6NZwSVMPhArRrnno8
-        adfBIGoNdf79r3r9JRz6vdJN9U69hLkBldhKGOdAfQ7/0jQInI5h9o2eAfysFNgJXcMbdE273YSX
-        LdZbCOjcTamYOP0uaEr1YodFkqDNSDWUjjXAYVoBlkgF2BXNx8wxljgLmD1luQ+aRseLwUWRr0Pt
-        y4JmMpZzl08lGDSwpjTVreAO9GYFsorRuRWjeyuGdStG71aM/jpGe717S0F2eyi5mmBXZFoTZ3vF
-        nG42ru7OuO5oXFbH3Mq4hqb1/2tcvS2Nq7czrq2Ny7rZuJZRTJvBAYh2BVTHwbAIStquB79aVNQV
-        Xh2cHr5/B6F7raSBq0LsK5r4PJs3cXXwbTfC7T1j72jnHZ5B6O32dqH38bxDp/9IodfYGdczCL1b
-        GZe1M64HN67uo4feG+Lgzgi/bYT7G5tE13igeLPT4W8bSHY6/AArqlcP6tZXJlv93QzsKTr/lclW
-        5yGXN9ZuBtY0VXP0OMubwc62nmJQuo9tbbu62dnW9rZ1x9XN4QNsLB6enB2eHm+1r/hxCgNJ/Dj3
-        E/Zom4u9nYd4DtHX3EXfR/QQj7S5uJvZPovou41tdXdpvQe3rc5ub/FJGuG2Aa6PfXtu+zI3K+tw
-        t+v36NqF84+Hnz5h4HjO2tWzdur1bGYQz0297rjOfdTtXms3KX6K8Xhl/quV6YEWnJ0nNSm+2Yis
-        x1kKWsrB79T+qU0U7qf2OJbPbqPlm+j9bnvxSU5g7qP2226BfB9af8fNiYdIDZxfHJyenm+VGjiX
-        NEnE7UmBBtfQdS8eF1O8WlQwbUJ1gO2jmFSLCc8Cnu0XE1DtBVCXq2ZOVXlZqBv2QRdF+UfjywgE
-        i7eRarCyXFW5aJZrMrFw1Z0uTU5d9GqC7PKG2ITNqxbaagwrIN4ZK1GrmgtIg94SbwPJSRyIzWR1
-        R8ryBmyJovrymqZxMq8hlSO0bLddCQ2dTE4zVDSPwbMaEJeHIfqrLa+LKNP0eerFGQucXmdhrgvY
-        w11oUJwtCXdVim0FWCKtHuJchVZozUTnKnD7vdb2ugBT+nWV1wZIIej6O5nfS+brAlSQFTaaMI3S
-        ZKEJslO0+qpv2lk3QCUCjPc1w7Z5sdkcoVrwu3bU7r8cWhkg09pm1OpYN4yase2obV6AtVelh++r
-        TDRhGqXJQBNkZ9wVQD5hwt25tZ1be9Yy37m1nVsrm//bpXCV3/7+1+ir3ZR86upV2s5l3sdlrsmv
-        fc2EYGdQO4PaGdR9DKpuRT4vMpmXCqO2a+qARbE+T5rFkgXkLdANeLpELfdv8ljGvpuzq5jN3JKT
-        UuU2Ftm4xaj5cBluaKn3cmen2CPmUEbkoBgXQhLcscT9xwpB4xbSx04JJp1uHxtahS7RBPN5FgiI
-        3gOzZ/WMBnZVqNFXt0mHJeZymzQWfNg3TLVH6uL2nIxTptD3jeG+ObwwR790jV8M42fD/AVb2lyh
-        pLsqAf0uJM3lmkw6JgjjAIYzeUiR9M1Ov2ttLRJLp0C2Fom13zHvI5JSBPp7nZQ+vvt4cXh2cPj2
-        +Mxu18AlihLDH1TKiM3IK17kGftJkHfQnZz6E5a/rCppeennOHD6J6+rksU3JrlxFnLnx0T+GsRX
-        P47lr026P9J0+ut/dEe/CiJkkWVgEmSa86Dw0VkTHtabJTmTUEmQOINRM4ZEcnJOg4TlNTKfWJII
-        EimrJV7OJywjNEmIx78CuRDsF8j4PA8ECYockXDvnswZrVMRQGWfFxIeqOBZCzvg5aSNPXjReLmI
-        YkFCWBPGV4zIHPwPQQA4NuQeC2VOA5bSfAJdnCcMwbNY7pEplREXBMaM6M3O2KcJSek49luNboc8
-        SfhMkMOE5rTG5BclwjkJc54SSryE0Qk5jPJYyJQKcgwMATdHeeso50IsKpL3+TSiGTi3PWg458U4
-        gtoiitOUKYGAjPbFhEp8noH2sjxBJhWjHHklYsp8Sf0CGCI+wOfI4wR7dj5jTMYMK9wgtPcJSCsn
-        dEbzYH8W63EHbYrHGYAPMhBMNiefoFS1egHeOp7wKzGZ17qfFn60n/ArcKUCBpSRKkSgeCMi4r/+
-        SpCuH0EhH+d0Gs3JuAAZZpLBWEUgnGu1sS5/GEMKQmYi2iNJPN0XKRQA5T3QjlzpGXQcRzlGpYUx
-        XI5BSHN2gxyazYPWQkt+FDPsk8ehE2C4QCn2lRigfzBCfgwtiMKHmYLQPUUli1FvMqq0MAOK5de8
-        CWRNbW4r5fLAEpgULXJa6byq/CGhIG0ghRr/SdlGCjoLg5qr4T7jc6j8jpbdK/MFe2hILEZe5YwT
-        HNMYRw8HVas1kBYgfJnMUXE8tLwrxFcSaZcO4YUSSWTh86cIrPWQZuSEvOG/Kyxd8KLmQQ6yOfo4
-        MucFDMeEvSQHgiQchgHEJ/F712rjiIrNZwRMuHVTq6A9R/zGVvFxig8XldP5qXI2KGIYQMFeqrrT
-        Cn1zW1TW2DvJ/KQIWHBdq+q75GSEOobdzdgNwnvDOZgKJ28zPruGHFgUmtpL8gfIGbwoUicyHkdS
-        /y+uJX5exBLzmeQ16MRhFCcBTCuvaeW8QOX4gvMNGHM0cuX0UJMoqBRLIS6AJqHebGh0EUIwcJRB
-        BO2YL/NYdWCJkbIgpjB5omqWD5NlcK3SUdCWzsQJsBU/avk441KFdpxBdAZecW45BbuAiJ0nTiTl
-        VPzSbm+u2xYwcWRBu9YqTMs43hBqj7rw8Q3LC42gY7GwGxg9NgxZaHl0MDBGQWhYXYtRs+u3vkzH
-        ELs3MmBnFCI4elAB3YHuqncbw4XzoM0rivY3lsFGCYhiOgW/IVxkRH0nYxPSRBDV91A2YHa7oRlP
-        R00GDD6GNfT7vV44GAUmZYZpmSN/1LE6xrBvBqHZ63vDbriFmsC84rJg2yvJnRt/DCW5MxN/PyXp
-        MfgYhhV2el6PUq8fWt2OHwxYf9gdeWBIVicY0l5oDrzblURcwqxnex25c9uPoSN3ZuIp6Ehgzr5a
-        s26v8NIg/tryE14EMDvPZCtj8nZVAUHdSGGTvNhX6UpYfhjtn8VcSJa6Swh2JIE52RYaUmLeqiPb
-        N3e7UjxiX7dQhvWhft4eIxzBh1IItBB+rcHA7xrdYDD0/J5pDHzfGPSsIBxafeoPb9cHWIwiyA1h
-        ur6137gzB4/hN+7MxFPwG9+DpsAKaKcp32OEKeXlKsz2qAcfb+R7Fh0NQzrweqblWVbfMkYDagwH
-        oecNvIFp+j7dXnlgMbit7tyXjUcIR/9Hjp5EjPrm+tTpwcfo94KR3w9ox+/3B2Z3BO+DAbUCy+r2
-        R33f7I2C7h30SUb59mui+zLy6Bp1Z46ehEZ9B7FMzvgulD1gKBOSykI4iZpMNkAVQuEFVNJ29S4x
-        bVPPJ2lAVYpH6kWMrLtaSgs0ddhePxdTTOK4SSxkI0d1vCFHdV3uCuBvP9bh7Q20x4xj9o3i7RAZ
-        yyJgTs9s9fBSSPlq4+60ftw3WiYWLQB2e1k/osLNOCZ2Q6Hk3wDgKXrMb7NgcXy+fFVH3XKdPtP5
-        P7NTnnZrQNXxqg14q1Ab95ndgE1pLlFNMJeo+NkEL5GLXKUHamgVRCNgH3ie4u+qaPbXoDaedtA/
-        rXJonhHr4h0YSwWyddJbVA9KGur3Zsp3bHcFVKK6tJARz/GaA7mA7kHbzYIKz+PB3DmkWcalyhGm
-        KVO5OZ3GmBGWYa7s5aK6wq8q1xLMBdsj5kBG5B2/YnjqA3PMvUW1Wqq5DqnnhnumaQ6aFZYp4hKa
-        0GzssGyBpd6rQp7HmA5K0LDbCygOrm651+qMyIc/FpWXJQ3cKEpTIRxz0BlhknxD0RJdJsz5mKWx
-        EJgneFnDxhIbk9BurpKKeJKn/lqhLh6WN0Gqn+JxJ6lTfYvmKtzGwVGapLVXu6UmzBawPAF0Gko8
-        /0HxEBRL8QaRXwjJU5arVJ7PxH8CRzkTgoPPbeFBjmtrVjSVfi42IhYVypso+kUrBpSTc7VxQf6H
-        5XyBqgVfe3ExpQsUsjAe31ytgVmRYNllEefxnfu4Wq+iF2fQ96xM/7kh/er8bFmg1F1idgcDy+ws
-        KKxjbqYxjWDK36TSMa6honErOgn3S8rGJgaWxc0KmoixqbU6QlUJ/Q4AaRDkDqa+GBn09sh/xXjS
-        K6aYMPXByDH9N8Os27mE+abcI69YEmJm9dWF2SG91/+9aKNOr2qj3MLSV48q/VnUaJRWVaQ64eE7
-        mIQDT6cSnqgdGD4Iz5J56wV4OSzIGdFujCZExSydkaXZnFAJhKcAkJxM1UkoqABdTIU+SaAdXrmd
-        RmYxHp5gmOb3obtldh0TxUAflKm14LhiDkw9L3wMEEGZxMNuM+yGmlMd6LdqhqXvvC3Sq2dcMA/T
-        kgfANXrSE4GJPsmzPaJvuy2TrOq4X6Gu11UtjGE4YLbgTjI+K9ur50UbjeJFwCY++OtceyKF9r58
-        Xau1xMMTYRg3y5t9ZYcV+gddRMoigkUQ6lCr1whuJiPKpKsLFV2/TLqW1DcmZNfoXkNhFlGJjejk
-        c0nxutT0GtHV2rOIZS7ohxu7Y74gVs/kbyDRqKJ+Lc0N+AqFWlb+Gm3ZLhm/1JOVhtprqqqUTtvp
-        puT/XbRzJatdo1y2oi+bHhydHp+dfzpWV05rBSWSvmba6GOFpsOGfl4cs1JNk5IqUWTJyTk5IB9O
-        Dw6PGzJZVrSv4gBmoXGYayHX3tzl8q4Bjhjm7p0uTmw2Faxg4+JvNpu15uA5Co/pJeE6SrOWXnzh
-        FCpovzH/OT3+x5v4r4m1UlEvqBqg9ZXMDcU3VC3XODchNGvDdMtVul0tMxeLupXO39qrdUrXtPRQ
-        7WxsZRYHIFwVLTfAm8BqdbRYJTV/QvJ/AXM6VYN/cgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['4080']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:39 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/AvailDetailTests.test_weekday_available.yaml
+++ b/tests/interface_objects/cassettes/AvailDetailTests.test_weekday_available.yaml
@@ -1,146 +1,119 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF92aWRlb19pZnJhbWUgLz48
+      cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNj
+      YXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21l
+      ZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9m
+      b3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlh
+      PnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVx
+      dWVzdF9tZWRpYT48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHJlcXVlc3RfYXZhaWxfZGV0YWlscyAv
+      PjxyZXF1ZXN0X2N1c3RvbV9maWVsZHMgLz48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxtaW1lX3Rl
+      eHRfdHlwZT5odG1sPC9taW1lX3RleHRfdHlwZT48cmVxdWVzdF9tZXRhX2NvbXBvbmVudHMgLz48
+      cmVxdWVzdF9leHRyYV9pbmZvIC8+PHJlcXVlc3Rfc291cmNlX2luZm8gLz48cmVxdWVzdF9jb3N0
+      X3JhbmdlIC8+PHJlcXVlc3RfcmV2aWV3cyAvPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['784']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+087XbbOK7/+xTs3HOme8/GtmRL/mi1mpukabdfaTdxp7v7R4eSKEu1JLoiFcfz
+        OvfPPsfeF7sAKdmS4yROP/Z0OpnjmZFAkABBAAQJKM4vl1lKLlghEp7/5Seza/xEWB7wMMlnf/np
+        /fRZZ/zTL+4Dh12wXHqC0SKIvYKJMpWuI0o/5BlNcq8UrPAS4fk0dHPu9Ha3OEGxWkju+SkP5m7g
+        dTrDji8+fnj7MT2bFawjnvovzyZvj4JoHL8aXn46P42ey9Pzd0fv/KGZGqvDxF88m87kkf/J/0cw
+        HB+X9uujdzR+f/7ubOIdi7//+s9L8Zs4L58Op/2F1c/9hX+2fPm3o5cnL/95+dxaHc/juE+TaJIO
+        Qjta+fEb+2/2m9PUWBxZnX84vRZ/TpgISfOACY8WzLugaaIntwuuBeQ6AKEeiI+5Jx+c3uZNN4RM
+        BO4JSHu1jFnBKgQFdegFTVJ4lvA/4ToyCeZMenK1gM6LIgkYiDAP23j1W1AWBazaCiRcPWmqM38B
+        k2qBNhgRDSQvXNMwGjgVcIOVl5nPCnfcHzawKuAGa5FSkIfbb+BUoAYOF6BBq8znaa8JBhlqqPvv
+        /23238BBTlvTVO/UT5kXUolUoqSA0VfwT5aFods3zKFhG7bT22pwUnoFbzwACbThFcUmhZCuvIyK
+        uTscgArUL86nkuYykSuPLySYECAqhfBquGs6vS3INkb/VozBrRjWrRj2rRjDqxi9q9MDHyCVPrrW
+        qAuC27yDPwDvQIsZc23Vsn6tF7DW2o0+a6U8dHrboCYOGgioTK9pBg370B2ODl8fvz0FI77S0sJV
+        xnZE04DnqzauNsNey/DurfDeCr9zKxzY11qh9c2t8N4k7k3iOzQJ42uZxNG9SdybxI9gEv2vtksc
+        f4VY7fjF2fHrk71CtfeLBStIkBRByu7jtXtL/P1bonmtJQ7u47V7k/hPm8SNymqOv5ayfkYkdWV3
+        OJ8evn59vte2cS5pmorbN4wW16hkKAg1ZsrzkOedcg6qtAbqdjXQa9VeNeqhA1h7Uf1P49NCAhMN
+        QNWo8A+hkfxMs8WT/xqMn5DjMpUlXgo2UJxEeOoaVQ+9YjBaG+RUd7JztlLUemq5aghe0VZ4dbc1
+        pDXYBm97vBCvOncPqqdUI7SAG5z6wiVlUk+WPN3qUK3LhoVeLUg09ILmqF4ZvYSRMz/JWejafVS+
+        FkghbN9NtWEapX1H1QY5Gcq1HlJ76hZIIWybRxumUdpm0gY5OfdEks9ShsL6Maf4h9vg1Rr++Pvn
+        9jR71+jy/fr/Qda/uegBL3NZVPNTG2cTsG7W57o8kSwkr0B3Qp5tUKudtEhgm/YKdpGwpQcnwACz
+        a1pCO5scDK40Hx7D4EG9q8GmcXlATCHJOVtIhvIiGK1h7FWjaOxSBh6PIsGkOxgiqW3oBk2wALZ/
+        4ZrWqD+yrTZ23ajR2yHixDArzE2ImAg+Hhqmig89DIZkkjGF3jEmHcOcmpPHA+OxYfzZMB8jpd0d
+        qnG3ZaDfhYTN/IpUbBmTN3T1NeUx7FujgbG3PFRofQd52PD7HHlU89dpbKWOp++nx2eHx69Ozpxe
+        A1yhKDG8oVLGbEmOeFnk7JEgpzCdgkL4WJDpyfm07qhlpp+T0B2+eFa3rDPDXpJH3P05lU/C5OLn
+        mXyCjwt8uEJEyDLPwSzIouBhGaB/ITxq0H5ICgaRYi5IksPSGWMiOTmnYcoK6P6BQeBLYnqBQ/gF
+        n7OcQPRFfH4Jw0Swf0P3gBehIGFZIBKeWMgK4jskDr07vJTwQAXPu8hmT/H5YM3xNE4EiZiQyQUj
+        soCwgCCgBCLAJzbKgoYso8UcJrNKGYKXiTwgCypjLggsEYE5UwnRBE1JRmdJ0G1NMOJpypeCHKe0
+        oMDWRyWcFYkKnhFK4DRF5+Q4LhIh4fREToAR4OJp0X1acCEekbfFIqY5nbEDIFTwchZDLxEnWcbU
+        lEEKHTGnEp+XoJysSJEpxRhH3ohYsEDSoAQGSADwFfI0x5mcLxmTCcMOO8XzNgW5FIQuaRF2lole
+        S1CRZJYD+DAHEeQr8gFaFb0phEzJnF+I+QommpVB3En5BbhGAYvESB2XoQBjIpLffktxvCCGRj4r
+        6CJekVkJUsolg9WIQQw3qO1DXCkKYmQiPiBpsuiIDBpgxANY8ULpDEwR1y9BxYPV2Ug5ogXbOeM2
+        QdA9oBHECcNZ+BzYBtuDMZJATRhmBKsQJDC2KAPYmoSeGypOgrqQU6VZOYxYFaYIZEodCpTC+Oo0
+        Ibrkda25qvO7FFzZBxgK9feD0vAM9BAWrlBLesZX0PmUVhObKg0EDQFzYAnyKpec4OoluE64fFpV
+        YWgB4pbpCpXDR/u5QPyGLNRTZdkPlGBiC5+floUip9o16MEuJ3BInvM0TLDuRJml6kQ6JOdwaAIk
+        liGW5FwNpN8InFBh2W5EUXwfkI8lyAlFUCSzWBKa4WarFhoc5R7T+BCDEzmmOXkBfP5y62TyFY5L
+        VrwEFZuzh+RQKGYJKIbEwpdHQpkjXxJwMd39GABbCDkwMLudgekVd4jqA8op2MN9aFFZnconTwR5
+        kQdpGbLwVqqqrkfGaEI485ztpSHPOQcfwMmrnC9vowA+A53JQ/IGlgN8PxKEJcQlVf8Ve9A7LxOJ
+        t1HkGVjFcZykIURytxE+L9FOlBaB+qNnUz4dNYqCdbEMdjhQWDShffk4xkuANNWK/o6nSbC6hotT
+        DgYXlRBBEGCZXYK/hB0dNKi+WAMeJFjsQp0+RaXPNcn1Toz7b7UXowflrt6BWI2ggRVGxsKEQhhK
+        VXgPUTJsW9INzeWltRzYpZ+FyWU3SHkZwo6Uy27OpNNTOE6SQ7wD8sIT9QLcFMRARerGUi7E417v
+        xiF6Ak7PLOw1eIBwl2MGpDcZwC8wLD8ywr7FokFo2Gwcscjy6WhkTMLIsAYWo+Yg6H5czCAo2smH
+        k1MIjXDvEjA5mLx6d3Bjdr8qeTWi832IYqcgRLlYgHMUHvJTFS02IW2E6rpsC+b0WuryverOiMHP
+        sMbB0Laj0SQ0KTNMy5wEk77VN8ZDM4xMe+iPB9EeugNh3aeS7a85dyb+DTXnzrz8AJrzBfLyFGav
+        P4HfyGL2eDQZUTC6iTmy+/5oENLBxKBsGI0jOmTWeNi/XX3wFhE8Ld5K5Pvq0Ofy8e006XM52kOf
+        rmrLd6ZQX2SBNoOfYVhR3/ZtSv1hZA36QThiw/Fg4oPztvrhmNqROfL30KVPcPDZ3xPdmfY39ER3
+        5uUP6onYpfQkE9Lo/VmshGSZt4HgRFI4q+2hKBXmraqyP7lvoBv7E//Du5FoAj9KIeKDONAajYKB
+        MQhHYz+wTWMUBMbItsJobA1pML5dO2SRIMiL4FC/tzO5Mwff0JncmZcfwJl8h+rDy9sdzL36fB/q
+        8+Wxn8Hg17ft0IomQz80+j6lIz8K+334N6D+xAjG0TBg4cDaX4d4vrcH+lw2vnlQfGeOfoTd7MvF
+        FgCA9kPLHk/oeGKNDdu04EQBkWHAgjGdjPtDu98fG8ZksL8+ySW/oz7dmY1vrk935ug/rE9asMMX
+        zzqZzoN0fJUH6YhOvk68dDCM69X9tcyqb2ollaVwUxV8tEA1QumHVNJe/S4xpddMMmpA3YplbSLB
+        qXu60m2Npgre9HO5wESflyZCthKXJzsSl6H75q9GE97bMcaMcUy/UqyLlIksQ+baZtfuT4amORhh
+        VWQFdTARoB87Rtc0hoZpD/uAsAY7vc1gMRVezjHLHwm1p7QAWNOG9wksXBezVa+qDqrQeVSdDTb7
+        VSlUC6oqmXbgbUMdvM33QragBdboqUyz4mcXvEKusjgNtBqiEXAOvMjwHlyzfwXqYKWG/pj42Dwj
+        1vQUzK0GOboCQtQPShrqa+vqHelugSpUj5Yy5oU7jRmZwvSAdruhxvN5uHKPaY45JkwaZxlTqVud
+        EVsSlmNq9eG6u8KvOzdqDUp2QMyRjMkpv1hXYNjrbo3CgyakWSlgm6Y5anfYFAxU0JTmM5flayz1
+        XjfyIsHMYoreoLeG4uJqyqbRNQxy+Gbde9PUQo7jLBMCS1FUkcOOpg26TJn7Ps8SITBN8bCBjS0O
+        1iR4hboOwzKk5muNeu3i1vp+w+piVpYcpumiYOLmFcaMV5WQe4hpUQIssw7LOyL4v3/lDBOgKkdP
+        0wOV82kln6FRZ9CjsmoWkherqlOeYMVBLqucPxesThF1uyTJA3D9CcimS148whoFRvxyhRk07bpE
+        lbut9Y3OaJKrodTTrXqHNS79MejdYTnD5BUoknUXrbOMcX/8e9Q6sNlHksyYvGKid9G93trFVNW/
+        9V8+8OaZW39jtw13cKWUG9OuU++jbZgjYIcMquLt9SUHoDXANY7+mwmXkhUqaQ+I5Ai3VFCCTQ8t
+        scaLh5UiMFAeJbO9erc61COx/FOZFAkTHsuwql1fy4j/ATGhUfFuwLtY53YNej0M+mzQARqGhYv5
+        V0ZG9gH5NcEKv4Ri3UIADhIz1UvMBp/LgjF5QI5YGmGBw9HU7BP72d/XdJrj1TSqGyNdOV2LdN2j
+        1Vp3kapWKnAxEwx+RGXnUUC49RKep6vuA3AG2FAworcAkKHa/HVhBM1XBJwMyxYAkHydgSUJSkkX
+        62jjrW6vyDLRVh7o7G9V1oL1GjA+OIrumuOaOdDUogxwcw2rHG7QyByDKDBzXEW9O3LKdfR7QdOS
+        4QcGO3s3dmbErqs2Wp3d761YQ5WllqrObc3+DPQH4kFvnvNlNZlmgcE1E7pLXcGGapsWbOyF9hqK
+        xNvq9RqK90Vv90Vv90Vvv/Oit40r2Bg/fiCCp6bqg6rKZSsf8E43kaqJYBMcdG5wtEecz4m/IgMD
+        QzgYOlXTahyRqk3GNMjLEjjt4FMV6+EkFiCbHLiHcZByBMoCfmUdT+6ayu4JiKpqygPCXlBVTVXz
+        2llRdc2MvqCQasPiNcwswQyQX12uVjF3XTHbNfzdXMO2YWGb1jJmuQcew0u8GV+TbhYNXreXfn6t
+        YJObFnX1t7W8kG8x0yggvIaZ/eoGW3SbhHpXQpXG6az9EcOuBgcCq5LpqO4MDkpwTIZt+FBBkbpf
+        kJ5yQS8EekOpq0rXUP09Ygv0/hXwuhm0IqA/pTx8+vrk7PzDifqgstFQIemPKFvCqNF0rK2f1TSn
+        Z4e/nrxuUW69nIKvwrjyPW45M9iY8vAxbAkzlpI/nYKLASnmsPg5++/bxzgDo3ysvhqBfRK3va0h
+        0FmpoW8Yi5BpiegsgrCqVKGV5gbv3TDwUA5bDa7CME5D3GjVyRehCNAn03NJXvI4ryL2LtleNvSi
+        yuHUwZzy+fhaFR8S6iMHoBMkY/AO4Qlf5q0+3VruWqUukpCBwkWFVuDGm7e50W6BY4bDuAO8cNnV
+        sIWNF93L5bILFilLn8ERJ9vup+7CWyB9B4pXO2HvuflycfLX58lvc2uro772bIGuZo1uaL6ha3Vf
+        exNCuzccyD3lN+pr9PV19dbkb53V1ZGuofS16OykskxCEK6Ft5c74G1gfYW7vspt/13H/wd2F8fQ
+        FFIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:39 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['4165']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:46 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_extra_info /><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><request_avail_details
-      /><request_video_iframe /><request_source_info /><request_reviews /><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><mime_text_type>html</mime_text_type><event_token_list>6IF</event_token_list></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['928']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+097XbbtpL/8xRI95z2R22JlKivlmXXsZ1c37hJajubzf7hAUlQZEQSMgFaUV/n
-        vsl9sp0BSImUZFv22hs7VY5OTA4Gg8FgPgAMINm/f00TcsVyEfPstx/MlvEDYZnPgzgb//bDx4vX
-        +8Mffnde2OyKZdIVjOZ+5OZMFIl0bFF4AU9pnLmFYLkbC9ejgTNnwm5vLrL9fD6V3PUS7k+cj+7+
-        /tVkGo4mh6Ppx957b3+c8zAw5ZuZ/+7D5y9d5osv3aPPZv/Ln5P3xudP2dFVevE2Egfdqfv14+Xg
-        7PT1/Mjv7Z8FZth/exkWn08uxwevxfuzbDa/pMaF2X9v5e5R2j09Of5zfpkff7kcjpK88+EkG3WP
-        JrNx8tluN3iyg1hImvlMuDRn7hVN4sDJuN3eBNdScWyAUBdkxpzjT3Z7+aYLAiZ85xhEPJ9FLGcl
-        goLa9IrGCTxL+CMcW8b+hElXzqdQeZrHPgOxZUETD948wZNCMlfQKxgnx+y0DCC7Ai0r+UWew4jO
-        Qfjlk2Zu7E2h7w3QEiOkvuS5YxpGDacELrGyIvVY7gw7/RpWCVxiTRMKYnM6NZwSVMPhArRrnno8
-        adfBIGoNdf79r3r9JRz6vdJN9U69hLkBldhKGOdAfQ7/0jQInI5h9o2eAfysFNgJXcMbdE273YSX
-        LdZbCOjcTamYOP0uaEr1YodFkqDNSDWUjjXAYVoBlkgF2BXNx8wxljgLmD1luQ+aRseLwUWRr0Pt
-        y4JmMpZzl08lGDSwpjTVreAO9GYFsorRuRWjeyuGdStG71aM/jpGe717S0F2eyi5mmBXZFoTZ3vF
-        nG42ru7OuO5oXFbH3Mq4hqb1/2tcvS2Nq7czrq2Ny7rZuJZRTJvBAYh2BVTHwbAIStquB79aVNQV
-        Xh2cHr5/B6F7raSBq0LsK5r4PJs3cXXwbTfC7T1j72jnHZ5B6O32dqH38bxDp/9IodfYGdczCL1b
-        GZe1M64HN67uo4feG+Lgzgi/bYT7G5tE13igeLPT4W8bSHY6/AArqlcP6tZXJlv93QzsKTr/lclW
-        5yGXN9ZuBtY0VXP0OMubwc62nmJQuo9tbbu62dnW9rZ1x9XN4QNsLB6enB2eHm+1r/hxCgNJ/Dj3
-        E/Zom4u9nYd4DtHX3EXfR/QQj7S5uJvZPovou41tdXdpvQe3rc5ub/FJGuG2Aa6PfXtu+zI3K+tw
-        t+v36NqF84+Hnz5h4HjO2tWzdur1bGYQz0297rjOfdTtXms3KX6K8Xhl/quV6YEWnJ0nNSm+2Yis
-        x1kKWsrB79T+qU0U7qf2OJbPbqPlm+j9bnvxSU5g7qP2226BfB9af8fNiYdIDZxfHJyenm+VGjiX
-        NEnE7UmBBtfQdS8eF1O8WlQwbUJ1gO2jmFSLCc8Cnu0XE1DtBVCXq2ZOVXlZqBv2QRdF+UfjywgE
-        i7eRarCyXFW5aJZrMrFw1Z0uTU5d9GqC7PKG2ITNqxbaagwrIN4ZK1GrmgtIg94SbwPJSRyIzWR1
-        R8ryBmyJovrymqZxMq8hlSO0bLddCQ2dTE4zVDSPwbMaEJeHIfqrLa+LKNP0eerFGQucXmdhrgvY
-        w11oUJwtCXdVim0FWCKtHuJchVZozUTnKnD7vdb2ugBT+nWV1wZIIej6O5nfS+brAlSQFTaaMI3S
-        ZKEJslO0+qpv2lk3QCUCjPc1w7Z5sdkcoVrwu3bU7r8cWhkg09pm1OpYN4yase2obV6AtVelh++r
-        TDRhGqXJQBNkZ9wVQD5hwt25tZ1be9Yy37m1nVsrm//bpXCV3/7+1+ir3ZR86upV2s5l3sdlrsmv
-        fc2EYGdQO4PaGdR9DKpuRT4vMpmXCqO2a+qARbE+T5rFkgXkLdANeLpELfdv8ljGvpuzq5jN3JKT
-        UuU2Ftm4xaj5cBluaKn3cmen2CPmUEbkoBgXQhLcscT9xwpB4xbSx04JJp1uHxtahS7RBPN5FgiI
-        3gOzZ/WMBnZVqNFXt0mHJeZymzQWfNg3TLVH6uL2nIxTptD3jeG+ObwwR790jV8M42fD/AVb2lyh
-        pLsqAf0uJM3lmkw6JgjjAIYzeUiR9M1Ov2ttLRJLp0C2Fom13zHvI5JSBPp7nZQ+vvt4cXh2cPj2
-        +Mxu18AlihLDH1TKiM3IK17kGftJkHfQnZz6E5a/rCppeennOHD6J6+rksU3JrlxFnLnx0T+GsRX
-        P47lr026P9J0+ut/dEe/CiJkkWVgEmSa86Dw0VkTHtabJTmTUEmQOINRM4ZEcnJOg4TlNTKfWJII
-        EimrJV7OJywjNEmIx78CuRDsF8j4PA8ECYockXDvnswZrVMRQGWfFxIeqOBZCzvg5aSNPXjReLmI
-        YkFCWBPGV4zIHPwPQQA4NuQeC2VOA5bSfAJdnCcMwbNY7pEplREXBMaM6M3O2KcJSek49luNboc8
-        SfhMkMOE5rTG5BclwjkJc54SSryE0Qk5jPJYyJQKcgwMATdHeeso50IsKpL3+TSiGTi3PWg458U4
-        gtoiitOUKYGAjPbFhEp8noH2sjxBJhWjHHklYsp8Sf0CGCI+wOfI4wR7dj5jTMYMK9wgtPcJSCsn
-        dEbzYH8W63EHbYrHGYAPMhBMNiefoFS1egHeOp7wKzGZ17qfFn60n/ArcKUCBpSRKkSgeCMi4r/+
-        SpCuH0EhH+d0Gs3JuAAZZpLBWEUgnGu1sS5/GEMKQmYi2iNJPN0XKRQA5T3QjlzpGXQcRzlGpYUx
-        XI5BSHN2gxyazYPWQkt+FDPsk8ehE2C4QCn2lRigfzBCfgwtiMKHmYLQPUUli1FvMqq0MAOK5de8
-        CWRNbW4r5fLAEpgULXJa6byq/CGhIG0ghRr/SdlGCjoLg5qr4T7jc6j8jpbdK/MFe2hILEZe5YwT
-        HNMYRw8HVas1kBYgfJnMUXE8tLwrxFcSaZcO4YUSSWTh86cIrPWQZuSEvOG/Kyxd8KLmQQ6yOfo4
-        MucFDMeEvSQHgiQchgHEJ/F712rjiIrNZwRMuHVTq6A9R/zGVvFxig8XldP5qXI2KGIYQMFeqrrT
-        Cn1zW1TW2DvJ/KQIWHBdq+q75GSEOobdzdgNwnvDOZgKJ28zPruGHFgUmtpL8gfIGbwoUicyHkdS
-        /y+uJX5exBLzmeQ16MRhFCcBTCuvaeW8QOX4gvMNGHM0cuX0UJMoqBRLIS6AJqHebGh0EUIwcJRB
-        BO2YL/NYdWCJkbIgpjB5omqWD5NlcK3SUdCWzsQJsBU/avk441KFdpxBdAZecW45BbuAiJ0nTiTl
-        VPzSbm+u2xYwcWRBu9YqTMs43hBqj7rw8Q3LC42gY7GwGxg9NgxZaHl0MDBGQWhYXYtRs+u3vkzH
-        ELs3MmBnFCI4elAB3YHuqncbw4XzoM0rivY3lsFGCYhiOgW/IVxkRH0nYxPSRBDV91A2YHa7oRlP
-        R00GDD6GNfT7vV44GAUmZYZpmSN/1LE6xrBvBqHZ63vDbriFmsC84rJg2yvJnRt/DCW5MxN/PyXp
-        MfgYhhV2el6PUq8fWt2OHwxYf9gdeWBIVicY0l5oDrzblURcwqxnex25c9uPoSN3ZuIp6Ehgzr5a
-        s26v8NIg/tryE14EMDvPZCtj8nZVAUHdSGGTvNhX6UpYfhjtn8VcSJa6Swh2JIE52RYaUmLeqiPb
-        N3e7UjxiX7dQhvWhft4eIxzBh1IItBB+rcHA7xrdYDD0/J5pDHzfGPSsIBxafeoPb9cHWIwiyA1h
-        ur6137gzB4/hN+7MxFPwG9+DpsAKaKcp32OEKeXlKsz2qAcfb+R7Fh0NQzrweqblWVbfMkYDagwH
-        oecNvIFp+j7dXnlgMbit7tyXjUcIR/9Hjp5EjPrm+tTpwcfo94KR3w9ox+/3B2Z3BO+DAbUCy+r2
-        R33f7I2C7h30SUb59mui+zLy6Bp1Z46ehEZ9B7FMzvgulD1gKBOSykI4iZpMNkAVQuEFVNJ29S4x
-        bVPPJ2lAVYpH6kWMrLtaSgs0ddhePxdTTOK4SSxkI0d1vCFHdV3uCuBvP9bh7Q20x4xj9o3i7RAZ
-        yyJgTs9s9fBSSPlq4+60ftw3WiYWLQB2e1k/osLNOCZ2Q6Hk3wDgKXrMb7NgcXy+fFVH3XKdPtP5
-        P7NTnnZrQNXxqg14q1Ab95ndgE1pLlFNMJeo+NkEL5GLXKUHamgVRCNgH3ie4u+qaPbXoDaedtA/
-        rXJonhHr4h0YSwWyddJbVA9KGur3Zsp3bHcFVKK6tJARz/GaA7mA7kHbzYIKz+PB3DmkWcalyhGm
-        KVO5OZ3GmBGWYa7s5aK6wq8q1xLMBdsj5kBG5B2/YnjqA3PMvUW1Wqq5DqnnhnumaQ6aFZYp4hKa
-        0GzssGyBpd6rQp7HmA5K0LDbCygOrm651+qMyIc/FpWXJQ3cKEpTIRxz0BlhknxD0RJdJsz5mKWx
-        EJgneFnDxhIbk9BurpKKeJKn/lqhLh6WN0Gqn+JxJ6lTfYvmKtzGwVGapLVXu6UmzBawPAF0Gko8
-        /0HxEBRL8QaRXwjJU5arVJ7PxH8CRzkTgoPPbeFBjmtrVjSVfi42IhYVypso+kUrBpSTc7VxQf6H
-        5XyBqgVfe3ExpQsUsjAe31ytgVmRYNllEefxnfu4Wq+iF2fQ96xM/7kh/er8bFmg1F1idgcDy+ws
-        KKxjbqYxjWDK36TSMa6honErOgn3S8rGJgaWxc0KmoixqbU6QlUJ/Q4AaRDkDqa+GBn09sh/xXjS
-        K6aYMPXByDH9N8Os27mE+abcI69YEmJm9dWF2SG91/+9aKNOr2qj3MLSV48q/VnUaJRWVaQ64eE7
-        mIQDT6cSnqgdGD4Iz5J56wV4OSzIGdFujCZExSydkaXZnFAJhKcAkJxM1UkoqABdTIU+SaAdXrmd
-        RmYxHp5gmOb3obtldh0TxUAflKm14LhiDkw9L3wMEEGZxMNuM+yGmlMd6LdqhqXvvC3Sq2dcMA/T
-        kgfANXrSE4GJPsmzPaJvuy2TrOq4X6Gu11UtjGE4YLbgTjI+K9ur50UbjeJFwCY++OtceyKF9r58
-        Xau1xMMTYRg3y5t9ZYcV+gddRMoigkUQ6lCr1whuJiPKpKsLFV2/TLqW1DcmZNfoXkNhFlGJjejk
-        c0nxutT0GtHV2rOIZS7ohxu7Y74gVs/kbyDRqKJ+Lc0N+AqFWlb+Gm3ZLhm/1JOVhtprqqqUTtvp
-        puT/XbRzJatdo1y2oi+bHhydHp+dfzpWV05rBSWSvmba6GOFpsOGfl4cs1JNk5IqUWTJyTk5IB9O
-        Dw6PGzJZVrSv4gBmoXGYayHX3tzl8q4Bjhjm7p0uTmw2Faxg4+JvNpu15uA5Co/pJeE6SrOWXnzh
-        FCpovzH/OT3+x5v4r4m1UlEvqBqg9ZXMDcU3VC3XODchNGvDdMtVul0tMxeLupXO39qrdUrXtPRQ
-        7WxsZRYHIFwVLTfAm8BqdbRYJTV/QvJ/AXM6VYN/cgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['4080']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:40 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/BundleTests.test_bundles_count.yaml
+++ b/tests/interface_objects/cassettes/BundleTests.test_bundles_count.yaml
@@ -1,1051 +1,1010 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48ZXZlbnRfdG9rZW5fbGlzdD42SUY8L2V2ZW50X3Rva2VuX2xpc3Q+PHJl
+      cXVlc3RfbWVkaWE+c3F1YXJlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPmxhbmRzY2Fw
+      ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X29uZTwvcmVxdWVzdF9tZWRp
+      YT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X3R3bzwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRp
+      YT50cmlwbGV0X3RocmVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZm91
+      cjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X2ZpdmU8L3JlcXVlc3RfbWVk
+      aWE+PHJlcXVlc3RfbWVkaWE+bWFycXVlZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5z
+      ZWF0aW5nX3BsYW48L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+c3VwcGxpZXI8L3JlcXVl
+      c3RfbWVkaWE+PHVzZXJfcGFzc3dkPmRlbW9wYXNzPC91c2VyX3Bhc3N3ZD48dXNlcl9pZD5kZW1v
+      PC91c2VyX2lkPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48cmVxdWVzdF9jdXN0b21fZmllbGRzIC8+
+      PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:15 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['778']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:15 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['365']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:16 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['449']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:16 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['1148']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:16 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order><crypto_block>E7--NuwIhns8SF9pSFmOCtayGoPi5orsAykdVtQtCufnKnVXd5ijHtnqR7hewEY9Siu9mKWZXgSi50wUnsm6QPTTn5Ap3rEh2y8qt7LQOigLgEgeiLH4ylijiJOz3cCcGHfmz-mr55XI7fNrF6K5mYhYQ3qn1nCceIO3_pGh-y2ODATK_1unwgfaRcvmf9rRBGVuoIht5KuL4JvyIf1HGwjOVpnEZgHPJm7kxU7hRzZCGSznxEZHloNsR7I2pTbq40t7v2mLo1javANm8iUGKktt-5o16BpnLLteyP0yqrtW48EZlb91SwCaca-PJX0S8BvzKCatNcVD_hETlolGxPekOoYcRxyhOS0oqh4PNL4fG5MfxXXjHxpdCbQvBrDibivFS6vhbjmFeBcQYWikaldIWXGQFooHSH2dWMs_BXrsAz6-j8VMn40F2LZish9H3g6jBjVkrnayZ4NMPTq5FtXcdK_5L7WFk2ASLauJCqJowO_bV8X2sPX_At8097h3QpXw1Kh0OkgxfUXvzDHbFI_bN0XSMiJ0al9y_p-VXab83-6hG9eHDURd6DtENaA6ZdPR1b2kCR_toknr_BpFKcDNzxpBDj9-GWfRRbpiCUM9rPYDDkijx5sFQiucuV4RNL_xRMwwjtm79e8Q_Ffs_Rbj0MXC_rEfuYOIlmhROtFCXJpXG4CNo46bV1NKHU8emAOPjTy5eN5yHKnfgvMsrKq0Ix6-yFmDNxXSz4pazVchj_p8eOwdiIe_aY0Ybh9RJBrav76RZUsxDdWqMKRqoWJyL_--Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>k0--5q_Eg4_-x1Nz1FPUkY_jXomw7H7E1_PjxiUKNYUK3emm0ERjusgvnWUYFQqZHjDGEekx61hC9iIriru1LpexlQdiFWf9oohhZR3m54tmVkLEMIItGP0eGhqQULniBgRbrSIgFusujEyS0Rw91TvO3pqX8rgNeFy0FDAL-H3GFetfBUfLnD1Zi-94KcFBeU0CKwDSXAHtxFWU5WZiFJ-wMeIriNlK_uoAMR58EAI8VqC-Z</discount_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></create_order>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['1384']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61Y23arNhB971e456UPLQGM7eCzKF2O7cSJr8eX2M4LC4NsEwMiSPj2O/2TflkH
-        JAw47urpJQ8J2rMljUaaPVK0346eW9qjkDjY//WLfCd9KSHfwrbjb379Mps+CuqX3/QfNCtEJkUG
-        Dm0UGiEikUt1jUQrG3um4xsRAdghxsq09RMimnjbpFlRGMLwp+zLgLmQvlkFmliEMsbatCgOdVmS
-        chwOZiw/8lYo1NVyLcfiYMYKXNNCRC/nOBzKcTChBjl5K+yKeThEHNX/+D3fP8MzFPqFp4BiY+Vi
-        a6fPDEHY74J1fdesB7PqcCVsQry2Zfp0sAaj5buCLPKutJZy7f3bbigt535r7027WzJrrduLozVr
-        dk4fS7e36ODFYycc7pzm49ZS3pUK8YYtuTYvnxfl1+FUmPq78NR4f1EHctUZHdQP1HHnZ9I9P66X
-        4F3eJ41tJsU75OvtsiBUUadq7KMoaLxvvlmbRefQD6aovqh/bCZueSm5i6Bq4f1hJhNSeZ4vHxrC
-        eKYaG2XUi9Tn7nmDwrOhdFxJUfCz8NpvW+et1Gjuh/35Uq2co6qC5s11Y9NYlPeV+5O6eXMx7TkV
-        ggeDtUqXiO4WH294JAzkrdudvewOb/ZqLjUnR1SbnTyzbb9PFuH5MJSGRms4HlvzoHZ8RuOHD2Oz
-        O1bmUX359jIiw261idqCGTwaPeXQDOyPLpooo5qhfHtr7MevU3v89BBNzhNh0XkJXmsR7ftC1OvK
-        C9MJBpFKW8+NoTto9NWn1pM1Wi7HMJJihB0Htu5bf9h7c04P/frD1vJPvaemOnVmw6k5PE4n87ra
-        wXar1Yx6HyevLffnlve6mGxrxxfyGvlWxaOjxWhwdO+FN03Mh5/tha7ZiAQmtbYGfFh6E7susmhp
-        HWKvRLcI8tSPkCYWWVknD9EttnNAkkjN4cMw14clV65JqC7fVQsMgP6jK3H+m9TUB7MpzJ/jpYaM
-        Sk8B0i02fo6YwLn2ZXEOsXDkg4cW9laOj2y9XL+LpSFtXihsrZPprNUeTGGoApyxEtcnNLKRT0sh
-        yFyOypblYwOvDQISSHRZE/NNbqOOtUN5awpoMS0IHQvp5VrsZtYG/QytrRlukK4klkszc0DXEEQa
-        /pggwMzx9lwTsxYzJG62QcZPhy0KEScw51fOJgqMvelGiGloHtAsh3LBdbFvY8iEHYTyAjJ7MlAv
-        sXMjG9pyTUL4H8aHo2HS2IEcxu1Jl2nRzoaB6pCUCjZcUj+KUBxEiI2xQ6d0BjGJZArGpYhT054X
-        pDBexrsx5M6xye1h2UK4vYBllGQtj6bnuKccia1QzOYV06DF2xvyMCdBzwMXc9J/5jsU2aUuFGWo
-        qhmV70LowGmDqrx30MEIUGjFJ4aVy5smzY5reWj6G2Qg3+Ztvj/RLyVZpdtSI9pEhJbKkgwFNSMw
-        bkQtOORrgqiu1OKJrtGMRpAFBwcyo3IvVytVqcBOjYx+gh/PsyGhYVJJlVXOvOCwuVitSbKRwKZv
-        Q5p5KKELkirI6lSuf1Wkr5L0syR/jWe63YGPex0B1ibUDOmnmJRlCEYDEtf9P0NSk8s1pfLdIamU
-        5X8UkopQlv9NSHgIEulh5zHW8XGj2W2PNTEHc0oShr5JIZEOpQcchT76iZQGsJzQBBkMf0w7sXix
-        b8fWa8+PqQVaHHfhlONMSPIgZ4B7NCK66+wvdg6lBFZkxLSd1BLieIGLuDCn/ViVYd9RQJDrwlSE
-        Fnxsf/bxr3yP8e4sj4s3xt4gbLAi6JrUiQuPXk1K8KWpgRhv2Kcg3cmx6QJoYtZ/axID6g0k9pro
-        PtbEAhBrYVxukH0RQd7UPPNohJHvQ1jZ/stlOBqfUM0DzbzBu0Y1HyEbdjeAcxPBfTg+S4k/t3BO
-        jqDUwqMjR0sRRojXgEPP9KFUJu5/QrX4ps5qYlMelyrTgSZeoFTgoZLSmG3sPF3iBfga18gWJ/K4
-        ZsthT5giphE410BPBkdHODqI0Hi4HJxymGyAvTQ5EYq80hsK8YXKkiC5QPEbSqPVa48n83avN9HE
-        nIGT2AXFtF0UQlrN4SCRlMbLC78k/KtshNLipQ+lWB5yTa0Q7Uzx5sgGRbyPq8T/r4j3IPz/QBHv
-        PyniX6VonBsBxi6/uSWbfIXFGeM6Xlxtk3OZa/6d0N5/r9AmR4p5JzTqDTiyHOAWYuwd4qxcfgyv
-        QcbKFI6dUJAxfjt85V0ySPucwMXkjX+zjbu/U6TSqK+JGcSs263nwa1FritJAc9jbL4sJ+O7Lbz2
-        Yb3J7PECr6A8J55DLCDZ0uI9gbvLR4TIReF9fIGQzW7T1xSNSXwuAs3ncbPXjt2+MhSo7KoVwGpK
-        lhNaLip24NHA1HSNq6fHFchJV6+Gz2CBl3tB3II59/o1cY2mtOLL4hr8bl3hz1Lx1r9//gSe8Zbz
-        OxIAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1828']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:17 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['108']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:17 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6L9</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['778']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1YW2/bNhR+368QgmEvq6OL7xmrImgu6Jo0bZqkyJNAS7StWKJkXmzr3++QlCzJ
-        cecGaIdha15ifufjOTwXUodEbzZpYq0I43FGXx+5x86RRWiYRTGdvT66v7vojI7e+L8gsiJUBJxg
-        Fs4DRrhMhI+4nERZimMaSE5YEPNggiO/IBzZ+0UoZEUusmCSZOHCvw86ndUin44Xb8f5ff9m0pmx
-        bBq54nIdfvj4+NQlIX/qnj26g6dPixvn8Qs9W6V37+f8tJsHm/vl8PbqojgL+53byJ0O3i+n8vHd
-        cnZ6wW9u6bpYYufOHdz0WHCWdq/enX8qluz8aTkaJ8z7+I6Ou2eL9Sx5RHZrTSiKucA0JDzAjAQr
-        nMSRTzNk78NNVHwECA4gZsQ//4LsemQEEeGhfw4hLtZzwkhJ0CiaxDOZK22S+H1kN4cojEVh9CSY
-        Bysyw7wjIbQ1biha0xXm1oOilHKjPoSZvPxnpog5wUItooGVcj3lri03aiB7OpVGnc5vG0JlYSxI
-        UVmwoQZqUJVKSa1mbpGWvpq3R2WIJxA7sV+z8aWmtOCapT16a1jWbzjN/7AeMIuJKBpzjNt2vRi7
-        imTGRcAwnYHKFG9AeTqJKYn8kXPsILsFaQKsVOQsDok/7FeMGjMUCb5gBiprxhZCqQryjpUmpAnP
-        rLQwQ9mx0oIQzQIOOz4hKl7/TReXElOhtkaWCzjrIJl6EwcV7rvI3kF2Gd5BRvcgo3eQ0T/IGDxn
-        2M/d0zkMQskYHOhAqX6ZHSF5BFXdgmrGFIciY77rOA1OCdYsKtMJYf6o12SVYM3KEwynpordLtTg
-        qJrjRTrJErsJw0lrUP/X5vQaRvaul/ZXSvln+v8f6W/mPMwkFWzrsRI2gK1Yn/b3NBYksj4LLAi3
-        sql1mhI4WnA9yXwUIpAb/QGhUTk2n05JXlnuWMytP2VSWJ7jQqJqsWFKEQbZdMqJ8Dte31MR3sVr
-        IidhRiPuu73BaDz2Bi12JTT0Av7SNIp8ZdYZuuOSucXhu5uNBo4baBjTKBBxSjS94ww77vjO8066
-        zonjwPBEWdo/odS7GwEzhhaJiVZM5vKV5blcWKdwUCffOSiuN+453xyUnue+KCi9jufeeSoiLwtK
-        GQTTMetKuzq9OL++Pkd2AyvlZfNmXZA0JVbFMLExv6HPHFyNK8m26wwSOOSyup9rgiUjJVGMocyx
-        PhJgZ81hb/iRu9701t2+nKRRvDkOk0xGU5ZRcUxV36Q5KKYQSQkbDT7CeUJUdFniz4XIT2z7bzXY
-        HL63JLIbS7DJRgSwq4Rrn3+xPc/ZuG7/+CmfQTj32kEUp6rrhUzC4sE5PUY5FnP/Zfr1FPQ1X/j3
-        dWavK1zmecYED5TB6m7UhNoMvoei+s9WRv/N6R06zqbrOIfTm2K2lOSFyW1p/9HJbRn7mVyIiNuD
-        cu99Q3I59CPshbltKf/RuW0Z+5nb33nBBUmDGlGOJDFh35DrkvmCbB8y90Ozf8j4P1wN0C4Iyf0k
-        Xm2/4iVUEeQEugtsV2ORLQht9gQGqKRFDimJ1dqhNwkXqnYaEjQjmWpewHyC4cIgoRXpDo5dxxv0
-        4fayxVCS0Zn52VEfOHfoDYbQP9UwsmtVc8wDuHflhE25fi1rAerJR13VSbR96ymH+nGASUqhbTGd
-        lOuV7wMtVF/vW8i4vOC3aZSQCJqnHBowlULVlOnl7MNLsmRY7cIGrUIMQbmQsVQ9/ZnVP0ORur7o
-        nu7Dw2jsOpCXLVK9YlWvh8Ei9fUDxx4c8Xm21pqNN6aC2hjimWQhMS3ktoCB1oArjmnAQW591gVv
-        3VCyZZoOU7/NMrKKiTYSqtfMIVxA9+EIikiWJq4vry9vTz+cXT3AVbSGS4rWDRTrEhriyGo8TTbk
-        ZVVu90T7afkvely8kpcWAAA=
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1442']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:17 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6L9</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['365']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+2dW3OiyhqG7/evoKZ2rattBESBtVis8px41nhIvKEQOkrkJA0q+fW7oVEwOmsy
-        KacmKrmJvP3S0P21/T3dMSL8szV0Yg0cqFnm39+oO/IbAUzFUjVz/ve30bCW4b79I/5HUGUXSK5m
-        AMmyXWSFkgOgp7uiAL2ZahmyZkoeBI6kQWkmq6IPoJA9XSQojm+7ljTTLWUpQimT4V+alLtcaZWy
-        /qbAyoin8ltqxClW0ZznKJWc9gZup7Q15uZ2ts1s6YJbrFQ5Q8lvRs9tr1VZNTRKm6rbMT0kuXHB
-        topVnVXGU41dwpxJL42marxVxj2WaTjerDmBOue4/sOm9Dqo8xmlz1YfpELGyXSni+XQ7cmsXn8x
-        J93C7LWkTe38bCpkD+5ZMAFQJRXYsuN6DpCCzhFNS8ie0oWFDCUbOC+SKRsAhr53kuBB1N1Y0TWI
-        OhWsgRn/kh0gSygmQKxOhGx8hAtUABWxikLobxbAAZEhVIWZNvdsaS3rHhDzQjZ5KCia6+N6dHQ7
-        azCXYcZDUYt1bAlrasmQGAeWqBxXr6AzYfQLn+IugOwGN5HQovLwlOFhOa4GDYxwlODqwqFzKAkQ
-        yI6ykJbA310hi4ZXLAajMLLuztwrB/XFvhNVKvIM9Z17umbclthyIMeusEVl7CL+kA37L2IsOxpw
-        /cQ5uNnZ+Gayu560oCs5sjlHVRryFlVuzDQTqCJH3pFC9kAKDehOXdvRFCCy+Z0j1rDFQ22RHVRl
-        7NhLghF08rurJKXQcHSVAw1b3l3lQBJMSwqGuA6C/rrOJq482XSDt0Y0QYoCep9pqrTTRUrIvlPe
-        O+gfOnI/dDA/dOR/6CgcO7LHzQtjKCme46CEgSy7V/gd4UEVjeoDKXa8yIprOSJFkglPJMYu0zNm
-        wBE5JumKxNhl67KC5lA64YmkhCcYc9A3ZpaeTcpojsaq+N/k6bEsZN+3MvudoZyG/zbCn4y5Ynmm
-        6+xbHBQmhH1xONuPTM0FKvHoIiaAhPVCFA2AphY5PgknhRC08FWBqUbHOHV64H8ExbsLouHpPkGT
-        FApUXIydnqtI1ssLBK6YofN00MPv9dgIgWKZKhQppsDxPF04cO8Ksd1HP4ahqmJwWZKl+Mi511He
-        tbgCSYXQI8mmGtJiaM+QbIbihzT9Z478kyTR4Z/BlU6fENX7vgfwMXQRWR30ycL7H0FT0CWKaKLW
-        z9wpFM0z5Ic7haGpn+oUJkNTQzrokZ/rlKgTQjbEI61VrFXb7aqQTWhReQRvRA0YBiB2Dtw3+LWm
-        ioUWvytBR5Guo0nOinkuKUYOdCOuB0VdW+/LI2lnQPwvu3J2d+z6NhChZth6sJZQlgFHJUqEObCC
-        hsuioMtosvFQM3KFO4qkC3k08+01QbfMOX6Zoaj8HcXSBRb1fSwL2biqgLXRnB3AdQzfeyHAxSDN
-        A3XPidFhCBaOZ5oBmodRoOiILQ7UEA0OFD6Cg0PbT60ZsOg5cjDZJmw7BRuCJliOIZuIUMK7P1KF
-        YOoLx0NnzPEUieK8V3YErKIVR2CWloYYwtEJXYALa4MXKGFr8PLuUBOghWgI4OEHtiioALooLEl5
-        58FvXlROPPrQBQbRNcHeiUdnuGR0wFoD4UWUYCXEouR1ShfQIPKiS7Tr7fqg2Km0xiiNxXJkCetG
-        FqKO3kwqkVjWJMqjUXmDSX3X8IMxpMjKAo2rHXfDoK4jLV26XG4Tb26Y3yi7pkuXmw5/MuaXg9Df
-        o9RwD9Wy9Cj/hETyTgvgTteMYOEVMlTi8GxkHvIPvrtMjx0gvoqEqARKaw1qMz1ipvcidsWgjHHK
-        WgJTXGYymemSaUGz+6Y+kfdmbdCdkYUWt2yDlsqXigZV3DTL45U2oTLUtNJ0nJHNDrpVrlndep1q
-        Z2s9PUdXxDVGtSPWjnaTi4PW3rFXhSOYPQTZ8K8A4dDg7kiS6LWFbCzh0sXCMCAa2SQZxj6p4cvF
-        fJqCRgoaaaa5skyTgsZNh/+3gEaOzF0oaHxsX/QQNB7PDBrNbrn04tOD8oRcvFXHevO+Me9UWvmu
-        8zCudeubV/J5NehXVxnLtNiWBifG9rHBfxQ0WsVh9QecEW6ufQ80KPIu9++kQedS0khJIyWNW0s1
-        KWncdPhPk0bN0RBp0Kb6i0iDI5mfIA36i5AG/bktjeGZScOuPYEXuedseNvqDZoTrTRYm8/DGfko
-        kW2nP9c9huPWGzixxkqp39tun3jNZ9MtjUvMwilopJnmSjJNCho3Hf7fBBr8hYLGZ7Y0RmcGDVjp
-        yxulyikVD+btufTUnT73Wr0RszXol6bx1mOsVv2ltYD2djh1KuXKY/3B+vDfTtItjS+VhlPSSFPN
-        laSalDRuOvynSeNRdhFp5JxfRBpMocD9BGnkvghp5D63pTE+M2k496/UfaXelOwO7ysQ9EvrokQ3
-        Wv5TrU/65kSbbVZrU3l2nmsTdVV2c8pr1y+kWxqXmIVT0EgzzZVkmhQ0bjr8vwc02PyFgsZntjQm
-        ZwYNauWp5nSqdQbKpjZx+3V7CBWnsip353m5IdutjbMYFGvdwoKqVdXFU7thqV76KY3LTMMpaaSp
-        5kpSTUoaNx3+75CGZyLSYNzFryGNfD5H/wRpMF+ENJjPbWk8nZk06hV/YXpbhprlGKXo9EavtXKF
-        XmTgs7m9RzC0VceZfuu5p77de/7SWLqNjVxMP6VxkVk4BY0001xJpklB46bD/3tAo0BfKGh8Zkvj
-        +cygYTwttFGtOQNArdKzZ2744Hc37ENzPrjnR8MeM9q0VMvy9Ee6We70Vd2cPU6o9FMal5mGU9JI
-        U82VpJqUNG46/KdJo20FpJH/VaRRyPEf/44+hs5/EdLIf25LY3pm0vDX9MPMqjyNcp7mMKWq8dDM
-        PFReTW1izwZmY+2/rTv9MucuOnL5nt2wZR6Mp+l3aVxkFk5BI800V5JpUtC46fD/HtBguAsFjU9s
-        aXDkmUGjV5q0RnbLYZR5a9qfU+UaWx03h3O+tdAeuttS2TLH3JycOQtq0iFV+kWq8U76KY3LTMMp
-        aaSp5kpSTUoaNx3+73xrV/DUAbrwq0iDDZ468HHSKHwR0ih8akuDo85MGvRg3W90R8vGcgCWfoHp
-        cOrKf+23K96kCxEjDu6N+cB+vKc4FkrAl/yy/EqnWxoXmYVT0EgzzZVkmhQ0bjr8vwc0cvkLBY3P
-        bGnQZwYNza4/292F89aWDH0wWMmLHC151VKff6tlXp3VutmZF3ypMqwvqmXQf5ypPjn48MdB0y2N
-        L5WGU9JIU82VpJqUNG46/KdJYwJURBrsryINjqJ/5lu72C9CGuzntjRyZyYN6TkPR9VptWM85Tlq
-        2yObmwa/WsqMZ5Qas9fedEw9GGqJZzYdesuym1dm01+l/3hykVk4BY0001xJpklB46bD/3tAg6Yu
-        FDQ+s6XBnPvRalOFer53l29zC7RLDDTaVUt+mLIFkNkwb/P5tPSUW6mVUpfcgtLyftsl/VH+w1/a
-        9RW2NLJeMCXhJ/TqGnSjgIuC7AA54qGJkI2PcEF4reoaOP5mAYJHP8eqMNPmni2hecADwZSRPBSU
-        YCII69HRWFkHT9XNhA9F3+vYEj2Sev/g3VgUFHQmjH7hU/bPn05oUXn0UKGDclwNGgSGHOTysLrd
-        c50T0u7Rx0vg766Q3T/3OBAFNGwi6+7MvXJQX+w7UaUiz1Dfuadrxm2JLQdy7ApbVMYu4g/ZsP8i
-        xrKjAddPnBM9tTi+meyuJ68Uq1JyTNHhStAhJcebDn8y5orlma6zb3FQmBD2xeFsPzID2CIeXcRM
-        kLBeiKIB0NQixyclEBNfFZjq0R/cKB7RacPT/TPDKcfz9Mc/QsxS/BGc/htFshmK/yhFZk/2AD6G
-        ruy4B33yxR+GfK6nFmePOwHjfwSvtWq7Xd0tCfDow68jeCNqwDAAsXPgvvnecgK/0tEkZ8U8lxQj
-        B7oR14Oirq335ZG0M+xZHh8HZC1CzbB1gNqlLAOOSpQIc2AFDZdFQZfRZOOhZuQKdxRJF/Jo5ttr
-        gm6Zc/wyQ1H5u+BDaSzq+1gWsnFVwUIIzdkBVcNw6XMgBLgYpHmEATtOjA5DsDheABypIRocbUge
-        iYIJgIo63kbB89AMEwQ0vJ1TemT2HDmYbBO2nYINydVDePdHqhBMfeF46Iw5niJRnPfKjoBVtNQI
-        zNLSEEM4OqELcGFt8MokbE14tXeaAC1EQ9HSCWxRUAF0UViS8s6D37yonHj0oQsMomuCvROPTg8C
-        R3LAWgPhRZRgJcTmg0XSsS6gQeRFl2jX2/VBsVNpjVEai+XIgv8bo94m6ujNpBKJZU2iPBqVu2F7
-        5an9e43Ec064Xo001O3Q013x/6bPnrOFlAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3276']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:17 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---ZZc1YHtkzgoeMB4smMEoaIZ76e-w4zggZBX3qdDBO0xeBkHxO0yU56KExuNENxoXY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1U8coAng31d0ZPRtNBxmgnxbx-x26tADE8mc5wUYMuLDqJi1iZdxV2T08V6poAEl7cVZi7ks3n2kmKdmzDVP74JrubKWsl8rtyIwBjRG9-cQ7EI_6-r-OZhkTtPa7lGfnWO6bjBiZp5bZ</crypto_block></availability_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['449']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA7VYW3OqyBp9P7+C2nXqPA0RUFH3YZhK1BgvqMn2EvNCNdAKkYvSDRF//XzQKGAy
-        s2dXnZOHhF7f6tt3Wd0d5Y+T53IxDokT+L9/E++Ebxz2zcBy/N3v35aLR7797Q/1XwqKkeMiw3Ed
-        mujBgQKb6CEmkUtVhUSGFXjI8fWI4FB3iG4gS00wUWpfm5RjhHxaGkpVYuQ6ln7BVVGp3SC3DOmn
-        jPpPGY2fMpo/ZcifGbXP2zPD5EAD3XADc6/KAs/z00RyppoRoGlMmv0POtsZmjca787Ps7W0kbU9
-        arzoi2Qwah+Xx8PgMZp09s/+bvjRpptetK3Hyxdp4YehPNNee8t9QN+bzXexvRKDiF9MDd1+aQrD
-        53231RuOhVXvx3jqJfY67GkxHuiDjRa/R/K8P/SMsKs1z4m4eh4kq6G7eHxv6Fvz/NyU9SDW+wLv
-        1vcDe/ahNeodWPabUqvsRcEx9iEHUIiRDnmD1f5aqRUtZrAwMdU+pFnyYeMQ54QMVQxnFx108GGE
-        U3eXm4qZOjEbx0VEj/EOET6CtCpwRslGmiDCrVJKbmfDm9CT5H9YF2pjRNNFlLDcnnVZVO1sGMjc
-        LI3ZcFluVyGFYBSatr7HyWWGGuR/AaZlklMvPa9IZbyC98WQJjLAd/TrkdleCkoFLljZjrqMxf0H
-        eYf/cisUOpgmpT5s27ViMbWLJ4PIp2Hu/iwYZeBqzvovfYdii/tBEcWEC7bcvYdDx0RFJzaNBXY9
-        RP4O69i38jYLRoR/48QOtblR5CacJIhQcIWZMSNq6sF2SzBVeakpCUJOKeEFkWAz8C2iig253elI
-        coV9MTJ6Aj+eZ1lqOq3QEjs584pDJIO2LIh6BiPf0qnj4YzOCy1e7Cwk6Xtd+C4I0PyezvR1h3zc
-        Ww+wNqEopBWf2NFvnCQSyt0fQsf9HztFlDoN4R87pSGJv+SUBi+JCyn1yK85JXdCpjYs0yb3j31N
-        6yu1EpbbczngHrHnYe7CYL5h346lypPOxQKtHHfh3AsKhSiDOQMWQiOiuk58tefQhQBHHqKodmnT
-        5IBV4ngHF8O+zH1amSWLssNBunGkKi6CQyOCbdTlO1GQ5CacYFdMcQN/xz55UWzeiS1JboHvC1ip
-        FUPZIJd+oB9wuCWqHyi1CpAKEOgHlOZVefKm4qGTHka+D1tmURAlCNAnVPFAqCpIJ6XdgoqPsQWO
-        P0DwohBnAc6W8xWek6MQpYdmiXZBGCHdQhB6yDcxW/0nVDkEhGb5MF21O6IAcb4iF021HIgakPW9
-        pwp3wlVPy7hC7OAjG5ntht1oqphCgigEejY4PkFQMaEQljJ84bDiBTv3IyEUe9zMx1cmy87slhTi
-        2MHZJGZ6trbgVPwKVyCJonwKbaANXu6nvckKriMFnFOysYHCDaCYLK50UJbseVaC98quLFRljS1Q
-        nRYo8f9FddqS2PgF1Wl9Up2/Kuw08w9B4GYpnh+1N1haD67jpWdVlnal5s/ErPVPFT5LGbY6ft6G
-        m+cFyC1wvXGIY7h5mt2CjFVoC8tAEJCLGC76eacCVD4XcrU6098seKJwVxe4uabUCoyZbdvz4NiX
-        pHp2KJQxNuE1VcwoDOHtkBRflzuCBed9BSoYW2TSIIT5hRInBwuWH3kGDtV2o8zKwYJ1cJGJSfoy
-        uIVKHBACnSSeEbi1MgwixFD13+XuBVygauU1lLopFfVczaE0oJgNlJ7hyCCBG0EWEBSD05nO3IKK
-        keVIsMe+qsHDwJKNtunIx9npdd5ebHqn8UtvPenMF8fRU0RHEUYrs3nyz2Sqn8Qu3zqej45sbAbP
-        r0trlExbs5cJ3zkFcrSVR87T+2LSc9BRduPDBrurybzx2n5rSe9HtyHsRK/5oJ1nveOKLJuRM96Y
-        Oh+9bd6P+tayJ/Lrfjp4nRLtfqgPB/xZtEMzWuGeIEadIW9MzP0pjPgX/LYcnp/GmmO0x3EQTe97
-        DpmLcn3b7KaPhdLu4GroGY4PRdXOPHFtpuUH2gCxzIuPNRQ/8NmnftPzC0OJnNZ0FgZQziq7sJTp
-        IL82Cnfw+rhhXw0ldh7sr8evGBWWn3qeLFDDIJefMCVXc7Qr0iSrqxuwlFishO6BdQOVOWkF1ypI
-        oR0h+oAO8ELdRUFEcg0U4ZT50pDRaUCRe8MsY8qt00uuvnFwya1fOLPqwlq5nEp1xvY7f+k/XnuU
-        ZK+MZEo2DzGEJ4SXSLoscGe110XtCoQlrKzzfHe+HiTooWN0k3NiD8SPdpe+39NAfNB8p7Ve/RD8
-        QWdiSQ920oma79LT6r0Rx42449KuEWkyXs/Oz4OHt3q/cTqjx02M9o994zWs99c7NJjNNtWl5JVS
-        q2hKrao3JvJ1F6MYcgO24uL8TPsMK7CxA6Jwq7n+H+KKeJjagVUCMtd1Zw8zOFgrWJlCKBOxKlQw
-        2MsycF1sUm4bBh4HV2kuu2SUOuXXhUuzSMwrxNywBP83eXt9WnZJK3hyFquB6djxKG6Fohlulqv1
-        qDd2vOgcdl1t7yHNOVGUaK3+6ImGy/3aHKB1623/THtk1VxgbLq71/a4ZZuPmxOZLN3uvLt1JL8t
-        robm06KzfPIPkqXNRrHdGmvB86DRmk82pXXnwSnaaXRMttsyjQXtk6trn8NR+7v/q/0JutlajZwT
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
         AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1997']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:17 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:02 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60---Ny2iNMboaNvs5EwtOgbMmJKgzQOW2Y6Mka4R_TyGJ8qUqpGFuL9kQngIw8tYDuf3vUR2Tnrr6OMXDUkotj55j18V1ou-TNb_hR50IQkC7DIK0VDSKNmyhWrDMveG_GYMvju6PEImbrCM5zy1VQGyVIlTFj4_fczQ56_ov_E0-l3kGhOwM439---Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>M0--d6b8ci6qOxXP8TYDxKRDWL9PTqJHutJueaVc5xnzsN_x1C-7qzqi6bYGQXUdJyN7ORL-9xo6uf6JiHjTLDiaq6lvpYelVLP4X8Z72jql40g1m5BMzODqVsU5uiKYc_-uZYjq_fdhL6XkNGXNsMAI_IG-z1hrcuVeD01u9I-bLckxru-ReZUIzHKMib8KvouNADisP163f5C-Z</band_token><despatch_token>U_--5-hWxUCs7oHiTVGcihvJv7r1crYUVWJDKimuzrClMkmaMixtayM7EJHtrUkWcGaW7ZkQtDsV5TeeclgX8K7hcFYxsLUlCPCfi2n81VIcHT9UHnp2dMOJvh7KMoQG47PLY</despatch_token></discount_options>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxldmVudF90b2tlbj42SUY8L2V2ZW50X3Rva2VuPjx1c2Vy
+      X2lkPmRlbW88L3VzZXJfaWQ+PHJlcXVlc3RfY29zdF9yYW5nZSAvPjxwdXp6bGVkPnllczwvcHV6
+      emxlZD48bGF0ZXN0X2RhdGU+MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['764']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1ZWZeiSBZ+n1/BqTNnnpqSRRFqaPugoumW7usLhyUQlE0iwNRfP8GioJldVTld
-        /db5UEl897uXuDfuEmSJf7y5DhGDENq+9/sX+iv1hQCe7hu2t//9y3LRIfkvfzT+JRo21P3IQ4of
-        IMyESghg5KCGCCPN8F3V9pQIglCxoaKpRuMCoFj5WCSCGHhYUQ2BquAXgYa8FivFKhMYAOoNGe/r
-        crZACHJCioqavY8CJVadCDRqYqW8FHUbXTI7jgqVGOxVSEZ4LwWeUVJLQxUSq4SSyzPzOtaE+a9M
-        BVlARckmSlguT1UWj/LMDHY39T0zlwbkERIhUEPdUo7gcntDBQetAJPY5tSb5h15sFfwPjCpqxqO
-        HfrYcuZLQXmAC1bqUStjEf9R3eC/xEoNbYAuJZ3M7UqxmcotkknihHn408MoA3dxqr/0bAQMYo5U
-        BCDhm4TkgtDW1UIpe42B5UqoenugAM/I19lhROA3ghaQRfQj50IwFM2JlUKcMSOkK75pQoAaJFNj
-        KCqnlPCCCIHuewZs0FWOFwSGe2DfhBn9gn9c1zAayWupOi3kzDuOT9LnOYpWUlj1DAXZLkjpJFUn
-        aWHBMN9Y6htF4eW35E0fK+R2nyOQrSFSQ/QQEyv6jWBoiAgpCG3nFweFZoQq9dNBqTL0p4JSJRl6
-        wSQR+VxQ8iCk3SbLtKHUkUcjWayUsFyetwOiA1wXEDdGFpvs2TYa3FC4SexbH1Mc3Cj9okOUwZyB
-        N4Ii2HDs+C7PoRsB90kVqZXbGl0C0IC2GzgA+6Ufk8osScQ98BPH1YboqMhGEXaD5b7SFMPVWLFy
-        x0TH9/bZI0nTta90neHqOPYFLFYKUxZul56vBCA0YcPzxcoDkDQg3D9wad47T74UXfVNCSPPwy5n
-        p0Az+IDeoaKLG9UDIiS0Z1D0ADBw4AN8eFEI0gNOt/MRnpOjUE1mUol2QzJC4oIfuqqng2z371Ax
-        8CFK8+F1xQs0hc/5jtx6Kp6AKCErR7dBfaXu/bSMi9Dyz6nlzJtsDD5iIvSjENNT4+ANHyqACB9L
-        Gb5xsuLFcmJ+gQi4xNgDd2aWneloDUFsg/QlejJb63gqfoSLOImi/BWj7qg7k17bw5VYKcE5JbWN
-        KUQXF5NBlAZlSZ5nJY5eOZRFV1kDA3edOu7Ef0vX4Rm6+omuU3/Xdf6ssJPMD3zfSVM8H7VPWFIP
-        ju0msypNu9LyR82s/rMdPk2ZbHfkhK/ilMyBXIKvNza0NSdPs2cwYxW9JctA3EBuzXAh50oFKL4v
-        5MfqTP7NDo+mvrIUMRmJlQLLxJblunjsMwybDoUylr3wnip6eAmQr2iOrx8bOkOSkcG1QRNYg9n+
-        ykama15lpaZLhw4ziy+UYADNba+kriQpU3W/PJqDi7GimL7sq/rrKdDo9mq82naGEazL8fgaxq23
-        9knxHNCcO73TQvNAsJ20Iu8Fgm7NQVOjFp216eZ1epJWRvNFEQ69LVWXOmr7jNrGtXd9aQ2psen7
-        0nXNSAxfVw7NVnSa6P3I7raXHqz3qz1Gjlpc7cK0yZGm7ZmDth1WF72BFbnR8IT69mS7vJ7e1txV
-        HZDL+cZlN2Gr47b4Odl/cSb91bR5iY8tbt6q0m2dtGx+bY6DtdNCHE92urO3SKgdqpsdmB+X4/B6
-        9ujVgOxtaqhN1S5s3Rt4QF3y1qX1Eslmfc14zoykhg57cHVGbk1kwE7Hx8nEOYZW3KHdrUEJXDuE
-        LbM2V+KYXr8ue6wc2R1hO915rCW8bM87S7Cq5A5fucrnI2qO6uFZpBSfAp5zyXLvY5GoR2GIPyZK
-        T7c7oIGNP0AFw1R15Ic4v6gSJwcLlhe5GggbfLXMysGCFTiqDnAqljg5VOLgRq/Ai6v5TqUM4yGT
-        oY1/l9ULuEAb988jWDzihgBRI+lPD4CIZ6pvKoUCHtnP0N0G/hjSoO9EuC9ANcZlmE2eZxBfoV3N
-        9nDz4VP5fVlsJg2y1B4uSvvJAn9fpiUsGfirjkgmmqGGBoHnKChp5G37Bx7el8g/Aq/BUSQ5j5SR
-        AqfncGtvqxcP+ZEpLF66vYF76pt0SzpEatW92sa6PRm/rtjeUJiT8l6xBIaudc4DViLhkXK96oSL
-        2nGzZoKeJy33fIed2o6iueSaJGOJMk9H+W0x77ds2+U3Q+vN9ITZgYs3uwNcN5u1nkA3hyiYG6A7
-        l4Lq2NItfWKNoUyZ8sKZRHVjHggd863pMS3SfsX73pWcy7wpeZdcxsreZ7cz3ILx2MJpmM+FbIGP
-        3cselafD+kBQIifjBg9P3C3rtUd2ISnT8c3AUsM9/jB+Yt8FJXZ2uVQ+tv8gFLPSUtRYtR01GS/4
-        xvIOE/OLhrov8jVt+U+gmBpVtGTWZYmJWU9QmZOkXeUBKcZaqJ6xgofsfeRHMB/PNL4AfShI6chH
-        qvPELGPic9BLoX4KcCmsHwTzMYSVoqr/7/qu09+r77XcHHc6P1XhZ6AR6Tn/khKXcam0VuYS7mfW
-        YkTLihRfZ/s+V9XoQ0+Te5Mud96CmcHWdltkOhI1GITo0J6E7nbX6didF2N0ngn7Uyfsurxry9xy
-        1p+1PdRBY5c5dnb9LncyJlsJznn2KE/4/s5l+PAwjahDVdrDdbypv6L4JdS5oxAwx/YJLcmu0eTn
-        B5/bxM3leKpcKKUfU93mdG2GylGxR5MarFurMacdmvYuqGk/LHX6L5R6dm4/W+oc/6lSZz9b6s/2
-        /yn1e1A+LHX2e6We6f36Uudq3yv15rw7+0GhNyOINSEk9qEfBb9slLPGgpH7Bh25vZFkjpvHq4/2
-        B7IWTtvWLGhqgcKxMcPi+znY8BuPPbK1wcTbMGhwQY5pLqdrdT3gW8p1Uj86bWoSeEvlzI8OA46H
-        44jcAIfjgHDs7eyZ1/ZavE3RS6o+MCejJhdwF2lZDasGMuYAzHyT2bj9WWs1gay3Ri3WqK35Lge9
-        tVOvm8rSoqrjUXAebHbKT4xy5i/UN1f7VH1Tf+8of7b/T33fg/L5UZ7p/Wl93x9h9oeDoiQt306+
-        NO5/PngnKeXb0/+q/A/knyNIlhkAAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2302']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:18 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:03 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order><crypto_block>c2--ud6DeBehKRgz3ufmfzE_5cAjF2Rvy09debmDVAGAA_QagUkfKydV02JEoacNqpb1DVOVYFLus7EvOzrvCxDq_nleBSlIqTbnepYPCunHseG5ltQd5uwbQXNQqAVdBH_9jIY07AFaDwtDdzIzHCL0OfooAzW2A287_jBCuqPcJuiGDUns7J4I2EuC65y2D-Mbbg2jbYL4TIKhumuLqtJiPYUzqxW6zaK-USXm3XrCFmC8S-JHlPJVQByvkC6SC41Dc-hi8WfOpWlCt68-FGRxu95j4XZeSkUOrzwn1VK-IX5tD05y37nKneaU8hyCHuEf7W2nlR-0Ll3jmc2ECPEe3QOkPPlkrhvF1mYd096DrsCf5S_vv1WNUI3EuiF9YQZn3h9HYwZh9h4-Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>60--Su_M_sQwrYiY4yntouf9THGIKmqJf1CAjua4mzidWDPONV3IL9S-Eg_h9215FwK3A-sk0mn4P6uDvB5feInAUg8F3Qil_bm-W--vA0fqkExTSJCiim8XLhxfn9Rj6vXZjsWBB5I91BLtpSdeGSAp4OhchcPhOsE0fETlPu7dSp9FfxBn2C-iN0--Z</discount_token><despatch_token>U_--5-hWxUCs7oHiTVGcihvJv7r1crYUVWJDKimuzrClMkmaMixtayM7EJHtrUkWcGaW7ZkQtDsV5TeeclgX8K7hcFYxsLUlCPCfi2n81VIcHT9UHnp2dMOJvh7KMoQG47PLY</despatch_token></create_order>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+LTAtLTYtYnNqV09qbFJnUHdhT1Rq
+      VWNscTNnVDMyR1UtS1lxUllYZk1mbEVTa2hDdHo5RWNtTmUtTDJkM1FnRHF5dDdQcVowazZGTG8t
+      QUF6b3JPX2Z4MXIyMWRWSG5DNE5veWhoU3gyTF9qSmRPOTF1X1MwZXJxY21RV3Y4YlZldUtKZHVH
+      bDdLZ1lwckNiNW92S3NsaUc4eHVqQ3kxQXJWMzVzU1dQSHA1ZWUzNS1ZPC9jcnlwdG9fYmxvY2s+
+      PHBlcmZfdG9rZW4+ay0tLTZTWUY5WjYxLWUwOThNeGdvdlVleU1OU1pacFJQc0RsRm1sMkVLNnJp
+      R2tpaF9hMHRMODIwUWY0Z1hlRmcwTm1ZPC9wZXJmX3Rva2VuPjxzZWxmX3ByaW50X21vZGU+aHRt
+      bDwvc2VsZl9wcmludF9tb2RlPjxwdXp6bGVkPnllczwvcHV6emxlZD48dXNlcl9pZD5kZW1vPC91
+      c2VyX2lkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['924']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7VYW3OjOhJ+319BTW3t0yFcbGM8y+GU4/iSxLckdmzPC4VBNoSLGCQc41+/DcIG
-        HG/tTO1uHhL09SfRaqm/bqL9dQx87oBi4uLwz2/SnfiNQ6GFbTfc//ltuRjw6re/9L9pVoxMigwc
-        2yg2YkQSn+oaSbY2Dkw3NBICsEuMrWnrKSKacNukWUkcw/Jp+WTAu5CeEFsT6lDJ2JkWxbEuiWKF
-        U4AlK0yCLYp1tVllFWDJinzTQkSXK5wCqnAwoQZJgy32hSocowLV/16dXsIlCtPiNKLY2PrY8vSl
-        wfMHL9p1vF4nWrZmW34f450t0eGnNZ1vPhrIIh+Nh42kfLx4M3GzCh8OweLZIcuHXX99tJa9Ufpz
-        44/XI7wejOKZ5/YGjtX4aDRJMHuQlJV8WsvvswW/CL047X48qVOp5c4/1Z9o5K9O5Pk02G3Au6pP
-        GjtLij0U6pbE85LiJbTzet/4ed867FU5VcmRSvvxajTcNR7FJ/XgDZb2iqrLndJ1Gqh/IOMxxenK
-        uR80lJEX7MIfisobR6d76ncfWz9Mo+2unGmvj2cvx/s3pdESnzcz9Dbf25/p2lg9H07r42YyXImr
-        zWATOYfh89PTmu+404f7U/t5/WkfdjGPwmE6UkWvF3kb5I3NSeuoTqdP86HtPb50osfeyplNTq8x
-        OqpSc/08br7QSWJ07XTcG60fXye97Zu7Djq+vQ9PTX7x8RYY6su6MRQXB2X4uVRn4udKfu0tXy3b
-        PtKRKHunh9lSlEIPdX03mmx32/bCf/Oe7FkgHT46U6XzZNB7e/44UcYvPM//0IRqKFlcdc1GJDKp
-        5RjwYOk97PvIotwuxgFHHQQpFyZIE+qsclKAqIPtCpDnRG92P6vMYXlSGRKqi3dijQHQf+lKlsom
-        NYUKRNMI6RZbpzIxhyvjyyZcYuEkBE8sHGzdENm6mvt5GV4obE/dh/EC1qlhJSX3r2uDBHGEmqFt
-        xjYXgzpVZrAthNjAO4OAchFd0oTqsLBR1/JQ1XoGtIwWxa6F9HYrc7Ucg+zFlmPGe6Qzy2VYOqBr
-        CKIKf0zQTeZ/f6UJ5YgZcjf7oL7pp4NiVBCY81t3n0TGwfQTeI8mVIea5dJCJX2TGAe0NwmfgOqW
-        OKPkK41Nwr1nlMLOlrdgJin+sClwFUyaOVHBCns+ZVG3s2VA2HOVZ8vl0l+HskBCfAwPpec3CHk0
-        z2BWRQrqeeYFqa1X8m4saZlbiB29vTLbS0mpwSWLZQdjcf8wg+if3LsZu4imlTls20LpjHCOZHbu
-        8aWeZZe7AlzM+fxl6FJkc28Ubi3h8I7rBgjulllOKnIwq7mxGe6RgUK7GLPDSNAfnNShDveU+Ckn
-        i5ICt+9iZsyEWnCndwRRnZdbclY/r/GSSJCFQxtSoamonY6s1NhnI6On8BMEtq1nrxXbUqdgXnA4
-        SawqomTkMKQo5FWAcjovtnmps5Dl7w3xuyjC8Hv2ptsTinWvI8DGkPsxrcXESf7gZIlQrguZ6v+P
-        gyLJnab4y0FpytJvBaXJy9JCziLye0EpgpCrDbtp4+6gP5n0NaGCFfZCDrgBCgLEnRksNuzZtXVl
-        3DlbYFTgPrSDuFSIKlgwwBGaEN13Dxd7AZ0JlzLCxnmxIG4Q+ahQ3fM8Vkb2CGcbN3XNN6lLE9hG
-        Q7mTRFlpNTThgmk+DvfskZek1p3UlpU2xL6ENaFcygG5BKGPULwjeog1oQZkApTpPLIvylMMtcA8
-        GnEShrBldgqSDAf0BdUCEKoa0slo16AWImRD4CM4vAT6x+xAc3du4QU5gRIHPXqFdkYYIdsCjgMz
-        hBKVe/8F1bLGNr8P03e1I4lwzhfkrKlQwGhGNryAtRI3cI04+DNfme2GNfx1TCMYyiJi1w8d4VAR
-        oXAsVfjMYckLdu4tJRQF3CxEFya7nflHRIwOLspfYmW1tQ1V8Rau5f0Me8VkOBm+dqcP43dNqMAF
-        JV8bKNwQksnmKoWyYi9u5a/kEIh6cP7kyNK3MtRqB1Fq0grZoFlt0PH/i2apstT8Dc1qf9GsfycL
-        Wd5EGPtFO5VfgSssyybfDbJKl1/ayvA/SWH7V+tDfuGYd/xcbcKFLoDCAs2RS9ytX1zSa5CxSmVi
-        9xfk5yyli34xqQS1rzJQz+3sNzs8SbxriNx8ogklxsyOEwTQNMhyIy8pVYy9sMzZrOeEj2fYMmuN
-        wX4FVTnZO4QaUu4uOxZIlp8JIhdxDvEFQjbrcq8pGlPnSgjmr/1B5vQVXCPmm53HaIfgi9jmsoUh
-        RPVZRUAwNX3j6svgCixIVw39V7DGqzT3t+CCe93oX6NnWr3pvwZ/T1GKT0Th1n9V/gVJHPmwkhEA
-        AA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1768']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:18 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:03 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGJhbmRfdG9rZW4+LTEtLVExbXpRMFpXS1NlY1prOXo0V1A3WkJK
+      LUZrMVFsalJMZUg4OXh2OXNDWWU4YkVldjEzaGhGSGF5eV82WWRVYkhBR3l3RVI2U1J5blktQmVY
+      aFR3cTJhZC1jNWhBdzhaaEtwSm5tM042Mktmek0zcHlCc21QLUN3Q1VJWS1jZ3NXcXZLWTFxLUJR
+      QV9DU3dKYThIUmN0ZnZaUWlKS1g3ckZkY0ZMeXBDNmNDb0NYZ09oX29zdldjb3lRTUxaN3VJaWli
+      T1JrWXI0VXZ0SXd6XzFtaG9XM1BVV2ZEZWdTMnNaSnNXRGlxTnptcmRnbjdOWDhyOV9mYVpEaE9I
+      N2M5SmJaPC9iYW5kX3Rva2VuPjxjcnlwdG9fYmxvY2s+RTAtLUV4STUySlJDcS1nTERzdng0d25V
+      WnpaU1dTWURxcWV2SkZHdmw0cG9DaXZDcVVVZnZVTEFYZzlicDlYZzYtY2NLNUx0UUpTdlJtTGV2
+      ZXhlMTMwaTV6NVFnRVd6bjFXbUUyeVh3Z1Z4ZE5vOVNtSmZjZVh5WTdLTU50OHp1eVZKdzlhUlhP
+      U2o1eUZOcC0wd0FkdjJLQkh2cGg2Y0ZxUk9jcno5LTRsRGh1eDJYSGFBbTFGNFNibmRKMm1xd2tS
+      Z1o8L2NyeXB0b19ibG9jaz48bm9fb2ZfdGlja2V0cz4xPC9ub19vZl90aWNrZXRzPjx1c2VyX2lk
+      PmRlbW88L3VzZXJfaWQ+PGRlc3BhdGNoX3Rva2VuPmNfLS1GeUpWRGY4RHlFRGhNWVU2Zllsa29B
+      MUcxempMbnZkVndoN0tMSmticlhpaC1aeTJ4U3BTT0RkSGFIemR5YUdqLXBySGQ0N0s3dmZDUkZY
+      dU1FSnVValJLQnNHbldScW1IdDk4LXNoTHNSWklFbjlMQlczV1ZLczNQLS13Sm5RSE9fenB5WnV5
+      VWlBLVk8L2Rlc3BhdGNoX3Rva2VuPjxwdXp6bGVkPnllczwvcHV6emxlZD48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS0HvDihIg7XFxZDKMgoBCj+Tv9Jf1kHg4Je
+        O4fKzLeqlauS2GfHCeLEOWcHJvPHxbYqEfADw3V+/0R8xj9VgKO6muEcfv+0EgdY89Mf7b8xmhGo
+        buhAyfUgYgaSD4LQgm0mCBXNtWXDkcIA+JIRSIqstR2Xqb62MCACDpon+0CW0DqgzW6YajHKDBoI
+        1DaLXis+68AHOSFFGdWAcca1XEdzHSw0mWoBZvaUOkntuTGfbMlBkP+V8WUfBohSALkx5XeQsfJ3
+        2fb+Xemh7YbJq5TMDNpUusPMbQyQp0eICYDsq7pkgjhdqYriUiBJ9HLebdodeXBW8J79abKjgtdO
+        s+3cCA9gwUn30ZUtC8B8o/2nCdlOq8UrVG9BTBLCz8OeHkIZuJvT+SvHgECrjFFaoaQoqPmp+AY0
+        VJRTkQHOkgd8NckRAscR8aWJ0WQIJF92DkACjpaPU2eiHv6rQgSwsgQeBLYC/AqJE3WmWlAydghV
+        yd3vAwDbVD1Z6hktaAFQUSoFbYJukI0a/ci+GTN6jP6zbU1rJ4viLZzImXccnbTbrOOElMKyo0nQ
+        sEFKx/AWhhMi0fqNwn/D8X/ixG/JSq8n5H6fY5CNA4iS40NUalCvTOX4Z8ajTtINCv/meNTw2nfF
+        o4b+/Jl45PtPe02WjvxK7Amd3pgVmGoJzilpGKYyhDo4V7pu6DvgH0GFR9vxZdVEKSSyS/E2MYtZ
+        9mxo7fpwcLMYt/4mWSjR3TZyJ8OkZ5TBnOHJUG9X0WTMztbFlHRdLMCc+7oYBAGs3uanU/LpaIcw
+        DNqWEd3d59CNgNqvDOXqbQxjD7QDw/YsgAKGnMPbvNSSs0IvAJaF3jSAD1tkP24RPU05vIxXX/g4
+        ADc5KLnNWDI0YIhiXiM+18hWnSCoBlO9owzq5ofsEcM/Ezg64VqdRIQ7zFQLZ7ocSI6b9IN9kKrN
+        A5B0U9QRUce5t9F8yNjyRfJDx0FHkeUNQaI9fEAZG3XdF7xnlHEA0FBGeCjfkDqkOZm+zys8J4e+
+        nGhoiXZDMkKyB9e3kzacvf4HlPHcAGbi2SOECi3yTPUO3SQCSTZM2JJpt/HP+F0jyjgT6G7aVffZ
+        dtLlnjAmQHmJ6KlzcEH5gnIycVeCb5xMty8Q+I5sVURErHSTRHa0SjEjq5/0UvCq478yMCixwnyt
+        Zac/YYXlhp1Mlky1ZMhJqfulrFnARzW8QakY3Gi5lOVXkIeIFt1wAzQkIMSv6JWtFkF/e68kPmrH
+        /2s6SfZ7rmulaZ7fHZ6wpCYsw05kOM280vArLZj4ZklKkyZ7O6yDz1FS5kBuCaTICAzFyhPtGcxY
+        RePKchB1p/yiuM6nFBDzsUQfyzP5f3Zwjc8UXplPmWoBZVZdt210nSFamY6VsWy9e46ofuxBV1Is
+        VzXbUwrDvHkNEtSBlVXalIXudWeTuhutBMPhuVlgkuo4UubOUbCgNrqQvd4RP9dbR77FLk5S5F35
+        2DT7K8FuGrQ+6jkreFUipdk5cUNLBc3x3pZ74tjXvL1lDYQmO5KPVmO6dq3RwWxQxHKCNa5DsS/W
+        pS0fen2bVcXTGIZDSu1btBoC1rBFZ4L7RmdPc7EAIHccWoK4PMCVt2GbEmsv+krUeANrsyX68/gw
+        P+v6ecguW+bUtg+z/uy9f9VDq7GmG5sWL0Flya3mZ3eh0YOr1j8tsV204eaDbp/g5pG55jcTjDxv
+        V9Pu+0ggllA4jKlOIOG0wq5rltPz9my0cFW18cZe6xam6ZFKBRNtAPvyXMPm516NdJeu4hIgNiPB
+        Hg1mKuQ9TtqO3ll8Rtgrj+pq/JEfnrjxmxWc1V7EwcF+KncGrLAJ3wMruA58F9DcdQ4243ptSvOD
+        3di3CfXisFAzzoPl5djvw+OkT485stsYyjVX0YQ3BXawXXLXLJ0vo1iyg1RSKj59HCtOS+e1pfhG
+        SuuqTaHqfUQYNfR99HUVF09ZGh8UD63+ABWMvaxC189vw09gwXLC5KrbbpL1EisHC5ZnySoI2mSJ
+        k0MlDhISKYhtxbWqZRipWIa2//uf8vwCL9AiGMFDXNCNAH8IS3JFQLLt7qViAo0U7wm6+0Dfh0rg
+        WiFqO4EcoTrPpO0ZRB8ftmI4qLdRrcR+HxYvk0a5019NxNILZaG/D7NvQA19+VUSzdRkXyuRcz34
+        yu7uQ+giHWyrOIadTKzVXY/jCx5zw8b727pPDh1BdLX94rR78whpEZIUy5HN96CGMm0VXTWcvcwI
+        +mw1WHuwhz2ObACbr8VU1xodD1YwkMddthlxTTpyur6+UehtxxjESmfKc9vOarzAj9aJXkP7PD5z
+        /MzpT8QemG0Wi94+gkGzZfqboOGdotp+PhiMdmezNbXOHe1AKFdlI7sxPFIm5UbWdGlSfJeXVq7W
+        s2EX7weqUbP2FuYd9dF4PN4u+ucBuSsFIdt1KQrJZbMcpez2iVQAKSfK1VyasgFKDSd7lJ4O9IWh
+        RE4Uz/MN1LOp2iO7sJTp6Fqiy/4BtOkn9t1QYmeXZ+m1/wcjk9WfJEeyYcmJwiFF/4Ax+SVHPhQ5
+        nQrPE8ikTiUlkdsseRHrCSpzkvSsPiCFsvryGU1woHEI3TDIbwgEuo6/NKR06ELZemKWMeY56KVQ
+        PwW4FNYXwXwMYbWo/D/dA0jiSz2gxw0n/a/0gJ5uWFoF3dLBj9Y/hup/MrPtKdcbqoPpZLVRjAO2
+        ssfieL2bAKTbI3vcXGMY2Y+3w51CBCJ+4PZCPzk6QG8miq0vunWjX9eIix7hsqGe4vCs26ap2dtA
+        wSSIBHl42I07kWVKFKcvWuxA1nbS25BerhoT1msK727Ei+PT6r0xmVDXQcvvXqh+h++1LrPNynwb
+        rsH1elI9aYdhX61l4gdqOTuYb61lovldtUx9by0/+/+rlu9BeVnL1JdqOZv3C2r5i3q+FFd9lv+a
+        oi+TnxMc+FPq2UT17GPxebJddlnWqznX/ZD2uzzRiHrWfOny5mEyn7iR8z7ZHvsX8chpR65Xj+Z2
+        NI15DzojxdKN6I2bDa2Q3bwfV+pKEt6l3tCGbOOkHK52d79Vh6fNsYOu9cLaP8lig641u9dQsE7u
+        uaY3LouDyHbZCF3FLd7t4cPl2TwbyKUn7bueQY5YZbicjI6NWcemPPYwmR2c4/xiYS3K655W5D6O
+        pyuBvtRngIhtasg1AqMJTD7e94Y0JvC0EPaImo3PZuTX+wH5I/3gu7SdrP/afvDs/69+cA/K9/eD
+        bN7P7wfUF7V91pl/rRcAx3D9impA4wqcn9IS6qglDEyKmxgcTte6Y0ne4wK7D4TgeMbttdUYGWK0
+        ah6W0LlsKa+3vhr+vjmCO6G31UdGf2SbMqV350rY6h54rTkX45ALdV912bXWXEN/esa242406ZHH
+        eG1uZ4Sxj5quxQn8pkZOehoei9KFvC75GPi7S3PhHWcCCXbXGqmfSJ2iRKsf8EJwUtXjEA99bo6j
+        b3TaOknfIPfUj1zdv0vuyV8s98/+/yrve1D+RHl/We7vj0H2W2VRkrprJD8/3H+x/GAp5dvTvz3/
+        D1lRoYe8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:18 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:04 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <trolley_add_order><describe_trolley /><user_id>whitelabel-testuser</user_id><order_token>E2--5eH5_vuupAjgQcgXHwMpTe9X9qgSl2Y0lXp5covwU1ss4IWYBA-RU8_g3PLu8IKzgerz_3Hl033oI-VMEczh0ACvOMWY84zu53eWCfAgAX2v47y8gZlotLi4soNNf8tYetkXqZoP-N1hlKUJkwZdbW0CSxe6UymaEdjSXrzwO0O_DORRcWp6xIeRBq_gkx4Wu9YZJPsOK5CeE-apF_L3wCpdqKeS3P6_3QZAvRVTdRGBuSzS-XHJpV6utMn-uLK1XaipNu8tDIAOlNAM8GDGcPYYRpF_3_rHi9pUQMOLZiyBM9BhcnyLGC8TiUOTaOxTSW98HodDDCuLqymE1MWcmVXSh6xJsVunc4mtPXPNxl7-Z</order_token><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></trolley_add_order>'
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcj48Y3J5cHRvX2Jsb2NrPk0zLS1wUDV0MTNnRWFjNGthUkJ6Wm0yaG92VVJp
+      bk5IT3NrMmNLdmJQbmpSbHRkSngyQ0NqMHc2OWpOOUVRcV92cHpOeWtrRFVSbThpNGhKQ25VdHpi
+      dmI4QXFISWxjZThLZm1hQ1RLcmRwZmxsRlI4RUphamw3TVZvbEpnazczMVNMLTd6SVREVDZfWE51
+      cERtRWNUcUt0dUkzY0RsNGN1ZUVpbVRuTDByaUFmNEh5UmV0SGpJbFJUU2d0VXBXRThfRW1RRGJ2
+      N0dlVms5VHJQeWdQd2hod0lFUzlrTW1tZ09ET1lEemh1bDdWNDdXOU5fdGJTSFVQd29RZDRGemRE
+      cVMtWnZXSFBGQkQxSFB2a1ZOV0wtMndYVU1CWUpSMVN0UmdLM0FzXzA0YkVWNWxuQ3BmRXZRb2Nj
+      N0dFejZsLWRodmMzc0xkRnREYVBkLVB3QzUyb1NvYm8xZXlrdlJtSkZPY3ROcEhfWEpZRTBPMW1V
+      cDNCZE5qTklxSEtHbHN3Y0N2SHRGZk1hQUZFUld1WXNsc3pGcm9lNEh6UGVXSzY1TTRORlpLcm0x
+      Y3huRXRkaXdGU3hqRER0akxENEtIMkI3SWE1b2JkUkdidEEtWjwvY3J5cHRvX2Jsb2NrPjxkZXNw
+      YXRjaF90b2tlbj5jXy0tRnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJY
+      aWgtWnkyeFNwU09EZEhhSHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5
+      OC1zaExzUlpJRW45TEJXM1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tl
+      bj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxwdXp6bGVkPnllczwvcHV6emxlZD48ZGlzY291bnRf
+      dG9rZW4+YzAtLXFrLTlCVkt5eDB5SEk3WUdWRDJJblJUb2RmUXFaR3AxX1F1MjNFSDI4WXM1YW5r
+      VXZ6ZDBFeE8xNHdsN0VtRmZ0Q0gyN2VtTjV5M0JsSmpnbHNGYUtCRTh2SDg0dm5CcmhXYjRYQWlG
+      eWJBTU5IWEFVS1EwamxxNFZ0bXdLd0hOT25ETFRDZU9XUVFDZnZ0czg5a3JXczdwcXY1ZlBGRkpa
+      d2s5TWx3QWRnMWJ6Yldhb3l0ajNrM292bE1TazNOQk5fVW9kQ210QjBEc2NpNWxmbC1wamhKS0tL
+      WFFEd0YyWjwvZGlzY291bnRfdG9rZW4+PC9jcmVhdGVfb3JkZXI+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['706']
+      Content-Length: ['1008']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61YyZbiOBbd91fQualFN4HNTB6X6zBGkBAQASYYNj7GEth4DEsGzO/Un/SXtWzJ
-        I2R1ZnXmIgPdd5+GpzdZwh9XyyydoYd0x/79C//EfSlBW3WAbh9//7KSRuX2lz/EfwjYc0wTBrIC
-        gOx4AHqyB5FvYlFA/h44lqLbso8IrCN5rwAxgEioPBYJqhe42JH3pqMa4koul8+Ge+gY/Y67asz3
-        5aPnHACPny/q7G17qkEVnWqDLd88vRtzbru2B2dLmmhoNTgMN1d11X8JPrfmdPPibEYv3tzQ+yNN
-        rZ1qdWTNB3xzXb1tqh9zqSzZhhd0T9/aM76hv13an/DFXN/Q5DY6bIVKbk9CeErXQUjfm5AeJYck
-        1sCOAW2xWS+XdamGlY+2U61hua87DXgz24u1PaqCi2J9PtvX7jV4GV1ul+m5DgdtUJ4fpE7Dfx13
-        WvBtMzPQ+HX8MeeWo8PGOrsjvfF5Ac83/Tg4OtaQO43gDh28+lXvfszWvqoFL9bQ3pd372tzLUNi
-        JSmozdu93v6wQB/c+MOWDbDRpt3XRb87O/Dqdbp7vaKPPexIvU/34jacz8ZAA9Kwf3h2LP0KBsRQ
-        Jv/+8aENXv25Xquqp9bu1IDBYHDqtnby+HZsD/zF1Lm0x3Z9vXr+9N6Pi5GM3qA0WS6MUc/aYvXZ
-        qLfxoXY4ti4zs76a11cvcEXOic6b3vR96kp+Q7+1LEM78/K6Pmmure6u6jRWBuirE9ezTe+0rIE3
-        tf920s6X3nZX7WxXxjoYDYddaXRDw/Gnuw9UHQwnx8GmCYatjS55U74qvbQG0sUdztZcT/12la5b
-        ubpuapfn+rLz3us/j8G3YATWPe/sHSdL3ZSnr+f9rnXrgWALlU79E8tb6CxtY+bOvr2OVz17NBnM
-        p4FR3uh827QMeJPVzRyM7IVuBDO3vz+eaiCAg0bQHu93XvtdW3S0/UwbvzfLO6GSd5DEX2jkqI5v
-        Y5FPWVk49D0IZB1DS7Z9aw+9kHkPxnOKwt63QeiU9G9xjQdozESO76mQgACK8IplDBHmEo2stKAB
-        IFJFibBLywCRPZV20HOKihEpVsQOVkwyl7XXbQjEaucpXaggK6ogLNa4p8YdHeEClSzoKljVRP6O
-        nYjyGggq2PV0FYrV5t2GUmFBiZxOU7wjFGv3OolMUH3PI4k0SH9RUx73Lsk2OShlHBQVO+TCOS7D
-        YWDKYh7QrjYzrNgtEsA1FRUisZrhMCjDIVaUUWDtHbOShT3IUPE/f2b1UzxFRQHAvU52KKuao0fz
-        MyCVUIfRYGngW1ZQ6iseKA2oTKjkSImKbmN49BRMypIMFKxUUpGtWFAE4UypcoQlDBy4d4wIS4bp
-        r3TbUYyEk1BnoRvqh1Gm4tLBc6wSJkc4Q9uHoXaWlSpZEGsOyADRFffnvXlGh157ZkicOfLaPPR/
-        biUsv8Ry4mwlkfUzvFiQUiPjqHT+DDGxWfFwOmKppBDSaRTHFHrWpbQaDGcSmSoHp6xo60vsA2jj
-        Erl2mKHSY9mO7ByiqERhXssOmQzrqgGz0hgQioGeie1COGciuJKeEhJLh6nZgwrd+HBNcnIyooJo
-        m0PSSgUXDXqQEVga1I++K58V04c0urOAoOqYpQLTsYFjl32DmDIBqTyaaBrJmZBOrZoKQuwP5RPX
-        UHC4gQzG5HEgZuV0GtKcRZ0anS7qefJQaERiG9kgNYetUIksGYNhJ8iosWaC5OZLeQ+mNHSAHk9L
-        D8LkOSylRGcZKZZuBhkSPWElXbcSGy28Xo+ZOTJ6FkjEkf7KJuUXlCakMSZNbUplt+DpxNtIU3zW
-        4UV2IamAYf2NEvlDkUAiEMqeYh+hDG3Axux+/H+X+DbWSl3/6JMqW+V4kupTAuX6WCVOfkCQFMhm
-        uFARTWkIqsRxSGTUW3yj3uBy7FhI6QH5Z1mABDRZlGvzbcZMcHK5TrvJ8XIEKzYgYUZyb0gvc+0y
-        35b4ztca95Xj/sXxX8OVHiuweYsWoGOEFQ/f2aTKE2N0SeCav9IkTb7arNV/2CT1Kv9TJqmXq/zf
-        MQkzQZR6qD+GeXzR7U+GC6GSgRklMsOrgkkgXUo90oPZ8DdUmpHjeApJg94/YyVqL/pbB2JzPIol
-        ZMRwk3i5kyaSLMgYZHvYR6KpnxM5g2ICLTKVeBzVEqRbbtgtRYk51qNVhv72XQRNkyyFcG6Pw/s9
-        fm/vIT5ZZfHKg7mP0JFpETRJkxEWHrERleBkKJBkfKQ/y9wTH4oSQKik+pqCZFJvSGAfkGiTPjgH
-        hLkwLDcQJEmQDQVLucqeb9vErPT++SpxjTtUsEjOfMArooINyTcCgC7xG590aqEvRft5hDOyTzus
-        DC1GKCE8g+NZiq2y7+A7VAh7SFoT+/yiVJdmQiWB4gRPKikO2bJhiRwrwEVcQJoTpccDPQ59Qchj
-        wnc+WXLfKn/9kZL7OokaKNahdAfT4WK5Hk6nS6GSETASbVAU0ut7JKzWxJFQTGPlhTUJfysaC597
-        uQ+9nLXTjLeGgGTEVlglfn1GbJHE/xMZsXWXEb8XomFsuI5jss4tuuQCFkaMqVthtY38MjP8X4m2
-        9aOJNnIpurtyt9MlLssAJkHyWc+8/hRBykozHPVQksZYd/jBVFJIuA/gfPCG/9OLaz3VuNLbq1BJ
-        ISrVNMsiXQvfqUUFPIvR9dKYDHtbeR+eN1o9PGABynLCNSo5JD1aeCekd/n0IUoyvO0kEAS0my5S
-        BJriMxbojxf96TDcdkGQo9JWyyWnKam6p5owr8Cs8eg1ofiMQMeFr4Z7MMfLfEE8goXHzwZ37wUP
-        HwruXgh+NK+wz9JfnPoq8bNR/AjFHjLuHqdy+E+9ZFWSJ6rKd5+P/wu8uhIsgBYAAA==
+        H4sIAAAAAAAAA7VY2XLjuBV9z1ew+mHmIaG5aO9wOKW9ZVleJFmS/cLiAkm0SEICQC3+nfxJviyX
+        BChSsqbSmSSuLps491wA9+IuQBu/H8NA2iNCfRz99k27U79JKHKx50er3769Tnty/dvv5l8MlyCb
+        IQsTDxGLIBoHzDRo7Hg4tP3IiinAPrUc2zMjbCi3JYYbEwKzn/IvC5ZC5srZGsollDOWtsswMTVV
+        LXAEmLOiOHQQMet6tcASYM7aBraLqKkXOAIqcDBlFj2FDg6UIkyQQM1//qOon+M5CnrktGXYcgLs
+        bkzXkuWq7NCP+dNHMF4RJNOOcz9uPLXcZX09rB53k8dlnz1OnlvPTlUL1FPTd7a96Wr8Uhp674PP
+        jk9XnztGG97sx2uLWCffDwYrHZfr82iP3iZPM2cR9OkMP+/mnfmh5jgvGpr9mPW2sku0T//9hOy5
+        u5r1ds1P0pHfYKfF/Rn8XBneoMis6rL8flRlbRAd2/t5a9hYdtnboq82WAc1SbsfPcz6h9Wu8mPR
+        H9XR8TCddOo7/aU/6O3wptq+Xyx71n21/PBWZq1HN3Le41pVnSH/1B2w8eDw2Qg6u8FLadHc6c1h
+        975B1eWL3w3aeDhh6nTf7ez9Zs/W/U515I7eV/KijJv3R28dbYa91uKw9BalaIlaFW0zGNn68Zmw
+        oFtvfp68NVKX/rv9uWmMYxmTUml3Qp3RyDno88/jev/08sZG+DirnWrTYzir3J9au1Kz9XL/OGnY
+        4Xo/bTmd9kelNNdPVth2lg3NPtgf8vuQ6m5ra+nHwJ8ebH+kq4/DnX2oTiqzUT0s43c3Umn51WrY
+        nWnY1/36y3bufiw+P96qbzPWWw/cx2CNdtFC7i+I68z1Pn43lKLLuf9Nw0N0azN3bcGHa7ZxECCX
+        SUuCQ4mtEaRpFCNDuWTlSiFia+wVgDSR2k+tp4IOT67CkDJTu6tcMAD6L7eS5L/NbPPxdQrrF3iZ
+        IKey0xaZLp+/QEzhwvhsnE9dHEewQxeHjh8hzyw17pLSkA3PFG5rs/P6MIWJLsCck2686UE9kyiz
+        I88mXoHMzYqwhZcWhQpITc1QikMhY767QUVpBhgJbUt8F5mlSrLNfAzlk7hrm6yQWU4l52G+AdNA
+        4Gn4Y0P95Vvvzg0lH3FBus0uVPHTYY0IEgS+eddnoqQGOPJwJMcbcNYZ5PKU+pDKhVAoBzal4g/n
+        24RRoOSAEHI/glD6xQ63f5fa4NE42UpBbEAfSJsCn/aEYKZLKHEXeMHaoFO6kpI6LEOShiN4mdoZ
+        uZgs513P59mRi25Pys3JCBdgzkntaNkQrUwY2rlS4JYq+RaUzInJgRLh9vQQisBZnOq/Rj5DnjSE
+        Lgx9NKeKUyE+xBe04b2PDtYWETeJEd4gb4oML2nexI5WyEKRJ8bpZNN1/DdJo0yaoC1DSbuUdFWD
+        JppTODtmLgT2kiJmlqrJUtdoTqPIhVCCbCjX9FqlfMnOhJx+gp8w9DwzWVRtqJpgnnE4aVyvqpqV
+        wpCgkFohSumy2pBVbao1vpfU76r6V1X7nqx0W0HMe+0DPobMJ+yLVypsLY3s0//SH1W9XCupP+2P
+        ilr5j/xRgX9/xh/C/rTW8HBMCve42R52x4ZSgAUldcPIZtAJDlILxyRCv1LpEcwhNtQ9Ik27k2mm
+        yH3Gv33PrA56mQRGAg8g0LEJ09ksqRlFUDCgC6xNBZTlkK8rO+m6MpWj87oyQ5QpmX6qItTBQhZT
+        M/D35+kFlBF4Y1Kycdp/qB9uAySKeabHOxP/jrcUBQHslLILE7tfTYSv0Q+1iCs35lghbPEGGdjM
+        ZzH4vALtWW9UNa1UM5QzakA1X/FPWb3TVDjhShXutTlsKPlka5ta0JigHixpekG/AJJqmvQlaJ5Z
+        GRVDI7SPFomjCI6Cx42mgw1fUCOEqnuDd40aEUIeRMQW4g26QxqT6X5u4YIcE7AZRwVahnBCYgMm
+        YVKG+fa/oEZypefNs62NpfL00VDOUNYioOWyhG1tQlMVnfoaN+gap1V1yc1Jl7vCDApxCfR0cnSE
+        eIGYTKYrwBmH9+0jQySyA2kKRKmVBHLkSbkGz5/0HXWr4t8SGOn1jK81aXYeuuPJvPvwMDGUgkCQ
+        0uknthcgAjk8h1CkGU20MnEF+dOpD60szJ5iST0qDI2LY8pL7Bx50JW0/0cBbjS08s8XYO1rQ/qj
+        Spak1BbjQNwM09i4wpJEC/ww6e1pOBeG/6auaz/d59JI5LuTm+ozRLoAhIRae5/6TiCi9xrkrLwa
+        8sCGkidunzOhkkPG17y/zPnkNz+42l1JlZ5HhpJDXLpehyHckbQGb45FjK+Xp3Jyd7acxF5+vQf5
+        FVTkJGsoF0huWnImkDm7GNFzN4jwGUIev61fUwzeDgoeaA/G7Ydusu0rwQWVX+y2YI3k+sQN0KWC
+        8AZmdmBdPW2uQEG6epV8BS94hRfKLVhwr18r12hGu3y5XIM/XVnEs1e59b9L/wL2/DbImhIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2158']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:18 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1879']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:05 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <trolley_add_order><describe_trolley /><trolley_token>64--iT3taV8o23t_Cio5ezl8RWnF2dwamqGnxAxyHFwzwLv4eD8d-OfT95uMI97ePXNksIMIVO0SFfXmvpFi5qwdGzigDgomE0jFeZsfr4xiAVNWuchyHmEnb-ZQWlW_eYj3Ty3O8BBbfRsV0IVn_kdXhLAMRCANf1cxLZMxsVbe9TBqpwp5oq5DhdTECfGomixdD6W2l1QVVhDMuOi32cj7Zj5eyDDjA7Z_Izg8DuRLow8In4WUGqrQgRF_sPeTKSRkFBmYtcGk48tf3fg7wNl4UO4UHeUT95svXBLQLpTu5iz7mkhv1_W4K6WmAZ2o5UkdCcKprnlrjS3dPcCPjhvwBYZ29YUkWyFEEATFzsEIqpbycidEKgDX6dE7XiTrL12TH7DTwpENW0BcJxTxY_2W6hwG4S9QBCGIdJyFdWBrvrgKSil_LMvbZ7zBdyYea94qt_YeoSnkNpNJMIUBnFKDOLyk-Xi18lmkez_cXOdFnRikyNpCbgj3dyeD5y8IbZr8QhR9hbNhIQ6-Z</trolley_token><user_id>whitelabel-testuser</user_id><order_token>c1--16kut9RB3qB5vg82y8sxt1gLWHGf3I0J8vkFUdWt8Uf6Ah3eEvsLLtoyWhBF36HkmfnZ68-_xhAzEAI5Za_7iWhNCEoOQxBS6350KYOeSPgdwyX_WKvzXxYMGW0WYFYphvGKJJX-9iNDBz7KXwdvfr-enGyH80kCpkYekLaM5x8NNJPGdkIQ9pICWhOMzRrex814XKL4QtMu_AdyLCHXIRMCbSiXm9ldgnz4-TjSm_8QX3G0Tv6GwU8O0wW2RCURcddxtH02kzDOU01nkeAlipMbfb7TlSkJdOm1vj9N69J_tBdPIM6LQ---Z</order_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsUDfEXxcUCHyqYlLXHoXFHrOkiCFhc3j34smOD16W2zX2VOT-TnkryAjJ8N15iPw8qeHlWzsKzFfY</crypto_block></trolley_add_order>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48ZXZlbnRfdG9rZW5fbGlzdD42TDk8L2V2ZW50X3Rva2VuX2xpc3Q+PHJl
+      cXVlc3RfbWVkaWE+c3F1YXJlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPmxhbmRzY2Fw
+      ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X29uZTwvcmVxdWVzdF9tZWRp
+      YT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X3R3bzwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRp
+      YT50cmlwbGV0X3RocmVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZm91
+      cjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X2ZpdmU8L3JlcXVlc3RfbWVk
+      aWE+PHJlcXVlc3RfbWVkaWE+bWFycXVlZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5z
+      ZWF0aW5nX3BsYW48L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+c3VwcGxpZXI8L3JlcXVl
+      c3RfbWVkaWE+PHVzZXJfcGFzc3dkPmRlbW9wYXNzPC91c2VyX3Bhc3N3ZD48dXNlcl9pZD5kZW1v
+      PC91c2VyX2lkPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48cmVxdWVzdF9jdXN0b21fZmllbGRzIC8+
+      PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1202']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a2XLjuBV9z1cwXankIUOLoESJnHCU0m5bm63V9guLIiGJ4moClCz/Tv4kXxaQ
-        oMRFUnsZ98wklX7oFs49AIFL3IuL05T/+WJbzBb6yHCdX76BK+4bAx3N1Q1n9cu36aTNit/+Wf2T
-        jH3XsuBeUXVdcX0d+ooPUWDhqoyChe7aquEoASKwgZSFqlf3EMmF8yZZ8/cedpWF5Wpmdaqw7Nb0
-        lpLZkLypMFywK99d6gB3dtrg7nFThBraFJuPoLy5N4fc49xpbu1Jd42mzWXr4UWbNq73z49W7+Ha
-        fWhf+0PTaLTXWnFTLCF72ATlOf/6wM+GE3bimP6+trkVB0Aw7nbiM7y25q+o+9pePsqFzJzkcJWe
-        i5CxsCBdSgY5egO7JnSqpsCyr9JWN3s1sfnEiVMIGuN9fQ7YErhvLvuq7wavQ0IoLzcV31G6s93O
-        qDe0uz7UYH09GAnlRrc8mBrzAASrWVFXRCu492aGX+Gndw+7ov3Cj0WrNq4IaumpjCWuab82xIkO
-        +i8ufvC2krEY19jdrTar8Uqfrc/U3q3ptYTO9ba+l2bdYFu/hTvx2kfrvjeyR2veHqOtdG9u9VVJ
-        MpH3fF1W/buSoTutxsrabWfmo/jEKdfqi3lTGQJ3f4fb3Rq3ao+e4eBWazz2wNqaduYvN+6s0uZH
-        asln+2vX2cxuuXLT91F7NLtv3JZ8OO9PWU1y1HvVtlXH2yhwM1pgsOgr6ryxugb36lPf3Arj9lKv
-        sba+Btxy/jha4actzzeGPpjXik7fXc30KT/CrzXdacPOQ6/I1wGUhE2jvVpUhCmSysGm2+LBAnv+
-        eHIvzUf1V/QglO7d1a6CzGl77y7bbUl7aRtipzG1y/Z9gNx+WXot8Y99pTUabSpPz9P+9ImzthrH
-        KYMOr2+NxqqzHAbqwrHrTfPBkIT7WW2FsVDfDBc9czMTNT/Qur2xO6rU3Mc2HhgK3r3suj3DqN28
-        tMTmsLPnppYj1ZtF5EJ411xN6m5x1/VU/9X1+rco2LY60Jts1Xs0Kj9Yte3D+nrWft7CpgnHt56i
-        LOfi3bi4sm+lrsLa7XmR7d3MrveTXWncYP0RX+/oG/PB7ArY6WhgfuMBcLMXnm5g9zWocSz7JBey
-        m/W4d2kUa27g4CqfsNJwGAdQVwwMbcUJ7AX0Q+YpeBizKi8CRw8DhP6bGQzIhTPogYncwNcgAXVY
-        hS9YwRBh7tgjbc310CHSqhPCZsZ7RObEPEHfzXeMSIeO2MWqRcayF4YD9SovXSUPytnyXRCuFrkr
-        4YSOcI5KHuipWFtXwQn7aMr2QFAlm9fQYJUvn0woMeY6kdWtVX8Fq8XTPkebrAW+T5L6PvlFXbla
-        eCTzZaCEsVQ17PpVwHEpTgwmrHgHiHw5xTpsiyPgWaoGUbh58lCKQ7yooL29cK1CGvZhjFb//a90
-        /wRP0Kqsw4VBZqhoa9eIxo+BxEI3zBoyzcC290xD9XWmSW1yIUM6djEcDFe+iskRqegqVguJyVFt
-        WNXDkZLOEXZk4L13woiwYzP5lUw7ipFwELpZ6IQaYZRpmFn6rs1gsoQtdAIY9k6zkk42xGtXTwHR
-        K24M68NUH/raU02ymaNdm4V+5VTCUoB4rjqYTsjzU7yDIaFGztHo+Cni0Wf5xRkoTiW5kE6i+ECh
-        ax1Pps3WYEKGysAJK5r6GAc6dDBDXjtMUemyHFdxl1FUojCvpZuxDRuaCdPWAyDnAz0V27lwTkVw
-        IVklJJ4OU7MPVTrx1pzk5GOLGqJptkhZt9+toQ9jQpwGjVXgKVvVCiCN7jQgawaOU4HlOrrrsIFJ
-        XHkEqT0aqBfZYyMdWrNUhOJ/KJ9sDRWHE0hhsf0QiGk7HYYUilHVSIeL6q8sFDqR+EYxyZkTP6EQ
-        efIAhlVpTD30PCKZ8RLemSFNQ0fnh6ULie0ZLKFEa2mrtmHtUyS6wkLy3MLBaeHr9WM3R05PA0dz
-        1H/qkONXZ7qkSCcFdkKN34JvkN1GCvStAXeKB8kJGJ6/USI/a5JJBELFV50VVKCjx+34/QQ/MUDE
-        a6YWrAJyyvIcIKk+IVBugDWyyZcIkgOyHD4ojyY0BDWycUhklCpAKAlchn0wUvqe/LFtnQQ0eSgn
-        AjFmHnHycl2xzAElglVHJ2FGcm9IZzmRBeIESD8XuZ857u8c+Dl80vkO8bh5D9A2wqqPT3zCA+KM
-        Gglc6ytdUgZ8uVh6t0tKPPiQS0osDz7jktgFUeqh+zHM46Nao9sayYUUHFMiN/RVTAJpx9RJDebA
-        vyFmQJbjqyQN+n8+dKL+or8NvVq+aR8spBXjFtnlbpJI0mDMINPDAapaxvZoj6EDgR4yhUM7OkuQ
-        YXthtRQl5kM/esrQ34GHoGWRRyGcmWPrdI6X5h7i3WkaL5wZewVdhR6CFikywoOnKkRH8LEpk2S8
-        oj9Z7gqEpiMgF5L+axUp5Lwhgb1EVYfUwRkgzIXhcQP1YxKMm7Ktvih+4DjErfT9A55sjRNUtknO
-        PMPLo7IDyR1Bh+SigwNSqYV7KZrPOTwmB7TCStEOCCWEa3B9covU4jv5CSqHNSQ9ExtgxJQmA7lw
-        hA4JnpykOGQrpl3l4gM4j8to7UbpcUmXQ9WMLCZfuLJk7irfv6RkbidRARVXKLVmrzUaz1u93lgu
-        pAwxiRYoKqn1fRJWc7KR0IEWHy9xkfCpaEzf7Eh6yVz0Mt5OMt4c6iQjVsJT4uszYoUk/g9kxMpJ
-        RrwUomFseK5rxZVb9JJzWBgxlmGHp220L1PNtxJt5b2JNtpSdHZsTaqRLRsDsQUpWyOlROVBykoy
-        HN2hJI3F1eEs7pJA8mkAZ4M3/Ju+uMpVkWPu+nIhgah1vbZtUrUAqRgd4GmMPi+JybC2VRbheqOn
-        hwvMQWlO+IxCBkmWFr4TUrs8BxAdM7zjHiGo02o6T5Fpik95oHEzavRa4bRzhgyVlloeWQ2jGb5m
-        wWyH2Bvn1IS8jEDbuVvDKZjhpW4Q52D5vGxwohecFQpOFIL35pX4WvrFqa+QlY2+SD4Cn5KPhg78
-        iHokch9Sj87SL6tHp+w31aOK8An16Eyft9WjAOlfpR6VuB+vHv3l/+LRbyMeRZv2R4hHhS8ViWgo
-        XhKJSAX2lkJU0wMLM2HRqIfb4AcKRTSmzwpFwm8kFAmXZSJSMW3hSkVsgC4pRSpiZiHlf1ks0tQF
-        8R3+nl6UUL4nGTUoi/mranv/YGaqb0D8CQUJvUdBGpMKCSLGXTI1G5K9pea1pO8oQwH8iQESqflv
-        A2v/dsnP8gL/7qJflCS+/O6ivwKkD8kgFRZIE56n1Tlp/n7K0IecAnip9H657FPaEB965GNOOdWG
-        erV2q99vXRSGeirThrYNmUsqUE/6Q6hAZ2SZYvkKcHxZKF7QZgAQrkCFL1fAH0ehkf6IAs1gJkqA
-        k35rfQa885IS3QIy5X/0BUtON6+QU/EcntZy+p1+Z1QbNHuzi0oOoTAdEkw6kzoo35BzLsRQ7r/q
-        f4h287GcJfLgI3r299SbbFr40erNO8+Ho3rTk9g7sfTF6k2vNmn9Gv0GcG8IODz/Xyng3I1a7XfJ
-        N3c+XEJyv9OZcGDiondoOPRm8HtoOLTQf1PDEd7ScN7OKN8Rcj6fI486zuFjolhSOPnIKIN/6Iuk
-        wvFTo8LFTxL/A9zjHdHUKAAA
+        H4sIAAAAAAAAA+1YXVPbOBR931/h4WFftsay80FgVXcIXzOUUEoCbPvikW0ldrFlI8mQ7K/fK8t2
+        7JIuZKbs7EMZZojOPbqS7rlS7gV/WKaJ8Ui5iDP2fsfeRTsGZUEWxmzxfudmdmqOdj64v2H6SJn0
+        BCU8iDxORZFIF4vCD7OUxMwrBOVeLDyfhC7LsLXZggO+ymXm+UkW3LuBZ5pD0xff7j59S64XnJri
+        2D+/3v80Duaj6ONw+TC9nJ/Jy+nV+Mof2glaHcZ+fjpbyLH/4H8JhqOjYnAxviLRzfTqet87En/d
+        fl2Kv8W0OB7OnLzvMD/3r5/OP4/PT86/Ls/6q6P7KHJIPN9PeuFgvvKjyeDzYHKZoHzcN79gq7M/
+        HMZCEhZQ4RFOvUeSxPpwm3AdIBcDQjwIH3VP7rC1HmlDSEXgnkC0V08R5bQilCgOYrnS3IQI75Eu
+        iDALAXtqcE0p2RdEGLeKUtkrFzBTVH/0FCIlJ4EEbRVzjVecctrhc452B6qVEmq3KwrmLoSrfLin
+        q/ZKFui/Nqgsqej17Abp+FzzfuA2ID7ES272rs+1pnTgNas82ZFmGb+TNP/TOI4Zo9yYRtmTaE3U
+        MbDWu7Lq8GYFk7zSpFSoDTTmcv4NiyUNjakkkgojmxuHKeVxQNaT9DIh2D1O2IJ6lIXVuDTNCvrO
+        cFhoHBaLQkjDQfYQUrCxa2ohAy+bzwWVrukMHIQqSgtfEwUNMhYK1+7vIQc5XXZt1PQV/KRpGLpq
+        WTRCTsVscNA0Gw2R7ZUwYaEn45SWdBONTOTMHOeghw4QMtHegVpp84TK7/ch0GO4blx2ghIV74yB
+        jIwJWf3ciAydAeoNXx2RARpsFZEB/M4cFY7tIlJFQL/CZZ5dHJ6eTCYn2Gphlb16IYxTmqa0JujQ
+        6M/wXg0v9mtL83p5CTz6mSsjSiRvJmqwYqQ0jAnkOMnVlbRcHGVCuqH9tOw/9QaFn4bxcjdIsiKc
+        84zJXabuYsnBMYNAFvBgBlmaJ1QFlyduJGV+YFn/6sESEVzX0GptwaJL6cGVkrZ1cmdBCi9te7D7
+        LV9ANDeugxlJ1csKQsLm4XDlGOdERu52/ssp+EdnET/3MBuPIoo8z7gUnlpQv6FdqMsQGyjqOeso
+        +n+Wdw+hZQ+hl+VNCX8o6Jbidry/tbidxX6JCxGx+5Du/VeIKx4KwrfUtuP8rbXtLPZL2z/ESkia
+        emtEHSSJKX+F1hVzC7VfWu5N1X9p8f84G3S44CveTIg5V1WAVfN0GKpuDqrSQrhJ/Nh82VdQTYAu
+        jkhi1WOZ3VPWLh00UFtXOSgXqyNCBRPcqxRrWfCCZqrEgV0mRMaygIKlN9y1Ua+PrQbBScYW+qOp
+        vgXtPccGcwNia+0mgj6JZV5O+VyUjVkHUN0GNApQfjdtRjXEKVl6vGAMKhtda9kOlGHPUJxCV9JB
+        9hXtexAzSkOor3Io0ZTKqmwrt7MJr8gFJ+qitmg1ognqCBlPVZepd/8MxTnc3rLqu7wd7dsINGmQ
+        uoGqG1XvPnXRLmoapzaOBfQ9pWd9Gp1kXQyLrOAB1UVmk+NAa8E1R7e4S0k5I4kxA6IxJpAM0MGs
+        Z+hiFHKjqGZPziZn14eXxxe32GrBFaWkA8U4g2o4NFrNb8teJVtzI7r/q/gHM25A9egQAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2754']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:19 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1250']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:06 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxldmVudF90b2tlbj42TDk8L2V2ZW50X3Rva2VuPjx1c2Vy
+      X2lkPmRlbW88L3VzZXJfaWQ+PHJlcXVlc3RfY29zdF9yYW5nZSAvPjxwdXp6bGVkPnllczwvcHV6
+      emxlZD48bGF0ZXN0X2RhdGU+MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['345']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1bWXOjOhp9n19B9cM8NTGLwdDD9S3v+4r3F0oGYRM2G4Rt8utHLF6SdM9NXHZN
+        kkoqVTHnO1r4dHQkgyL9fbAtYgc933Cdv37QD9QPAjqqqxnO6q8f41GVFH78nf+XpAEEFWTYUHE3
+        CFN9xYN+YKG85AdLzbWB4SiBDz3F8JUl0PKOK2V+H5FUL9wgV1larmrmSYokBWq3r5UofVfbjaeG
+        smcelcdAqdLLsiXaO45aGE+FXS5XoUq6yC88gWxZkxZ7yIrmoneYUAdS7nbqvQrPgwnaB1Vr2m0d
+        psV9tdwqHwZVYRHOq8ZIfZTr4WDQlWc12M9pTLgRH9t9u7mv6WxfWWitVq59UPdBg0H1PrfedW2v
+        0V/DltwU1AZNDkfC06Ehkgsp86z/kgOhpmhwAzwUeFCJ8hTf/O9waQ18ZQM9XXGADf2Y9wKSAh9n
+        PkEsw8f5hTvonP8ADwIFDw/MV6ZS5nyVBDToq/kKHs1wv4YeTAkxKqkGChOuhZvcwRXwycDHt3PC
+        E0rMbgOfmESUNJ5WgUv66Z+kCEDIA2osCMw84yknLlZ4zUmqw4KI1ZFUG0Icfg5JPgSeulZMGF62
+        lMHSOgciAab0Y+kT8qzOM+8P1apgifOFfl97cl9nyjP4zIrvrJSwiH8De/Mfomw4DvQIee3u/YuC
+        SQ4y515ljul1Awd56ZjEI3QJnMJx+bFjIKgRMsLy8glXJwo29AwVnAslzcTT1wPOCirQ0dLrODQK
+        4E+CcTSiEKwCHxEMRfNS5hxPqAFSFVfXfYjyJMMxFJVSLvAz0Yeq62h+ns7mKIZinrOPwYQe4h/b
+        1rR81CwlUEzKPOF4TF2Bp+h4AinA0WITiukkJZAUM2KYXyz1i6JIKvcraun3BdJ6X6YgufYRnqXP
+        krIOfhIcWhMdEN42IzzDUSz/5oxwFPeujHD4d8RE6XhfRtIMxCaT6KxdqFY6nYqUucDSeOoQRBXa
+        NjwSktQknw0tz7fFYwRfpbiFrc3NozUEyDsVTMCUsQFonc/gwqQFSD2qP3PkxaGUhruLAj9vGbtT
+        NSl0JOClByCQOV6jcAPzvmFvrGgVU81oCl9EpBV0o/SAvGQBZKAA3yzLP9AUm5UyJ0SyXGeVfCRp
+        mnugcwyNwydQypyriWzdcWMfP/v8CYicCpsMnroni0ovJRscFC9wnGgViMeJZvAQvkIlGzvaM0SM
+        aC/B9y1PCRh4IPLDC9oRSQjRLbieDRwVJr1/hUob10exYroTQaQpLIUTcjRfDS9uEVkx7Tz1QJ1M
+        9xKXfOyZyVoY303c2gtM8t3Aw/S4cnjAAwp9hIflEj5ykuXxgKDnAIsYYSJRBFgM2P3OJRIhY20E
+        aelOrVMbFrrl9kTKXMApJaZjClHDM0kjLhbOi3gqtry0DYCDogU13UXhWoBlaMoRz+N+vEBeMph/
+        ZLD/yMi+ZmRed+3Y6WdD+0lM8k9GFG+3XNeK51u6QXiBRZPTMuxoYY3nwMXlzbw31m/SO7KVxQN2
+        BNII3qAZvrG0Us2/BBPW2eSS6eBiJedNkiS97oLx2HABd2xLbpnFhlMR666+d6b1RseW25Ta1bll
+        UC4WOgX0xHO57sYrWbbeJyuDcZMczdMWkxrT2rFPphvPwrB9YpxQ6ZUZPTei+LtDLA3hgaKIfkfK
+        nKEkul7bNt4AYZlQUeousaS5s7/8HxRJM59UkW/bHz1XZPbGigTmdl5ptdqoUB4a8z3dlOe9QbPX
+        wkYOVrWB2Wi0H0Fvhbi6yVPmtjRF1cfVmxXZLowq/yDIeBX9kyJp6oH935Jk2CslWfWMnwR/J0mK
+        yUR5oyT5DyJJ/jqT5G4sSXOTk9vkyAqNpt40+pWCu59s9P7INAf6Iy/76h5YHLNhc9tBz8v2trDK
+        KUXn85vkfRUpfghFHjfV75DkNS7J31iSPW+f9Wervi9YhjxjJkuTX4P+lDvIwy0ozmgVjbcz1RIF
+        GG7DMapaT6HbfLMkP7BLygD9JHL30SSf47Pv0GTug7hk7jqXzN1Ykvu+jjeRw4nNocLiUYwejXZ6
+        oy03Xg8QKLT6gs1zXY6m5GGL7whzc8Zbof8FXPKuihS4D6HI97pk7jqXFG7tki0xWBTWmiB2uNmu
+        KZDswp9CY8fmzOZAc0vVYbXDbWembA5b2QFcBA19XP4SLhk4PwnhPprM8YzwDk0KH8QlhetcUryx
+        JOdMXXlqUlqrVnLmnsK7oWw/ceSgWub3NoDrOW0VqopWtNasNh+zsMlrevgVXPKeiszRn1SR15hk
+        4caKHPNqAemzrFfbUFk/0Nu1dTDsDuuM0Kc3u4nhoKzqbpm6CPtjtnvoL3k+J3wFk+y4WJLifSQp
+        ZMW3v8ziosfeH0KS4nUmWbyxJJ8eRWNgt8hRmeZhvd2w+W4uy8tyr7Q8GGhwqPnFunGwqhVI7QXU
+        HbUrj8OK/flN8q6K5IRPqshrTLJ06y83vZaw79FK90lr9NaL8kwtKHtlxM2USXbjj0rCprvbr6bI
+        0hlyG9a0ktLvLs0vYJLxS3+auo8mRZZ7x5NymvoYmqSp61yyfOsn5WQ429CV/ajjFVq93cRUd9vy
+        aCdT/VlVpEFBX5iiZ6CV1yO3up4DC1Fedr/Cu5u7SjKb/aSSvMYmKzeWpNnpt/cz0RxQptNXWo3m
+        U2mXrYz9sq+rDVkNPdYcuu4cjij/aQnErTNr9NBXeHkzhRrWJH0XTbLxwai3a5L+IJqkr7PJ6o01
+        2aw0KqvVHLGlHh9ao95s0+wuSaQH1X7RCtsltwoYfL+9fd8UF+1xdtBpO+AL2OR9JcnSn1SS19hk
+        7caSHMCCt6m6dXbskJMSmrbkeq4oN4zdWh6xtWDmDgRjKm+rK698aGgdkQn5mv2pvnJn/nQ4+ftU
+        8vep5O9Tyd+nkr9PJX+fSv4+lfzpTiUnmvvAZ5P/1MHELOIdy4t/S/svFfqH4Ng2AAA=
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2216']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:07 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+LTAtLTgwdndHQzBmdkd2VVdpX3cy
+      al9qdV9GMWJEbDltdjUwWml6QXY3N0UwQ2Y5NlpyOC1LbFZLM3g0OWtaT3hWMHgtU05NSE9FNjZh
+      VnR3dUZsV05LeFdCd0ZES0R4UUY4WnlZRmlUY2pTSHlRUU5TWEdlUDdkMnlwOWpMUG1Kd0dmM1Bf
+      WmRLSzdMeGN3dUkydEhQNWh2Tm1ySVBoZUtTSjhjSTEtUlQ4enhJOS1aPC9jcnlwdG9fYmxvY2s+
+      PHBlcmZfdG9rZW4+ay0tLVFlQXJwRm9IM1VuLVZDdFdLU0g3QlNJaXZoU1QzR3VYb1E4aVdTcUZn
+      ckR4SWRNOTJ5Nkdtbm1mUC1FUVVKLVRZPC9wZXJmX3Rva2VuPjxzZWxmX3ByaW50X21vZGU+aHRt
+      bDwvc2VsZl9wcmludF9tb2RlPjxwdXp6bGVkPnllczwvcHV6emxlZD48dXNlcl9pZD5kZW1vPC91
+      c2VyX2lkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['429']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VYaXPiOhb9Pr/C1TU1n9rxwmLo8fMrEpZmDSEEEr64hC3AxLaMJbP9+rm2DLYh
+        b7pf1UwqlaBzz5WluxzJ6H8ePVfY45A6xP/jm/IgfxOwbxHb8dd/fHubtsXatz+Nf+hojxwXLR3X
+        YSeTBAzY1AwxjVxm6DRa2sRDjm9GFIemQ80lsg2f6NLXFn0XIZ/lZjL0PXId27zghqJLN8gtQ/0l
+        o/RLRvmeId0vzQpPASPm0iXWp9GSRfF9XqVvXSSrmzE1/cfWqMs27WG7OfJK9XNnVZ4ptGcH73X5
+        PHuxrW1tdySdceSUtP6Ozdft/nT40nv/iPrj2tNwVi49f5Q6FTk0T+2jGZFT2wy3Zfft/DqYq+Rx
+        rg2iAXK3HnuavIzwu93uLMQX1W+hwSPDUXXx7A/xCFYsPpfXi1XH1D6r3arlNs35oaRoxOnZpWPF
+        f9I+fLunervD52S90KXCnnS8xz6kEYUYmZB6bLTmupSNuMHG1DJaUCmnwwaHOCUkqG7FAUu4LqLm
+        Hq8RFSMKj7ninJKwB4gKs5iS2tMpwJOm/7gLYixEVpIEYGZ4ykncGvccPh1UWlJ2fNoTBnMR0ilG
+        obUxP/Ep/yQJajYzxJWd0i/eV6QwZ8b7i2kttIR4sa9n5/vKKAU4YyU7e+Is4V/IC/4tNB3fx6Hw
+        uiEHmnPkMZCyVUmX8JLIZ2GakyRDeeBqTvzffIdhW3hliGEqkJXQ8HDoWChz4o+xwW6GyF9jE/t2
+        Ok5M0wh/F1TfFhrROqJMUGWlqkuZnVMjZplktaKYGaJaUWU5peTwjEixRXybGkpZk1VZLbIvRk4/
+        wY/n2bYRP1auyWrKvOKQU1KryoqZwMi3TeZ4OKGLck2U1amq/ijJP2RZlLUf8ZO+dkjnvQ0BH1OG
+        QlYIyib6LlTYRhii0/82IlW1Ipeqvx2Rilz5WxGpwO9UjcPx9yKSRiARGV5ng0a7NRy2dCmHpfZU
+        IYQ29jx8IfDQ8M+ObVQH9YsFRinuwoFFDLbBiIVXRw6mjACxjSGBs+gicRXPL114iSmlwXJZRA3X
+        2V+nSaELAc40xJB0GbNTgA3qeIGLYffWZ9zCOYu+xiQODzJ0F8HJEsFmS9UHRS7B8XNFdJf4a/5R
+        VJTKg6KpcAZmoC5l02xAY31iBjhc0eSULQCxUoHIQOteJSod6h46mmHk+xAVnidFhRTeoboHilZA
+        6jHtFtR9jG3ITQDpjUKclECynK/wlByFKNbDHO2CcEK8BRJ6yLcwX/0dqgeEsqRiRrNaXZGhFK7I
+        RXxtBzIGZPPTM+QH+Sq6eVynoJnJzHw3ydNuMJ2SKAR6Mjk+QkIxZZCWPHzh8OPxyHDoI1eYAlF4
+        RFAMoH6ZBy9kqI0o9R52hp1JY9QczOAqksEpJaEDRehAJ9lC7uDM2dNig8Dko5RJyhzb3wVF+b8I
+        TkkuKfLvC46i3AnOXzV1XNIBIW5Su+lhe4PFhe46XnxIJfWUG/5CxxTld5U9qQW+OrFf7kCtpUBq
+        gcuOQ52lm9bPLchZmWDw0gJVuOjgtJU6ZaB+36HFtov/8uQp8kNJFsZDXcowbt5sPA/Oe1UtJenJ
+        Y/yB10KxojCEC/8p+3S5HNhw0BegjLGCaw0J4flyjpOCGcuPvCUOjVo5z0rBjBW4yMI0vs/fQjkO
+        dLhJT96SuFIeBnXhqPHPvHsGZ6hReIWJwxQrdSrRAdxrMLyaxGc3WlLiRlAFFO0h6FxAbkF9mdQI
+        gf42hvBKUJePP83BYvuh+o31wcITub1WyG65c1qbWl97be5ng2oVLctkN4s+g5r56DiVl3p33p2S
+        xkvXeZxFWnM3azS3x/FMY5/bzpuiyJ9ltKfbz2BrdUwLR4v+TG6yY2VTNt0FPVRNcd9TnXNdHbMD
+        nU3eRXvqllpnszNpb8b2R98Z+wfx5/L49KI8rnfnSYAa4+OsWxlZ0Wt93jODiXbc98NIG+FZfRj6
+        Ddej/bIIrwe53cGd0Fs6PjRVLYnEdRi3H2gD5DJtPj7QfeLzj+aN5xeGHDnu6SQNhlYpsjNLng56
+        ukHhGhu37Kshx06T/fX8BaPO69NMiwV6GE7pOyxuZAukCq2zMkn66gbMFRZvoQawbqA8J+5gqYBk
+        2hGiAzjAm946IhFNNVCBK9yXhoTOCEPuDTOP6bdBz4X6JsC5sH4RzGIIpXw75fqM73c8abWvHjnZ
+        yyOJko1DDOkJ4RUkXhaEs+h1UbsM4QULbSE6b154aHX30XbF6LzXnJDo5/mMnnpnZRZafbXeOVMN
+        +vM4NKvn5lP3pWfvD1FgtZ/Debe53vq78tCcO9vpuVSbzzR1NUaPb+NOafwKZevOJh/FpaSdIhU0
+        RSrqjYV808VoD7UBW3FxeqbdwzpsDO6jcF25fgNxRTzMNsTOAUnonp4fn+FgLWB5CmVcxIpQxuDv
+        lcR1scWEVUg8Aa7RQnLFyDml14XLMCvMK8TD8Abx762qUWWi9ZbWsDo6OIvd6VzqVhSidcUaDXq7
+        Yb3xvtuO99r5fSMuTurxNXh9VmjkDtajcUU9LKohnpx3NUzEpTud7cZmI6qsO8fjqbWpPp83RN0O
+        Ve38c28Hx8Zouu+oK7P99Nw9HQOEldH2I7fuNDnZOM6OxXebp/Gk3YVauk+H9N++DPsPYdEuYlET
+        AAA=
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1997']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:07 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGJhbmRfdG9rZW4+TTAtLTkweEhfTFpqWTJuQWd3Y2VSMEZnMW9x
+      YnFpRWg4SzdTRHZWTDY2YWI0b3FWdWtwOF9CaWk1UTlJV0lUb0FRSWlCVnU3RHFWQURqeFBWN3Rr
+      akdVMTEwazRhdnNqa3BqY0dfY2V1WktWMER0eDVoNF9sWnN3Nl8tdkoyaXo5MlB0d3NWUlgtZFRs
+      M0V6X0dSRmhQZFlLaVBudy1IYnhDUTFCZ3F6UnBhQVB4Vkk1TmN1UzlXSl9wUjd4dktydTdOZVY5
+      TXJuQWxtc0s0LVo8L2JhbmRfdG9rZW4+PGNyeXB0b19ibG9jaz5FMC0tWFc2c1VJYTAyaFBzX25C
+      RU5JdGhGTUZETm0zOXpHZjRWMXNKZHBYOTB6VlFkY2o4cXhvR1B1aTM3S3F0V2dGS1RNUUpYWXVL
+      UDhDTVY0M09ZM0c1MHJfeUZ4X3VveUZfcmo0bFV6U0xXMm9CVzdMdUxhbGptdENSUU5lWGRGR1ot
+      UTJuRWFMQnRldTZaT25NZU5udGktTzRnWmZHXzdrNkk2Y2xEX1d3MzE3b2lKZDN4NW5DN1luZEoy
+      bXF3a1JnWjwvY3J5cHRvX2Jsb2NrPjxub19vZl90aWNrZXRzPjE8L25vX29mX3RpY2tldHM+PHVz
+      ZXJfaWQ+ZGVtbzwvdXNlcl9pZD48ZGVzcGF0Y2hfdG9rZW4+VV8tLUpmNnU1UjdKYmNNNk53aVpx
+      eXozSTUxbzdJLThzcEpxTTlBWHFqUHY3elhoLVp5MnhTcFNPMXN1bExnTlA1MndaNnJlUnpxOGVv
+      LWJsVFZxUF9BdTVnR3h4eUVoNk96aG8yak0yN3pIdmRweEFOVHZHMmZfRkNPSXl4cGFlMU5qWTwv
+      ZGVzcGF0Y2hfdG9rZW4+PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjwvZGlzY291bnRfb3B0aW9ucz4=
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['740']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1ZWZOiShZ+n19BdEzMU9MCbtjD5Yb7UuIuLi9EAimgLEomKv76SRYFreptbt+3
+        W1FRkt/5ziHz5FkyLeHPq2NTZ+gjy3P/+MR+YT5R0NU83XKNPz4tFx2a//Sn+C9Bt5DmBS5WvCMm
+        TKT4EAU2FgUUqLrnAMtVAgR9xUKKCnTR9YTCxxIBnqFL9IAPgULeA8X2Sihko0SgQ6SJbTKt8GJC
+        H6aEGBU0C4cJ1wZIOUMDIDpAQiHDE0rMHgJEyREllacmiCZKPxIVgLEPtHhphJnhKSdWq7/nJObI
+        0uJ1JmZDSMTPkIAg8DVTOcAw/6YCcVImiFyZ0u/aD+TJZsb7hlkNqMRf+GPryboyyhOcseKVNRMW
+        9R/gHP9LtSzXhT41N70LyikmPihksyrc3RsFjJ/uSbxDeeAhjvWXroWhTs0xwBBR3o6qO9C3NJAp
+        Ja/RiVzxgWtABbp6Oo5FiwB+pjhXp+qBESBMcQxbEQqZPKEGWFO83Q5BLNJcmWOYlJLDMyKCmufq
+        SGRLVYZjuGf2XZjQQ/LjOLouRq9leIZLmQ+c7KnHVxhWiWHg6gq2HBjTaYanGW7BcV+LzFeGoZnq
+        1+hNHyukdl9dkIwRBj5+cooZfKbK2KQkEP5ej1S4MlOs/LRHykz5lzxSJr8LLnLHr3kk9UBcZJI4
+        G9Y7bUlqC4UclsrTCkF1oOPAOyFxTfJs6WJlWLtLrHv1UmxSHT0RmxBg/6GYgCnjCLApFogybQN6
+        F9kv3HmxKKWR6eIAibZ1fphJoTuBFFGAQeE+xuERishyjjYkq9cOUQrnJIIBvcg9QBRsgC0ckMUW
+        K19YplgSCg9EsD3XSB5pli1/YascS8QPUChkZkxSY11POUJ/h+Ky/gRElYoUGZK6jxKVDgUHXBU/
+        cF3ilWSfWI5s4TtUcEhFe0JqEe0VFFwIdbI3R7K9gQ/jEIin8xGekgMfRPUwR7sjCSFaguc7wNVg
+        Mvt3qHD0EI4jZiTzNZYhofBA7sWXdEYckZWDIzJfmEfRzeMCIjUztpysJn7bCyYgL/AJPTYOr2RD
+        IcJkW/LwnZO0xyuGvgtsakGIVAOQYCDVL9NIApnERpBqS12pO6uPWkNZKOTglBLTCYXqkkzSqVzj
+        zMnTYCOOyXspKykrqH+mWPZvKThFpsgyP19wWPZdwflWUkchffQ8O47dtNm+YFGg25YTNak4nnLD
+        H9Qxlv3Zyh7HQjI7+q3UJbGWAqmEHHYsZKl2Gj+vYMLKCkYSWqQq3Ovgop0qZaDwPkOf0y76m2we
+        y3wpMtREEgoZlohN03FIv+e4Yrw9eSx54SNQND88Yk9RbU87iAeOpmELjK3FvjQaal1GXs8bfbbt
+        2q3FbVUfoR5XuprLE15N16He0FZN4srKCsD9asB7/WB8PM97i7DmVabX5hjUN7eOsh/uKkWvwwTy
+        qN73jyde6uL91ZTWvUCpn5ar1tieB3y17KoMh53TxOjSN7TU9utw0C1VPXPnsUPQm9TkcUOvdNpW
+        ebNRlzLt1LfNeq9TD/D55IWNE7tZXAYD0xjxHZve9M431VxtkYPR4TqZnFZ6WG3WimG3VNsi31I2
+        vYAcXmfuzR7KJ93g5HU1oOdjy+DW59nmML5tO5WK3Lk2T7LWo/EykNndQR5aLbXcqKnTowLNuV0a
+        2qpaDpSgP6Tru6Ba8XxpW5melcFaCfU92kEGrmx1w55rtz7gsRMCTVkRf1+a+nIEABiV9FBek/nN
+        ZkzRmNXc2pt87qiHS7derl174ap2PcxGRXisMDS9Jeeu/F4Jqg1c0myU7B7g2mEShx+LBC3wfXKT
+        yD3dD4I6Mf4EZYwdOcJ6Pok1JsdJwYzlBo4KfZEv5VkpmLGONtAgCcscJ4VyHFLNFRQ6qmcX8jDp
+        JAkq/juvnsEZKj7uRih7JMUBYTGqVU+AQBqnt1MyhSJpOi/Qwwa5CqnIswNSIxA4k5RM2ssrSM7R
+        jmq5pBDxsfwxzCYTO7neGi5y80kc/xgmFxydXOmoqG3pwNcp0ixhTiMt4T9Y4WOIPdKPxCiYgnFx
+        NLUBEwwQsnl37i9cpn5BrtuoF4cDdTpUyq3Tfnl4u/YWVrF0G9Fqba82ORO151OZxdC4VsH50A/g
+        zJKOt56xPau3cIvZLl/vMQY42JPt1NUGS23trC/20jxI6u04lxa6sQuZ1c5QtLe3vdSv9qoHsGv3
+        mpK82BjQYC/umJcXgdzcSqU1LXmN/nLYY7k32ekt6DgJXlaTW1102sqvPjl+kXJMWhgJw7RHJAOy
+        7W7yqLxs1geCHDlqPUdyC4JitfzMziR5Omn7JvANKL6yH4IcOzk9Kh/bfxIKSWop4AwsG0SthrTW
+        d1jUbzTSUYGRxWtc/l9AITaqqFHfSwKTsF6gPCcKu8ITkrU4H1yIgostI/AClLZqltw0PhTEdOxh
+        YL8w85jw6vScq18cnHPrB858dmEhy+r/O7+r7Pfye9VujDudn8rwC1SpeJ9/S4q3SYr7gdmieacI
+        p7wrn91wE6gc373yLXjbaxPXlquzRmgGvcHuNOvjozJ15Nu+UevPrbY8ldaN2nU1aW5IT7+NOwej
+        tJMPzX675dKyN2mObohuTYs9pVxWe8puwNobYGB7VYHapnJpb8ctWrtKWlm9TGvbg7KquZJOujFX
+        c1BvsNSlNcsowUEvHTqHljfD0mgAqma/XuLkboP2rvrF75k/THX2L6R6sm8/m+oV/pdSvfirqf5q
+        /59Ufzjlw1Qvfi/VE73fn+qV8vdSvTHvzn6Q6I0AEU2EKMP3guNva+XcRJo0urcNV1ttd62K1FU7
+        jh6+9fHlwJ7sA1ZqFlTftMt6jtrNSVuhw66G4GU7gCV/6xne4ozAGO+Xw/NWlv3SBDt+5W3RmXQM
+        +8ZzF9ycAdRWLnN06kzGJ2bSWHv8eL+1Znse0Tea6Q77++VyEE7xsayh8fAi6RLTaHRPHeeG1lWV
+        HYej5bxe1BwDrvTpEWpvClB+opVzfyG/K+Vfym/m723lr/b/ye+HU369lSd638zvxyNKvkTIUtL0
+        rOim8fgq4Z0kF28v/1L5Hy7T1raTGQAA
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2304']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:08 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcj48Y3J5cHRvX2Jsb2NrPmsyLS1lRGFPaVRqNE5MY0cwVlhTQkkxRW5sRFR6
+      V0FOc0gyNHhoVXF0V1FYeWRCY1dDMTFUNldhZWpXSjhvSXVPcHZTSFR5OW82UXhDT2FBWXpGX2pM
+      ZjYzb0YwdVZOQUlycHE4TUd0anhoTVhIdV9BcVVXRE9sU3U4NzVuYjAydG1xUGdHLXpzVWNqWHlK
+      RzQ3b2hmbzFMYUhQOVZPQmQ2RkVpNVlZYlVWLW1BWkNBSEZBdXR2cW95QnExWVR3SkpoZ044Rmwt
+      WUh2emJoV1pzbXRza3hQUHFXZHk3QzkzeUc0OVpzcmlfWUh1ZWFfUm56bExWcWRnMlZYN3UtU09p
+      ZzJYdlJZa096WkY2NlZGeENxVmNILXRVdVYxZmtWTGlEYjVCOWJRcF9laFNsNExsYmI1dV91SUwt
+      QWZ1NzZvck1aNlF2X0pYX3lkanNmZTBlV2xiWTF2OXpJYTh0bXlhY19Xcnlwd0NkVU5hYWFONGR5
+      Vlh4UFBSUjAzZ1I5bjlLVnZGYmt3R0E1OXhIeVc5eGtSTjNlcDYwLS1aPC9jcnlwdG9fYmxvY2s+
+      PGRlc3BhdGNoX3Rva2VuPlVfLS1KZjZ1NVI3SmJjTTZOd2lacXl6M0k1MW83SS04c3BKcU05QVhx
+      alB2N3pYaC1aeTJ4U3BTTzFzdWxMZ05QNTJ3WjZyZVJ6cThlby1ibFRWcVBfQXU1Z0d4eHlFaDZP
+      emhvMmpNMjd6SHZkcHhBTlR2RzJmX0ZDT0l5eHBhZTFOalk8L2Rlc3BhdGNoX3Rva2VuPjx1c2Vy
+      X2lkPmRlbW88L3VzZXJfaWQ+PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjxkaXNjb3VudF90b2tlbj42
+      MC0tdU8zTlFsYTB1SnNzbDhuU3JUbjBBd3NubkJBM0xKYlFMXzVEcWpVa0t4SFRpMzR6Ti1iOWpi
+      QzJoc0VTUVYxdGVneDdhdmtJdWVSaU1wekhnWnZienladDFHOEFIMGdha2xQWlFuY0pVY1htWHds
+      VWhrTWJ6cFNNVGRnZnkwV2ZnX2NLS2pNSTdIN2thZkVIQ01WVFlnZWcxd25POFZUdVZDWk00WC1N
+      b0JJVUxIMTJLVm1IVC0tLVo8L2Rpc2NvdW50X3Rva2VuPjwvY3JlYXRlX29yZGVyPg==
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['904']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VYa3PiOhL9vr/CNbW1n8bxg2dmfX0LhkcmPAIJAyRfXH4I48SywJIJ5tfftiWw
+        TXJrZ2p3U6mATp+WpVb3aTnGn0ccSgcU04BEf3zRbtQvEopc4gWR/8eXn4uB3P7yp/kPw42RzZBF
+        Yg/FVoxoEjLToInjEWwHkZVQgANqObZnRsRQPrcYbhLHMHtafLPgUchMqGcoVahgbGyXkdjUVLXE
+        EWDBihLsoNhs18ssARasXWi7iJp6iSOgEodQZtEUOyRUynCMBGr+s+xewAUKbnG6Y8RyQuK+ma4l
+        y03Zoa+rh9fw0Y+RTHvO/ePtQ9fdtLej5nH/NN0M2fRp1p05TS1U007g7AYL/3FeG3kvP069gPqn
+        PaO33vLuZze20iAIf/g6qbdX0QE9Pz0snXU4pEsy2696q/eW48w1tLxbDnayG2un4CVF9sr1l4N9
+        5xT35GdYaXl9Bj9WRt5QZLqaLNt+Ko8i1Z2z2jh6eVruJ/Epxd/99+YsGuDxpH9Mxz9O6iw9RovO
+        ZBX0t8/Nt/vmaD/dtobd1wWejzraOmztNfX07OmtetLue91nrzVfNd+n8mF1WK/fcL+h3vf7c8Zc
+        u/7cpY0Dbr5qYzS/G3ba6FXDzX3HPq2tw8+ZOgyx371/SI9TvK8/3j9OEdnP79IdbrfrzdFqP2tY
+        Dn5zHfp4bCekO1otppOn8HX/koy9Oe6+NLqz2eBOG422qIbeX/YD6stLv/f0/NqT1+vJSKVLzLSD
+        myJrYLnL2qTVpzN9G3V7t0TVbL89urP2azZ4xkt3oa4x26fh7j35cXib3J8a+PbFdw6qLL8YSjmU
+        PK6m4SG6s5m7teCLa34nYYhcJm1igiW2RVB9UYIMpcoqnDBiW+KVgLw+vj90H0o+vGZKQ8pM9Uat
+        MAD6L5eSlbXNbKUEsXSHTJfPU3LM4dL4somAuiSJYCUuwU4QIc9s5+u8DC8UvqdOb7yAeSpYQcnX
+        1/FAjSTK7MizY0+KQahKHnwLEbHIxqIgYtTUDKU8FDYWuG+obD0DRkbbxYGLzFYjW2oxBgWM3a0d
+        +8jklsuwWIBpIIgqfNggoXz9/ZWhFCNuyJfZByFO37coRoLAF+8GTKhiaFPrgHybygmFmF1wTsnZ
+        Y5tKy4wi7GIK8KTig7vYjMUgoiD7GbPABYdH9iOHTweCnqs7nzZFYK5CWdAgFtYbSstPUvLonQ1Z
+        AxH0s/cFqcxZ8P5mWtd2IF7s89n5vgpKBS5YvCI4S/qXjXf/lnpBFKFYetqSd1py5DFQilUp5/Bm
+        Bx5fmlqW1SXgYs79f0YBQ570xCBdqUQ2UgcjSCq7cBLFl/Xd2I58ZKHIE+PctEjQV0mPPKmT+All
+        kq5qTci7i51TE+ZCNm8oYqasN/Ssi17jBZEil0QeFEG9peqqXmWfjZyewg/Gnmdmj1Xbqi6YFxzO
+        lLSbqmblMBQnVBRGOV1W27KqL3T9W039pqqy2vqWPelzBzHvdQj4GKo+ZpWgbJOvUoNtpYmd/m8j
+        0tQbaq35yxFpqI3fikgDfhd6Fo7fi4iIQC4yPM/GnUF/MukbSgkTdqEQ0gBhjM4EHhr+PfDM5vj2
+        bIGRwEO4DxITWoTN4osjBwUDdH5rKuAsh7a8yeZXzrzcJGiwXJZQMwwOl2kEdCZcegwf552EBngX
+        IiHJZz/eY3xEsvDYphHaLGAJbLbWvNHUWt1QLogRksjnX2VNa9xoLR10vgANpZhmCxoLHWCH4g3N
+        L7MVIFOqrAFApzpLlBga2D5acRJFEBV+TpoOR/gBNTAoWgW5zWjXoBEh5MHZ7OB4E7hkZkeeL+cz
+        XJAT6H2ghyXaGeGEbAskxnYEvStf/QfUyG6/ecZMl+1bTYVUuCBn8YXOxjKy9Yb5HeMT3KCgmfnM
+        fDf5064wgxLol4gnKDrCgSLK4FjK8JnD2+ORoTiyQ2kBRKlrQzKA+hUePJHzOwz3ngwnw8fOtDde
+        GkoJFpScDhRpCJXkSaXGWbKLZPuFAgI5x+c3jqx0S0OjEuJCj1bI+ypp2v9FrWpqDV6ZflmtNO2D
+        Wv2dImT1sCMkFPen/GivsKxKwgBnHS5PxtLwP4igpv1qW8gTia9OHtWHkKgCEBa4KQU0cEKRfNcg
+        ZxVqw/MSJOUsoou+cCpA42N5V2s2+8sPT1Nvaqo0mxhKgXHzdosxXBZ0vZYfTxnjDyxqMbtkwpsz
+        bJnfhcF+BZU52TOUClLsLjsWeG/fJ4heBDciFwh5/Fp7TTG44pZCMHvsD7JFX8EVYr7ZWYw2CF6H
+        PSmbGEJU9RIBIcwOratXgStQkK5u8B/BCq90m/8MFtzrm/01eqZVb/nX4O/JiXgnVD77j8pfSB2H
+        3I4RAAA=
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1772']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:08 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PHN0YXJ0X3Nlc3Npb24+PHVzZXJfaWQ+ZGVtbzwvdXNlcl9pZD48dXNlcl9wYXNzd2Q+ZGVtb3Bh
+      c3M8L3VzZXJfcGFzc3dkPjwvc3RhcnRfc2Vzc2lvbj4=
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['89']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA21SXW/aMBR9369AvHuhTGIgua7GECtjgg4atvFi+eMmNSR2ajsM+utnB7ouGi+J
+        r8+x7rnnXHx3LIvOAaxTRt92b973uh3Qwkil89tu+jhFw+4deYedZ9ZTBy7yqAVXF55gV3NpSqY0
+        rR1YqhzlTBJtcHIdwcKeKm8oL4zYk5QiNEDc7X4sd8Uqt4DchH9djZZjkQ2f5oPj83qRffGL9cP4
+        gQ9uit7pk+LV9DFfff8wl9vZy0S5/OXZu5Hc3Kdju/im5HC72Y6edp/zTTWq7bL/Uez1nOdgit1h
+        uq5m5vBzdhjzdTbo6W3//vcvnLQ0YVtrHWZvZBPMmdiDljS3pq6IhNJQpT1YzQoqgSt/RnDSJmJh
+        Aktf0IRgCRkLjlFhau3tKfwlkHqPk6sAjnb1eWPk5YgthJaalUAmQYV23jIfouikQSdO3tCYlIcy
+        NpfghFVhNpvE61MBJFNHkMgz7kJEzU3MkJ6PzVcilmXoIqvJkf5L/FsGj8IWOINy0GCVuFDb9Ghi
+        6H1eAdn4h5PXKqhuef2fN21PXqs4FUm18iA78/A6rNkbtQHjaFe29Q9od30C6wIAAA==
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['448']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:09 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PHRyb2xsZXlfYWRkX29yZGVyPjxjcnlwdG9fYmxvY2s+VV8tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRnUlEzS2RaSXpEaXNnenF0czlkVkhVQnJO
+      TGlkOFpWWjloakNnVnA5dXJPMjdja25LYmdlb2xqdkZTcElvdlhJdkJiU2Y2MG5aMkh3WTwvY3J5
+      cHRvX2Jsb2NrPjxvcmRlcl90b2tlbj42Mi0tWngwLTFJbnhDdldCSzlmRXRZWEcwOXREZUFyQ0du
+      TFZHd2dxNUhYR004ZXh3VFNEOHEyUUdJRnFvazZDSlhmRl9KNjRMWTR0Qk5jbmJadTc2MFZlaXlF
+      SXRSSXd6OWxEcUlRM1hBcTJBS0VKOXMwZlFpRWxDb0tTdDBUdkVEdmlBRmEyaUQ2TWNNWmctWDRv
+      QUp4ZGhua0tGQlh3ZmRYM25mZUI1MWtJTWEyeFBydGxFOEF6eWRoZTBmaVphems5UnUtb3IzM3F5
+      ZURNTWJ3Mld6eGh2T1FZdE1veFY3eTdUeG1WNUp5QnEzQUJRSk5TOWFtaHZUQmJEQ2o1M1cyeV9t
+      Q2JmOTFhd2FqLVpLczJjQnBfMnhsaVR3YWlNMjBOS3FhdzZTNVZNOG00b1pjbjBzNFVfOWFEVG1H
+      Mmk4UXBXY2pYempZNllWdEZoSWNObGhlcW5YLUdYcmNiVzJHb1o8L29yZGVyX3Rva2VuPjxkZXNj
+      cmliZV90cm9sbGV5IC8+PHVzZXJfaWQ+ZGVtbzwvdXNlcl9pZD48cHV6emxlZD55ZXM8L3B1enps
+      ZWQ+PC90cm9sbGV5X2FkZF9vcmRlcj4=
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['650']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VY2XLqSBJ9n68g7sPMw4wsiZ07anWwGS+A2TG8KLQUIKONqhK2+J35k/6yTqkk
+        tMCNud0z7XDY0smTVZVZWZlZkn79sq3SGWFius4v38QH4VsJObprmM7+l2/LxSPX/Par/DeJYtey
+        UKCohqG42EBYwYj4FpUl4muGa6umo/gEYJMommrIjivx9yWSjgOPuopmufpR1hWOq3Ma+Vi/fViz
+        PUYc6Wkvs9ZbR981D6/1r9N8vBvQ8XzSmWh10RKCtql5j4v9bFp5NbbPl55J9pcTJS1j9bTsYCUw
+        Tet5X3arzbVzRpv520p7twZk5U5O6976s6FpUxGtnlaPHqdj8WJuA6Su9f3q8dS+4B63kfjc+qTQ
+        YM8lxNQsJAeISHwOuTqGukfkyPUKx1HltKPN4eZY/uQmY/OptqzOp4Y4OiCn2zMGtQDhz4G2Pguz
+        zVzbUkvd4O6upzoz1fQUNDY/4LF9IC+HdqX2YdSmi+eX2X4wtt6f943eevh+mXK1Chl0q4/meXS8
+        LH3zNH45dgJ62jp1vTzcfwUcev7s69MWVha2s3ndHmtvDj4/NbYNQ7QWRlM1zFdaGc0NI/CHh8eX
+        Dlcr94YeFygf/ZZm+ZfutPxWNTRjUz4tuu7r61PD7ArKhbaXA6WL/W6lhbTatvuiiFPRPVU3uvf+
+        Wf0Uh8qL3l8ZDc/ptBtH/VQdjQZ+q+NazY0uBo35YmXsyeSwmfc6fvujgrwGOl0Cd3z0a0652dOV
+        dr1RW5y1lepsyNtw2xla50V3Ig5O5TWtNN87Z63zPL+sZ+vlBW/JadhZdD/Gu7H4rin13mZbFyvT
+        WXnT2I1OC7wZzDa7yevmYz3ZzNr9CapNB8EXXZKn3mbzrgTTL6XpcX2s2YueJ3DcVuLzm3ndWxbw
+        uus7VBZTVhYO4wQZikmRrTi+rSEcMm/BZExZ0nzHCAOI/S/OcQdNmMT1sY4ANJCMvqhCEaHCVSMr
+        LWgYiOhy/4si7KhWaQFqpY6qg6VG6UY/4ib61KWqBUPamukgQ660HlJ+QVZUIVSuCg+1GzqhBSpM
+        6KlUP8jiDfsqymsQpFIPmzqSK7WbBaXCghJYd1DxHsnVW52rTNJ9jCENBukT8+he8yBB5KCUsVN1
+        6sK+C0KGE4MpKw6EZrmeYSXRcQU8S9URkcsZTgxlOOBFhQS25lp8FsYoRuXf/pPVT/EUlaUoxGQp
+        cTLb+W4YpDot7bBrl+gBQYVwfCTxeVaqZCN6cI0MELmm+9Z5y+gwd2VeIQii3c5D/+NSwqqjUlUe
+        Lxcwf4aXCFIqDTwk62z8DDGCM+9X40wSn8TCUUijP6EwW9u95XABA+XAlBMtvG1AFS0RqjqGio0M
+        mZnluIq7i6KZhGkh+xrLqAlHOCtNAKl4QDJnonAMMpHPp1Yi8HSY2TBS2dL7a0hp1zcmYEkFGojg
+        84Awigls8bpJ40NiuY7hOpx/BGddQSaPqMNIHgtjZUslJP7H+CqmUH4zQCxkfgRh6e+q7f271AWP
+        +uFSMmIJuo+oFWHDRoU8D4XuAi8oR0jO4Ux85LAECducmJeoXZHcYCmvOJ6hOjq6PygzJyHkwJQT
+        2dFRIVppbGivoMAs5dMl8IkTww3FsdujTcgCV3Gkv3SgXhmlV2gAoXtLqfGuYBPiC5q/s4k+FQ9B
+        rQgLVpTy7ookOHNIwaqzRwpUmvg9Gmxx8P9VEqEKzZEHJRISYKksiJAWUwpj+1SHwN4RROVKPZyq
+        iKY0gnQIJTgN1Ua5Uavm2YmQ0QP4sW3DkMNJhZYgxswrDjvtNuuCqEQwHFA4WjaK6JzQ4gRxIba+
+        V4TvgvBPQfweznRfIR636AP2Dicf0xuv1OihNFKD/6c/6uVqoyL8tD9qQu0P+aMGv3/GH7H9Ua5h
+        4Rgm7lm7+9qfSXwGjimRG0YqhUrwWepAs+Kgf5DSGMzBYS+DS4v+fJEoMp+xZ9OQ68+PiQTeYtyC
+        QHdlGE6lYc7IgjEDqsBB5kGZs9m8nBbNyxHOuc7LhW0Yn+hHKrE6WEh9Ilvm+Tp8DCUEVpj45D2q
+        P8S0vbAziZJ5oscqE3v2PYIsC1ZKaM7E/q2J8DR6ErI4f2eMPXIVViAtlZrUB5/XoDyXW3VRrDQk
+        /opKkM337JETHkQBdrhWh04lhSU+HeygEgUKE+SDHYmuhTkgzKZhXYLimaTR+FWy1S8F+44DW8Hi
+        RiyDDTeoZEPWvcMropKDoBc3kAfxBtUhisloPffwmOxjsNl1MrQEYYTQBhfbYRpmy79BpbBJY8Wz
+        K85K1cVY4q9QUiKg5NKQrRxtWYgrdRGXyMGNsuqOmRNNV8CkH1wNcneCn7oM5G4B0e39Xsa/J5Ci
+        9ozNNW/3hv3ZfN0fDucSnxHEpGj4uQodOIYzvIZQJAktLmVxC/Knj37hPpa7ieW2KU2xa2RAVRL/
+        igTcaonVn0/A4m1B+lEmC4+U57pW3BlGsVHAwoNmmXZY26Nwzrz+l7wu/nSdiyKRrY5rCxOI9BiI
+        JUQ5m5kPKUWQsdJsyAIbUl7cfa5ilRSSbs99/syHf9nGNR4qQmkygtv7FWLSw8G2oUcSW6w4ZjE2
+        X3qUw95Z0UJ7WXsP8gKU5YRz8DkkNS3cEzg5Jx+RazVw3CuEDNatFykSKwcZD3SfZ91hP1x2QZCj
+        ssbOA2tKuol1C+UVYm/cu+UXr/fsvXAruQVzvMwN5R4s3b/O39zj717gb27uP5tZ4mvvX5Mx+eTj
+        TvKpKP7OcPMJKYf/oe9N/PVDEv/Db7O/A9pPXdzdFQAA
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2085']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:09 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PHRyb2xsZXlfYWRkX29yZGVyPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRnUlEzS2RaSXpEaXNnenF0czlkVkhVQnJf
+      eWlpbElnMm80OFdudmVZU09WYlhsR3NWb1BxV0RXdzdiYlExZVZIVkZwLWNyMXppWnllYVdjZ1ZG
+      cUF6ckQtWTwvY3J5cHRvX2Jsb2NrPjx0cm9sbGV5X3Rva2VuPjYzLS10X3FmdDhMWWsydy1QTmlI
+      NVU0U1FkMU1oZW5DRGRHNXllcndHYld2MFJZU2JadGxhWXJDZkRhblJhaXBfZU5pamFuUkFoc0po
+      QTM1amQ1UVRJSlJnR05sWElnN0RXTFh6US01M3NHQzRGaXZNa3pVdWlxTkprQnl0cVpuNmMyTGd4
+      eS1lSXdFY1E5cl9UbW5ZS1prNU9ucnZIN1o3ZDFsVGQ4YWRpS3QzTVNkZHl1TGhGSkItNTJETHAt
+      eV9qRTlibHV6Q1EyTzRkYmRZMnFUQ29LS0g3aUMwX3p0QVVHX0NydUMzOWViNVpDSl8xUTFvcTRZ
+      Y3BYdzR3MUxfSmNFVmQ3cG5CQTdrY3E0TU1HdTlCb2w4WWMxeTdTVFZkZ3NQaFlTREJ1QWozZXA3
+      ZXF6eW9Oa3U1bjI4RGNfQTY3NVR2YlZhbllzT0xaQkxsdlRDUDFHcTJXdDM4WEJ2YkJJU3pXUldV
+      enJac3FMQlRDak5mTjFYYl82RFlaNjEzUVIyWTdmTXFUcllHUllmUEtZaldQWVJBRVBlNVFHeXh0
+      VXNIRFlZWF95UXhfOHAtRXJibVREcDAtLVo8L3Ryb2xsZXlfdG9rZW4+PG9yZGVyX3Rva2VuPmMx
+      LS1hZ3ktS24wY1F0M0xuWlNWcU1yenltQ2d3NlBuRm1MTUV4eUxJejBQeXhuVEFNV2lFaFk2a0o2
+      S3FOaDdHQmpUbVFLQTFYbDdxMTB6WWQyNzR1OEVkQllkN1FXNndOLXZXdlhYa21FNTBKRUVRdHRj
+      YTRZQnM1dm02ajFMZVFIR0E4ZWoxbTZxQWF6WF92VVAwR2xtZ0JKT3l4Tm1xNFJKUk5lb3FRSHlw
+      bTg4NDZLV3FQNV9ibWtjYnNSeDh1b0JLV1ROTVNsanFadUxkUW1CWjVCUFBGSDFLS2hlM2V3WnFG
+      c2ctVmdEU1lqRC1YWE1LMHNWbXQxdmN5ZV9GX2NWM003RXNQMmhuQkQ5bzAxYWc4S0hfcVh0Rllt
+      VmNUMFhtdHF5bHB3dUl2a01KejVtOVpnYnYwLS1aPC9vcmRlcl90b2tlbj48ZGVzY3JpYmVfdHJv
+      bGxleSAvPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjwvdHJv
+      bGxleV9hZGRfb3JkZXI+
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['1098']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA9Va23LiSBJ9369QdGzsPuzISOI+q9GEuBiwuRkwGF4UuhQgowuoJAz+nf2T/bJN
+        qSR0Adu4uz0z2+Foo1MnS6pUVmbWMfzvB9Og9sjBum399o29Yb5RyFJtTbdWv317nNzSlW+/C3/j
+        Xcc2DHSUZE2TbEdDjuQg7BmuwGNP0WxT1i3JwwDrWFJkTbBsPnd5hFed49a1JcWw1Y2gSjRdohX8
+        PBs8G6OVg2jcUO5G1UFNXVbW96XDbtxfttz+eFgbKiXWYI6irmxvJ6vRQ/5eW3ReGzpeve5cXNWm
+        7ceaIx113eisOLtQmVl7NB8PpsqT0cJTe7ibNWYvZUV5YNG0Pb3d0qrDvuqLI5Jn6mp6uxNfnQY9
+        53Op5+P9BW9tjHXFQMIRYT6XQk6Oce0NsoRegab1w6E74w67+biLR69mp2VPam3Vkuq9FduvcfPF
+        ZqHtxNakMVCOvQ43kQfLscLJ/alyV9k83KE99/K4qrgSazw7HmKfFq2nRkfE6GXXc/D4YaZtSqhr
+        qIVly+JYb+Wynj3VR+OZN/AWJeZWwXK7VdqNGsVt7WU4cegmY8o7s7hHHo0PGzS297edfCNfmy0W
+        xfZi9LqXO7v11n5e5SvifM6Iu91rrYrUVnu21Iu3zcKIvRuo7FNr9VJtcBvzxWt0lEp+Wdi8mqXh
+        qJpfOcWK0j6oD8siqitqJy/qUrvbf563W02D3mjey325PK9iufcoliWNhtfXrC2dWrEv6oMKXepM
+        x/NZkWVr2nrHaUozr89b4uuquVw91VX20Wx1HXvl2aP5cqIfjKd1/eleOtg6fmw9Y5cxufLixbg3
+        7KrcneCHiZc3bxFbGzaG00OjM8G90Z1YKIjiXVPcveZdb1eY7w4Dp/taLh674529f7zfVBvy2Kwd
+        aXtitueGOX7cNUxXHz+sFoW7UblTfzZqO8ksqs/N8fp5WHcHdlnb7/aDqvNMy8OS3VxOFvv7ti5a
+        o764OG63NbliPFb7leGsv3kdastef3CHvFKVXZfb2wWfSwfNKYbIxlJtz3IFLmYlYT8ekSbpLjIl
+        yzMV5PjMczCaU+AVz9L8QCW/U5OxfO4CGjGx7TkqAlBDAjq4kovA3SeL5GjGQkNYFZoHFzmWbFAT
+        MKNqsgor1agz+4Ab2bu2KxswpanoFtKEfPUm5mfGsibYFQrMTfGMjt0MFW64lV11LbBn7NNQ2gIj
+        2d06uoqEfPHsgeLBjBGsbi07KyQUzm1OY7zqOQ6k22P8iXh0pWwhEaWgmLGUVdd2BJZhEpwQjFlh
+        IFS4UoIVRccJ2BqyirAfQ1kowQEvSvhoKraRS8IOClHhv/9J2sd4jAp8EGICHzmZvPm6H6SqSy0d
+        26TcNYJKZHmIz6VZsZGJ3LWtJYDANfVBbZCwIe5KXEIQBG87Df3go/jVTXZlof84gfsneNFATHWP
+        WySoZP4EMYAT16fF6TjciZmtEEd/RCFrFRuP3QlMlAJjTvDgogbVmsKubGmyoyXIZFmWLdnLIJqx
+        nxaSl+GYq8MWTo5GAJ/dIIk9kdkGicjPxatE4Gk/szlIJo/enEFKO12RAZJUoFE5vqyRg0ICeXhV
+        d8NNYtiWZlu0twFnnUAyHlC7wXg4GBobMsbhL8KXHRfKfAIIB4kfYZD6h2xu/03VwaOe/yiJYR66
+        nKDlIdMGDUMa8t0FXpA2kJz9O+UCh0WI306FvMjshKQmi3nZ+TTZUtHlSclyIkIKjDnBOmoyRKsb
+        LrSRMSArzcWPkIuc6L9QJ3R78BKSwGk4sH+0oF5p1D00mtAlxtTwrTg6xBc0mXsdvUhbBLXCL1hB
+        yrs4xMOeQ5IjWyskQaUJr4PJJmvvF4qFKjRGWyiRkAApjmEhLcYUwvZcFQJ7iZEr5Ev+rbJoTMNI
+        hVCC3VAoc+ViIc2OBgn9CP9MU9ME/6ZMlWFD5gmHN21XSgwrBTBsUNhaJgroNFOlGXbCVn/NM78y
+        zL8Y9lf/TpcNwnmzPiDXsPMd98wrRXdN9eTjz/RHiSuU88zV/igyxU/5owg/3+OPcP1BriHh6Cfu
+        kVi/b474XAIOKYEberILleCFqkGzYqF/YqoPy3H8XsahJs3xJDIkPiOfdU0odW6jEbgKcQMC3RZg
+        Otn1c0YSDBlQBdZCDoxpk9yXVoL70pi2Tvel/TYsF9kHJqE5rND1sGDo+9P0IRQRSGHKRddB/cG6
+        ufU7kyCZR3akMpHP3hYjw4AnxW5qic3zJcKnXptJ4rkLc6yQLZECaciu7nrg8yKUZ65aYtl8mc+d
+        UB6y+Yp8pJkbloE3XCxBpxLDfC6ebC1jCQoT5IMlDo6fKcDPpn5dguIZpdHwkjflg+R4lgWvgsQN
+        y8EazlDehKx7gZdFeQtBL66hLcQbVIcgJoPnuYSHZM+BNdtWghYhhOCvwXZMPw2Txz9Deb9JI8Wz
+        zo6owqTP505QVCKg5Lo+W9qYAhNW6izO47UdZNUlWU5wuwzGv3E0SJ0JrjoMpE4BgUpwKeNfGuCD
+        9ozcayw2uk04ATe73TGfSwyEpGD6sQwduAN7eAahiCNaWMrCFuS7t37y6AX5PXUSS72mOMXOkAZV
+        if2KBFytsoXrEzB7XpDeymT+ltrathF2hkFsZDB/oxm66df2IJwTlx/kdfbqOhdEInk6WmSGEOkh
+        EI5gaa8nBJssSFhxNiSBDSkv7D6noUkM8ef7Pr3n/f/Jiyvf5Blq2IPT+wkio+u1aUKPxFZJcUxi
+        5H7xVvZ7Z0nx10vaexjPQEmOf49cComX5r8T2Dk7D+FTNbDsE4Q00q1nKTwpBwkP1DujerfpP3Zm
+        IEUljd0WVkOpuqMaKG0QeuPSKT97vCfXmVPJOZjiJU4ol2D+8nH+7Bx/8QB/dnK/NrOEx96vyZi5
+        tLjzk0Qe9gdFnjP790SeCvMpkeci/W2R55z9ochT/h6R54LNxyKPh7WfJfIUmK8Xef7+V9d4gpf9
+        FRpP7qdqOSSE39ZyPinlUNApoi/Sc8pv6znFP0bPgeZij1Yypj38lqQjY2rqUz5SdVwX2je/qX5H
+        3DnnfI+qE8/yU8WdxLSqrIC/3PdUnpjyns5TJ6xI6NEtC2r3GNp9/Hm9B1+j94yhw0CYspeUaCII
+        Kjmr/Lyj43joF4qDAiN6Kw/qzYc9M80VuatlHIZjOO7qrrnCcJ+SLSo0w004jrS3NFP+k2Scz3ik
+        xBWZ/PXC1ncJOZzvjs955FzI6Yq3zV6v+aaK05WpW2Sa6C21plv9AbWmW6UNmV768/8xqswF+SRf
+        umGZfOEN6YRlizdsmWP/OsJJ9a+om/SnlSrLVP9o2YT99CGAzRwCEnpHr9VrjcR+ozt9UwYBCtWC
+        naRRicL5gRZyeQNl/gb9BZrHp7JVnsmzn5Cd31U90hnhq1WPK8vCSfWAlHNfaP1k1aMrTpo/onuw
+        zAfCB8f9Xwofw1Hz9irZY+igJYKDkEb5E4OLrtA+yFHgz9A+ytdpH8WPtI+P08k7AsiP576TABJ9
+        VyY8g599hyaFf+oLN7nTN2lyb34J7n+GQWWhRicAAA==
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2653']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:09 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/BundleTests.test_float_properties.yaml
+++ b/tests/interface_objects/cassettes/BundleTests.test_float_properties.yaml
@@ -1,1051 +1,1019 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48ZXZlbnRfdG9rZW5fbGlzdD42SUY8L2V2ZW50X3Rva2VuX2xpc3Q+PHJl
+      cXVlc3RfbWVkaWE+c3F1YXJlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPmxhbmRzY2Fw
+      ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X29uZTwvcmVxdWVzdF9tZWRp
+      YT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X3R3bzwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRp
+      YT50cmlwbGV0X3RocmVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZm91
+      cjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X2ZpdmU8L3JlcXVlc3RfbWVk
+      aWE+PHJlcXVlc3RfbWVkaWE+bWFycXVlZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5z
+      ZWF0aW5nX3BsYW48L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+c3VwcGxpZXI8L3JlcXVl
+      c3RfbWVkaWE+PHVzZXJfcGFzc3dkPmRlbW9wYXNzPC91c2VyX3Bhc3N3ZD48dXNlcl9pZD5kZW1v
+      PC91c2VyX2lkPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48cmVxdWVzdF9jdXN0b21fZmllbGRzIC8+
+      PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:19 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['778']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:19 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['365']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:20 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['449']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:20 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['1148']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:20 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order><crypto_block>E7--NuwIhns8SF9pSFmOCtayGoPi5orsAykdVtQtCufnKnVXd5ijHtnqR7hewEY9Siu9mKWZXgSi50wUnsm6QPTTn5Ap3rEh2y8qt7LQOigLgEgeiLH4ylijiJOz3cCcGHfmz-mr55XI7fNrF6K5mYhYQ3qn1nCceIO3_pGh-y2ODATK_1unwgfaRcvmf9rRBGVuoIht5KuL4JvyIf1HGwjOVpnEZgHPJm7kxU7hRzZCGSznxEZHloNsR7I2pTbq40t7v2mLo1javANm8iUGKktt-5o16BpnLLteyP0yqrtW48EZlb91SwCaca-PJX0S8BvzKCatNcVD_hETlolGxPekOoYcRxyhOS0oqh4PNL4fG5MfxXXjHxpdCbQvBrDibivFS6vhbjmFeBcQYWikaldIWXGQFooHSH2dWMs_BXrsAz6-j8VMn40F2LZish9H3g6jBjVkrnayZ4NMPTq5FtXcdK_5L7WFk2ASLauJCqJowO_bV8X2sPX_At8097h3QpXw1Kh0OkgxfUXvzDHbFI_bN0XSMiJ0al9y_p-VXab83-6hG9eHDURd6DtENaA6ZdPR1b2kCR_toknr_BpFKcDNzxpBDj9-GWfRRbpiCUM9rPYDDkijx5sFQiucuV4RNL_xRMwwjtm79e8Q_Ffs_Rbj0MXC_rEfuYOIlmhROtFCXJpXG4CNo46bV1NKHU8emAOPjTy5eN5yHKnfgvMsrKq0Ix6-yFmDNxXSz4pazVchj_p8eOwdiIe_aY0Ybh9RJBrav76RZUsxDdWqMKRqoWJyL_--Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>k0--5q_Eg4_-x1Nz1FPUkY_jXomw7H7E1_PjxiUKNYUK3emm0ERjusgvnWUYFQqZHjDGEekx61hC9iIriru1LpexlQdiFWf9oohhZR3m54tmVkLEMIItGP0eGhqQULniBgRbrSIgFusujEyS0Rw91TvO3pqX8rgNeFy0FDAL-H3GFetfBUfLnD1Zi-94KcFBeU0CKwDSXAHtxFWU5WZiFJ-wMeIriNlK_uoAMR58EAI8VqC-Z</discount_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></create_order>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['1384']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61Y23arNhB971e456UPLQGM7eCzKF2O7cSJr8eX2M4LC4NsEwMiSPj2O/2TflkH
-        JAw47urpJQ8J2rMljUaaPVK0346eW9qjkDjY//WLfCd9KSHfwrbjb379Mps+CuqX3/QfNCtEJkUG
-        Dm0UGiEikUt1jUQrG3um4xsRAdghxsq09RMimnjbpFlRGMLwp+zLgLmQvlkFmliEMsbatCgOdVmS
-        chwOZiw/8lYo1NVyLcfiYMYKXNNCRC/nOBzKcTChBjl5K+yKeThEHNX/+D3fP8MzFPqFp4BiY+Vi
-        a6fPDEHY74J1fdesB7PqcCVsQry2Zfp0sAaj5buCLPKutJZy7f3bbigt535r7027WzJrrduLozVr
-        dk4fS7e36ODFYycc7pzm49ZS3pUK8YYtuTYvnxfl1+FUmPq78NR4f1EHctUZHdQP1HHnZ9I9P66X
-        4F3eJ41tJsU75OvtsiBUUadq7KMoaLxvvlmbRefQD6aovqh/bCZueSm5i6Bq4f1hJhNSeZ4vHxrC
-        eKYaG2XUi9Tn7nmDwrOhdFxJUfCz8NpvW+et1Gjuh/35Uq2co6qC5s11Y9NYlPeV+5O6eXMx7TkV
-        ggeDtUqXiO4WH294JAzkrdudvewOb/ZqLjUnR1SbnTyzbb9PFuH5MJSGRms4HlvzoHZ8RuOHD2Oz
-        O1bmUX359jIiw261idqCGTwaPeXQDOyPLpooo5qhfHtr7MevU3v89BBNzhNh0XkJXmsR7ftC1OvK
-        C9MJBpFKW8+NoTto9NWn1pM1Wi7HMJJihB0Htu5bf9h7c04P/frD1vJPvaemOnVmw6k5PE4n87ra
-        wXar1Yx6HyevLffnlve6mGxrxxfyGvlWxaOjxWhwdO+FN03Mh5/tha7ZiAQmtbYGfFh6E7susmhp
-        HWKvRLcI8tSPkCYWWVknD9EttnNAkkjN4cMw14clV65JqC7fVQsMgP6jK3H+m9TUB7MpzJ/jpYaM
-        Sk8B0i02fo6YwLn2ZXEOsXDkg4cW9laOj2y9XL+LpSFtXihsrZPprNUeTGGoApyxEtcnNLKRT0sh
-        yFyOypblYwOvDQISSHRZE/NNbqOOtUN5awpoMS0IHQvp5VrsZtYG/QytrRlukK4klkszc0DXEEQa
-        /pggwMzx9lwTsxYzJG62QcZPhy0KEScw51fOJgqMvelGiGloHtAsh3LBdbFvY8iEHYTyAjJ7MlAv
-        sXMjG9pyTUL4H8aHo2HS2IEcxu1Jl2nRzoaB6pCUCjZcUj+KUBxEiI2xQ6d0BjGJZArGpYhT054X
-        pDBexrsx5M6xye1h2UK4vYBllGQtj6bnuKccia1QzOYV06DF2xvyMCdBzwMXc9J/5jsU2aUuFGWo
-        qhmV70LowGmDqrx30MEIUGjFJ4aVy5smzY5reWj6G2Qg3+Ztvj/RLyVZpdtSI9pEhJbKkgwFNSMw
-        bkQtOORrgqiu1OKJrtGMRpAFBwcyo3IvVytVqcBOjYx+gh/PsyGhYVJJlVXOvOCwuVitSbKRwKZv
-        Q5p5KKELkirI6lSuf1Wkr5L0syR/jWe63YGPex0B1ibUDOmnmJRlCEYDEtf9P0NSk8s1pfLdIamU
-        5X8UkopQlv9NSHgIEulh5zHW8XGj2W2PNTEHc0oShr5JIZEOpQcchT76iZQGsJzQBBkMf0w7sXix
-        b8fWa8+PqQVaHHfhlONMSPIgZ4B7NCK66+wvdg6lBFZkxLSd1BLieIGLuDCn/ViVYd9RQJDrwlSE
-        Fnxsf/bxr3yP8e4sj4s3xt4gbLAi6JrUiQuPXk1K8KWpgRhv2Kcg3cmx6QJoYtZ/axID6g0k9pro
-        PtbEAhBrYVxukH0RQd7UPPNohJHvQ1jZ/stlOBqfUM0DzbzBu0Y1HyEbdjeAcxPBfTg+S4k/t3BO
-        jqDUwqMjR0sRRojXgEPP9KFUJu5/QrX4ps5qYlMelyrTgSZeoFTgoZLSmG3sPF3iBfga18gWJ/K4
-        ZsthT5giphE410BPBkdHODqI0Hi4HJxymGyAvTQ5EYq80hsK8YXKkiC5QPEbSqPVa48n83avN9HE
-        nIGT2AXFtF0UQlrN4SCRlMbLC78k/KtshNLipQ+lWB5yTa0Q7Uzx5sgGRbyPq8T/r4j3IPz/QBHv
-        PyniX6VonBsBxi6/uSWbfIXFGeM6Xlxtk3OZa/6d0N5/r9AmR4p5JzTqDTiyHOAWYuwd4qxcfgyv
-        QcbKFI6dUJAxfjt85V0ySPucwMXkjX+zjbu/U6TSqK+JGcSs263nwa1FritJAc9jbL4sJ+O7Lbz2
-        Yb3J7PECr6A8J55DLCDZ0uI9gbvLR4TIReF9fIGQzW7T1xSNSXwuAs3ncbPXjt2+MhSo7KoVwGpK
-        lhNaLip24NHA1HSNq6fHFchJV6+Gz2CBl3tB3II59/o1cY2mtOLL4hr8bl3hz1Lx1r9//gSe8Zbz
-        OxIAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1828']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:21 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['108']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:21 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6L9</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['778']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1YW2/bNhR+368QgmEvq6OL7xmrImgu6Jo0bZqkyJNAS7StWKJkXmzr3++QlCzJ
-        cecGaIdha15ifufjOTwXUodEbzZpYq0I43FGXx+5x86RRWiYRTGdvT66v7vojI7e+L8gsiJUBJxg
-        Fs4DRrhMhI+4nERZimMaSE5YEPNggiO/IBzZ+0UoZEUusmCSZOHCvw86ndUin44Xb8f5ff9m0pmx
-        bBq54nIdfvj4+NQlIX/qnj26g6dPixvn8Qs9W6V37+f8tJsHm/vl8PbqojgL+53byJ0O3i+n8vHd
-        cnZ6wW9u6bpYYufOHdz0WHCWdq/enX8qluz8aTkaJ8z7+I6Ou2eL9Sx5RHZrTSiKucA0JDzAjAQr
-        nMSRTzNk78NNVHwECA4gZsQ//4LsemQEEeGhfw4hLtZzwkhJ0CiaxDOZK22S+H1kN4cojEVh9CSY
-        Bysyw7wjIbQ1biha0xXm1oOilHKjPoSZvPxnpog5wUItooGVcj3lri03aiB7OpVGnc5vG0JlYSxI
-        UVmwoQZqUJVKSa1mbpGWvpq3R2WIJxA7sV+z8aWmtOCapT16a1jWbzjN/7AeMIuJKBpzjNt2vRi7
-        imTGRcAwnYHKFG9AeTqJKYn8kXPsILsFaQKsVOQsDok/7FeMGjMUCb5gBiprxhZCqQryjpUmpAnP
-        rLQwQ9mx0oIQzQIOOz4hKl7/TReXElOhtkaWCzjrIJl6EwcV7rvI3kF2Gd5BRvcgo3eQ0T/IGDxn
-        2M/d0zkMQskYHOhAqX6ZHSF5BFXdgmrGFIciY77rOA1OCdYsKtMJYf6o12SVYM3KEwynpordLtTg
-        qJrjRTrJErsJw0lrUP/X5vQaRvaul/ZXSvln+v8f6W/mPMwkFWzrsRI2gK1Yn/b3NBYksj4LLAi3
-        sql1mhI4WnA9yXwUIpAb/QGhUTk2n05JXlnuWMytP2VSWJ7jQqJqsWFKEQbZdMqJ8Dte31MR3sVr
-        IidhRiPuu73BaDz2Bi12JTT0Av7SNIp8ZdYZuuOSucXhu5uNBo4baBjTKBBxSjS94ww77vjO8066
-        zonjwPBEWdo/odS7GwEzhhaJiVZM5vKV5blcWKdwUCffOSiuN+453xyUnue+KCi9jufeeSoiLwtK
-        GQTTMetKuzq9OL++Pkd2AyvlZfNmXZA0JVbFMLExv6HPHFyNK8m26wwSOOSyup9rgiUjJVGMocyx
-        PhJgZ81hb/iRu9701t2+nKRRvDkOk0xGU5ZRcUxV36Q5KKYQSQkbDT7CeUJUdFniz4XIT2z7bzXY
-        HL63JLIbS7DJRgSwq4Rrn3+xPc/ZuG7/+CmfQTj32kEUp6rrhUzC4sE5PUY5FnP/Zfr1FPQ1X/j3
-        dWavK1zmecYED5TB6m7UhNoMvoei+s9WRv/N6R06zqbrOIfTm2K2lOSFyW1p/9HJbRn7mVyIiNuD
-        cu99Q3I59CPshbltKf/RuW0Z+5nb33nBBUmDGlGOJDFh35DrkvmCbB8y90Ozf8j4P1wN0C4Iyf0k
-        Xm2/4iVUEeQEugtsV2ORLQht9gQGqKRFDimJ1dqhNwkXqnYaEjQjmWpewHyC4cIgoRXpDo5dxxv0
-        4fayxVCS0Zn52VEfOHfoDYbQP9UwsmtVc8wDuHflhE25fi1rAerJR13VSbR96ymH+nGASUqhbTGd
-        lOuV7wMtVF/vW8i4vOC3aZSQCJqnHBowlULVlOnl7MNLsmRY7cIGrUIMQbmQsVQ9/ZnVP0ORur7o
-        nu7Dw2jsOpCXLVK9YlWvh8Ei9fUDxx4c8Xm21pqNN6aC2hjimWQhMS3ktoCB1oArjmnAQW591gVv
-        3VCyZZoOU7/NMrKKiTYSqtfMIVxA9+EIikiWJq4vry9vTz+cXT3AVbSGS4rWDRTrEhriyGo8TTbk
-        ZVVu90T7afkvely8kpcWAAA=
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1442']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:21 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6L9</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['365']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+2dW3OiyhqG7/evoKZ2rattBESBtVis8px41nhIvKEQOkrkJA0q+fW7oVEwOmsy
-        KacmKrmJvP3S0P21/T3dMSL8szV0Yg0cqFnm39+oO/IbAUzFUjVz/ve30bCW4b79I/5HUGUXSK5m
-        AMmyXWSFkgOgp7uiAL2ZahmyZkoeBI6kQWkmq6IPoJA9XSQojm+7ljTTLWUpQimT4V+alLtcaZWy
-        /qbAyoin8ltqxClW0ZznKJWc9gZup7Q15uZ2ts1s6YJbrFQ5Q8lvRs9tr1VZNTRKm6rbMT0kuXHB
-        topVnVXGU41dwpxJL42marxVxj2WaTjerDmBOue4/sOm9Dqo8xmlz1YfpELGyXSni+XQ7cmsXn8x
-        J93C7LWkTe38bCpkD+5ZMAFQJRXYsuN6DpCCzhFNS8ie0oWFDCUbOC+SKRsAhr53kuBB1N1Y0TWI
-        OhWsgRn/kh0gSygmQKxOhGx8hAtUABWxikLobxbAAZEhVIWZNvdsaS3rHhDzQjZ5KCia6+N6dHQ7
-        azCXYcZDUYt1bAlrasmQGAeWqBxXr6AzYfQLn+IugOwGN5HQovLwlOFhOa4GDYxwlODqwqFzKAkQ
-        yI6ykJbA310hi4ZXLAajMLLuztwrB/XFvhNVKvIM9Z17umbclthyIMeusEVl7CL+kA37L2IsOxpw
-        /cQ5uNnZ+Gayu560oCs5sjlHVRryFlVuzDQTqCJH3pFC9kAKDehOXdvRFCCy+Z0j1rDFQ22RHVRl
-        7NhLghF08rurJKXQcHSVAw1b3l3lQBJMSwqGuA6C/rrOJq482XSDt0Y0QYoCep9pqrTTRUrIvlPe
-        O+gfOnI/dDA/dOR/6CgcO7LHzQtjKCme46CEgSy7V/gd4UEVjeoDKXa8yIprOSJFkglPJMYu0zNm
-        wBE5JumKxNhl67KC5lA64YmkhCcYc9A3ZpaeTcpojsaq+N/k6bEsZN+3MvudoZyG/zbCn4y5Ynmm
-        6+xbHBQmhH1xONuPTM0FKvHoIiaAhPVCFA2AphY5PgknhRC08FWBqUbHOHV64H8ExbsLouHpPkGT
-        FApUXIydnqtI1ssLBK6YofN00MPv9dgIgWKZKhQppsDxPF04cO8Ksd1HP4ahqmJwWZKl+Mi511He
-        tbgCSYXQI8mmGtJiaM+QbIbihzT9Z478kyTR4Z/BlU6fENX7vgfwMXQRWR30ycL7H0FT0CWKaKLW
-        z9wpFM0z5Ic7haGpn+oUJkNTQzrokZ/rlKgTQjbEI61VrFXb7aqQTWhReQRvRA0YBiB2Dtw3+LWm
-        ioUWvytBR5Guo0nOinkuKUYOdCOuB0VdW+/LI2lnQPwvu3J2d+z6NhChZth6sJZQlgFHJUqEObCC
-        hsuioMtosvFQM3KFO4qkC3k08+01QbfMOX6Zoaj8HcXSBRb1fSwL2biqgLXRnB3AdQzfeyHAxSDN
-        A3XPidFhCBaOZ5oBmodRoOiILQ7UEA0OFD6Cg0PbT60ZsOg5cjDZJmw7BRuCJliOIZuIUMK7P1KF
-        YOoLx0NnzPEUieK8V3YErKIVR2CWloYYwtEJXYALa4MXKGFr8PLuUBOghWgI4OEHtiioALooLEl5
-        58FvXlROPPrQBQbRNcHeiUdnuGR0wFoD4UWUYCXEouR1ShfQIPKiS7Tr7fqg2Km0xiiNxXJkCetG
-        FqKO3kwqkVjWJMqjUXmDSX3X8IMxpMjKAo2rHXfDoK4jLV26XG4Tb26Y3yi7pkuXmw5/MuaXg9Df
-        o9RwD9Wy9Cj/hETyTgvgTteMYOEVMlTi8GxkHvIPvrtMjx0gvoqEqARKaw1qMz1ipvcidsWgjHHK
-        WgJTXGYymemSaUGz+6Y+kfdmbdCdkYUWt2yDlsqXigZV3DTL45U2oTLUtNJ0nJHNDrpVrlndep1q
-        Z2s9PUdXxDVGtSPWjnaTi4PW3rFXhSOYPQTZ8K8A4dDg7kiS6LWFbCzh0sXCMCAa2SQZxj6p4cvF
-        fJqCRgoaaaa5skyTgsZNh/+3gEaOzF0oaHxsX/QQNB7PDBrNbrn04tOD8oRcvFXHevO+Me9UWvmu
-        8zCudeubV/J5NehXVxnLtNiWBifG9rHBfxQ0WsVh9QecEW6ufQ80KPIu9++kQedS0khJIyWNW0s1
-        KWncdPhPk0bN0RBp0Kb6i0iDI5mfIA36i5AG/bktjeGZScOuPYEXuedseNvqDZoTrTRYm8/DGfko
-        kW2nP9c9huPWGzixxkqp39tun3jNZ9MtjUvMwilopJnmSjJNCho3Hf7fBBr8hYLGZ7Y0RmcGDVjp
-        yxulyikVD+btufTUnT73Wr0RszXol6bx1mOsVv2ltYD2djh1KuXKY/3B+vDfTtItjS+VhlPSSFPN
-        laSalDRuOvynSeNRdhFp5JxfRBpMocD9BGnkvghp5D63pTE+M2k496/UfaXelOwO7ysQ9EvrokQ3
-        Wv5TrU/65kSbbVZrU3l2nmsTdVV2c8pr1y+kWxqXmIVT0EgzzZVkmhQ0bjr8vwc02PyFgsZntjQm
-        ZwYNauWp5nSqdQbKpjZx+3V7CBWnsip353m5IdutjbMYFGvdwoKqVdXFU7thqV76KY3LTMMpaaSp
-        5kpSTUoaNx3+75CGZyLSYNzFryGNfD5H/wRpMF+ENJjPbWk8nZk06hV/YXpbhprlGKXo9EavtXKF
-        XmTgs7m9RzC0VceZfuu5p77de/7SWLqNjVxMP6VxkVk4BY0001xJpklB46bD/3tAo0BfKGh8Zkvj
-        +cygYTwttFGtOQNArdKzZ2744Hc37ENzPrjnR8MeM9q0VMvy9Ee6We70Vd2cPU6o9FMal5mGU9JI
-        U82VpJqUNG46/KdJo20FpJH/VaRRyPEf/44+hs5/EdLIf25LY3pm0vDX9MPMqjyNcp7mMKWq8dDM
-        PFReTW1izwZmY+2/rTv9MucuOnL5nt2wZR6Mp+l3aVxkFk5BI800V5JpUtC46fD/HtBguAsFjU9s
-        aXDkmUGjV5q0RnbLYZR5a9qfU+UaWx03h3O+tdAeuttS2TLH3JycOQtq0iFV+kWq8U76KY3LTMMp
-        aaSp5kpSTUoaNx3+73xrV/DUAbrwq0iDDZ468HHSKHwR0ih8akuDo85MGvRg3W90R8vGcgCWfoHp
-        cOrKf+23K96kCxEjDu6N+cB+vKc4FkrAl/yy/EqnWxoXmYVT0EgzzZVkmhQ0bjr8vwc0cvkLBY3P
-        bGnQZwYNza4/292F89aWDH0wWMmLHC151VKff6tlXp3VutmZF3ypMqwvqmXQf5ypPjn48MdB0y2N
-        L5WGU9JIU82VpJqUNG46/KdJYwJURBrsryINjqJ/5lu72C9CGuzntjRyZyYN6TkPR9VptWM85Tlq
-        2yObmwa/WsqMZ5Qas9fedEw9GGqJZzYdesuym1dm01+l/3hykVk4BY0001xJpklB46bD/3tAg6Yu
-        FDQ+s6XBnPvRalOFer53l29zC7RLDDTaVUt+mLIFkNkwb/P5tPSUW6mVUpfcgtLyftsl/VH+w1/a
-        9RW2NLJeMCXhJ/TqGnSjgIuC7AA54qGJkI2PcEF4reoaOP5mAYJHP8eqMNPmni2hecADwZSRPBSU
-        YCII69HRWFkHT9XNhA9F3+vYEj2Sev/g3VgUFHQmjH7hU/bPn05oUXn0UKGDclwNGgSGHOTysLrd
-        c50T0u7Rx0vg766Q3T/3OBAFNGwi6+7MvXJQX+w7UaUiz1Dfuadrxm2JLQdy7ApbVMYu4g/ZsP8i
-        xrKjAddPnBM9tTi+meyuJ68Uq1JyTNHhStAhJcebDn8y5orlma6zb3FQmBD2xeFsPzID2CIeXcRM
-        kLBeiKIB0NQixyclEBNfFZjq0R/cKB7RacPT/TPDKcfz9Mc/QsxS/BGc/htFshmK/yhFZk/2AD6G
-        ruy4B33yxR+GfK6nFmePOwHjfwSvtWq7Xd0tCfDow68jeCNqwDAAsXPgvvnecgK/0tEkZ8U8lxQj
-        B7oR14Oirq335ZG0M+xZHh8HZC1CzbB1gNqlLAOOSpQIc2AFDZdFQZfRZOOhZuQKdxRJF/Jo5ttr
-        gm6Zc/wyQ1H5u+BDaSzq+1gWsnFVwUIIzdkBVcNw6XMgBLgYpHmEATtOjA5DsDheABypIRocbUge
-        iYIJgIo63kbB89AMEwQ0vJ1TemT2HDmYbBO2nYINydVDePdHqhBMfeF46Iw5niJRnPfKjoBVtNQI
-        zNLSEEM4OqELcGFt8MokbE14tXeaAC1EQ9HSCWxRUAF0UViS8s6D37yonHj0oQsMomuCvROPTg8C
-        R3LAWgPhRZRgJcTmg0XSsS6gQeRFl2jX2/VBsVNpjVEai+XIgv8bo94m6ujNpBKJZU2iPBqVu2F7
-        5an9e43Ec064Xo001O3Q013x/6bPnrOFlAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3276']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:21 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---ZZc1YHtkzgoeMB4smMEoaIZ76e-w4zggZBX3qdDBO0xeBkHxO0yU56KExuNENxoXY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1U8coAng31d0ZPRtNBxmgnxbx-x26tADE8mc5wUYMuLDqJi1iZdxV2T08V6poAEl7cVZi7ks3n2kmKdmzDVP74JrubKWsl8rtyIwBjRG9-cQ7EI_6-r-OZhkTtPa7lGfnWO6bjBiZp5bZ</crypto_block></availability_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['449']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA7VYW3OqyBp9P7+C2nXqPA0RUFH3YZhK1BgvqMn2EvNCNdAKkYvSDRF//XzQKGAy
-        s2dXnZOHhF7f6tt3Wd0d5Y+T53IxDokT+L9/E++Ebxz2zcBy/N3v35aLR7797Q/1XwqKkeMiw3Ed
-        mujBgQKb6CEmkUtVhUSGFXjI8fWI4FB3iG4gS00wUWpfm5RjhHxaGkpVYuQ6ln7BVVGp3SC3DOmn
-        jPpPGY2fMpo/ZcifGbXP2zPD5EAD3XADc6/KAs/z00RyppoRoGlMmv0POtsZmjca787Ps7W0kbU9
-        arzoi2Qwah+Xx8PgMZp09s/+bvjRpptetK3Hyxdp4YehPNNee8t9QN+bzXexvRKDiF9MDd1+aQrD
-        53231RuOhVXvx3jqJfY67GkxHuiDjRa/R/K8P/SMsKs1z4m4eh4kq6G7eHxv6Fvz/NyU9SDW+wLv
-        1vcDe/ahNeodWPabUqvsRcEx9iEHUIiRDnmD1f5aqRUtZrAwMdU+pFnyYeMQ54QMVQxnFx108GGE
-        U3eXm4qZOjEbx0VEj/EOET6CtCpwRslGmiDCrVJKbmfDm9CT5H9YF2pjRNNFlLDcnnVZVO1sGMjc
-        LI3ZcFluVyGFYBSatr7HyWWGGuR/AaZlklMvPa9IZbyC98WQJjLAd/TrkdleCkoFLljZjrqMxf0H
-        eYf/cisUOpgmpT5s27ViMbWLJ4PIp2Hu/iwYZeBqzvovfYdii/tBEcWEC7bcvYdDx0RFJzaNBXY9
-        RP4O69i38jYLRoR/48QOtblR5CacJIhQcIWZMSNq6sF2SzBVeakpCUJOKeEFkWAz8C2iig253elI
-        coV9MTJ6Aj+eZ1lqOq3QEjs584pDJIO2LIh6BiPf0qnj4YzOCy1e7Cwk6Xtd+C4I0PyezvR1h3zc
-        Ww+wNqEopBWf2NFvnCQSyt0fQsf9HztFlDoN4R87pSGJv+SUBi+JCyn1yK85JXdCpjYs0yb3j31N
-        6yu1EpbbczngHrHnYe7CYL5h346lypPOxQKtHHfh3AsKhSiDOQMWQiOiuk58tefQhQBHHqKodmnT
-        5IBV4ngHF8O+zH1amSWLssNBunGkKi6CQyOCbdTlO1GQ5CacYFdMcQN/xz55UWzeiS1JboHvC1ip
-        FUPZIJd+oB9wuCWqHyi1CpAKEOgHlOZVefKm4qGTHka+D1tmURAlCNAnVPFAqCpIJ6XdgoqPsQWO
-        P0DwohBnAc6W8xWek6MQpYdmiXZBGCHdQhB6yDcxW/0nVDkEhGb5MF21O6IAcb4iF021HIgakPW9
-        pwp3wlVPy7hC7OAjG5ntht1oqphCgigEejY4PkFQMaEQljJ84bDiBTv3IyEUe9zMx1cmy87slhTi
-        2MHZJGZ6trbgVPwKVyCJonwKbaANXu6nvckKriMFnFOysYHCDaCYLK50UJbseVaC98quLFRljS1Q
-        nRYo8f9FddqS2PgF1Wl9Up2/Kuw08w9B4GYpnh+1N1haD67jpWdVlnal5s/ErPVPFT5LGbY6ft6G
-        m+cFyC1wvXGIY7h5mt2CjFVoC8tAEJCLGC76eacCVD4XcrU6098seKJwVxe4uabUCoyZbdvz4NiX
-        pHp2KJQxNuE1VcwoDOHtkBRflzuCBed9BSoYW2TSIIT5hRInBwuWH3kGDtV2o8zKwYJ1cJGJSfoy
-        uIVKHBACnSSeEbi1MgwixFD13+XuBVygauU1lLopFfVczaE0oJgNlJ7hyCCBG0EWEBSD05nO3IKK
-        keVIsMe+qsHDwJKNtunIx9npdd5ebHqn8UtvPenMF8fRU0RHEUYrs3nyz2Sqn8Qu3zqej45sbAbP
-        r0trlExbs5cJ3zkFcrSVR87T+2LSc9BRduPDBrurybzx2n5rSe9HtyHsRK/5oJ1nveOKLJuRM96Y
-        Oh+9bd6P+tayJ/Lrfjp4nRLtfqgPB/xZtEMzWuGeIEadIW9MzP0pjPgX/LYcnp/GmmO0x3EQTe97
-        DpmLcn3b7KaPhdLu4GroGY4PRdXOPHFtpuUH2gCxzIuPNRQ/8NmnftPzC0OJnNZ0FgZQziq7sJTp
-        IL82Cnfw+rhhXw0ldh7sr8evGBWWn3qeLFDDIJefMCVXc7Qr0iSrqxuwlFishO6BdQOVOWkF1ypI
-        oR0h+oAO8ELdRUFEcg0U4ZT50pDRaUCRe8MsY8qt00uuvnFwya1fOLPqwlq5nEp1xvY7f+k/XnuU
-        ZK+MZEo2DzGEJ4SXSLoscGe110XtCoQlrKzzfHe+HiTooWN0k3NiD8SPdpe+39NAfNB8p7Ve/RD8
-        QWdiSQ920oma79LT6r0Rx42449KuEWkyXs/Oz4OHt3q/cTqjx02M9o994zWs99c7NJjNNtWl5JVS
-        q2hKrao3JvJ1F6MYcgO24uL8TPsMK7CxA6Jwq7n+H+KKeJjagVUCMtd1Zw8zOFgrWJlCKBOxKlQw
-        2MsycF1sUm4bBh4HV2kuu2SUOuXXhUuzSMwrxNywBP83eXt9WnZJK3hyFquB6djxKG6Fohlulqv1
-        qDd2vOgcdl1t7yHNOVGUaK3+6ImGy/3aHKB1623/THtk1VxgbLq71/a4ZZuPmxOZLN3uvLt1JL8t
-        robm06KzfPIPkqXNRrHdGmvB86DRmk82pXXnwSnaaXRMttsyjQXtk6trn8NR+7v/q/0JutlajZwT
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
         AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1997']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:21 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:10 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60---Ny2iNMboaNvs5EwtOgbMmJKgzQOW2Y6Mka4R_TyGJ8qUqpGFuL9kQngIw8tYDuf3vUR2Tnrr6OMXDUkotj55j18V1ou-TNb_hR50IQkC7DIK0VDSKNmyhWrDMveG_GYMvju6PEImbrCM5zy1VQGyVIlTFj4_fczQ56_ov_E0-l3kGhOwM439---Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>M0--d6b8ci6qOxXP8TYDxKRDWL9PTqJHutJueaVc5xnzsN_x1C-7qzqi6bYGQXUdJyN7ORL-9xo6uf6JiHjTLDiaq6lvpYelVLP4X8Z72jql40g1m5BMzODqVsU5uiKYc_-uZYjq_fdhL6XkNGXNsMAI_IG-z1hrcuVeD01u9I-bLckxru-ReZUIzHKMib8KvouNADisP163f5C-Z</band_token><despatch_token>U_--5-hWxUCs7oHiTVGcihvJv7r1crYUVWJDKimuzrClMkmaMixtayM7EJHtrUkWcGaW7ZkQtDsV5TeeclgX8K7hcFYxsLUlCPCfi2n81VIcHT9UHnp2dMOJvh7KMoQG47PLY</despatch_token></discount_options>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxldmVudF90b2tlbj42SUY8L2V2ZW50X3Rva2VuPjx1c2Vy
+      X2lkPmRlbW88L3VzZXJfaWQ+PHJlcXVlc3RfY29zdF9yYW5nZSAvPjxwdXp6bGVkPnllczwvcHV6
+      emxlZD48bGF0ZXN0X2RhdGU+MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['764']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1ZWZeiSBZ+n1/BqTNnnpqSRRFqaPugoumW7usLhyUQlE0iwNRfP8GioJldVTld
-        /db5UEl897uXuDfuEmSJf7y5DhGDENq+9/sX+iv1hQCe7hu2t//9y3LRIfkvfzT+JRo21P3IQ4of
-        IMyESghg5KCGCCPN8F3V9pQIglCxoaKpRuMCoFj5WCSCGHhYUQ2BquAXgYa8FivFKhMYAOoNGe/r
-        crZACHJCioqavY8CJVadCDRqYqW8FHUbXTI7jgqVGOxVSEZ4LwWeUVJLQxUSq4SSyzPzOtaE+a9M
-        BVlARckmSlguT1UWj/LMDHY39T0zlwbkERIhUEPdUo7gcntDBQetAJPY5tSb5h15sFfwPjCpqxqO
-        HfrYcuZLQXmAC1bqUStjEf9R3eC/xEoNbYAuJZ3M7UqxmcotkknihHn408MoA3dxqr/0bAQMYo5U
-        BCDhm4TkgtDW1UIpe42B5UqoenugAM/I19lhROA3ghaQRfQj50IwFM2JlUKcMSOkK75pQoAaJFNj
-        KCqnlPCCCIHuewZs0FWOFwSGe2DfhBn9gn9c1zAayWupOi3kzDuOT9LnOYpWUlj1DAXZLkjpJFUn
-        aWHBMN9Y6htF4eW35E0fK+R2nyOQrSFSQ/QQEyv6jWBoiAgpCG3nFweFZoQq9dNBqTL0p4JSJRl6
-        wSQR+VxQ8iCk3SbLtKHUkUcjWayUsFyetwOiA1wXEDdGFpvs2TYa3FC4SexbH1Mc3Cj9okOUwZyB
-        N4Ii2HDs+C7PoRsB90kVqZXbGl0C0IC2GzgA+6Ufk8osScQ98BPH1YboqMhGEXaD5b7SFMPVWLFy
-        x0TH9/bZI0nTta90neHqOPYFLFYKUxZul56vBCA0YcPzxcoDkDQg3D9wad47T74UXfVNCSPPwy5n
-        p0Az+IDeoaKLG9UDIiS0Z1D0ADBw4AN8eFEI0gNOt/MRnpOjUE1mUol2QzJC4oIfuqqng2z371Ax
-        8CFK8+F1xQs0hc/5jtx6Kp6AKCErR7dBfaXu/bSMi9Dyz6nlzJtsDD5iIvSjENNT4+ANHyqACB9L
-        Gb5xsuLFcmJ+gQi4xNgDd2aWneloDUFsg/QlejJb63gqfoSLOImi/BWj7qg7k17bw5VYKcE5JbWN
-        KUQXF5NBlAZlSZ5nJY5eOZRFV1kDA3edOu7Ef0vX4Rm6+omuU3/Xdf6ssJPMD3zfSVM8H7VPWFIP
-        ju0msypNu9LyR82s/rMdPk2ZbHfkhK/ilMyBXIKvNza0NSdPs2cwYxW9JctA3EBuzXAh50oFKL4v
-        5MfqTP7NDo+mvrIUMRmJlQLLxJblunjsMwybDoUylr3wnip6eAmQr2iOrx8bOkOSkcG1QRNYg9n+
-        ykama15lpaZLhw4ziy+UYADNba+kriQpU3W/PJqDi7GimL7sq/rrKdDo9mq82naGEazL8fgaxq23
-        9knxHNCcO73TQvNAsJ20Iu8Fgm7NQVOjFp216eZ1epJWRvNFEQ69LVWXOmr7jNrGtXd9aQ2psen7
-        0nXNSAxfVw7NVnSa6P3I7raXHqz3qz1Gjlpc7cK0yZGm7ZmDth1WF72BFbnR8IT69mS7vJ7e1txV
-        HZDL+cZlN2Gr47b4Odl/cSb91bR5iY8tbt6q0m2dtGx+bY6DtdNCHE92urO3SKgdqpsdmB+X4/B6
-        9ujVgOxtaqhN1S5s3Rt4QF3y1qX1Eslmfc14zoykhg57cHVGbk1kwE7Hx8nEOYZW3KHdrUEJXDuE
-        LbM2V+KYXr8ue6wc2R1hO915rCW8bM87S7Cq5A5fucrnI2qO6uFZpBSfAp5zyXLvY5GoR2GIPyZK
-        T7c7oIGNP0AFw1R15Ic4v6gSJwcLlhe5GggbfLXMysGCFTiqDnAqljg5VOLgRq/Ai6v5TqUM4yGT
-        oY1/l9ULuEAb988jWDzihgBRI+lPD4CIZ6pvKoUCHtnP0N0G/hjSoO9EuC9ANcZlmE2eZxBfoV3N
-        9nDz4VP5fVlsJg2y1B4uSvvJAn9fpiUsGfirjkgmmqGGBoHnKChp5G37Bx7el8g/Aq/BUSQ5j5SR
-        AqfncGtvqxcP+ZEpLF66vYF76pt0SzpEatW92sa6PRm/rtjeUJiT8l6xBIaudc4DViLhkXK96oSL
-        2nGzZoKeJy33fIed2o6iueSaJGOJMk9H+W0x77ds2+U3Q+vN9ITZgYs3uwNcN5u1nkA3hyiYG6A7
-        l4Lq2NItfWKNoUyZ8sKZRHVjHggd863pMS3SfsX73pWcy7wpeZdcxsreZ7cz3ILx2MJpmM+FbIGP
-        3cselafD+kBQIifjBg9P3C3rtUd2ISnT8c3AUsM9/jB+Yt8FJXZ2uVQ+tv8gFLPSUtRYtR01GS/4
-        xvIOE/OLhrov8jVt+U+gmBpVtGTWZYmJWU9QmZOkXeUBKcZaqJ6xgofsfeRHMB/PNL4AfShI6chH
-        qvPELGPic9BLoX4KcCmsHwTzMYSVoqr/7/qu09+r77XcHHc6P1XhZ6AR6Tn/khKXcam0VuYS7mfW
-        YkTLihRfZ/s+V9XoQ0+Te5Mud96CmcHWdltkOhI1GITo0J6E7nbX6didF2N0ngn7Uyfsurxry9xy
-        1p+1PdRBY5c5dnb9LncyJlsJznn2KE/4/s5l+PAwjahDVdrDdbypv6L4JdS5oxAwx/YJLcmu0eTn
-        B5/bxM3leKpcKKUfU93mdG2GylGxR5MarFurMacdmvYuqGk/LHX6L5R6dm4/W+oc/6lSZz9b6s/2
-        /yn1e1A+LHX2e6We6f36Uudq3yv15rw7+0GhNyOINSEk9qEfBb9slLPGgpH7Bh25vZFkjpvHq4/2
-        B7IWTtvWLGhqgcKxMcPi+znY8BuPPbK1wcTbMGhwQY5pLqdrdT3gW8p1Uj86bWoSeEvlzI8OA46H
-        44jcAIfjgHDs7eyZ1/ZavE3RS6o+MCejJhdwF2lZDasGMuYAzHyT2bj9WWs1gay3Ri3WqK35Lge9
-        tVOvm8rSoqrjUXAebHbKT4xy5i/UN1f7VH1Tf+8of7b/T33fg/L5UZ7p/Wl93x9h9oeDoiQt306+
-        NO5/PngnKeXb0/+q/A/knyNIlhkAAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2302']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:22 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:10 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order><crypto_block>c2--ud6DeBehKRgz3ufmfzE_5cAjF2Rvy09debmDVAGAA_QagUkfKydV02JEoacNqpb1DVOVYFLus7EvOzrvCxDq_nleBSlIqTbnepYPCunHseG5ltQd5uwbQXNQqAVdBH_9jIY07AFaDwtDdzIzHCL0OfooAzW2A287_jBCuqPcJuiGDUns7J4I2EuC65y2D-Mbbg2jbYL4TIKhumuLqtJiPYUzqxW6zaK-USXm3XrCFmC8S-JHlPJVQByvkC6SC41Dc-hi8WfOpWlCt68-FGRxu95j4XZeSkUOrzwn1VK-IX5tD05y37nKneaU8hyCHuEf7W2nlR-0Ll3jmc2ECPEe3QOkPPlkrhvF1mYd096DrsCf5S_vv1WNUI3EuiF9YQZn3h9HYwZh9h4-Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>60--Su_M_sQwrYiY4yntouf9THGIKmqJf1CAjua4mzidWDPONV3IL9S-Eg_h9215FwK3A-sk0mn4P6uDvB5feInAUg8F3Qil_bm-W--vA0fqkExTSJCiim8XLhxfn9Rj6vXZjsWBB5I91BLtpSdeGSAp4OhchcPhOsE0fETlPu7dSp9FfxBn2C-iN0--Z</discount_token><despatch_token>U_--5-hWxUCs7oHiTVGcihvJv7r1crYUVWJDKimuzrClMkmaMixtayM7EJHtrUkWcGaW7ZkQtDsV5TeeclgX8K7hcFYxsLUlCPCfi2n81VIcHT9UHnp2dMOJvh7KMoQG47PLY</despatch_token></create_order>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+LTAtLTYtYnNqV09qbFJnUHdhT1Rq
+      VWNscTNnVDMyR1UtS1lxUllYZk1mbEVTa2hDdHo5RWNtTmUtTDJkM1FnRHF5dDdQcVowazZGTG8t
+      QUF6b3JPX2Z4MXIyMWRWSG5DNE5veWhoU3gyTF9qSmRPOTF1X1MwZXJxY21RV3Y4YlZldUtKZHVH
+      bDdLZ1lwckNiNW92S3NsaUc4eHVqQ3kxQXJWMzVzU1dQSHA1ZWUzNS1ZPC9jcnlwdG9fYmxvY2s+
+      PHBlcmZfdG9rZW4+ay0tLTZTWUY5WjYxLWUwOThNeGdvdlVleU1OU1pacFJQc0RsRm1sMkVLNnJp
+      R2tpaF9hMHRMODIwUWY0Z1hlRmcwTm1ZPC9wZXJmX3Rva2VuPjxzZWxmX3ByaW50X21vZGU+aHRt
+      bDwvc2VsZl9wcmludF9tb2RlPjxwdXp6bGVkPnllczwvcHV6emxlZD48dXNlcl9pZD5kZW1vPC91
+      c2VyX2lkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['924']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7VYW3OjOhJ+319BTW3t0yFcbGM8y+GU4/iSxLckdmzPC4VBNoSLGCQc41+/DcIG
-        HG/tTO1uHhL09SfRaqm/bqL9dQx87oBi4uLwz2/SnfiNQ6GFbTfc//ltuRjw6re/9L9pVoxMigwc
-        2yg2YkQSn+oaSbY2Dkw3NBICsEuMrWnrKSKacNukWUkcw/Jp+WTAu5CeEFsT6lDJ2JkWxbEuiWKF
-        U4AlK0yCLYp1tVllFWDJinzTQkSXK5wCqnAwoQZJgy32hSocowLV/16dXsIlCtPiNKLY2PrY8vSl
-        wfMHL9p1vF4nWrZmW34f450t0eGnNZ1vPhrIIh+Nh42kfLx4M3GzCh8OweLZIcuHXX99tJa9Ufpz
-        44/XI7wejOKZ5/YGjtX4aDRJMHuQlJV8WsvvswW/CL047X48qVOp5c4/1Z9o5K9O5Pk02G3Au6pP
-        GjtLij0U6pbE85LiJbTzet/4ed867FU5VcmRSvvxajTcNR7FJ/XgDZb2iqrLndJ1Gqh/IOMxxenK
-        uR80lJEX7MIfisobR6d76ncfWz9Mo+2unGmvj2cvx/s3pdESnzcz9Dbf25/p2lg9H07r42YyXImr
-        zWATOYfh89PTmu+404f7U/t5/WkfdjGPwmE6UkWvF3kb5I3NSeuoTqdP86HtPb50osfeyplNTq8x
-        OqpSc/08br7QSWJ07XTcG60fXye97Zu7Djq+vQ9PTX7x8RYY6su6MRQXB2X4uVRn4udKfu0tXy3b
-        PtKRKHunh9lSlEIPdX03mmx32/bCf/Oe7FkgHT46U6XzZNB7e/44UcYvPM//0IRqKFlcdc1GJDKp
-        5RjwYOk97PvIotwuxgFHHQQpFyZIE+qsclKAqIPtCpDnRG92P6vMYXlSGRKqi3dijQHQf+lKlsom
-        NYUKRNMI6RZbpzIxhyvjyyZcYuEkBE8sHGzdENm6mvt5GV4obE/dh/EC1qlhJSX3r2uDBHGEmqFt
-        xjYXgzpVZrAthNjAO4OAchFd0oTqsLBR1/JQ1XoGtIwWxa6F9HYrc7Ucg+zFlmPGe6Qzy2VYOqBr
-        CKIKf0zQTeZ/f6UJ5YgZcjf7oL7pp4NiVBCY81t3n0TGwfQTeI8mVIea5dJCJX2TGAe0NwmfgOqW
-        OKPkK41Nwr1nlMLOlrdgJin+sClwFUyaOVHBCns+ZVG3s2VA2HOVZ8vl0l+HskBCfAwPpec3CHk0
-        z2BWRQrqeeYFqa1X8m4saZlbiB29vTLbS0mpwSWLZQdjcf8wg+if3LsZu4imlTls20LpjHCOZHbu
-        8aWeZZe7AlzM+fxl6FJkc28Ubi3h8I7rBgjulllOKnIwq7mxGe6RgUK7GLPDSNAfnNShDveU+Ckn
-        i5ICt+9iZsyEWnCndwRRnZdbclY/r/GSSJCFQxtSoamonY6s1NhnI6On8BMEtq1nrxXbUqdgXnA4
-        SawqomTkMKQo5FWAcjovtnmps5Dl7w3xuyjC8Hv2ptsTinWvI8DGkPsxrcXESf7gZIlQrguZ6v+P
-        gyLJnab4y0FpytJvBaXJy9JCziLye0EpgpCrDbtp4+6gP5n0NaGCFfZCDrgBCgLEnRksNuzZtXVl
-        3DlbYFTgPrSDuFSIKlgwwBGaEN13Dxd7AZ0JlzLCxnmxIG4Q+ahQ3fM8Vkb2CGcbN3XNN6lLE9hG
-        Q7mTRFlpNTThgmk+DvfskZek1p3UlpU2xL6ENaFcygG5BKGPULwjeog1oQZkApTpPLIvylMMtcA8
-        GnEShrBldgqSDAf0BdUCEKoa0slo16AWImRD4CM4vAT6x+xAc3du4QU5gRIHPXqFdkYYIdsCjgMz
-        hBKVe/8F1bLGNr8P03e1I4lwzhfkrKlQwGhGNryAtRI3cI04+DNfme2GNfx1TCMYyiJi1w8d4VAR
-        oXAsVfjMYckLdu4tJRQF3CxEFya7nflHRIwOLspfYmW1tQ1V8Rau5f0Me8VkOBm+dqcP43dNqMAF
-        JV8bKNwQksnmKoWyYi9u5a/kEIh6cP7kyNK3MtRqB1Fq0grZoFlt0PH/i2apstT8Dc1qf9GsfycL
-        Wd5EGPtFO5VfgSssyybfDbJKl1/ayvA/SWH7V+tDfuGYd/xcbcKFLoDCAs2RS9ytX1zSa5CxSmVi
-        9xfk5yyli34xqQS1rzJQz+3sNzs8SbxriNx8ogklxsyOEwTQNMhyIy8pVYy9sMzZrOeEj2fYMmuN
-        wX4FVTnZO4QaUu4uOxZIlp8JIhdxDvEFQjbrcq8pGlPnSgjmr/1B5vQVXCPmm53HaIfgi9jmsoUh
-        RPVZRUAwNX3j6svgCixIVw39V7DGqzT3t+CCe93oX6NnWr3pvwZ/T1GKT0Th1n9V/gVJHPmwkhEA
-        AA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1768']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:22 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:11 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGJhbmRfdG9rZW4+LTEtLVExbXpRMFpXS1NlY1prOXo0V1A3WkJK
+      LUZrMVFsalJMZUg4OXh2OXNDWWU4YkVldjEzaGhGSGF5eV82WWRVYkhBR3l3RVI2U1J5blktQmVY
+      aFR3cTJhZC1jNWhBdzhaaEtwSm5tM042Mktmek0zcHlCc21QLUN3Q1VJWS1jZ3NXcXZLWTFxLUJR
+      QV9DU3dKYThIUmN0ZnZaUWlKS1g3ckZkY0ZMeXBDNmNDb0NYZ09oX29zdldjb3lRTUxaN3VJaWli
+      T1JrWXI0VXZ0SXd6XzFtaG9XM1BVV2ZEZWdTMnNaSnNXRGlxTnptcmRnbjdOWDhyOV9mYVpEaE9I
+      N2M5SmJaPC9iYW5kX3Rva2VuPjxjcnlwdG9fYmxvY2s+RTAtLUV4STUySlJDcS1nTERzdng0d25V
+      WnpaU1dTWURxcWV2SkZHdmw0cG9DaXZDcVVVZnZVTEFYZzlicDlYZzYtY2NLNUx0UUpTdlJtTGV2
+      ZXhlMTMwaTV6NVFnRVd6bjFXbUUyeVh3Z1Z4ZE5vOVNtSmZjZVh5WTdLTU50OHp1eVZKdzlhUlhP
+      U2o1eUZOcC0wd0FkdjJLQkh2cGg2Y0ZxUk9jcno5LTRsRGh1eDJYSGFBbTFGNFNibmRKMm1xd2tS
+      Z1o8L2NyeXB0b19ibG9jaz48bm9fb2ZfdGlja2V0cz4xPC9ub19vZl90aWNrZXRzPjx1c2VyX2lk
+      PmRlbW88L3VzZXJfaWQ+PGRlc3BhdGNoX3Rva2VuPmNfLS1GeUpWRGY4RHlFRGhNWVU2Zllsa29B
+      MUcxempMbnZkVndoN0tMSmticlhpaC1aeTJ4U3BTT0RkSGFIemR5YUdqLXBySGQ0N0s3dmZDUkZY
+      dU1FSnVValJLQnNHbldScW1IdDk4LXNoTHNSWklFbjlMQlczV1ZLczNQLS13Sm5RSE9fenB5WnV5
+      VWlBLVk8L2Rlc3BhdGNoX3Rva2VuPjxwdXp6bGVkPnllczwvcHV6emxlZD48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS0HvDihIg7XFxZDKMgoBCj+Tv9Jf1kHg4Je
+        O4fKzLeqlauS2GfHCeLEOWcHJvPHxbYqEfADw3V+/0R8xj9VgKO6muEcfv+0EgdY89Mf7b8xmhGo
+        buhAyfUgYgaSD4LQgm0mCBXNtWXDkcIA+JIRSIqstR2Xqb62MCACDpon+0CW0DqgzW6YajHKDBoI
+        1DaLXis+68AHOSFFGdWAcca1XEdzHSw0mWoBZvaUOkntuTGfbMlBkP+V8WUfBohSALkx5XeQsfJ3
+        2fb+Xemh7YbJq5TMDNpUusPMbQyQp0eICYDsq7pkgjhdqYriUiBJ9HLebdodeXBW8J79abKjgtdO
+        s+3cCA9gwUn30ZUtC8B8o/2nCdlOq8UrVG9BTBLCz8OeHkIZuJvT+SvHgECrjFFaoaQoqPmp+AY0
+        VJRTkQHOkgd8NckRAscR8aWJ0WQIJF92DkACjpaPU2eiHv6rQgSwsgQeBLYC/AqJE3WmWlAydghV
+        yd3vAwDbVD1Z6hktaAFQUSoFbYJukI0a/ci+GTN6jP6zbU1rJ4viLZzImXccnbTbrOOElMKyo0nQ
+        sEFKx/AWhhMi0fqNwn/D8X/ixG/JSq8n5H6fY5CNA4iS40NUalCvTOX4Z8ajTtINCv/meNTw2nfF
+        o4b+/Jl45PtPe02WjvxK7Amd3pgVmGoJzilpGKYyhDo4V7pu6DvgH0GFR9vxZdVEKSSyS/E2MYtZ
+        9mxo7fpwcLMYt/4mWSjR3TZyJ8OkZ5TBnOHJUG9X0WTMztbFlHRdLMCc+7oYBAGs3uanU/LpaIcw
+        DNqWEd3d59CNgNqvDOXqbQxjD7QDw/YsgAKGnMPbvNSSs0IvAJaF3jSAD1tkP24RPU05vIxXX/g4
+        ADc5KLnNWDI0YIhiXiM+18hWnSCoBlO9owzq5ofsEcM/Ezg64VqdRIQ7zFQLZ7ocSI6b9IN9kKrN
+        A5B0U9QRUce5t9F8yNjyRfJDx0FHkeUNQaI9fEAZG3XdF7xnlHEA0FBGeCjfkDqkOZm+zys8J4e+
+        nGhoiXZDMkKyB9e3kzacvf4HlPHcAGbi2SOECi3yTPUO3SQCSTZM2JJpt/HP+F0jyjgT6G7aVffZ
+        dtLlnjAmQHmJ6KlzcEH5gnIycVeCb5xMty8Q+I5sVURErHSTRHa0SjEjq5/0UvCq478yMCixwnyt
+        Zac/YYXlhp1Mlky1ZMhJqfulrFnARzW8QakY3Gi5lOVXkIeIFt1wAzQkIMSv6JWtFkF/e68kPmrH
+        /2s6SfZ7rmulaZ7fHZ6wpCYsw05kOM280vArLZj4ZklKkyZ7O6yDz1FS5kBuCaTICAzFyhPtGcxY
+        RePKchB1p/yiuM6nFBDzsUQfyzP5f3Zwjc8UXplPmWoBZVZdt210nSFamY6VsWy9e46ofuxBV1Is
+        VzXbUwrDvHkNEtSBlVXalIXudWeTuhutBMPhuVlgkuo4UubOUbCgNrqQvd4RP9dbR77FLk5S5F35
+        2DT7K8FuGrQ+6jkreFUipdk5cUNLBc3x3pZ74tjXvL1lDYQmO5KPVmO6dq3RwWxQxHKCNa5DsS/W
+        pS0fen2bVcXTGIZDSu1btBoC1rBFZ4L7RmdPc7EAIHccWoK4PMCVt2GbEmsv+krUeANrsyX68/gw
+        P+v6ecguW+bUtg+z/uy9f9VDq7GmG5sWL0Flya3mZ3eh0YOr1j8tsV204eaDbp/g5pG55jcTjDxv
+        V9Pu+0ggllA4jKlOIOG0wq5rltPz9my0cFW18cZe6xam6ZFKBRNtAPvyXMPm516NdJeu4hIgNiPB
+        Hg1mKuQ9TtqO3ll8Rtgrj+pq/JEfnrjxmxWc1V7EwcF+KncGrLAJ3wMruA58F9DcdQ4243ptSvOD
+        3di3CfXisFAzzoPl5djvw+OkT485stsYyjVX0YQ3BXawXXLXLJ0vo1iyg1RSKj59HCtOS+e1pfhG
+        SuuqTaHqfUQYNfR99HUVF09ZGh8UD63+ABWMvaxC189vw09gwXLC5KrbbpL1EisHC5ZnySoI2mSJ
+        k0MlDhISKYhtxbWqZRipWIa2//uf8vwCL9AiGMFDXNCNAH8IS3JFQLLt7qViAo0U7wm6+0Dfh0rg
+        WiFqO4EcoTrPpO0ZRB8ftmI4qLdRrcR+HxYvk0a5019NxNILZaG/D7NvQA19+VUSzdRkXyuRcz34
+        yu7uQ+giHWyrOIadTKzVXY/jCx5zw8b727pPDh1BdLX94rR78whpEZIUy5HN96CGMm0VXTWcvcwI
+        +mw1WHuwhz2ObACbr8VU1xodD1YwkMddthlxTTpyur6+UehtxxjESmfKc9vOarzAj9aJXkP7PD5z
+        /MzpT8QemG0Wi94+gkGzZfqboOGdotp+PhiMdmezNbXOHe1AKFdlI7sxPFIm5UbWdGlSfJeXVq7W
+        s2EX7weqUbP2FuYd9dF4PN4u+ucBuSsFIdt1KQrJZbMcpez2iVQAKSfK1VyasgFKDSd7lJ4O9IWh
+        RE4Uz/MN1LOp2iO7sJTp6Fqiy/4BtOkn9t1QYmeXZ+m1/wcjk9WfJEeyYcmJwiFF/4Ax+SVHPhQ5
+        nQrPE8ikTiUlkdsseRHrCSpzkvSsPiCFsvryGU1woHEI3TDIbwgEuo6/NKR06ELZemKWMeY56KVQ
+        PwW4FNYXwXwMYbWo/D/dA0jiSz2gxw0n/a/0gJ5uWFoF3dLBj9Y/hup/MrPtKdcbqoPpZLVRjAO2
+        ssfieL2bAKTbI3vcXGMY2Y+3w51CBCJ+4PZCPzk6QG8miq0vunWjX9eIix7hsqGe4vCs26ap2dtA
+        wSSIBHl42I07kWVKFKcvWuxA1nbS25BerhoT1msK727Ei+PT6r0xmVDXQcvvXqh+h++1LrPNynwb
+        rsH1elI9aYdhX61l4gdqOTuYb61lovldtUx9by0/+/+rlu9BeVnL1JdqOZv3C2r5i3q+FFd9lv+a
+        oi+TnxMc+FPq2UT17GPxebJddlnWqznX/ZD2uzzRiHrWfOny5mEyn7iR8z7ZHvsX8chpR65Xj+Z2
+        NI15DzojxdKN6I2bDa2Q3bwfV+pKEt6l3tCGbOOkHK52d79Vh6fNsYOu9cLaP8lig641u9dQsE7u
+        uaY3LouDyHbZCF3FLd7t4cPl2TwbyKUn7bueQY5YZbicjI6NWcemPPYwmR2c4/xiYS3K655W5D6O
+        pyuBvtRngIhtasg1AqMJTD7e94Y0JvC0EPaImo3PZuTX+wH5I/3gu7SdrP/afvDs/69+cA/K9/eD
+        bN7P7wfUF7V91pl/rRcAx3D9impA4wqcn9IS6qglDEyKmxgcTte6Y0ne4wK7D4TgeMbttdUYGWK0
+        ah6W0LlsKa+3vhr+vjmCO6G31UdGf2SbMqV350rY6h54rTkX45ALdV912bXWXEN/esa242406ZHH
+        eG1uZ4Sxj5quxQn8pkZOehoei9KFvC75GPi7S3PhHWcCCXbXGqmfSJ2iRKsf8EJwUtXjEA99bo6j
+        b3TaOknfIPfUj1zdv0vuyV8s98/+/yrve1D+RHl/We7vj0H2W2VRkrprJD8/3H+x/GAp5dvTvz3/
+        D1lRoYe8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:22 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:11 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <trolley_add_order><describe_trolley /><user_id>whitelabel-testuser</user_id><order_token>E2--5eH5_vuupAjgQcgXHwMpTe9X9qgSl2Y0lXp5covwU1ss4IWYBA-RU8_g3PLu8IKzgerz_3Hl033oI-VMEczh0ACvOMWY84zu53eWCfAgAX2v47y8gZlotLi4soNNf8tYetkXqZoP-N1hlKUJkwZdbW0CSxe6UymaEdjSXrzwO0O_DORRcWp6xIeRBq_gkx4Wu9YZJPsOK5CeE-apF_L3wCpdqKeS3P6_3QZAvRVTdRGBuSzS-XHJpV6utMn-uLK1XaipNu8tDIAOlNAM8GDGcPYYRpF_3_rHi9pUQMOLZiyBM9BhcnyLGC8TiUOTaOxTSW98HodDDCuLqymE1MWcmVXSh6xJsVunc4mtPXPNxl7-Z</order_token><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></trolley_add_order>'
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcj48Y3J5cHRvX2Jsb2NrPk0zLS1wUDV0MTNnRWFjNGthUkJ6Wm0yaG92VVJp
+      bk5IT3NrMmNLdmJQbmpSbHRkSngyQ0NqMHc2OWpOOUVRcV92cHpOeWtrRFVSbThpNGhKQ25VdHpi
+      dmI4QXFISWxjZThLZm1hQ1RLcmRwZmxsRlI4RUphamw3TVZvbEpnazczMVNMLTd6SVREVDZfWE51
+      cERtRWNUcUt0dUkzY0RsNGN1ZUVpbVRuTDByaUFmNEh5UmV0SGpJbFJUU2d0VXBXRThfRW1RRGJ2
+      N0dlVms5VHJQeWdQd2hod0lFUzlrTW1tZ09ET1lEemh1bDdWNDdXOU5fdGJTSFVQd29RZDRGemRE
+      cVMtWnZXSFBGQkQxSFB2a1ZOV0wtMndYVU1CWUpSMVN0UmdLM0FzXzA0YkVWNWxuQ3BmRXZRb2Nj
+      N0dFejZsLWRodmMzc0xkRnREYVBkLVB3QzUyb1NvYm8xZXlrdlJtSkZPY3ROcEhfWEpZRTBPMW1V
+      cDNCZE5qTklxSEtHbHN3Y0N2SHRGZk1hQUZFUld1WXNsc3pGcm9lNEh6UGVXSzY1TTRORlpLcm0x
+      Y3huRXRkaXdGU3hqRER0akxENEtIMkI3SWE1b2JkUkdidEEtWjwvY3J5cHRvX2Jsb2NrPjxkZXNw
+      YXRjaF90b2tlbj5jXy0tRnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJY
+      aWgtWnkyeFNwU09EZEhhSHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5
+      OC1zaExzUlpJRW45TEJXM1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tl
+      bj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxwdXp6bGVkPnllczwvcHV6emxlZD48ZGlzY291bnRf
+      dG9rZW4+YzAtLXFrLTlCVkt5eDB5SEk3WUdWRDJJblJUb2RmUXFaR3AxX1F1MjNFSDI4WXM1YW5r
+      VXZ6ZDBFeE8xNHdsN0VtRmZ0Q0gyN2VtTjV5M0JsSmpnbHNGYUtCRTh2SDg0dm5CcmhXYjRYQWlG
+      eWJBTU5IWEFVS1EwamxxNFZ0bXdLd0hOT25ETFRDZU9XUVFDZnZ0czg5a3JXczdwcXY1ZlBGRkpa
+      d2s5TWx3QWRnMWJ6Yldhb3l0ajNrM292bE1TazNOQk5fVW9kQ210QjBEc2NpNWxmbC1wamhKS0tL
+      WFFEd0YyWjwvZGlzY291bnRfdG9rZW4+PC9jcmVhdGVfb3JkZXI+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['706']
+      Content-Length: ['1008']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61YyZbiOBbd91fQualFN4HNTB6X6zBGkBAQASYYNj7GEth4DEsGzO/Un/SXtWzJ
-        I2R1ZnXmIgPdd5+GpzdZwh9XyyydoYd0x/79C//EfSlBW3WAbh9//7KSRuX2lz/EfwjYc0wTBrIC
-        gOx4AHqyB5FvYlFA/h44lqLbso8IrCN5rwAxgEioPBYJqhe42JH3pqMa4koul8+Ge+gY/Y67asz3
-        5aPnHACPny/q7G17qkEVnWqDLd88vRtzbru2B2dLmmhoNTgMN1d11X8JPrfmdPPibEYv3tzQ+yNN
-        rZ1qdWTNB3xzXb1tqh9zqSzZhhd0T9/aM76hv13an/DFXN/Q5DY6bIVKbk9CeErXQUjfm5AeJYck
-        1sCOAW2xWS+XdamGlY+2U61hua87DXgz24u1PaqCi2J9PtvX7jV4GV1ul+m5DgdtUJ4fpE7Dfx13
-        WvBtMzPQ+HX8MeeWo8PGOrsjvfF5Ac83/Tg4OtaQO43gDh28+lXvfszWvqoFL9bQ3pd372tzLUNi
-        JSmozdu93v6wQB/c+MOWDbDRpt3XRb87O/Dqdbp7vaKPPexIvU/34jacz8ZAA9Kwf3h2LP0KBsRQ
-        Jv/+8aENXv25Xquqp9bu1IDBYHDqtnby+HZsD/zF1Lm0x3Z9vXr+9N6Pi5GM3qA0WS6MUc/aYvXZ
-        qLfxoXY4ti4zs76a11cvcEXOic6b3vR96kp+Q7+1LEM78/K6Pmmure6u6jRWBuirE9ezTe+0rIE3
-        tf920s6X3nZX7WxXxjoYDYddaXRDw/Gnuw9UHQwnx8GmCYatjS55U74qvbQG0sUdztZcT/12la5b
-        ubpuapfn+rLz3us/j8G3YATWPe/sHSdL3ZSnr+f9rnXrgWALlU79E8tb6CxtY+bOvr2OVz17NBnM
-        p4FR3uh827QMeJPVzRyM7IVuBDO3vz+eaiCAg0bQHu93XvtdW3S0/UwbvzfLO6GSd5DEX2jkqI5v
-        Y5FPWVk49D0IZB1DS7Z9aw+9kHkPxnOKwt63QeiU9G9xjQdozESO76mQgACK8IplDBHmEo2stKAB
-        IFJFibBLywCRPZV20HOKihEpVsQOVkwyl7XXbQjEaucpXaggK6ogLNa4p8YdHeEClSzoKljVRP6O
-        nYjyGggq2PV0FYrV5t2GUmFBiZxOU7wjFGv3OolMUH3PI4k0SH9RUx73Lsk2OShlHBQVO+TCOS7D
-        YWDKYh7QrjYzrNgtEsA1FRUisZrhMCjDIVaUUWDtHbOShT3IUPE/f2b1UzxFRQHAvU52KKuao0fz
-        MyCVUIfRYGngW1ZQ6iseKA2oTKjkSImKbmN49BRMypIMFKxUUpGtWFAE4UypcoQlDBy4d4wIS4bp
-        r3TbUYyEk1BnoRvqh1Gm4tLBc6wSJkc4Q9uHoXaWlSpZEGsOyADRFffnvXlGh157ZkicOfLaPPR/
-        biUsv8Ry4mwlkfUzvFiQUiPjqHT+DDGxWfFwOmKppBDSaRTHFHrWpbQaDGcSmSoHp6xo60vsA2jj
-        Erl2mKHSY9mO7ByiqERhXssOmQzrqgGz0hgQioGeie1COGciuJKeEhJLh6nZgwrd+HBNcnIyooJo
-        m0PSSgUXDXqQEVga1I++K58V04c0urOAoOqYpQLTsYFjl32DmDIBqTyaaBrJmZBOrZoKQuwP5RPX
-        UHC4gQzG5HEgZuV0GtKcRZ0anS7qefJQaERiG9kgNYetUIksGYNhJ8iosWaC5OZLeQ+mNHSAHk9L
-        D8LkOSylRGcZKZZuBhkSPWElXbcSGy28Xo+ZOTJ6FkjEkf7KJuUXlCakMSZNbUplt+DpxNtIU3zW
-        4UV2IamAYf2NEvlDkUAiEMqeYh+hDG3Axux+/H+X+DbWSl3/6JMqW+V4kupTAuX6WCVOfkCQFMhm
-        uFARTWkIqsRxSGTUW3yj3uBy7FhI6QH5Z1mABDRZlGvzbcZMcHK5TrvJ8XIEKzYgYUZyb0gvc+0y
-        35b4ztca95Xj/sXxX8OVHiuweYsWoGOEFQ/f2aTKE2N0SeCav9IkTb7arNV/2CT1Kv9TJqmXq/zf
-        MQkzQZR6qD+GeXzR7U+GC6GSgRklMsOrgkkgXUo90oPZ8DdUmpHjeApJg94/YyVqL/pbB2JzPIol
-        ZMRwk3i5kyaSLMgYZHvYR6KpnxM5g2ICLTKVeBzVEqRbbtgtRYk51qNVhv72XQRNkyyFcG6Pw/s9
-        fm/vIT5ZZfHKg7mP0JFpETRJkxEWHrERleBkKJBkfKQ/y9wTH4oSQKik+pqCZFJvSGAfkGiTPjgH
-        hLkwLDcQJEmQDQVLucqeb9vErPT++SpxjTtUsEjOfMArooINyTcCgC7xG590aqEvRft5hDOyTzus
-        DC1GKCE8g+NZiq2y7+A7VAh7SFoT+/yiVJdmQiWB4gRPKikO2bJhiRwrwEVcQJoTpccDPQ59Qchj
-        wnc+WXLfKn/9kZL7OokaKNahdAfT4WK5Hk6nS6GSETASbVAU0ut7JKzWxJFQTGPlhTUJfysaC597
-        uQ+9nLXTjLeGgGTEVlglfn1GbJHE/xMZsXWXEb8XomFsuI5jss4tuuQCFkaMqVthtY38MjP8X4m2
-        9aOJNnIpurtyt9MlLssAJkHyWc+8/hRBykozHPVQksZYd/jBVFJIuA/gfPCG/9OLaz3VuNLbq1BJ
-        ISrVNMsiXQvfqUUFPIvR9dKYDHtbeR+eN1o9PGABynLCNSo5JD1aeCekd/n0IUoyvO0kEAS0my5S
-        BJriMxbojxf96TDcdkGQo9JWyyWnKam6p5owr8Cs8eg1ofiMQMeFr4Z7MMfLfEE8goXHzwZ37wUP
-        HwruXgh+NK+wz9JfnPoq8bNR/AjFHjLuHqdy+E+9ZFWSJ6rKd5+P/wu8uhIsgBYAAA==
+        H4sIAAAAAAAAA7VY2XLjuBV9z1ew+mHmIaG5aO9wOKW9ZVleJFmS/cLiAkm0SEICQC3+nfxJviyX
+        BChSsqbSmSSuLps491wA9+IuQBu/H8NA2iNCfRz99k27U79JKHKx50er3769Tnty/dvv5l8MlyCb
+        IQsTDxGLIBoHzDRo7Hg4tP3IiinAPrUc2zMjbCi3JYYbEwKzn/IvC5ZC5srZGsollDOWtsswMTVV
+        LXAEmLOiOHQQMet6tcASYM7aBraLqKkXOAIqcDBlFj2FDg6UIkyQQM1//qOon+M5CnrktGXYcgLs
+        bkzXkuWq7NCP+dNHMF4RJNOOcz9uPLXcZX09rB53k8dlnz1OnlvPTlUL1FPTd7a96Wr8Uhp674PP
+        jk9XnztGG97sx2uLWCffDwYrHZfr82iP3iZPM2cR9OkMP+/mnfmh5jgvGpr9mPW2sku0T//9hOy5
+        u5r1ds1P0pHfYKfF/Rn8XBneoMis6rL8flRlbRAd2/t5a9hYdtnboq82WAc1SbsfPcz6h9Wu8mPR
+        H9XR8TCddOo7/aU/6O3wptq+Xyx71n21/PBWZq1HN3Le41pVnSH/1B2w8eDw2Qg6u8FLadHc6c1h
+        975B1eWL3w3aeDhh6nTf7ez9Zs/W/U515I7eV/KijJv3R28dbYa91uKw9BalaIlaFW0zGNn68Zmw
+        oFtvfp68NVKX/rv9uWmMYxmTUml3Qp3RyDno88/jev/08sZG+DirnWrTYzir3J9au1Kz9XL/OGnY
+        4Xo/bTmd9kelNNdPVth2lg3NPtgf8vuQ6m5ra+nHwJ8ebH+kq4/DnX2oTiqzUT0s43c3Umn51WrY
+        nWnY1/36y3bufiw+P96qbzPWWw/cx2CNdtFC7i+I68z1Pn43lKLLuf9Nw0N0azN3bcGHa7ZxECCX
+        SUuCQ4mtEaRpFCNDuWTlSiFia+wVgDSR2k+tp4IOT67CkDJTu6tcMAD6L7eS5L/NbPPxdQrrF3iZ
+        IKey0xaZLp+/QEzhwvhsnE9dHEewQxeHjh8hzyw17pLSkA3PFG5rs/P6MIWJLsCck2686UE9kyiz
+        I88mXoHMzYqwhZcWhQpITc1QikMhY767QUVpBhgJbUt8F5mlSrLNfAzlk7hrm6yQWU4l52G+AdNA
+        4Gn4Y0P95Vvvzg0lH3FBus0uVPHTYY0IEgS+eddnoqQGOPJwJMcbcNYZ5PKU+pDKhVAoBzal4g/n
+        24RRoOSAEHI/glD6xQ63f5fa4NE42UpBbEAfSJsCn/aEYKZLKHEXeMHaoFO6kpI6LEOShiN4mdoZ
+        uZgs513P59mRi25Pys3JCBdgzkntaNkQrUwY2rlS4JYq+RaUzInJgRLh9vQQisBZnOq/Rj5DnjSE
+        Lgx9NKeKUyE+xBe04b2PDtYWETeJEd4gb4oML2nexI5WyEKRJ8bpZNN1/DdJo0yaoC1DSbuUdFWD
+        JppTODtmLgT2kiJmlqrJUtdoTqPIhVCCbCjX9FqlfMnOhJx+gp8w9DwzWVRtqJpgnnE4aVyvqpqV
+        wpCgkFohSumy2pBVbao1vpfU76r6V1X7nqx0W0HMe+0DPobMJ+yLVypsLY3s0//SH1W9XCupP+2P
+        ilr5j/xRgX9/xh/C/rTW8HBMCve42R52x4ZSgAUldcPIZtAJDlILxyRCv1LpEcwhNtQ9Ik27k2mm
+        yH3Gv33PrA56mQRGAg8g0LEJ09ksqRlFUDCgC6xNBZTlkK8rO+m6MpWj87oyQ5QpmX6qItTBQhZT
+        M/D35+kFlBF4Y1Kycdp/qB9uAySKeabHOxP/jrcUBQHslLILE7tfTYSv0Q+1iCs35lghbPEGGdjM
+        ZzH4vALtWW9UNa1UM5QzakA1X/FPWb3TVDjhShXutTlsKPlka5ta0JigHixpekG/AJJqmvQlaJ5Z
+        GRVDI7SPFomjCI6Cx42mgw1fUCOEqnuDd40aEUIeRMQW4g26QxqT6X5u4YIcE7AZRwVahnBCYgMm
+        YVKG+fa/oEZypefNs62NpfL00VDOUNYioOWyhG1tQlMVnfoaN+gap1V1yc1Jl7vCDApxCfR0cnSE
+        eIGYTKYrwBmH9+0jQySyA2kKRKmVBHLkSbkGz5/0HXWr4t8SGOn1jK81aXYeuuPJvPvwMDGUgkCQ
+        0uknthcgAjk8h1CkGU20MnEF+dOpD60szJ5iST0qDI2LY8pL7Bx50JW0/0cBbjS08s8XYO1rQ/qj
+        Spak1BbjQNwM09i4wpJEC/ww6e1pOBeG/6auaz/d59JI5LuTm+ozRLoAhIRae5/6TiCi9xrkrLwa
+        8sCGkidunzOhkkPG17y/zPnkNz+42l1JlZ5HhpJDXLpehyHckbQGb45FjK+Xp3Jyd7acxF5+vQf5
+        FVTkJGsoF0huWnImkDm7GNFzN4jwGUIev61fUwzeDgoeaA/G7Ydusu0rwQWVX+y2YI3k+sQN0KWC
+        8AZmdmBdPW2uQEG6epV8BS94hRfKLVhwr18r12hGu3y5XIM/XVnEs1e59b9L/wL2/DbImhIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2158']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:22 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1879']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:11 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <trolley_add_order><describe_trolley /><trolley_token>64--iT3taV8o23t_Cio5ezl8RWnF2dwamqGnxAxyHFwzwLv4eD8d-OfT95uMI97ePXNksIMIVO0SFfXmvpFi5qwdGzigDgomE0jFeZsfr4xiAVNWuchyHmEnb-ZQWlW_eYj3Ty3O8BBbfRsV0IVn_kdXhLAMRCANf1cxLZMxsVbe9TBqpwp5oq5DhdTECfGomixdD6W2l1QVVhDMuOi32cj7Zj5eyDDjA7Z_Izg8DuRLow8In4WUGqrQgRF_sPeTKSRkFBmYtcGk48tf3fg7wNl4UO4UHeUT95svXBLQLpTu5iz7mkhv1_W4K6WmAZ2o5UkdCcKprnlrjS3dPcCPjhvwBYZ29YUkWyFEEATFzsEIqpbycidEKgDX6dE7XiTrL12TH7DTwpENW0BcJxTxY_2W6hwG4S9QBCGIdJyFdWBrvrgKSil_LMvbZ7zBdyYea94qt_YeoSnkNpNJMIUBnFKDOLyk-Xi18lmkez_cXOdFnRikyNpCbgj3dyeD5y8IbZr8QhR9hbNhIQ6-Z</trolley_token><user_id>whitelabel-testuser</user_id><order_token>c1--16kut9RB3qB5vg82y8sxt1gLWHGf3I0J8vkFUdWt8Uf6Ah3eEvsLLtoyWhBF36HkmfnZ68-_xhAzEAI5Za_7iWhNCEoOQxBS6350KYOeSPgdwyX_WKvzXxYMGW0WYFYphvGKJJX-9iNDBz7KXwdvfr-enGyH80kCpkYekLaM5x8NNJPGdkIQ9pICWhOMzRrex814XKL4QtMu_AdyLCHXIRMCbSiXm9ldgnz4-TjSm_8QX3G0Tv6GwU8O0wW2RCURcddxtH02kzDOU01nkeAlipMbfb7TlSkJdOm1vj9N69J_tBdPIM6LQ---Z</order_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsUDfEXxcUCHyqYlLXHoXFHrOkiCFhc3j34smOD16W2zX2VOT-TnkryAjJ8N15iPw8qeHlWzsKzFfY</crypto_block></trolley_add_order>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48ZXZlbnRfdG9rZW5fbGlzdD42TDk8L2V2ZW50X3Rva2VuX2xpc3Q+PHJl
+      cXVlc3RfbWVkaWE+c3F1YXJlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPmxhbmRzY2Fw
+      ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X29uZTwvcmVxdWVzdF9tZWRp
+      YT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X3R3bzwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRp
+      YT50cmlwbGV0X3RocmVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZm91
+      cjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X2ZpdmU8L3JlcXVlc3RfbWVk
+      aWE+PHJlcXVlc3RfbWVkaWE+bWFycXVlZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5z
+      ZWF0aW5nX3BsYW48L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+c3VwcGxpZXI8L3JlcXVl
+      c3RfbWVkaWE+PHVzZXJfcGFzc3dkPmRlbW9wYXNzPC91c2VyX3Bhc3N3ZD48dXNlcl9pZD5kZW1v
+      PC91c2VyX2lkPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48cmVxdWVzdF9jdXN0b21fZmllbGRzIC8+
+      PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1202']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a2XLjuBV9z1cwXankIUOLoESJnHCU0m5bm63V9guLIiGJ4moClCz/Tv4kXxaQ
-        oMRFUnsZ98wklX7oFs49AIFL3IuL05T/+WJbzBb6yHCdX76BK+4bAx3N1Q1n9cu36aTNit/+Wf2T
-        jH3XsuBeUXVdcX0d+ooPUWDhqoyChe7aquEoASKwgZSFqlf3EMmF8yZZ8/cedpWF5Wpmdaqw7Nb0
-        lpLZkLypMFywK99d6gB3dtrg7nFThBraFJuPoLy5N4fc49xpbu1Jd42mzWXr4UWbNq73z49W7+Ha
-        fWhf+0PTaLTXWnFTLCF72ATlOf/6wM+GE3bimP6+trkVB0Aw7nbiM7y25q+o+9pePsqFzJzkcJWe
-        i5CxsCBdSgY5egO7JnSqpsCyr9JWN3s1sfnEiVMIGuN9fQ7YErhvLvuq7wavQ0IoLzcV31G6s93O
-        qDe0uz7UYH09GAnlRrc8mBrzAASrWVFXRCu492aGX+Gndw+7ov3Cj0WrNq4IaumpjCWuab82xIkO
-        +i8ufvC2krEY19jdrTar8Uqfrc/U3q3ptYTO9ba+l2bdYFu/hTvx2kfrvjeyR2veHqOtdG9u9VVJ
-        MpH3fF1W/buSoTutxsrabWfmo/jEKdfqi3lTGQJ3f4fb3Rq3ao+e4eBWazz2wNqaduYvN+6s0uZH
-        asln+2vX2cxuuXLT91F7NLtv3JZ8OO9PWU1y1HvVtlXH2yhwM1pgsOgr6ryxugb36lPf3Arj9lKv
-        sba+Btxy/jha4actzzeGPpjXik7fXc30KT/CrzXdacPOQ6/I1wGUhE2jvVpUhCmSysGm2+LBAnv+
-        eHIvzUf1V/QglO7d1a6CzGl77y7bbUl7aRtipzG1y/Z9gNx+WXot8Y99pTUabSpPz9P+9ImzthrH
-        KYMOr2+NxqqzHAbqwrHrTfPBkIT7WW2FsVDfDBc9czMTNT/Qur2xO6rU3Mc2HhgK3r3suj3DqN28
-        tMTmsLPnppYj1ZtF5EJ411xN6m5x1/VU/9X1+rco2LY60Jts1Xs0Kj9Yte3D+nrWft7CpgnHt56i
-        LOfi3bi4sm+lrsLa7XmR7d3MrveTXWncYP0RX+/oG/PB7ArY6WhgfuMBcLMXnm5g9zWocSz7JBey
-        m/W4d2kUa27g4CqfsNJwGAdQVwwMbcUJ7AX0Q+YpeBizKi8CRw8DhP6bGQzIhTPogYncwNcgAXVY
-        hS9YwRBh7tgjbc310CHSqhPCZsZ7RObEPEHfzXeMSIeO2MWqRcayF4YD9SovXSUPytnyXRCuFrkr
-        4YSOcI5KHuipWFtXwQn7aMr2QFAlm9fQYJUvn0woMeY6kdWtVX8Fq8XTPkebrAW+T5L6PvlFXbla
-        eCTzZaCEsVQ17PpVwHEpTgwmrHgHiHw5xTpsiyPgWaoGUbh58lCKQ7yooL29cK1CGvZhjFb//a90
-        /wRP0Kqsw4VBZqhoa9eIxo+BxEI3zBoyzcC290xD9XWmSW1yIUM6djEcDFe+iskRqegqVguJyVFt
-        WNXDkZLOEXZk4L13woiwYzP5lUw7ipFwELpZ6IQaYZRpmFn6rs1gsoQtdAIY9k6zkk42xGtXTwHR
-        K24M68NUH/raU02ymaNdm4V+5VTCUoB4rjqYTsjzU7yDIaFGztHo+Cni0Wf5xRkoTiW5kE6i+ECh
-        ax1Pps3WYEKGysAJK5r6GAc6dDBDXjtMUemyHFdxl1FUojCvpZuxDRuaCdPWAyDnAz0V27lwTkVw
-        IVklJJ4OU7MPVTrx1pzk5GOLGqJptkhZt9+toQ9jQpwGjVXgKVvVCiCN7jQgawaOU4HlOrrrsIFJ
-        XHkEqT0aqBfZYyMdWrNUhOJ/KJ9sDRWHE0hhsf0QiGk7HYYUilHVSIeL6q8sFDqR+EYxyZkTP6EQ
-        efIAhlVpTD30PCKZ8RLemSFNQ0fnh6ULie0ZLKFEa2mrtmHtUyS6wkLy3MLBaeHr9WM3R05PA0dz
-        1H/qkONXZ7qkSCcFdkKN34JvkN1GCvStAXeKB8kJGJ6/USI/a5JJBELFV50VVKCjx+34/QQ/MUDE
-        a6YWrAJyyvIcIKk+IVBugDWyyZcIkgOyHD4ojyY0BDWycUhklCpAKAlchn0wUvqe/LFtnQQ0eSgn
-        AjFmHnHycl2xzAElglVHJ2FGcm9IZzmRBeIESD8XuZ857u8c+Dl80vkO8bh5D9A2wqqPT3zCA+KM
-        Gglc6ytdUgZ8uVh6t0tKPPiQS0osDz7jktgFUeqh+zHM46Nao9sayYUUHFMiN/RVTAJpx9RJDebA
-        vyFmQJbjqyQN+n8+dKL+or8NvVq+aR8spBXjFtnlbpJI0mDMINPDAapaxvZoj6EDgR4yhUM7OkuQ
-        YXthtRQl5kM/esrQ34GHoGWRRyGcmWPrdI6X5h7i3WkaL5wZewVdhR6CFikywoOnKkRH8LEpk2S8
-        oj9Z7gqEpiMgF5L+axUp5Lwhgb1EVYfUwRkgzIXhcQP1YxKMm7Ktvih+4DjErfT9A55sjRNUtknO
-        PMPLo7IDyR1Bh+SigwNSqYV7KZrPOTwmB7TCStEOCCWEa3B9covU4jv5CSqHNSQ9ExtgxJQmA7lw
-        hA4JnpykOGQrpl3l4gM4j8to7UbpcUmXQ9WMLCZfuLJk7irfv6RkbidRARVXKLVmrzUaz1u93lgu
-        pAwxiRYoKqn1fRJWc7KR0IEWHy9xkfCpaEzf7Eh6yVz0Mt5OMt4c6iQjVsJT4uszYoUk/g9kxMpJ
-        RrwUomFseK5rxZVb9JJzWBgxlmGHp220L1PNtxJt5b2JNtpSdHZsTaqRLRsDsQUpWyOlROVBykoy
-        HN2hJI3F1eEs7pJA8mkAZ4M3/Ju+uMpVkWPu+nIhgah1vbZtUrUAqRgd4GmMPi+JybC2VRbheqOn
-        hwvMQWlO+IxCBkmWFr4TUrs8BxAdM7zjHiGo02o6T5Fpik95oHEzavRa4bRzhgyVlloeWQ2jGb5m
-        wWyH2Bvn1IS8jEDbuVvDKZjhpW4Q52D5vGxwohecFQpOFIL35pX4WvrFqa+QlY2+SD4Cn5KPhg78
-        iHokch9Sj87SL6tHp+w31aOK8An16Eyft9WjAOlfpR6VuB+vHv3l/+LRbyMeRZv2R4hHhS8ViWgo
-        XhKJSAX2lkJU0wMLM2HRqIfb4AcKRTSmzwpFwm8kFAmXZSJSMW3hSkVsgC4pRSpiZiHlf1ks0tQF
-        8R3+nl6UUL4nGTUoi/mranv/YGaqb0D8CQUJvUdBGpMKCSLGXTI1G5K9pea1pO8oQwH8iQESqflv
-        A2v/dsnP8gL/7qJflCS+/O6ivwKkD8kgFRZIE56n1Tlp/n7K0IecAnip9H657FPaEB965GNOOdWG
-        erV2q99vXRSGeirThrYNmUsqUE/6Q6hAZ2SZYvkKcHxZKF7QZgAQrkCFL1fAH0ehkf6IAs1gJkqA
-        k35rfQa885IS3QIy5X/0BUtON6+QU/EcntZy+p1+Z1QbNHuzi0oOoTAdEkw6kzoo35BzLsRQ7r/q
-        f4h287GcJfLgI3r299SbbFr40erNO8+Ho3rTk9g7sfTF6k2vNmn9Gv0GcG8IODz/Xyng3I1a7XfJ
-        N3c+XEJyv9OZcGDiondoOPRm8HtoOLTQf1PDEd7ScN7OKN8Rcj6fI486zuFjolhSOPnIKIN/6Iuk
-        wvFTo8LFTxL/A9zjHdHUKAAA
+        H4sIAAAAAAAAA+1YWW/cNhB+768QjKIvjaxjD69dRoHXF+B6HcfeOE1eBErirhRLlMzD3u2v71DU
+        ud7UMZAUQZHAQFbffBxyDpIzRG9WWWo8EMaTnL7ecXbtHYPQMI8Suny9835+ak523ni/IPJAqPA5
+        wSyMfUa4TIWHuAyiPMMJ9SUnzE+4H+DIozmytktQyNaFyP0gzcM7L/RNc2wG/POHt5/T6yUjJj8O
+        zq/3307DxST+c7y6v7lcnInLm6vpVTB2Unt9mATF6XwppsF98DEcT47k6GJ6heP3N1fX+/4R/+v2
+        04r/zW/k8XjuFkOXBkVw/Xj+bnp+cv5pdTZcH93FsYuTxX46iEaLdRDPRu9Gs8vULqZD8yOyeutD
+        UcIFpiHhPmbEf8Bpoo3bhmsHeQgQ7IP7iHfyAVntlxZEhIfeCXh7/RgTRipCiaIwEWvNTTH3H8gS
+        c1NyWFODa0rJvsDcuFWUSl6pgJG8+k8PwUIwHAqIrWK2eMUphx0+5Wh1ELUyhFrtmoC4D6EqH+7I
+        ujuTBfFvBSpLKno9ukF6OlveF9SGOAB/ie3atV0tpQe3rNKyI80yfsNZ8YdxnFBKmHET54+8M1D7
+        wGpXZdXuzbnwGaZL0JvhFcyQBQklkTexd21k9aCSAMsVBUtC4u2NakaLaYoEgzADlS2jgVCmPL4x
+        SxcqCU9m6WGasjFLD0I09zns+pQop/0/TbyXmAq1X/KiTCkPlbvXr3HPQdYGsslwn2UMnmUMnzKs
+        p0sr/e+HkjE4kIFS/9IpLXkEGdmDWsYCtkzOPMe2O5wKbFlUZgFh3mTYZVVgyypSDEedsnsT6nBU
+        vvB1FuSp1YXheNSo92t3eAsja9NK6wtp+DN0P37ouvEKc0kFayxWwg7QiMtT9j1NBImMG4EF4Ua+
+        MA4zAlsat4P0YRyBXOv3CY2q71I0l+SV4dLIOJRLyYXh2s4YLupGrqlShH6+WHAiPNMducrFm3hL
+        5CTMacQ9Z7hnu7bbZ9dCTV/DvyyLIk9Na09st2I2ONx8+WRsO34JYxr5IslISTftiWm7c9c9GNgH
+        tm3aewdqpu0DKr2bLtDfUJQw0XNKLF8ZIxEbM7z+th4ZuyN7MP5qj4zs0Ys8MoK/uavc8TKPVB7Q
+        tWqZZxeHpyez2QmyOlglr+oo45RkGakJ2jX6N1R144v9WtLUeH4Kp1PuiRguHtYM1GDFyEiUYMhx
+        XJ4HsK1i2Bhe5Dyuho+DkQyyKFnthmkuowXLqdilqmIpOSih4EgJuwxuviIlyrks9WIhigPL+lcN
+        FodLjkRWZwkWWQkftpRwrJMPFqTwynFGu5+LJXhz6zyI4kzVnxBIWDwYV36jAovYe5n+cgj6ki38
+        2xqz1RQuiyJngvtqQl1p9qE+g2+hqKKvF9EfObx7tr0a2Pbz4c0wu5fkhcHtaf/ewe1N9jO44BFn
+        COk+/IrgcihG2Atj21P+vWPbm+xnbH/nay5I5reIMiRNCPuKWFfMF0T7uem+a/Sfm/w/zgbtLrji
+        zRSbC1UFWDVPu6F684KqVHIvTR6ay76CaoIMoAbBVv0t8jtCu6WDBmrpuoDIJcpEqGDCO5ViHQla
+        klyVOLDKFENTIaFgGYx3HXsAnUeDoDSnS/3TVLegs+dC+9OCyGrVxJj70FMVhC14+XzVA9SbjGqh
+        ocWuH2Oqz7JpZ5JSqGx0reW4Vd/eQ8u2u4fsV413n0YJiaC+KqBEU1FWZVu5nG14RZYMq43aodWI
+        JigTcpaptzi9+icoUu1NWfVd3k72HRti0iD1M1P9nOffZV758LAFRzzOH0vN2hqdZH0M8VyykOgi
+        s8lxoHXgmqMfAleCMIpTYw5EY4ohGaCDaUfoYhRyQ1ajZ2ezs+vDy+OLW+hCW7iilHSgGGdQDUdG
+        54mwI6+SrdkR/RfdfwBjn1trDhYAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2754']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:23 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1447']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:11 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxldmVudF90b2tlbj42TDk8L2V2ZW50X3Rva2VuPjx1c2Vy
+      X2lkPmRlbW88L3VzZXJfaWQ+PHJlcXVlc3RfY29zdF9yYW5nZSAvPjxwdXp6bGVkPnllczwvcHV6
+      emxlZD48bGF0ZXN0X2RhdGU+MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['345']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1cW3OqShp9n19h7Zqap00EFIQ9HE8Z7/cL3uIL1UKjhJtCo5Jff5qLomZnTmKZ
+        mZgxlarI6tXd9NeL1V8jRPhzZxqpDXRczbb++EE9kD9S0JJtRbMWf/wYDSsE9+PP/D8EBSAoIc2E
+        kr1CmOpKDnQ9A+UF15srtgk0S/Jc6EiaK82BkrdsIf37EkF2/BWypblhy3qeIAmCIzfbapFUN9XN
+        aKJJW/pZevakCjUvGby5YciZ9lLY5HJlsqjy7MzhiKYxbmZ2WV6fdXdjckeInXatW2ZZMEZbr2JM
+        Os3d5HFbKTVLu36Fm/lPFW0oP4s1v9/viNMq7OUU2l/xz62e2dhW1UxPminNZq61k7denUa1HrPc
+        dEyn3lvCptjg5DpFDIbcy67OEzMhfXL+ggWhIilwBRzkOVAK4hQO/ne4sASutIKOKlnAhG7IO4ME
+        z8WRjxBDc3F84QZayR/gQCDh6YH58kRIJ0dRgQJdOV/Gs+lvl9CBMSFEBVlDfsQ1cJcbuAAu4bl4
+        OAc8ooTsFnBT44ASl8dN4Jpu/CeqAhBygBwKAjMTPOaE1QqvOVFzWBChOqJmfYiLTyHBhcCRl5IO
+        /eOe0lhaSUEgwJi+r31ATtpMeG80K4M5jhf6fevRuBLKCZywwpEVI1bqX8Bc/TtV0iwLOilxaW/d
+        o4pRDNLJWaX34bVdJDnAWuB2TbDDPZhzzYJKniMfSCF9AoUEfLpo5WgyzOeYPSPBIoqHBwQc3GTC
+        OECCGUT8rJdjKCS86uUEiyhnvZxAgmVLgbYNGATtew5x7QELBddLbJJ5YQMMTZH2eJ4S0mfIOYP+
+        W0bmbxnZ14z061ML4y/JnuNgw8eU/adI0p6rYEWeQAlDxZeM7eQpkjzixGDCsjxzDp08lz1mxWDC
+        WhlAxsZHH3Fi6IgT6MX1zbltpI9hbKwRmv/ncfUEFtLno0y/IcP71H39qTueL9n2LOQcRhwUHgGH
+        4tBlR5aGoJISEV6E3ZStpgomxJc0SCpFZhwmOVGv0FLi47Bo6MGfKdpSUgVv4bkoRZMUK6ST8ojq
+        IVmyVdWFKE/QDB2E+BxPiC6UbUtx81Q2R9IkfcreF0Z0H/+YpqLkg25JjqRj5gHHK5/NsSQVphkS
+        sJQwVQvpBMkRJD2k6V8Z8hdJEmTuV9DT7yvE7Z6HIDp2Ec5lToKy9H6mGLRMtYF/3YiwNENm2HdH
+        hCGZD0WEwb9DOgjHxyISRyBMxSKdtQqVcrtdFtJHWFwe51GpCjRNuCdEoYk+a0qebfH7EnwU4wZ2
+        JzuPlnjhcQ4VIzBmrABa5tO4MmEAQg3aT+95YVFMw6eLPDdvaJtDMzG0J+AEHSCQ3h8jfwXzrmau
+        jCDXl/Ug0TkqERbQDsID8oIBsCF5eLAZ9oEiM9i1Dohg2NYi+khQFPNA5WhsnQkopJNmguQX+3GQ
+        7SbZ8AEI8rlg+cXL8z6Riw/DBd/xLCvIlcN5ouh4zT9BwyX7BOHjRfuU9qEkPgI9BwRmfETbIxEh
+        GILtmMDCmUN49q9QIbDGUDGdMcdTJJbCAdmnqAreAgRkSTfzYdLyG1xwcWYZ7RjC0YS9nWGCa+Ms
+        BUYChTs8odBFeFqO4T0n2kTsEHQsYKSGmJh6BFgM2P2SGpGQsTa8uHa72q4OCp1Sa4xXsASOKSEd
+        U1JVfCUpqaPtxVF5LLYbW4v3J30ytTdikm8ZUbgptW0jvN7ibdQZFlychmYGC2t4DRwdXs17Q/1G
+        Z0c0s3jC9kBcgrexmqvNjVjz52DESkwuuhxsrOS8ThCE05nRTsafwU2mKTb1x7pV5mu2urUmtXrb
+        FFuk3FGZuVd6LLQL6IVlcp2VUzRMtUeU+6MGMXyKe4xajFvHPhlvzwuD1oFxQIVXZnRqROEdllAa
+        3ANJpnptIZ1AUelyaZp4m4hlQgahO8ai7hJ/+R8okqJvVJHvy49OFZm9siKBvn4qN5stVCgNtKct
+        1RCfuv1Gt4mNHCyqfb1ebz2D7gIxNZ0l9XVxgirPi3crslUYlv9GkOEq+pYiKfIh858lSWculGTF
+        0X6m2E+SJB9dKO+UJPtFJMleZpLMlSWpr3JiixgavtZQG1qvXLC345XaG+p6X31mRVfeAoOhV5nc
+        ut91st01rDDSo3X7Jvm5iuS/hCL3SfUHJHmJS7JXlmTX2Wbd6aLncoYmTunxXGeXoDdhduJgDR6n
+        lIxG66ls8Bz01/4IVYwX3268W5Jf2CVFgH6mcp+jSTbHZj+gydwXccncZS6Zu7Iktz0VJ5GDscmg
+        wuyZD75AaneHa2a07CNQaPY4k2U6DEWKgybb5p70KWv47jdwyU9VJMd8CUV+1CVzl7kkd22XbPLe
+        rLBUOL7NTDcNjsjM3AnUNpmc3ugrdrEyqLSZ9VQX9UEz24czr66OSt/CJT3rZ4r7HE3mWJr7gCa5
+        L+KS3GUuyV9Zkk90TXppkEqzWrSeHIm1fdF8YYh+pcRuTQCXT5RRqEjKo7HMKE+jDGywiup/B5f8
+        TEXmqBtV5CUmWbiyIkesXEDqNOtUV2TW9dRWdekNOoMazfWo1WasWSgr22u6xsPeKNPZ9eYsm+O+
+        g0m2bSxJ/nMkyWX593+ZxQS3vb+EJPnLTPLxypJ8eea1vtkkhiWKhbVW3WQ7uSwrit3ifKeh/q7q
+        Pta0nVEpQ3LLoc6wVX4elM3bN8lPVSTD3agiLzHJ4rU3N90mt+1SUudFqXeXs9JULkhbachMpXF2
+        5Q6L3Kqz2S4myFBpYu1XlaLU68z1b2CS4Zf+FPk5muQzzAfulFPk19AkRV7mkqVr3ykn/OmKKm+H
+        bafQ7G7GurxZl4YbkexNKzwFCupM5x0NLZwusVbVHJjx4rzzHb67+VRJZrM3KslLbLJ8ZUnq7V5r
+        O+X1PqlbPalZb7wUN9nyyC25qlwXZd/J6APbfoJD0n2ZA35tTetd9B2+vJlABWuS+hRNZsIHo96v
+        SeqLaJK6zCYrV9Zko1wvLxZPKFPssr4x7E5Xjc6cQKpX6T0afqtoVwCNx9vd9nR+1hpl++2WBW7W
+        JmUgL6Ei7Z8NdoMHOF5h98erb3eIN/Vc0P/pM7r3x6tvduqO5+u/tbxnqBtd3i9JOatXXt77sOCs
+        KnYtM7KIcRFNmmIt9yjWtc1SHGaq3tTuc9pEXFcWTmlXV9o87bNV86ZuX6bfeh3u/h7c/T24G81i
+        7onafbX/Aqv9PVG72am7vwd3fw/u/h7c/T24+3tw3/s9uEhzX3hFfusEI7MI93Vn/y7mL+x50c9w
+        RgAA
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2454']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:12 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+LTAtLTgwdndHQzBmdkd2VVdpX3cy
+      al9qdV9GMWJEbDltdjUwWml6QXY3N0UwQ2Y5NlpyOC1LbFZLM3g0OWtaT3hWMHgtU05NSE9FNjZh
+      VnR3dUZsV05LeFdCd0ZES0R4UUY4WnlZRmlUY2pTSHlRUU5TWEdlUDdkMnlwOWpMUG1Kd0dmM1Bf
+      WmRLSzdMeGN3dUkydEhQNWh2Tm1ySVBoZUtTSjhjSTEtUlQ4enhJOS1aPC9jcnlwdG9fYmxvY2s+
+      PHBlcmZfdG9rZW4+ay0tLVFlQXJwRm9IM1VuLVZDdFdLU0g3QlNJaXZoU1QzR3VYb1E4aVdTcUZn
+      ckR4SWRNOTJ5Nkdtbm1mUC1FUVVKLVRZPC9wZXJmX3Rva2VuPjxzZWxmX3ByaW50X21vZGU+aHRt
+      bDwvc2VsZl9wcmludF9tb2RlPjxwdXp6bGVkPnllczwvcHV6emxlZD48dXNlcl9pZD5kZW1vPC91
+      c2VyX2lkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['429']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VYaXPiOhb9Pr/C1TU1n9rxwmLo8fMrEpZmDSEEEr64hC3AxLaMJbP9+rm2DLYh
+        b7pf1UwqlaBzz5WluxzJ6H8ePVfY45A6xP/jm/IgfxOwbxHb8dd/fHubtsXatz+Nf+hojxwXLR3X
+        YSeTBAzY1AwxjVxm6DRa2sRDjm9GFIemQ80lsg2f6NLXFn0XIZ/lZjL0PXId27zghqJLN8gtQ/0l
+        o/RLRvmeId0vzQpPASPm0iXWp9GSRfF9XqVvXSSrmzE1/cfWqMs27WG7OfJK9XNnVZ4ptGcH73X5
+        PHuxrW1tdySdceSUtP6Ozdft/nT40nv/iPrj2tNwVi49f5Q6FTk0T+2jGZFT2wy3Zfft/DqYq+Rx
+        rg2iAXK3HnuavIzwu93uLMQX1W+hwSPDUXXx7A/xCFYsPpfXi1XH1D6r3arlNs35oaRoxOnZpWPF
+        f9I+fLunervD52S90KXCnnS8xz6kEYUYmZB6bLTmupSNuMHG1DJaUCmnwwaHOCUkqG7FAUu4LqLm
+        Hq8RFSMKj7ninJKwB4gKs5iS2tMpwJOm/7gLYixEVpIEYGZ4ykncGvccPh1UWlJ2fNoTBnMR0ilG
+        obUxP/Ep/yQJajYzxJWd0i/eV6QwZ8b7i2kttIR4sa9n5/vKKAU4YyU7e+Is4V/IC/4tNB3fx6Hw
+        uiEHmnPkMZCyVUmX8JLIZ2GakyRDeeBqTvzffIdhW3hliGEqkJXQ8HDoWChz4o+xwW6GyF9jE/t2
+        Ok5M0wh/F1TfFhrROqJMUGWlqkuZnVMjZplktaKYGaJaUWU5peTwjEixRXybGkpZk1VZLbIvRk4/
+        wY/n2bYRP1auyWrKvOKQU1KryoqZwMi3TeZ4OKGLck2U1amq/ijJP2RZlLUf8ZO+dkjnvQ0BH1OG
+        QlYIyib6LlTYRhii0/82IlW1Ipeqvx2Rilz5WxGpwO9UjcPx9yKSRiARGV5ng0a7NRy2dCmHpfZU
+        IYQ29jx8IfDQ8M+ObVQH9YsFRinuwoFFDLbBiIVXRw6mjACxjSGBs+gicRXPL114iSmlwXJZRA3X
+        2V+nSaELAc40xJB0GbNTgA3qeIGLYffWZ9zCOYu+xiQODzJ0F8HJEsFmS9UHRS7B8XNFdJf4a/5R
+        VJTKg6KpcAZmoC5l02xAY31iBjhc0eSULQCxUoHIQOteJSod6h46mmHk+xAVnidFhRTeoboHilZA
+        6jHtFtR9jG3ITQDpjUKclECynK/wlByFKNbDHO2CcEK8BRJ6yLcwX/0dqgeEsqRiRrNaXZGhFK7I
+        RXxtBzIGZPPTM+QH+Sq6eVynoJnJzHw3ydNuMJ2SKAR6Mjk+QkIxZZCWPHzh8OPxyHDoI1eYAlF4
+        RFAMoH6ZBy9kqI0o9R52hp1JY9QczOAqksEpJaEDRehAJ9lC7uDM2dNig8Dko5RJyhzb3wVF+b8I
+        TkkuKfLvC46i3AnOXzV1XNIBIW5Su+lhe4PFhe46XnxIJfWUG/5CxxTld5U9qQW+OrFf7kCtpUBq
+        gcuOQ52lm9bPLchZmWDw0gJVuOjgtJU6ZaB+36HFtov/8uQp8kNJFsZDXcowbt5sPA/Oe1UtJenJ
+        Y/yB10KxojCEC/8p+3S5HNhw0BegjLGCaw0J4flyjpOCGcuPvCUOjVo5z0rBjBW4yMI0vs/fQjkO
+        dLhJT96SuFIeBnXhqPHPvHsGZ6hReIWJwxQrdSrRAdxrMLyaxGc3WlLiRlAFFO0h6FxAbkF9mdQI
+        gf42hvBKUJePP83BYvuh+o31wcITub1WyG65c1qbWl97be5ng2oVLctkN4s+g5r56DiVl3p33p2S
+        xkvXeZxFWnM3azS3x/FMY5/bzpuiyJ9ltKfbz2BrdUwLR4v+TG6yY2VTNt0FPVRNcd9TnXNdHbMD
+        nU3eRXvqllpnszNpb8b2R98Z+wfx5/L49KI8rnfnSYAa4+OsWxlZ0Wt93jODiXbc98NIG+FZfRj6
+        Ddej/bIIrwe53cGd0Fs6PjRVLYnEdRi3H2gD5DJtPj7QfeLzj+aN5xeGHDnu6SQNhlYpsjNLng56
+        ukHhGhu37Kshx06T/fX8BaPO69NMiwV6GE7pOyxuZAukCq2zMkn66gbMFRZvoQawbqA8J+5gqYBk
+        2hGiAzjAm946IhFNNVCBK9yXhoTOCEPuDTOP6bdBz4X6JsC5sH4RzGIIpXw75fqM73c8abWvHjnZ
+        yyOJko1DDOkJ4RUkXhaEs+h1UbsM4QULbSE6b154aHX30XbF6LzXnJDo5/mMnnpnZRZafbXeOVMN
+        +vM4NKvn5lP3pWfvD1FgtZ/Debe53vq78tCcO9vpuVSbzzR1NUaPb+NOafwKZevOJh/FpaSdIhU0
+        RSrqjYV808VoD7UBW3FxeqbdwzpsDO6jcF25fgNxRTzMNsTOAUnonp4fn+FgLWB5CmVcxIpQxuDv
+        lcR1scWEVUg8Aa7RQnLFyDml14XLMCvMK8TD8Abx762qUWWi9ZbWsDo6OIvd6VzqVhSidcUaDXq7
+        Yb3xvtuO99r5fSMuTurxNXh9VmjkDtajcUU9LKohnpx3NUzEpTud7cZmI6qsO8fjqbWpPp83RN0O
+        Ve38c28Hx8Zouu+oK7P99Nw9HQOEldH2I7fuNDnZOM6OxXebp/Gk3YVauk+H9N++DPsPYdEuYlET
+        AAA=
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1997']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:12 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGJhbmRfdG9rZW4+TTAtLTkweEhfTFpqWTJuQWd3Y2VSMEZnMW9x
+      YnFpRWg4SzdTRHZWTDY2YWI0b3FWdWtwOF9CaWk1UTlJV0lUb0FRSWlCVnU3RHFWQURqeFBWN3Rr
+      akdVMTEwazRhdnNqa3BqY0dfY2V1WktWMER0eDVoNF9sWnN3Nl8tdkoyaXo5MlB0d3NWUlgtZFRs
+      M0V6X0dSRmhQZFlLaVBudy1IYnhDUTFCZ3F6UnBhQVB4Vkk1TmN1UzlXSl9wUjd4dktydTdOZVY5
+      TXJuQWxtc0s0LVo8L2JhbmRfdG9rZW4+PGNyeXB0b19ibG9jaz5FMC0tWFc2c1VJYTAyaFBzX25C
+      RU5JdGhGTUZETm0zOXpHZjRWMXNKZHBYOTB6VlFkY2o4cXhvR1B1aTM3S3F0V2dGS1RNUUpYWXVL
+      UDhDTVY0M09ZM0c1MHJfeUZ4X3VveUZfcmo0bFV6U0xXMm9CVzdMdUxhbGptdENSUU5lWGRGR1ot
+      UTJuRWFMQnRldTZaT25NZU5udGktTzRnWmZHXzdrNkk2Y2xEX1d3MzE3b2lKZDN4NW5DN1luZEoy
+      bXF3a1JnWjwvY3J5cHRvX2Jsb2NrPjxub19vZl90aWNrZXRzPjE8L25vX29mX3RpY2tldHM+PHVz
+      ZXJfaWQ+ZGVtbzwvdXNlcl9pZD48ZGVzcGF0Y2hfdG9rZW4+VV8tLUpmNnU1UjdKYmNNNk53aVpx
+      eXozSTUxbzdJLThzcEpxTTlBWHFqUHY3elhoLVp5MnhTcFNPMXN1bExnTlA1MndaNnJlUnpxOGVv
+      LWJsVFZxUF9BdTVnR3h4eUVoNk96aG8yak0yN3pIdmRweEFOVHZHMmZfRkNPSXl4cGFlMU5qWTwv
+      ZGVzcGF0Y2hfdG9rZW4+PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjwvZGlzY291bnRfb3B0aW9ucz4=
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['740']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1ZWZOiShZ+n19BdEzMU9MCbtjD5Yb7UuIuLi9EAimgLEomKv76SRYFreptbt+3
+        W1FRkt/5ziHz5FkyLeHPq2NTZ+gjy3P/+MR+YT5R0NU83XKNPz4tFx2a//Sn+C9Bt5DmBS5WvCMm
+        TKT4EAU2FgUUqLrnAMtVAgR9xUKKCnTR9YTCxxIBnqFL9IAPgULeA8X2Sihko0SgQ6SJbTKt8GJC
+        H6aEGBU0C4cJ1wZIOUMDIDpAQiHDE0rMHgJEyREllacmiCZKPxIVgLEPtHhphJnhKSdWq7/nJObI
+        0uJ1JmZDSMTPkIAg8DVTOcAw/6YCcVImiFyZ0u/aD+TJZsb7hlkNqMRf+GPryboyyhOcseKVNRMW
+        9R/gHP9LtSzXhT41N70LyikmPihksyrc3RsFjJ/uSbxDeeAhjvWXroWhTs0xwBBR3o6qO9C3NJAp
+        Ja/RiVzxgWtABbp6Oo5FiwB+pjhXp+qBESBMcQxbEQqZPKEGWFO83Q5BLNJcmWOYlJLDMyKCmufq
+        SGRLVYZjuGf2XZjQQ/LjOLouRq9leIZLmQ+c7KnHVxhWiWHg6gq2HBjTaYanGW7BcV+LzFeGoZnq
+        1+hNHyukdl9dkIwRBj5+cooZfKbK2KQkEP5ej1S4MlOs/LRHykz5lzxSJr8LLnLHr3kk9UBcZJI4
+        G9Y7bUlqC4UclsrTCkF1oOPAOyFxTfJs6WJlWLtLrHv1UmxSHT0RmxBg/6GYgCnjCLApFogybQN6
+        F9kv3HmxKKWR6eIAibZ1fphJoTuBFFGAQeE+xuERishyjjYkq9cOUQrnJIIBvcg9QBRsgC0ckMUW
+        K19YplgSCg9EsD3XSB5pli1/YascS8QPUChkZkxSY11POUJ/h+Ky/gRElYoUGZK6jxKVDgUHXBU/
+        cF3ilWSfWI5s4TtUcEhFe0JqEe0VFFwIdbI3R7K9gQ/jEIin8xGekgMfRPUwR7sjCSFaguc7wNVg
+        Mvt3qHD0EI4jZiTzNZYhofBA7sWXdEYckZWDIzJfmEfRzeMCIjUztpysJn7bCyYgL/AJPTYOr2RD
+        IcJkW/LwnZO0xyuGvgtsakGIVAOQYCDVL9NIApnERpBqS12pO6uPWkNZKOTglBLTCYXqkkzSqVzj
+        zMnTYCOOyXspKykrqH+mWPZvKThFpsgyP19wWPZdwflWUkchffQ8O47dtNm+YFGg25YTNak4nnLD
+        H9Qxlv3Zyh7HQjI7+q3UJbGWAqmEHHYsZKl2Gj+vYMLKCkYSWqQq3Ovgop0qZaDwPkOf0y76m2we
+        y3wpMtREEgoZlohN03FIv+e4Yrw9eSx54SNQND88Yk9RbU87iAeOpmELjK3FvjQaal1GXs8bfbbt
+        2q3FbVUfoR5XuprLE15N16He0FZN4srKCsD9asB7/WB8PM97i7DmVabX5hjUN7eOsh/uKkWvwwTy
+        qN73jyde6uL91ZTWvUCpn5ar1tieB3y17KoMh53TxOjSN7TU9utw0C1VPXPnsUPQm9TkcUOvdNpW
+        ebNRlzLt1LfNeq9TD/D55IWNE7tZXAYD0xjxHZve9M431VxtkYPR4TqZnFZ6WG3WimG3VNsi31I2
+        vYAcXmfuzR7KJ93g5HU1oOdjy+DW59nmML5tO5WK3Lk2T7LWo/EykNndQR5aLbXcqKnTowLNuV0a
+        2qpaDpSgP6Tru6Ba8XxpW5melcFaCfU92kEGrmx1w55rtz7gsRMCTVkRf1+a+nIEABiV9FBek/nN
+        ZkzRmNXc2pt87qiHS7derl174ap2PcxGRXisMDS9Jeeu/F4Jqg1c0myU7B7g2mEShx+LBC3wfXKT
+        yD3dD4I6Mf4EZYwdOcJ6Pok1JsdJwYzlBo4KfZEv5VkpmLGONtAgCcscJ4VyHFLNFRQ6qmcX8jDp
+        JAkq/juvnsEZKj7uRih7JMUBYTGqVU+AQBqnt1MyhSJpOi/Qwwa5CqnIswNSIxA4k5RM2ssrSM7R
+        jmq5pBDxsfwxzCYTO7neGi5y80kc/xgmFxydXOmoqG3pwNcp0ixhTiMt4T9Y4WOIPdKPxCiYgnFx
+        NLUBEwwQsnl37i9cpn5BrtuoF4cDdTpUyq3Tfnl4u/YWVrF0G9Fqba82ORO151OZxdC4VsH50A/g
+        zJKOt56xPau3cIvZLl/vMQY42JPt1NUGS23trC/20jxI6u04lxa6sQuZ1c5QtLe3vdSv9qoHsGv3
+        mpK82BjQYC/umJcXgdzcSqU1LXmN/nLYY7k32ekt6DgJXlaTW1102sqvPjl+kXJMWhgJw7RHJAOy
+        7W7yqLxs1geCHDlqPUdyC4JitfzMziR5Omn7JvANKL6yH4IcOzk9Kh/bfxIKSWop4AwsG0SthrTW
+        d1jUbzTSUYGRxWtc/l9AITaqqFHfSwKTsF6gPCcKu8ITkrU4H1yIgostI/AClLZqltw0PhTEdOxh
+        YL8w85jw6vScq18cnHPrB858dmEhy+r/O7+r7Pfye9VujDudn8rwC1SpeJ9/S4q3SYr7gdmieacI
+        p7wrn91wE6gc373yLXjbaxPXlquzRmgGvcHuNOvjozJ15Nu+UevPrbY8ldaN2nU1aW5IT7+NOwej
+        tJMPzX675dKyN2mObohuTYs9pVxWe8puwNobYGB7VYHapnJpb8ctWrtKWlm9TGvbg7KquZJOujFX
+        c1BvsNSlNcsowUEvHTqHljfD0mgAqma/XuLkboP2rvrF75k/THX2L6R6sm8/m+oV/pdSvfirqf5q
+        /59Ufzjlw1Qvfi/VE73fn+qV8vdSvTHvzn6Q6I0AEU2EKMP3guNva+XcRJo0urcNV1ttd62K1FU7
+        jh6+9fHlwJ7sA1ZqFlTftMt6jtrNSVuhw66G4GU7gCV/6xne4ozAGO+Xw/NWlv3SBDt+5W3RmXQM
+        +8ZzF9ycAdRWLnN06kzGJ2bSWHv8eL+1Znse0Tea6Q77++VyEE7xsayh8fAi6RLTaHRPHeeG1lWV
+        HYej5bxe1BwDrvTpEWpvClB+opVzfyG/K+Vfym/m723lr/b/ye+HU369lSd638zvxyNKvkTIUtL0
+        rOim8fgq4Z0kF28v/1L5Hy7T1raTGQAA
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2304']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:13 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcj48Y3J5cHRvX2Jsb2NrPmsyLS1lRGFPaVRqNE5MY0cwVlhTQkkxRW5sRFR6
+      V0FOc0gyNHhoVXF0V1FYeWRCY1dDMTFUNldhZWpXSjhvSXVPcHZTSFR5OW82UXhDT2FBWXpGX2pM
+      ZjYzb0YwdVZOQUlycHE4TUd0anhoTVhIdV9BcVVXRE9sU3U4NzVuYjAydG1xUGdHLXpzVWNqWHlK
+      RzQ3b2hmbzFMYUhQOVZPQmQ2RkVpNVlZYlVWLW1BWkNBSEZBdXR2cW95QnExWVR3SkpoZ044Rmwt
+      WUh2emJoV1pzbXRza3hQUHFXZHk3QzkzeUc0OVpzcmlfWUh1ZWFfUm56bExWcWRnMlZYN3UtU09p
+      ZzJYdlJZa096WkY2NlZGeENxVmNILXRVdVYxZmtWTGlEYjVCOWJRcF9laFNsNExsYmI1dV91SUwt
+      QWZ1NzZvck1aNlF2X0pYX3lkanNmZTBlV2xiWTF2OXpJYTh0bXlhY19Xcnlwd0NkVU5hYWFONGR5
+      Vlh4UFBSUjAzZ1I5bjlLVnZGYmt3R0E1OXhIeVc5eGtSTjNlcDYwLS1aPC9jcnlwdG9fYmxvY2s+
+      PGRlc3BhdGNoX3Rva2VuPlVfLS1KZjZ1NVI3SmJjTTZOd2lacXl6M0k1MW83SS04c3BKcU05QVhx
+      alB2N3pYaC1aeTJ4U3BTTzFzdWxMZ05QNTJ3WjZyZVJ6cThlby1ibFRWcVBfQXU1Z0d4eHlFaDZP
+      emhvMmpNMjd6SHZkcHhBTlR2RzJmX0ZDT0l5eHBhZTFOalk8L2Rlc3BhdGNoX3Rva2VuPjx1c2Vy
+      X2lkPmRlbW88L3VzZXJfaWQ+PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjxkaXNjb3VudF90b2tlbj42
+      MC0tdU8zTlFsYTB1SnNzbDhuU3JUbjBBd3NubkJBM0xKYlFMXzVEcWpVa0t4SFRpMzR6Ti1iOWpi
+      QzJoc0VTUVYxdGVneDdhdmtJdWVSaU1wekhnWnZienladDFHOEFIMGdha2xQWlFuY0pVY1htWHds
+      VWhrTWJ6cFNNVGRnZnkwV2ZnX2NLS2pNSTdIN2thZkVIQ01WVFlnZWcxd25POFZUdVZDWk00WC1N
+      b0JJVUxIMTJLVm1IVC0tLVo8L2Rpc2NvdW50X3Rva2VuPjwvY3JlYXRlX29yZGVyPg==
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['904']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VYa3PiOhL9vr/CNbW1n8bxg2dmfX0LhkcmPAIJAyRfXH4I48SywJIJ5tfftiWw
+        TXJrZ2p3U6mATp+WpVb3aTnGn0ccSgcU04BEf3zRbtQvEopc4gWR/8eXn4uB3P7yp/kPw42RzZBF
+        Yg/FVoxoEjLToInjEWwHkZVQgANqObZnRsRQPrcYbhLHMHtafLPgUchMqGcoVahgbGyXkdjUVLXE
+        EWDBihLsoNhs18ssARasXWi7iJp6iSOgEodQZtEUOyRUynCMBGr+s+xewAUKbnG6Y8RyQuK+ma4l
+        y03Zoa+rh9fw0Y+RTHvO/ePtQ9fdtLej5nH/NN0M2fRp1p05TS1U007g7AYL/3FeG3kvP069gPqn
+        PaO33vLuZze20iAIf/g6qbdX0QE9Pz0snXU4pEsy2696q/eW48w1tLxbDnayG2un4CVF9sr1l4N9
+        5xT35GdYaXl9Bj9WRt5QZLqaLNt+Ko8i1Z2z2jh6eVruJ/Epxd/99+YsGuDxpH9Mxz9O6iw9RovO
+        ZBX0t8/Nt/vmaD/dtobd1wWejzraOmztNfX07OmtetLue91nrzVfNd+n8mF1WK/fcL+h3vf7c8Zc
+        u/7cpY0Dbr5qYzS/G3ba6FXDzX3HPq2tw8+ZOgyx371/SI9TvK8/3j9OEdnP79IdbrfrzdFqP2tY
+        Dn5zHfp4bCekO1otppOn8HX/koy9Oe6+NLqz2eBOG422qIbeX/YD6stLv/f0/NqT1+vJSKVLzLSD
+        myJrYLnL2qTVpzN9G3V7t0TVbL89urP2azZ4xkt3oa4x26fh7j35cXib3J8a+PbFdw6qLL8YSjmU
+        PK6m4SG6s5m7teCLa34nYYhcJm1igiW2RVB9UYIMpcoqnDBiW+KVgLw+vj90H0o+vGZKQ8pM9Uat
+        MAD6L5eSlbXNbKUEsXSHTJfPU3LM4dL4somAuiSJYCUuwU4QIc9s5+u8DC8UvqdOb7yAeSpYQcnX
+        1/FAjSTK7MizY0+KQahKHnwLEbHIxqIgYtTUDKU8FDYWuG+obD0DRkbbxYGLzFYjW2oxBgWM3a0d
+        +8jklsuwWIBpIIgqfNggoXz9/ZWhFCNuyJfZByFO37coRoLAF+8GTKhiaFPrgHybygmFmF1wTsnZ
+        Y5tKy4wi7GIK8KTig7vYjMUgoiD7GbPABYdH9iOHTweCnqs7nzZFYK5CWdAgFtYbSstPUvLonQ1Z
+        AxH0s/cFqcxZ8P5mWtd2IF7s89n5vgpKBS5YvCI4S/qXjXf/lnpBFKFYetqSd1py5DFQilUp5/Bm
+        Bx5fmlqW1SXgYs79f0YBQ570xCBdqUQ2UgcjSCq7cBLFl/Xd2I58ZKHIE+PctEjQV0mPPKmT+All
+        kq5qTci7i51TE+ZCNm8oYqasN/Ssi17jBZEil0QeFEG9peqqXmWfjZyewg/Gnmdmj1Xbqi6YFxzO
+        lLSbqmblMBQnVBRGOV1W27KqL3T9W039pqqy2vqWPelzBzHvdQj4GKo+ZpWgbJOvUoNtpYmd/m8j
+        0tQbaq35yxFpqI3fikgDfhd6Fo7fi4iIQC4yPM/GnUF/MukbSgkTdqEQ0gBhjM4EHhr+PfDM5vj2
+        bIGRwEO4DxITWoTN4osjBwUDdH5rKuAsh7a8yeZXzrzcJGiwXJZQMwwOl2kEdCZcegwf552EBngX
+        IiHJZz/eY3xEsvDYphHaLGAJbLbWvNHUWt1QLogRksjnX2VNa9xoLR10vgANpZhmCxoLHWCH4g3N
+        L7MVIFOqrAFApzpLlBga2D5acRJFEBV+TpoOR/gBNTAoWgW5zWjXoBEh5MHZ7OB4E7hkZkeeL+cz
+        XJAT6H2ghyXaGeGEbAskxnYEvStf/QfUyG6/ecZMl+1bTYVUuCBn8YXOxjKy9Yb5HeMT3KCgmfnM
+        fDf5064wgxLol4gnKDrCgSLK4FjK8JnD2+ORoTiyQ2kBRKlrQzKA+hUePJHzOwz3ngwnw8fOtDde
+        GkoJFpScDhRpCJXkSaXGWbKLZPuFAgI5x+c3jqx0S0OjEuJCj1bI+ypp2v9FrWpqDV6ZflmtNO2D
+        Wv2dImT1sCMkFPen/GivsKxKwgBnHS5PxtLwP4igpv1qW8gTia9OHtWHkKgCEBa4KQU0cEKRfNcg
+        ZxVqw/MSJOUsoou+cCpA42N5V2s2+8sPT1Nvaqo0mxhKgXHzdosxXBZ0vZYfTxnjDyxqMbtkwpsz
+        bJnfhcF+BZU52TOUClLsLjsWeG/fJ4heBDciFwh5/Fp7TTG44pZCMHvsD7JFX8EVYr7ZWYw2CF6H
+        PSmbGEJU9RIBIcwOratXgStQkK5u8B/BCq90m/8MFtzrm/01eqZVb/nX4O/JiXgnVD77j8pfSB2H
+        3I4RAAA=
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1772']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:13 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PHN0YXJ0X3Nlc3Npb24+PHVzZXJfaWQ+ZGVtbzwvdXNlcl9pZD48dXNlcl9wYXNzd2Q+ZGVtb3Bh
+      c3M8L3VzZXJfcGFzc3dkPjwvc3RhcnRfc2Vzc2lvbj4=
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['89']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA21SXW/aMBR9369AvHuhTGIgua7GECtjgg4atvFi+eMmNSR2ajsM+utnB7ouGi+J
+        r8+x7rnnXHx3LIvOAaxTRt92b973uh3Qwkil89tu+jhFw+4deYedZ9ZTBy7yqAVXF55gV3NpSqY0
+        rR1YqhzlTBJtcHIdwcKeKm8oL4zYk5QiNEDc7X4sd8Uqt4DchH9djZZjkQ2f5oPj83qRffGL9cP4
+        gQ9uit7pk+LV9DFfff8wl9vZy0S5/OXZu5Hc3Kdju/im5HC72Y6edp/zTTWq7bL/Uez1nOdgit1h
+        uq5m5vBzdhjzdTbo6W3//vcvnLQ0YVtrHWZvZBPMmdiDljS3pq6IhNJQpT1YzQoqgSt/RnDSJmJh
+        Aktf0IRgCRkLjlFhau3tKfwlkHqPk6sAjnb1eWPk5YgthJaalUAmQYV23jIfouikQSdO3tCYlIcy
+        NpfghFVhNpvE61MBJFNHkMgz7kJEzU3MkJ6PzVcilmXoIqvJkf5L/FsGj8IWOINy0GCVuFDb9Ghi
+        6H1eAdn4h5PXKqhuef2fN21PXqs4FUm18iA78/A6rNkbtQHjaFe29Q9od30C6wIAAA==
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['448']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:13 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PHRyb2xsZXlfYWRkX29yZGVyPjxjcnlwdG9fYmxvY2s+VV8tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRnUlEzS2RaSXpEaXNnenF0czlkVkhVQnJO
+      TGlkOFpWWjloakNnVnA5dXJPMjdja25LYmdlb2xqdkZTcElvdlhJdkJiU2Y2MG5aMkh3WTwvY3J5
+      cHRvX2Jsb2NrPjxvcmRlcl90b2tlbj42Mi0tWngwLTFJbnhDdldCSzlmRXRZWEcwOXREZUFyQ0du
+      TFZHd2dxNUhYR004ZXh3VFNEOHEyUUdJRnFvazZDSlhmRl9KNjRMWTR0Qk5jbmJadTc2MFZlaXlF
+      SXRSSXd6OWxEcUlRM1hBcTJBS0VKOXMwZlFpRWxDb0tTdDBUdkVEdmlBRmEyaUQ2TWNNWmctWDRv
+      QUp4ZGhua0tGQlh3ZmRYM25mZUI1MWtJTWEyeFBydGxFOEF6eWRoZTBmaVphems5UnUtb3IzM3F5
+      ZURNTWJ3Mld6eGh2T1FZdE1veFY3eTdUeG1WNUp5QnEzQUJRSk5TOWFtaHZUQmJEQ2o1M1cyeV9t
+      Q2JmOTFhd2FqLVpLczJjQnBfMnhsaVR3YWlNMjBOS3FhdzZTNVZNOG00b1pjbjBzNFVfOWFEVG1H
+      Mmk4UXBXY2pYempZNllWdEZoSWNObGhlcW5YLUdYcmNiVzJHb1o8L29yZGVyX3Rva2VuPjxkZXNj
+      cmliZV90cm9sbGV5IC8+PHVzZXJfaWQ+ZGVtbzwvdXNlcl9pZD48cHV6emxlZD55ZXM8L3B1enps
+      ZWQ+PC90cm9sbGV5X2FkZF9vcmRlcj4=
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['650']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VY2XLqSBJ9n68g7sPMw4wsiZ07anWwGS+A2TG8KLQUIKONqhK2+J35k/6yTqkk
+        tMCNud0z7XDY0smTVZVZWZlZkn79sq3SGWFius4v38QH4VsJObprmM7+l2/LxSPX/Par/DeJYtey
+        UKCohqG42EBYwYj4FpUl4muGa6umo/gEYJMommrIjivx9yWSjgOPuopmufpR1hWOq3Ma+Vi/fViz
+        PUYc6Wkvs9ZbR981D6/1r9N8vBvQ8XzSmWh10RKCtql5j4v9bFp5NbbPl55J9pcTJS1j9bTsYCUw
+        Tet5X3arzbVzRpv520p7twZk5U5O6976s6FpUxGtnlaPHqdj8WJuA6Su9f3q8dS+4B63kfjc+qTQ
+        YM8lxNQsJAeISHwOuTqGukfkyPUKx1HltKPN4eZY/uQmY/OptqzOp4Y4OiCn2zMGtQDhz4G2Pguz
+        zVzbUkvd4O6upzoz1fQUNDY/4LF9IC+HdqX2YdSmi+eX2X4wtt6f943eevh+mXK1Chl0q4/meXS8
+        LH3zNH45dgJ62jp1vTzcfwUcev7s69MWVha2s3ndHmtvDj4/NbYNQ7QWRlM1zFdaGc0NI/CHh8eX
+        Dlcr94YeFygf/ZZm+ZfutPxWNTRjUz4tuu7r61PD7ArKhbaXA6WL/W6lhbTatvuiiFPRPVU3uvf+
+        Wf0Uh8qL3l8ZDc/ptBtH/VQdjQZ+q+NazY0uBo35YmXsyeSwmfc6fvujgrwGOl0Cd3z0a0652dOV
+        dr1RW5y1lepsyNtw2xla50V3Ig5O5TWtNN87Z63zPL+sZ+vlBW/JadhZdD/Gu7H4rin13mZbFyvT
+        WXnT2I1OC7wZzDa7yevmYz3ZzNr9CapNB8EXXZKn3mbzrgTTL6XpcX2s2YueJ3DcVuLzm3ndWxbw
+        uus7VBZTVhYO4wQZikmRrTi+rSEcMm/BZExZ0nzHCAOI/S/OcQdNmMT1sY4ANJCMvqhCEaHCVSMr
+        LWgYiOhy/4si7KhWaQFqpY6qg6VG6UY/4ib61KWqBUPamukgQ660HlJ+QVZUIVSuCg+1GzqhBSpM
+        6KlUP8jiDfsqymsQpFIPmzqSK7WbBaXCghJYd1DxHsnVW52rTNJ9jCENBukT8+he8yBB5KCUsVN1
+        6sK+C0KGE4MpKw6EZrmeYSXRcQU8S9URkcsZTgxlOOBFhQS25lp8FsYoRuXf/pPVT/EUlaUoxGQp
+        cTLb+W4YpDot7bBrl+gBQYVwfCTxeVaqZCN6cI0MELmm+9Z5y+gwd2VeIQii3c5D/+NSwqqjUlUe
+        Lxcwf4aXCFIqDTwk62z8DDGCM+9X40wSn8TCUUijP6EwW9u95XABA+XAlBMtvG1AFS0RqjqGio0M
+        mZnluIq7i6KZhGkh+xrLqAlHOCtNAKl4QDJnonAMMpHPp1Yi8HSY2TBS2dL7a0hp1zcmYEkFGojg
+        84Awigls8bpJ40NiuY7hOpx/BGddQSaPqMNIHgtjZUslJP7H+CqmUH4zQCxkfgRh6e+q7f271AWP
+        +uFSMmIJuo+oFWHDRoU8D4XuAi8oR0jO4Ux85LAECducmJeoXZHcYCmvOJ6hOjq6PygzJyHkwJQT
+        2dFRIVppbGivoMAs5dMl8IkTww3FsdujTcgCV3Gkv3SgXhmlV2gAoXtLqfGuYBPiC5q/s4k+FQ9B
+        rQgLVpTy7ookOHNIwaqzRwpUmvg9Gmxx8P9VEqEKzZEHJRISYKksiJAWUwpj+1SHwN4RROVKPZyq
+        iKY0gnQIJTgN1Ua5Uavm2YmQ0QP4sW3DkMNJhZYgxswrDjvtNuuCqEQwHFA4WjaK6JzQ4gRxIba+
+        V4TvgvBPQfweznRfIR636AP2Dicf0xuv1OihNFKD/6c/6uVqoyL8tD9qQu0P+aMGv3/GH7H9Ua5h
+        4Rgm7lm7+9qfSXwGjimRG0YqhUrwWepAs+Kgf5DSGMzBYS+DS4v+fJEoMp+xZ9OQ68+PiQTeYtyC
+        QHdlGE6lYc7IgjEDqsBB5kGZs9m8nBbNyxHOuc7LhW0Yn+hHKrE6WEh9Ilvm+Tp8DCUEVpj45D2q
+        P8S0vbAziZJ5oscqE3v2PYIsC1ZKaM7E/q2J8DR6ErI4f2eMPXIVViAtlZrUB5/XoDyXW3VRrDQk
+        /opKkM337JETHkQBdrhWh04lhSU+HeygEgUKE+SDHYmuhTkgzKZhXYLimaTR+FWy1S8F+44DW8Hi
+        RiyDDTeoZEPWvcMropKDoBc3kAfxBtUhisloPffwmOxjsNl1MrQEYYTQBhfbYRpmy79BpbBJY8Wz
+        K85K1cVY4q9QUiKg5NKQrRxtWYgrdRGXyMGNsuqOmRNNV8CkH1wNcneCn7oM5G4B0e39Xsa/J5Ci
+        9ozNNW/3hv3ZfN0fDucSnxHEpGj4uQodOIYzvIZQJAktLmVxC/Knj37hPpa7ieW2KU2xa2RAVRL/
+        igTcaonVn0/A4m1B+lEmC4+U57pW3BlGsVHAwoNmmXZY26Nwzrz+l7wu/nSdiyKRrY5rCxOI9BiI
+        JUQ5m5kPKUWQsdJsyAIbUl7cfa5ilRSSbs99/syHf9nGNR4qQmkygtv7FWLSw8G2oUcSW6w4ZjE2
+        X3qUw95Z0UJ7WXsP8gKU5YRz8DkkNS3cEzg5Jx+RazVw3CuEDNatFykSKwcZD3SfZ91hP1x2QZCj
+        ssbOA2tKuol1C+UVYm/cu+UXr/fsvXAruQVzvMwN5R4s3b/O39zj717gb27uP5tZ4mvvX5Mx+eTj
+        TvKpKP7OcPMJKYf/oe9N/PVDEv/Db7O/A9pPXdzdFQAA
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2085']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:14 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PHRyb2xsZXlfYWRkX29yZGVyPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRnUlEzS2RaSXpEaXNnenF0czlkVkhVQnJf
+      eWlpbElnMm80OFdudmVZU09WYlhsR3NWb1BxV0RXdzdiYlExZVZIVkZwLWNyMXppWnllYVdjZ1ZG
+      cUF6ckQtWTwvY3J5cHRvX2Jsb2NrPjx0cm9sbGV5X3Rva2VuPjYzLS10X3FmdDhMWWsydy1QTmlI
+      NVU0U1FkMU1oZW5DRGRHNXllcndHYld2MFJZU2JadGxhWXJDZkRhblJhaXBfZU5pamFuUkFoc0po
+      QTM1amQ1UVRJSlJnR05sWElnN0RXTFh6US01M3NHQzRGaXZNa3pVdWlxTkprQnl0cVpuNmMyTGd4
+      eS1lSXdFY1E5cl9UbW5ZS1prNU9ucnZIN1o3ZDFsVGQ4YWRpS3QzTVNkZHl1TGhGSkItNTJETHAt
+      eV9qRTlibHV6Q1EyTzRkYmRZMnFUQ29LS0g3aUMwX3p0QVVHX0NydUMzOWViNVpDSl8xUTFvcTRZ
+      Y3BYdzR3MUxfSmNFVmQ3cG5CQTdrY3E0TU1HdTlCb2w4WWMxeTdTVFZkZ3NQaFlTREJ1QWozZXA3
+      ZXF6eW9Oa3U1bjI4RGNfQTY3NVR2YlZhbllzT0xaQkxsdlRDUDFHcTJXdDM4WEJ2YkJJU3pXUldV
+      enJac3FMQlRDak5mTjFYYl82RFlaNjEzUVIyWTdmTXFUcllHUllmUEtZaldQWVJBRVBlNVFHeXh0
+      VXNIRFlZWF95UXhfOHAtRXJibVREcDAtLVo8L3Ryb2xsZXlfdG9rZW4+PG9yZGVyX3Rva2VuPmMx
+      LS1hZ3ktS24wY1F0M0xuWlNWcU1yenltQ2d3NlBuRm1MTUV4eUxJejBQeXhuVEFNV2lFaFk2a0o2
+      S3FOaDdHQmpUbVFLQTFYbDdxMTB6WWQyNzR1OEVkQllkN1FXNndOLXZXdlhYa21FNTBKRUVRdHRj
+      YTRZQnM1dm02ajFMZVFIR0E4ZWoxbTZxQWF6WF92VVAwR2xtZ0JKT3l4Tm1xNFJKUk5lb3FRSHlw
+      bTg4NDZLV3FQNV9ibWtjYnNSeDh1b0JLV1ROTVNsanFadUxkUW1CWjVCUFBGSDFLS2hlM2V3WnFG
+      c2ctVmdEU1lqRC1YWE1LMHNWbXQxdmN5ZV9GX2NWM003RXNQMmhuQkQ5bzAxYWc4S0hfcVh0Rllt
+      VmNUMFhtdHF5bHB3dUl2a01KejVtOVpnYnYwLS1aPC9vcmRlcl90b2tlbj48ZGVzY3JpYmVfdHJv
+      bGxleSAvPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjwvdHJv
+      bGxleV9hZGRfb3JkZXI+
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['1098']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA9Va23LiSBJ9369QdGzsPuzISOI+q9GEuBiwuRkwGF4UuhQgowuoJAz+nf2T/bJN
+        qSR0Adu4uz0z2+Foo1MnS6pUVmbWMfzvB9Og9sjBum399o29Yb5RyFJtTbdWv317nNzSlW+/C3/j
+        Xcc2DHSUZE2TbEdDjuQg7BmuwGNP0WxT1i3JwwDrWFJkTbBsPnd5hFed49a1JcWw1Y2gSjRdohX8
+        PBs8G6OVg2jcUO5G1UFNXVbW96XDbtxfttz+eFgbKiXWYI6irmxvJ6vRQ/5eW3ReGzpeve5cXNWm
+        7ceaIx113eisOLtQmVl7NB8PpsqT0cJTe7ibNWYvZUV5YNG0Pb3d0qrDvuqLI5Jn6mp6uxNfnQY9
+        53Op5+P9BW9tjHXFQMIRYT6XQk6Oce0NsoRegab1w6E74w67+biLR69mp2VPam3Vkuq9FduvcfPF
+        ZqHtxNakMVCOvQ43kQfLscLJ/alyV9k83KE99/K4qrgSazw7HmKfFq2nRkfE6GXXc/D4YaZtSqhr
+        qIVly+JYb+Wynj3VR+OZN/AWJeZWwXK7VdqNGsVt7WU4cegmY8o7s7hHHo0PGzS297edfCNfmy0W
+        xfZi9LqXO7v11n5e5SvifM6Iu91rrYrUVnu21Iu3zcKIvRuo7FNr9VJtcBvzxWt0lEp+Wdi8mqXh
+        qJpfOcWK0j6oD8siqitqJy/qUrvbf563W02D3mjey325PK9iufcoliWNhtfXrC2dWrEv6oMKXepM
+        x/NZkWVr2nrHaUozr89b4uuquVw91VX20Wx1HXvl2aP5cqIfjKd1/eleOtg6fmw9Y5cxufLixbg3
+        7KrcneCHiZc3bxFbGzaG00OjM8G90Z1YKIjiXVPcveZdb1eY7w4Dp/taLh674529f7zfVBvy2Kwd
+        aXtitueGOX7cNUxXHz+sFoW7UblTfzZqO8ksqs/N8fp5WHcHdlnb7/aDqvNMy8OS3VxOFvv7ti5a
+        o764OG63NbliPFb7leGsv3kdastef3CHvFKVXZfb2wWfSwfNKYbIxlJtz3IFLmYlYT8ekSbpLjIl
+        yzMV5PjMczCaU+AVz9L8QCW/U5OxfO4CGjGx7TkqAlBDAjq4kovA3SeL5GjGQkNYFZoHFzmWbFAT
+        MKNqsgor1agz+4Ab2bu2KxswpanoFtKEfPUm5mfGsibYFQrMTfGMjt0MFW64lV11LbBn7NNQ2gIj
+        2d06uoqEfPHsgeLBjBGsbi07KyQUzm1OY7zqOQ6k22P8iXh0pWwhEaWgmLGUVdd2BJZhEpwQjFlh
+        IFS4UoIVRccJ2BqyirAfQ1kowQEvSvhoKraRS8IOClHhv/9J2sd4jAp8EGICHzmZvPm6H6SqSy0d
+        26TcNYJKZHmIz6VZsZGJ3LWtJYDANfVBbZCwIe5KXEIQBG87Df3go/jVTXZlof84gfsneNFATHWP
+        WySoZP4EMYAT16fF6TjciZmtEEd/RCFrFRuP3QlMlAJjTvDgogbVmsKubGmyoyXIZFmWLdnLIJqx
+        nxaSl+GYq8MWTo5GAJ/dIIk9kdkGicjPxatE4Gk/szlIJo/enEFKO12RAZJUoFE5vqyRg0ICeXhV
+        d8NNYtiWZlu0twFnnUAyHlC7wXg4GBobMsbhL8KXHRfKfAIIB4kfYZD6h2xu/03VwaOe/yiJYR66
+        nKDlIdMGDUMa8t0FXpA2kJz9O+UCh0WI306FvMjshKQmi3nZ+TTZUtHlSclyIkIKjDnBOmoyRKsb
+        LrSRMSArzcWPkIuc6L9QJ3R78BKSwGk4sH+0oF5p1D00mtAlxtTwrTg6xBc0mXsdvUhbBLXCL1hB
+        yrs4xMOeQ5IjWyskQaUJr4PJJmvvF4qFKjRGWyiRkAApjmEhLcYUwvZcFQJ7iZEr5Ev+rbJoTMNI
+        hVCC3VAoc+ViIc2OBgn9CP9MU9ME/6ZMlWFD5gmHN21XSgwrBTBsUNhaJgroNFOlGXbCVn/NM78y
+        zL8Y9lf/TpcNwnmzPiDXsPMd98wrRXdN9eTjz/RHiSuU88zV/igyxU/5owg/3+OPcP1BriHh6Cfu
+        kVi/b474XAIOKYEberILleCFqkGzYqF/YqoPy3H8XsahJs3xJDIkPiOfdU0odW6jEbgKcQMC3RZg
+        Otn1c0YSDBlQBdZCDoxpk9yXVoL70pi2Tvel/TYsF9kHJqE5rND1sGDo+9P0IRQRSGHKRddB/cG6
+        ufU7kyCZR3akMpHP3hYjw4AnxW5qic3zJcKnXptJ4rkLc6yQLZECaciu7nrg8yKUZ65aYtl8mc+d
+        UB6y+Yp8pJkbloE3XCxBpxLDfC6ebC1jCQoT5IMlDo6fKcDPpn5dguIZpdHwkjflg+R4lgWvgsQN
+        y8EazlDehKx7gZdFeQtBL66hLcQbVIcgJoPnuYSHZM+BNdtWghYhhOCvwXZMPw2Txz9Deb9JI8Wz
+        zo6owqTP505QVCKg5Lo+W9qYAhNW6izO47UdZNUlWU5wuwzGv3E0SJ0JrjoMpE4BgUpwKeNfGuCD
+        9ozcayw2uk04ATe73TGfSwyEpGD6sQwduAN7eAahiCNaWMrCFuS7t37y6AX5PXUSS72mOMXOkAZV
+        if2KBFytsoXrEzB7XpDeymT+ltrathF2hkFsZDB/oxm66df2IJwTlx/kdfbqOhdEInk6WmSGEOkh
+        EI5gaa8nBJssSFhxNiSBDSkv7D6noUkM8ef7Pr3n/f/Jiyvf5Blq2IPT+wkio+u1aUKPxFZJcUxi
+        5H7xVvZ7Z0nx10vaexjPQEmOf49cComX5r8T2Dk7D+FTNbDsE4Q00q1nKTwpBwkP1DujerfpP3Zm
+        IEUljd0WVkOpuqMaKG0QeuPSKT97vCfXmVPJOZjiJU4ol2D+8nH+7Bx/8QB/dnK/NrOEx96vyZi5
+        tLjzk0Qe9gdFnjP790SeCvMpkeci/W2R55z9ochT/h6R54LNxyKPh7WfJfIUmK8Xef7+V9d4gpf9
+        FRpP7qdqOSSE39ZyPinlUNApoi/Sc8pv6znFP0bPgeZij1Yypj38lqQjY2rqUz5SdVwX2je/qX5H
+        3DnnfI+qE8/yU8WdxLSqrIC/3PdUnpjyns5TJ6xI6NEtC2r3GNp9/Hm9B1+j94yhw0CYspeUaCII
+        Kjmr/Lyj43joF4qDAiN6Kw/qzYc9M80VuatlHIZjOO7qrrnCcJ+SLSo0w004jrS3NFP+k2Scz3ik
+        xBWZ/PXC1ncJOZzvjs955FzI6Yq3zV6v+aaK05WpW2Sa6C21plv9AbWmW6UNmV768/8xqswF+SRf
+        umGZfOEN6YRlizdsmWP/OsJJ9a+om/SnlSrLVP9o2YT99CGAzRwCEnpHr9VrjcR+ozt9UwYBCtWC
+        naRRicL5gRZyeQNl/gb9BZrHp7JVnsmzn5Cd31U90hnhq1WPK8vCSfWAlHNfaP1k1aMrTpo/onuw
+        zAfCB8f9Xwofw1Hz9irZY+igJYKDkEb5E4OLrtA+yFHgz9A+ytdpH8WPtI+P08k7AsiP576TABJ9
+        VyY8g599hyaFf+oLN7nTN2lyb34J7n+GQWWhRicAAA==
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2653']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:14 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/BundleTests.test_int_properties.yaml
+++ b/tests/interface_objects/cassettes/BundleTests.test_int_properties.yaml
@@ -1,1051 +1,1019 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48ZXZlbnRfdG9rZW5fbGlzdD42SUY8L2V2ZW50X3Rva2VuX2xpc3Q+PHJl
+      cXVlc3RfbWVkaWE+c3F1YXJlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPmxhbmRzY2Fw
+      ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X29uZTwvcmVxdWVzdF9tZWRp
+      YT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X3R3bzwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRp
+      YT50cmlwbGV0X3RocmVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZm91
+      cjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X2ZpdmU8L3JlcXVlc3RfbWVk
+      aWE+PHJlcXVlc3RfbWVkaWE+bWFycXVlZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5z
+      ZWF0aW5nX3BsYW48L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+c3VwcGxpZXI8L3JlcXVl
+      c3RfbWVkaWE+PHVzZXJfcGFzc3dkPmRlbW9wYXNzPC91c2VyX3Bhc3N3ZD48dXNlcl9pZD5kZW1v
+      PC91c2VyX2lkPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48cmVxdWVzdF9jdXN0b21fZmllbGRzIC8+
+      PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:23 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['778']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:24 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['365']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:24 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['449']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:24 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['1148']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:25 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order><crypto_block>E7--NuwIhns8SF9pSFmOCtayGoPi5orsAykdVtQtCufnKnVXd5ijHtnqR7hewEY9Siu9mKWZXgSi50wUnsm6QPTTn5Ap3rEh2y8qt7LQOigLgEgeiLH4ylijiJOz3cCcGHfmz-mr55XI7fNrF6K5mYhYQ3qn1nCceIO3_pGh-y2ODATK_1unwgfaRcvmf9rRBGVuoIht5KuL4JvyIf1HGwjOVpnEZgHPJm7kxU7hRzZCGSznxEZHloNsR7I2pTbq40t7v2mLo1javANm8iUGKktt-5o16BpnLLteyP0yqrtW48EZlb91SwCaca-PJX0S8BvzKCatNcVD_hETlolGxPekOoYcRxyhOS0oqh4PNL4fG5MfxXXjHxpdCbQvBrDibivFS6vhbjmFeBcQYWikaldIWXGQFooHSH2dWMs_BXrsAz6-j8VMn40F2LZish9H3g6jBjVkrnayZ4NMPTq5FtXcdK_5L7WFk2ASLauJCqJowO_bV8X2sPX_At8097h3QpXw1Kh0OkgxfUXvzDHbFI_bN0XSMiJ0al9y_p-VXab83-6hG9eHDURd6DtENaA6ZdPR1b2kCR_toknr_BpFKcDNzxpBDj9-GWfRRbpiCUM9rPYDDkijx5sFQiucuV4RNL_xRMwwjtm79e8Q_Ffs_Rbj0MXC_rEfuYOIlmhROtFCXJpXG4CNo46bV1NKHU8emAOPjTy5eN5yHKnfgvMsrKq0Ix6-yFmDNxXSz4pazVchj_p8eOwdiIe_aY0Ybh9RJBrav76RZUsxDdWqMKRqoWJyL_--Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>k0--5q_Eg4_-x1Nz1FPUkY_jXomw7H7E1_PjxiUKNYUK3emm0ERjusgvnWUYFQqZHjDGEekx61hC9iIriru1LpexlQdiFWf9oohhZR3m54tmVkLEMIItGP0eGhqQULniBgRbrSIgFusujEyS0Rw91TvO3pqX8rgNeFy0FDAL-H3GFetfBUfLnD1Zi-94KcFBeU0CKwDSXAHtxFWU5WZiFJ-wMeIriNlK_uoAMR58EAI8VqC-Z</discount_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></create_order>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['1384']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61Y23arNhB971e456UPLQGM7eCzKF2O7cSJr8eX2M4LC4NsEwMiSPj2O/2TflkH
-        JAw47urpJQ8J2rMljUaaPVK0346eW9qjkDjY//WLfCd9KSHfwrbjb379Mps+CuqX3/QfNCtEJkUG
-        Dm0UGiEikUt1jUQrG3um4xsRAdghxsq09RMimnjbpFlRGMLwp+zLgLmQvlkFmliEMsbatCgOdVmS
-        chwOZiw/8lYo1NVyLcfiYMYKXNNCRC/nOBzKcTChBjl5K+yKeThEHNX/+D3fP8MzFPqFp4BiY+Vi
-        a6fPDEHY74J1fdesB7PqcCVsQry2Zfp0sAaj5buCLPKutJZy7f3bbigt535r7027WzJrrduLozVr
-        dk4fS7e36ODFYycc7pzm49ZS3pUK8YYtuTYvnxfl1+FUmPq78NR4f1EHctUZHdQP1HHnZ9I9P66X
-        4F3eJ41tJsU75OvtsiBUUadq7KMoaLxvvlmbRefQD6aovqh/bCZueSm5i6Bq4f1hJhNSeZ4vHxrC
-        eKYaG2XUi9Tn7nmDwrOhdFxJUfCz8NpvW+et1Gjuh/35Uq2co6qC5s11Y9NYlPeV+5O6eXMx7TkV
-        ggeDtUqXiO4WH294JAzkrdudvewOb/ZqLjUnR1SbnTyzbb9PFuH5MJSGRms4HlvzoHZ8RuOHD2Oz
-        O1bmUX359jIiw261idqCGTwaPeXQDOyPLpooo5qhfHtr7MevU3v89BBNzhNh0XkJXmsR7ftC1OvK
-        C9MJBpFKW8+NoTto9NWn1pM1Wi7HMJJihB0Htu5bf9h7c04P/frD1vJPvaemOnVmw6k5PE4n87ra
-        wXar1Yx6HyevLffnlve6mGxrxxfyGvlWxaOjxWhwdO+FN03Mh5/tha7ZiAQmtbYGfFh6E7susmhp
-        HWKvRLcI8tSPkCYWWVknD9EttnNAkkjN4cMw14clV65JqC7fVQsMgP6jK3H+m9TUB7MpzJ/jpYaM
-        Sk8B0i02fo6YwLn2ZXEOsXDkg4cW9laOj2y9XL+LpSFtXihsrZPprNUeTGGoApyxEtcnNLKRT0sh
-        yFyOypblYwOvDQISSHRZE/NNbqOOtUN5awpoMS0IHQvp5VrsZtYG/QytrRlukK4klkszc0DXEEQa
-        /pggwMzx9lwTsxYzJG62QcZPhy0KEScw51fOJgqMvelGiGloHtAsh3LBdbFvY8iEHYTyAjJ7MlAv
-        sXMjG9pyTUL4H8aHo2HS2IEcxu1Jl2nRzoaB6pCUCjZcUj+KUBxEiI2xQ6d0BjGJZArGpYhT054X
-        pDBexrsx5M6xye1h2UK4vYBllGQtj6bnuKccia1QzOYV06DF2xvyMCdBzwMXc9J/5jsU2aUuFGWo
-        qhmV70LowGmDqrx30MEIUGjFJ4aVy5smzY5reWj6G2Qg3+Ztvj/RLyVZpdtSI9pEhJbKkgwFNSMw
-        bkQtOORrgqiu1OKJrtGMRpAFBwcyo3IvVytVqcBOjYx+gh/PsyGhYVJJlVXOvOCwuVitSbKRwKZv
-        Q5p5KKELkirI6lSuf1Wkr5L0syR/jWe63YGPex0B1ibUDOmnmJRlCEYDEtf9P0NSk8s1pfLdIamU
-        5X8UkopQlv9NSHgIEulh5zHW8XGj2W2PNTEHc0oShr5JIZEOpQcchT76iZQGsJzQBBkMf0w7sXix
-        b8fWa8+PqQVaHHfhlONMSPIgZ4B7NCK66+wvdg6lBFZkxLSd1BLieIGLuDCn/ViVYd9RQJDrwlSE
-        Fnxsf/bxr3yP8e4sj4s3xt4gbLAi6JrUiQuPXk1K8KWpgRhv2Kcg3cmx6QJoYtZ/axID6g0k9pro
-        PtbEAhBrYVxukH0RQd7UPPNohJHvQ1jZ/stlOBqfUM0DzbzBu0Y1HyEbdjeAcxPBfTg+S4k/t3BO
-        jqDUwqMjR0sRRojXgEPP9KFUJu5/QrX4ps5qYlMelyrTgSZeoFTgoZLSmG3sPF3iBfga18gWJ/K4
-        ZsthT5giphE410BPBkdHODqI0Hi4HJxymGyAvTQ5EYq80hsK8YXKkiC5QPEbSqPVa48n83avN9HE
-        nIGT2AXFtF0UQlrN4SCRlMbLC78k/KtshNLipQ+lWB5yTa0Q7Uzx5sgGRbyPq8T/r4j3IPz/QBHv
-        PyniX6VonBsBxi6/uSWbfIXFGeM6Xlxtk3OZa/6d0N5/r9AmR4p5JzTqDTiyHOAWYuwd4qxcfgyv
-        QcbKFI6dUJAxfjt85V0ySPucwMXkjX+zjbu/U6TSqK+JGcSs263nwa1FritJAc9jbL4sJ+O7Lbz2
-        Yb3J7PECr6A8J55DLCDZ0uI9gbvLR4TIReF9fIGQzW7T1xSNSXwuAs3ncbPXjt2+MhSo7KoVwGpK
-        lhNaLip24NHA1HSNq6fHFchJV6+Gz2CBl3tB3II59/o1cY2mtOLL4hr8bl3hz1Lx1r9//gSe8Zbz
-        OxIAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1828']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:25 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['108']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:25 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6L9</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['778']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1YW2/bNhR+368QgmEvq6OL7xmrImgu6Jo0bZqkyJNAS7StWKJkXmzr3++QlCzJ
-        cecGaIdha15ifufjOTwXUodEbzZpYq0I43FGXx+5x86RRWiYRTGdvT66v7vojI7e+L8gsiJUBJxg
-        Fs4DRrhMhI+4nERZimMaSE5YEPNggiO/IBzZ+0UoZEUusmCSZOHCvw86ndUin44Xb8f5ff9m0pmx
-        bBq54nIdfvj4+NQlIX/qnj26g6dPixvn8Qs9W6V37+f8tJsHm/vl8PbqojgL+53byJ0O3i+n8vHd
-        cnZ6wW9u6bpYYufOHdz0WHCWdq/enX8qluz8aTkaJ8z7+I6Ou2eL9Sx5RHZrTSiKucA0JDzAjAQr
-        nMSRTzNk78NNVHwECA4gZsQ//4LsemQEEeGhfw4hLtZzwkhJ0CiaxDOZK22S+H1kN4cojEVh9CSY
-        Bysyw7wjIbQ1biha0xXm1oOilHKjPoSZvPxnpog5wUItooGVcj3lri03aiB7OpVGnc5vG0JlYSxI
-        UVmwoQZqUJVKSa1mbpGWvpq3R2WIJxA7sV+z8aWmtOCapT16a1jWbzjN/7AeMIuJKBpzjNt2vRi7
-        imTGRcAwnYHKFG9AeTqJKYn8kXPsILsFaQKsVOQsDok/7FeMGjMUCb5gBiprxhZCqQryjpUmpAnP
-        rLQwQ9mx0oIQzQIOOz4hKl7/TReXElOhtkaWCzjrIJl6EwcV7rvI3kF2Gd5BRvcgo3eQ0T/IGDxn
-        2M/d0zkMQskYHOhAqX6ZHSF5BFXdgmrGFIciY77rOA1OCdYsKtMJYf6o12SVYM3KEwynpordLtTg
-        qJrjRTrJErsJw0lrUP/X5vQaRvaul/ZXSvln+v8f6W/mPMwkFWzrsRI2gK1Yn/b3NBYksj4LLAi3
-        sql1mhI4WnA9yXwUIpAb/QGhUTk2n05JXlnuWMytP2VSWJ7jQqJqsWFKEQbZdMqJ8Dte31MR3sVr
-        IidhRiPuu73BaDz2Bi12JTT0Av7SNIp8ZdYZuuOSucXhu5uNBo4baBjTKBBxSjS94ww77vjO8066
-        zonjwPBEWdo/odS7GwEzhhaJiVZM5vKV5blcWKdwUCffOSiuN+453xyUnue+KCi9jufeeSoiLwtK
-        GQTTMetKuzq9OL++Pkd2AyvlZfNmXZA0JVbFMLExv6HPHFyNK8m26wwSOOSyup9rgiUjJVGMocyx
-        PhJgZ81hb/iRu9701t2+nKRRvDkOk0xGU5ZRcUxV36Q5KKYQSQkbDT7CeUJUdFniz4XIT2z7bzXY
-        HL63JLIbS7DJRgSwq4Rrn3+xPc/ZuG7/+CmfQTj32kEUp6rrhUzC4sE5PUY5FnP/Zfr1FPQ1X/j3
-        dWavK1zmecYED5TB6m7UhNoMvoei+s9WRv/N6R06zqbrOIfTm2K2lOSFyW1p/9HJbRn7mVyIiNuD
-        cu99Q3I59CPshbltKf/RuW0Z+5nb33nBBUmDGlGOJDFh35DrkvmCbB8y90Ozf8j4P1wN0C4Iyf0k
-        Xm2/4iVUEeQEugtsV2ORLQht9gQGqKRFDimJ1dqhNwkXqnYaEjQjmWpewHyC4cIgoRXpDo5dxxv0
-        4fayxVCS0Zn52VEfOHfoDYbQP9UwsmtVc8wDuHflhE25fi1rAerJR13VSbR96ymH+nGASUqhbTGd
-        lOuV7wMtVF/vW8i4vOC3aZSQCJqnHBowlULVlOnl7MNLsmRY7cIGrUIMQbmQsVQ9/ZnVP0ORur7o
-        nu7Dw2jsOpCXLVK9YlWvh8Ei9fUDxx4c8Xm21pqNN6aC2hjimWQhMS3ktoCB1oArjmnAQW591gVv
-        3VCyZZoOU7/NMrKKiTYSqtfMIVxA9+EIikiWJq4vry9vTz+cXT3AVbSGS4rWDRTrEhriyGo8TTbk
-        ZVVu90T7afkvely8kpcWAAA=
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1442']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:25 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6L9</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['365']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+2dW3OiyhqG7/evoKZ2rattBESBtVis8px41nhIvKEQOkrkJA0q+fW7oVEwOmsy
-        KacmKrmJvP3S0P21/T3dMSL8szV0Yg0cqFnm39+oO/IbAUzFUjVz/ve30bCW4b79I/5HUGUXSK5m
-        AMmyXWSFkgOgp7uiAL2ZahmyZkoeBI6kQWkmq6IPoJA9XSQojm+7ljTTLWUpQimT4V+alLtcaZWy
-        /qbAyoin8ltqxClW0ZznKJWc9gZup7Q15uZ2ts1s6YJbrFQ5Q8lvRs9tr1VZNTRKm6rbMT0kuXHB
-        topVnVXGU41dwpxJL42marxVxj2WaTjerDmBOue4/sOm9Dqo8xmlz1YfpELGyXSni+XQ7cmsXn8x
-        J93C7LWkTe38bCpkD+5ZMAFQJRXYsuN6DpCCzhFNS8ie0oWFDCUbOC+SKRsAhr53kuBB1N1Y0TWI
-        OhWsgRn/kh0gSygmQKxOhGx8hAtUABWxikLobxbAAZEhVIWZNvdsaS3rHhDzQjZ5KCia6+N6dHQ7
-        azCXYcZDUYt1bAlrasmQGAeWqBxXr6AzYfQLn+IugOwGN5HQovLwlOFhOa4GDYxwlODqwqFzKAkQ
-        yI6ykJbA310hi4ZXLAajMLLuztwrB/XFvhNVKvIM9Z17umbclthyIMeusEVl7CL+kA37L2IsOxpw
-        /cQ5uNnZ+Gayu560oCs5sjlHVRryFlVuzDQTqCJH3pFC9kAKDehOXdvRFCCy+Z0j1rDFQ22RHVRl
-        7NhLghF08rurJKXQcHSVAw1b3l3lQBJMSwqGuA6C/rrOJq482XSDt0Y0QYoCep9pqrTTRUrIvlPe
-        O+gfOnI/dDA/dOR/6CgcO7LHzQtjKCme46CEgSy7V/gd4UEVjeoDKXa8yIprOSJFkglPJMYu0zNm
-        wBE5JumKxNhl67KC5lA64YmkhCcYc9A3ZpaeTcpojsaq+N/k6bEsZN+3MvudoZyG/zbCn4y5Ynmm
-        6+xbHBQmhH1xONuPTM0FKvHoIiaAhPVCFA2AphY5PgknhRC08FWBqUbHOHV64H8ExbsLouHpPkGT
-        FApUXIydnqtI1ssLBK6YofN00MPv9dgIgWKZKhQppsDxPF04cO8Ksd1HP4ahqmJwWZKl+Mi511He
-        tbgCSYXQI8mmGtJiaM+QbIbihzT9Z478kyTR4Z/BlU6fENX7vgfwMXQRWR30ycL7H0FT0CWKaKLW
-        z9wpFM0z5Ic7haGpn+oUJkNTQzrokZ/rlKgTQjbEI61VrFXb7aqQTWhReQRvRA0YBiB2Dtw3+LWm
-        ioUWvytBR5Guo0nOinkuKUYOdCOuB0VdW+/LI2lnQPwvu3J2d+z6NhChZth6sJZQlgFHJUqEObCC
-        hsuioMtosvFQM3KFO4qkC3k08+01QbfMOX6Zoaj8HcXSBRb1fSwL2biqgLXRnB3AdQzfeyHAxSDN
-        A3XPidFhCBaOZ5oBmodRoOiILQ7UEA0OFD6Cg0PbT60ZsOg5cjDZJmw7BRuCJliOIZuIUMK7P1KF
-        YOoLx0NnzPEUieK8V3YErKIVR2CWloYYwtEJXYALa4MXKGFr8PLuUBOghWgI4OEHtiioALooLEl5
-        58FvXlROPPrQBQbRNcHeiUdnuGR0wFoD4UWUYCXEouR1ShfQIPKiS7Tr7fqg2Km0xiiNxXJkCetG
-        FqKO3kwqkVjWJMqjUXmDSX3X8IMxpMjKAo2rHXfDoK4jLV26XG4Tb26Y3yi7pkuXmw5/MuaXg9Df
-        o9RwD9Wy9Cj/hETyTgvgTteMYOEVMlTi8GxkHvIPvrtMjx0gvoqEqARKaw1qMz1ipvcidsWgjHHK
-        WgJTXGYymemSaUGz+6Y+kfdmbdCdkYUWt2yDlsqXigZV3DTL45U2oTLUtNJ0nJHNDrpVrlndep1q
-        Z2s9PUdXxDVGtSPWjnaTi4PW3rFXhSOYPQTZ8K8A4dDg7kiS6LWFbCzh0sXCMCAa2SQZxj6p4cvF
-        fJqCRgoaaaa5skyTgsZNh/+3gEaOzF0oaHxsX/QQNB7PDBrNbrn04tOD8oRcvFXHevO+Me9UWvmu
-        8zCudeubV/J5NehXVxnLtNiWBifG9rHBfxQ0WsVh9QecEW6ufQ80KPIu9++kQedS0khJIyWNW0s1
-        KWncdPhPk0bN0RBp0Kb6i0iDI5mfIA36i5AG/bktjeGZScOuPYEXuedseNvqDZoTrTRYm8/DGfko
-        kW2nP9c9huPWGzixxkqp39tun3jNZ9MtjUvMwilopJnmSjJNCho3Hf7fBBr8hYLGZ7Y0RmcGDVjp
-        yxulyikVD+btufTUnT73Wr0RszXol6bx1mOsVv2ltYD2djh1KuXKY/3B+vDfTtItjS+VhlPSSFPN
-        laSalDRuOvynSeNRdhFp5JxfRBpMocD9BGnkvghp5D63pTE+M2k496/UfaXelOwO7ysQ9EvrokQ3
-        Wv5TrU/65kSbbVZrU3l2nmsTdVV2c8pr1y+kWxqXmIVT0EgzzZVkmhQ0bjr8vwc02PyFgsZntjQm
-        ZwYNauWp5nSqdQbKpjZx+3V7CBWnsip353m5IdutjbMYFGvdwoKqVdXFU7thqV76KY3LTMMpaaSp
-        5kpSTUoaNx3+75CGZyLSYNzFryGNfD5H/wRpMF+ENJjPbWk8nZk06hV/YXpbhprlGKXo9EavtXKF
-        XmTgs7m9RzC0VceZfuu5p77de/7SWLqNjVxMP6VxkVk4BY0001xJpklB46bD/3tAo0BfKGh8Zkvj
-        +cygYTwttFGtOQNArdKzZ2744Hc37ENzPrjnR8MeM9q0VMvy9Ee6We70Vd2cPU6o9FMal5mGU9JI
-        U82VpJqUNG46/KdJo20FpJH/VaRRyPEf/44+hs5/EdLIf25LY3pm0vDX9MPMqjyNcp7mMKWq8dDM
-        PFReTW1izwZmY+2/rTv9MucuOnL5nt2wZR6Mp+l3aVxkFk5BI800V5JpUtC46fD/HtBguAsFjU9s
-        aXDkmUGjV5q0RnbLYZR5a9qfU+UaWx03h3O+tdAeuttS2TLH3JycOQtq0iFV+kWq8U76KY3LTMMp
-        aaSp5kpSTUoaNx3+73xrV/DUAbrwq0iDDZ468HHSKHwR0ih8akuDo85MGvRg3W90R8vGcgCWfoHp
-        cOrKf+23K96kCxEjDu6N+cB+vKc4FkrAl/yy/EqnWxoXmYVT0EgzzZVkmhQ0bjr8vwc0cvkLBY3P
-        bGnQZwYNza4/292F89aWDH0wWMmLHC151VKff6tlXp3VutmZF3ypMqwvqmXQf5ypPjn48MdB0y2N
-        L5WGU9JIU82VpJqUNG46/KdJYwJURBrsryINjqJ/5lu72C9CGuzntjRyZyYN6TkPR9VptWM85Tlq
-        2yObmwa/WsqMZ5Qas9fedEw9GGqJZzYdesuym1dm01+l/3hykVk4BY0001xJpklB46bD/3tAg6Yu
-        FDQ+s6XBnPvRalOFer53l29zC7RLDDTaVUt+mLIFkNkwb/P5tPSUW6mVUpfcgtLyftsl/VH+w1/a
-        9RW2NLJeMCXhJ/TqGnSjgIuC7AA54qGJkI2PcEF4reoaOP5mAYJHP8eqMNPmni2hecADwZSRPBSU
-        YCII69HRWFkHT9XNhA9F3+vYEj2Sev/g3VgUFHQmjH7hU/bPn05oUXn0UKGDclwNGgSGHOTysLrd
-        c50T0u7Rx0vg766Q3T/3OBAFNGwi6+7MvXJQX+w7UaUiz1Dfuadrxm2JLQdy7ApbVMYu4g/ZsP8i
-        xrKjAddPnBM9tTi+meyuJ68Uq1JyTNHhStAhJcebDn8y5orlma6zb3FQmBD2xeFsPzID2CIeXcRM
-        kLBeiKIB0NQixyclEBNfFZjq0R/cKB7RacPT/TPDKcfz9Mc/QsxS/BGc/htFshmK/yhFZk/2AD6G
-        ruy4B33yxR+GfK6nFmePOwHjfwSvtWq7Xd0tCfDow68jeCNqwDAAsXPgvvnecgK/0tEkZ8U8lxQj
-        B7oR14Oirq335ZG0M+xZHh8HZC1CzbB1gNqlLAOOSpQIc2AFDZdFQZfRZOOhZuQKdxRJF/Jo5ttr
-        gm6Zc/wyQ1H5u+BDaSzq+1gWsnFVwUIIzdkBVcNw6XMgBLgYpHmEATtOjA5DsDheABypIRocbUge
-        iYIJgIo63kbB89AMEwQ0vJ1TemT2HDmYbBO2nYINydVDePdHqhBMfeF46Iw5niJRnPfKjoBVtNQI
-        zNLSEEM4OqELcGFt8MokbE14tXeaAC1EQ9HSCWxRUAF0UViS8s6D37yonHj0oQsMomuCvROPTg8C
-        R3LAWgPhRZRgJcTmg0XSsS6gQeRFl2jX2/VBsVNpjVEai+XIgv8bo94m6ujNpBKJZU2iPBqVu2F7
-        5an9e43Ec064Xo001O3Q013x/6bPnrOFlAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3276']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:26 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---ZZc1YHtkzgoeMB4smMEoaIZ76e-w4zggZBX3qdDBO0xeBkHxO0yU56KExuNENxoXY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1U8coAng31d0ZPRtNBxmgnxbx-x26tADE8mc5wUYMuLDqJi1iZdxV2T08V6poAEl7cVZi7ks3n2kmKdmzDVP74JrubKWsl8rtyIwBjRG9-cQ7EI_6-r-OZhkTtPa7lGfnWO6bjBiZp5bZ</crypto_block></availability_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['449']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA7VYW3OqyBp9P7+C2nXqPA0RUFH3YZhK1BgvqMn2EvNCNdAKkYvSDRF//XzQKGAy
-        s2dXnZOHhF7f6tt3Wd0d5Y+T53IxDokT+L9/E++Ebxz2zcBy/N3v35aLR7797Q/1XwqKkeMiw3Ed
-        mujBgQKb6CEmkUtVhUSGFXjI8fWI4FB3iG4gS00wUWpfm5RjhHxaGkpVYuQ6ln7BVVGp3SC3DOmn
-        jPpPGY2fMpo/ZcifGbXP2zPD5EAD3XADc6/KAs/z00RyppoRoGlMmv0POtsZmjca787Ps7W0kbU9
-        arzoi2Qwah+Xx8PgMZp09s/+bvjRpptetK3Hyxdp4YehPNNee8t9QN+bzXexvRKDiF9MDd1+aQrD
-        53231RuOhVXvx3jqJfY67GkxHuiDjRa/R/K8P/SMsKs1z4m4eh4kq6G7eHxv6Fvz/NyU9SDW+wLv
-        1vcDe/ahNeodWPabUqvsRcEx9iEHUIiRDnmD1f5aqRUtZrAwMdU+pFnyYeMQ54QMVQxnFx108GGE
-        U3eXm4qZOjEbx0VEj/EOET6CtCpwRslGmiDCrVJKbmfDm9CT5H9YF2pjRNNFlLDcnnVZVO1sGMjc
-        LI3ZcFluVyGFYBSatr7HyWWGGuR/AaZlklMvPa9IZbyC98WQJjLAd/TrkdleCkoFLljZjrqMxf0H
-        eYf/cisUOpgmpT5s27ViMbWLJ4PIp2Hu/iwYZeBqzvovfYdii/tBEcWEC7bcvYdDx0RFJzaNBXY9
-        RP4O69i38jYLRoR/48QOtblR5CacJIhQcIWZMSNq6sF2SzBVeakpCUJOKeEFkWAz8C2iig253elI
-        coV9MTJ6Aj+eZ1lqOq3QEjs584pDJIO2LIh6BiPf0qnj4YzOCy1e7Cwk6Xtd+C4I0PyezvR1h3zc
-        Ww+wNqEopBWf2NFvnCQSyt0fQsf9HztFlDoN4R87pSGJv+SUBi+JCyn1yK85JXdCpjYs0yb3j31N
-        6yu1EpbbczngHrHnYe7CYL5h346lypPOxQKtHHfh3AsKhSiDOQMWQiOiuk58tefQhQBHHqKodmnT
-        5IBV4ngHF8O+zH1amSWLssNBunGkKi6CQyOCbdTlO1GQ5CacYFdMcQN/xz55UWzeiS1JboHvC1ip
-        FUPZIJd+oB9wuCWqHyi1CpAKEOgHlOZVefKm4qGTHka+D1tmURAlCNAnVPFAqCpIJ6XdgoqPsQWO
-        P0DwohBnAc6W8xWek6MQpYdmiXZBGCHdQhB6yDcxW/0nVDkEhGb5MF21O6IAcb4iF021HIgakPW9
-        pwp3wlVPy7hC7OAjG5ntht1oqphCgigEejY4PkFQMaEQljJ84bDiBTv3IyEUe9zMx1cmy87slhTi
-        2MHZJGZ6trbgVPwKVyCJonwKbaANXu6nvckKriMFnFOysYHCDaCYLK50UJbseVaC98quLFRljS1Q
-        nRYo8f9FddqS2PgF1Wl9Up2/Kuw08w9B4GYpnh+1N1haD67jpWdVlnal5s/ErPVPFT5LGbY6ft6G
-        m+cFyC1wvXGIY7h5mt2CjFVoC8tAEJCLGC76eacCVD4XcrU6098seKJwVxe4uabUCoyZbdvz4NiX
-        pHp2KJQxNuE1VcwoDOHtkBRflzuCBed9BSoYW2TSIIT5hRInBwuWH3kGDtV2o8zKwYJ1cJGJSfoy
-        uIVKHBACnSSeEbi1MgwixFD13+XuBVygauU1lLopFfVczaE0oJgNlJ7hyCCBG0EWEBSD05nO3IKK
-        keVIsMe+qsHDwJKNtunIx9npdd5ebHqn8UtvPenMF8fRU0RHEUYrs3nyz2Sqn8Qu3zqej45sbAbP
-        r0trlExbs5cJ3zkFcrSVR87T+2LSc9BRduPDBrurybzx2n5rSe9HtyHsRK/5oJ1nveOKLJuRM96Y
-        Oh+9bd6P+tayJ/Lrfjp4nRLtfqgPB/xZtEMzWuGeIEadIW9MzP0pjPgX/LYcnp/GmmO0x3EQTe97
-        DpmLcn3b7KaPhdLu4GroGY4PRdXOPHFtpuUH2gCxzIuPNRQ/8NmnftPzC0OJnNZ0FgZQziq7sJTp
-        IL82Cnfw+rhhXw0ldh7sr8evGBWWn3qeLFDDIJefMCVXc7Qr0iSrqxuwlFishO6BdQOVOWkF1ypI
-        oR0h+oAO8ELdRUFEcg0U4ZT50pDRaUCRe8MsY8qt00uuvnFwya1fOLPqwlq5nEp1xvY7f+k/XnuU
-        ZK+MZEo2DzGEJ4SXSLoscGe110XtCoQlrKzzfHe+HiTooWN0k3NiD8SPdpe+39NAfNB8p7Ve/RD8
-        QWdiSQ920oma79LT6r0Rx42449KuEWkyXs/Oz4OHt3q/cTqjx02M9o994zWs99c7NJjNNtWl5JVS
-        q2hKrao3JvJ1F6MYcgO24uL8TPsMK7CxA6Jwq7n+H+KKeJjagVUCMtd1Zw8zOFgrWJlCKBOxKlQw
-        2MsycF1sUm4bBh4HV2kuu2SUOuXXhUuzSMwrxNywBP83eXt9WnZJK3hyFquB6djxKG6Fohlulqv1
-        qDd2vOgcdl1t7yHNOVGUaK3+6ImGy/3aHKB1623/THtk1VxgbLq71/a4ZZuPmxOZLN3uvLt1JL8t
-        robm06KzfPIPkqXNRrHdGmvB86DRmk82pXXnwSnaaXRMttsyjQXtk6trn8NR+7v/q/0JutlajZwT
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
         AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1997']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:26 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:14 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60---Ny2iNMboaNvs5EwtOgbMmJKgzQOW2Y6Mka4R_TyGJ8qUqpGFuL9kQngIw8tYDuf3vUR2Tnrr6OMXDUkotj55j18V1ou-TNb_hR50IQkC7DIK0VDSKNmyhWrDMveG_GYMvju6PEImbrCM5zy1VQGyVIlTFj4_fczQ56_ov_E0-l3kGhOwM439---Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>M0--d6b8ci6qOxXP8TYDxKRDWL9PTqJHutJueaVc5xnzsN_x1C-7qzqi6bYGQXUdJyN7ORL-9xo6uf6JiHjTLDiaq6lvpYelVLP4X8Z72jql40g1m5BMzODqVsU5uiKYc_-uZYjq_fdhL6XkNGXNsMAI_IG-z1hrcuVeD01u9I-bLckxru-ReZUIzHKMib8KvouNADisP163f5C-Z</band_token><despatch_token>U_--5-hWxUCs7oHiTVGcihvJv7r1crYUVWJDKimuzrClMkmaMixtayM7EJHtrUkWcGaW7ZkQtDsV5TeeclgX8K7hcFYxsLUlCPCfi2n81VIcHT9UHnp2dMOJvh7KMoQG47PLY</despatch_token></discount_options>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxldmVudF90b2tlbj42SUY8L2V2ZW50X3Rva2VuPjx1c2Vy
+      X2lkPmRlbW88L3VzZXJfaWQ+PHJlcXVlc3RfY29zdF9yYW5nZSAvPjxwdXp6bGVkPnllczwvcHV6
+      emxlZD48bGF0ZXN0X2RhdGU+MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['764']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1ZWZeiSBZ+n1/BqTNnnpqSRRFqaPugoumW7usLhyUQlE0iwNRfP8GioJldVTld
-        /db5UEl897uXuDfuEmSJf7y5DhGDENq+9/sX+iv1hQCe7hu2t//9y3LRIfkvfzT+JRo21P3IQ4of
-        IMyESghg5KCGCCPN8F3V9pQIglCxoaKpRuMCoFj5WCSCGHhYUQ2BquAXgYa8FivFKhMYAOoNGe/r
-        crZACHJCioqavY8CJVadCDRqYqW8FHUbXTI7jgqVGOxVSEZ4LwWeUVJLQxUSq4SSyzPzOtaE+a9M
-        BVlARckmSlguT1UWj/LMDHY39T0zlwbkERIhUEPdUo7gcntDBQetAJPY5tSb5h15sFfwPjCpqxqO
-        HfrYcuZLQXmAC1bqUStjEf9R3eC/xEoNbYAuJZ3M7UqxmcotkknihHn408MoA3dxqr/0bAQMYo5U
-        BCDhm4TkgtDW1UIpe42B5UqoenugAM/I19lhROA3ghaQRfQj50IwFM2JlUKcMSOkK75pQoAaJFNj
-        KCqnlPCCCIHuewZs0FWOFwSGe2DfhBn9gn9c1zAayWupOi3kzDuOT9LnOYpWUlj1DAXZLkjpJFUn
-        aWHBMN9Y6htF4eW35E0fK+R2nyOQrSFSQ/QQEyv6jWBoiAgpCG3nFweFZoQq9dNBqTL0p4JSJRl6
-        wSQR+VxQ8iCk3SbLtKHUkUcjWayUsFyetwOiA1wXEDdGFpvs2TYa3FC4SexbH1Mc3Cj9okOUwZyB
-        N4Ii2HDs+C7PoRsB90kVqZXbGl0C0IC2GzgA+6Ufk8osScQ98BPH1YboqMhGEXaD5b7SFMPVWLFy
-        x0TH9/bZI0nTta90neHqOPYFLFYKUxZul56vBCA0YcPzxcoDkDQg3D9wad47T74UXfVNCSPPwy5n
-        p0Az+IDeoaKLG9UDIiS0Z1D0ADBw4AN8eFEI0gNOt/MRnpOjUE1mUol2QzJC4oIfuqqng2z371Ax
-        8CFK8+F1xQs0hc/5jtx6Kp6AKCErR7dBfaXu/bSMi9Dyz6nlzJtsDD5iIvSjENNT4+ANHyqACB9L
-        Gb5xsuLFcmJ+gQi4xNgDd2aWneloDUFsg/QlejJb63gqfoSLOImi/BWj7qg7k17bw5VYKcE5JbWN
-        KUQXF5NBlAZlSZ5nJY5eOZRFV1kDA3edOu7Ef0vX4Rm6+omuU3/Xdf6ssJPMD3zfSVM8H7VPWFIP
-        ju0msypNu9LyR82s/rMdPk2ZbHfkhK/ilMyBXIKvNza0NSdPs2cwYxW9JctA3EBuzXAh50oFKL4v
-        5MfqTP7NDo+mvrIUMRmJlQLLxJblunjsMwybDoUylr3wnip6eAmQr2iOrx8bOkOSkcG1QRNYg9n+
-        ykama15lpaZLhw4ziy+UYADNba+kriQpU3W/PJqDi7GimL7sq/rrKdDo9mq82naGEazL8fgaxq23
-        9knxHNCcO73TQvNAsJ20Iu8Fgm7NQVOjFp216eZ1epJWRvNFEQ69LVWXOmr7jNrGtXd9aQ2psen7
-        0nXNSAxfVw7NVnSa6P3I7raXHqz3qz1Gjlpc7cK0yZGm7ZmDth1WF72BFbnR8IT69mS7vJ7e1txV
-        HZDL+cZlN2Gr47b4Odl/cSb91bR5iY8tbt6q0m2dtGx+bY6DtdNCHE92urO3SKgdqpsdmB+X4/B6
-        9ujVgOxtaqhN1S5s3Rt4QF3y1qX1Eslmfc14zoykhg57cHVGbk1kwE7Hx8nEOYZW3KHdrUEJXDuE
-        LbM2V+KYXr8ue6wc2R1hO915rCW8bM87S7Cq5A5fucrnI2qO6uFZpBSfAp5zyXLvY5GoR2GIPyZK
-        T7c7oIGNP0AFw1R15Ic4v6gSJwcLlhe5GggbfLXMysGCFTiqDnAqljg5VOLgRq/Ai6v5TqUM4yGT
-        oY1/l9ULuEAb988jWDzihgBRI+lPD4CIZ6pvKoUCHtnP0N0G/hjSoO9EuC9ANcZlmE2eZxBfoV3N
-        9nDz4VP5fVlsJg2y1B4uSvvJAn9fpiUsGfirjkgmmqGGBoHnKChp5G37Bx7el8g/Aq/BUSQ5j5SR
-        AqfncGtvqxcP+ZEpLF66vYF76pt0SzpEatW92sa6PRm/rtjeUJiT8l6xBIaudc4DViLhkXK96oSL
-        2nGzZoKeJy33fIed2o6iueSaJGOJMk9H+W0x77ds2+U3Q+vN9ITZgYs3uwNcN5u1nkA3hyiYG6A7
-        l4Lq2NItfWKNoUyZ8sKZRHVjHggd863pMS3SfsX73pWcy7wpeZdcxsreZ7cz3ILx2MJpmM+FbIGP
-        3cselafD+kBQIifjBg9P3C3rtUd2ISnT8c3AUsM9/jB+Yt8FJXZ2uVQ+tv8gFLPSUtRYtR01GS/4
-        xvIOE/OLhrov8jVt+U+gmBpVtGTWZYmJWU9QmZOkXeUBKcZaqJ6xgofsfeRHMB/PNL4AfShI6chH
-        qvPELGPic9BLoX4KcCmsHwTzMYSVoqr/7/qu09+r77XcHHc6P1XhZ6AR6Tn/khKXcam0VuYS7mfW
-        YkTLihRfZ/s+V9XoQ0+Te5Mud96CmcHWdltkOhI1GITo0J6E7nbX6didF2N0ngn7Uyfsurxry9xy
-        1p+1PdRBY5c5dnb9LncyJlsJznn2KE/4/s5l+PAwjahDVdrDdbypv6L4JdS5oxAwx/YJLcmu0eTn
-        B5/bxM3leKpcKKUfU93mdG2GylGxR5MarFurMacdmvYuqGk/LHX6L5R6dm4/W+oc/6lSZz9b6s/2
-        /yn1e1A+LHX2e6We6f36Uudq3yv15rw7+0GhNyOINSEk9qEfBb9slLPGgpH7Bh25vZFkjpvHq4/2
-        B7IWTtvWLGhqgcKxMcPi+znY8BuPPbK1wcTbMGhwQY5pLqdrdT3gW8p1Uj86bWoSeEvlzI8OA46H
-        44jcAIfjgHDs7eyZ1/ZavE3RS6o+MCejJhdwF2lZDasGMuYAzHyT2bj9WWs1gay3Ri3WqK35Lge9
-        tVOvm8rSoqrjUXAebHbKT4xy5i/UN1f7VH1Tf+8of7b/T33fg/L5UZ7p/Wl93x9h9oeDoiQt306+
-        NO5/PngnKeXb0/+q/A/knyNIlhkAAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2302']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:26 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:15 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order><crypto_block>c2--ud6DeBehKRgz3ufmfzE_5cAjF2Rvy09debmDVAGAA_QagUkfKydV02JEoacNqpb1DVOVYFLus7EvOzrvCxDq_nleBSlIqTbnepYPCunHseG5ltQd5uwbQXNQqAVdBH_9jIY07AFaDwtDdzIzHCL0OfooAzW2A287_jBCuqPcJuiGDUns7J4I2EuC65y2D-Mbbg2jbYL4TIKhumuLqtJiPYUzqxW6zaK-USXm3XrCFmC8S-JHlPJVQByvkC6SC41Dc-hi8WfOpWlCt68-FGRxu95j4XZeSkUOrzwn1VK-IX5tD05y37nKneaU8hyCHuEf7W2nlR-0Ll3jmc2ECPEe3QOkPPlkrhvF1mYd096DrsCf5S_vv1WNUI3EuiF9YQZn3h9HYwZh9h4-Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>60--Su_M_sQwrYiY4yntouf9THGIKmqJf1CAjua4mzidWDPONV3IL9S-Eg_h9215FwK3A-sk0mn4P6uDvB5feInAUg8F3Qil_bm-W--vA0fqkExTSJCiim8XLhxfn9Rj6vXZjsWBB5I91BLtpSdeGSAp4OhchcPhOsE0fETlPu7dSp9FfxBn2C-iN0--Z</discount_token><despatch_token>U_--5-hWxUCs7oHiTVGcihvJv7r1crYUVWJDKimuzrClMkmaMixtayM7EJHtrUkWcGaW7ZkQtDsV5TeeclgX8K7hcFYxsLUlCPCfi2n81VIcHT9UHnp2dMOJvh7KMoQG47PLY</despatch_token></create_order>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+LTAtLTYtYnNqV09qbFJnUHdhT1Rq
+      VWNscTNnVDMyR1UtS1lxUllYZk1mbEVTa2hDdHo5RWNtTmUtTDJkM1FnRHF5dDdQcVowazZGTG8t
+      QUF6b3JPX2Z4MXIyMWRWSG5DNE5veWhoU3gyTF9qSmRPOTF1X1MwZXJxY21RV3Y4YlZldUtKZHVH
+      bDdLZ1lwckNiNW92S3NsaUc4eHVqQ3kxQXJWMzVzU1dQSHA1ZWUzNS1ZPC9jcnlwdG9fYmxvY2s+
+      PHBlcmZfdG9rZW4+ay0tLTZTWUY5WjYxLWUwOThNeGdvdlVleU1OU1pacFJQc0RsRm1sMkVLNnJp
+      R2tpaF9hMHRMODIwUWY0Z1hlRmcwTm1ZPC9wZXJmX3Rva2VuPjxzZWxmX3ByaW50X21vZGU+aHRt
+      bDwvc2VsZl9wcmludF9tb2RlPjxwdXp6bGVkPnllczwvcHV6emxlZD48dXNlcl9pZD5kZW1vPC91
+      c2VyX2lkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['924']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7VYW3OjOhJ+319BTW3t0yFcbGM8y+GU4/iSxLckdmzPC4VBNoSLGCQc41+/DcIG
-        HG/tTO1uHhL09SfRaqm/bqL9dQx87oBi4uLwz2/SnfiNQ6GFbTfc//ltuRjw6re/9L9pVoxMigwc
-        2yg2YkQSn+oaSbY2Dkw3NBICsEuMrWnrKSKacNukWUkcw/Jp+WTAu5CeEFsT6lDJ2JkWxbEuiWKF
-        U4AlK0yCLYp1tVllFWDJinzTQkSXK5wCqnAwoQZJgy32hSocowLV/16dXsIlCtPiNKLY2PrY8vSl
-        wfMHL9p1vF4nWrZmW34f450t0eGnNZ1vPhrIIh+Nh42kfLx4M3GzCh8OweLZIcuHXX99tJa9Ufpz
-        44/XI7wejOKZ5/YGjtX4aDRJMHuQlJV8WsvvswW/CL047X48qVOp5c4/1Z9o5K9O5Pk02G3Au6pP
-        GjtLij0U6pbE85LiJbTzet/4ed867FU5VcmRSvvxajTcNR7FJ/XgDZb2iqrLndJ1Gqh/IOMxxenK
-        uR80lJEX7MIfisobR6d76ncfWz9Mo+2unGmvj2cvx/s3pdESnzcz9Dbf25/p2lg9H07r42YyXImr
-        zWATOYfh89PTmu+404f7U/t5/WkfdjGPwmE6UkWvF3kb5I3NSeuoTqdP86HtPb50osfeyplNTq8x
-        OqpSc/08br7QSWJ07XTcG60fXye97Zu7Djq+vQ9PTX7x8RYY6su6MRQXB2X4uVRn4udKfu0tXy3b
-        PtKRKHunh9lSlEIPdX03mmx32/bCf/Oe7FkgHT46U6XzZNB7e/44UcYvPM//0IRqKFlcdc1GJDKp
-        5RjwYOk97PvIotwuxgFHHQQpFyZIE+qsclKAqIPtCpDnRG92P6vMYXlSGRKqi3dijQHQf+lKlsom
-        NYUKRNMI6RZbpzIxhyvjyyZcYuEkBE8sHGzdENm6mvt5GV4obE/dh/EC1qlhJSX3r2uDBHGEmqFt
-        xjYXgzpVZrAthNjAO4OAchFd0oTqsLBR1/JQ1XoGtIwWxa6F9HYrc7Ucg+zFlmPGe6Qzy2VYOqBr
-        CKIKf0zQTeZ/f6UJ5YgZcjf7oL7pp4NiVBCY81t3n0TGwfQTeI8mVIea5dJCJX2TGAe0NwmfgOqW
-        OKPkK41Nwr1nlMLOlrdgJin+sClwFUyaOVHBCns+ZVG3s2VA2HOVZ8vl0l+HskBCfAwPpec3CHk0
-        z2BWRQrqeeYFqa1X8m4saZlbiB29vTLbS0mpwSWLZQdjcf8wg+if3LsZu4imlTls20LpjHCOZHbu
-        8aWeZZe7AlzM+fxl6FJkc28Ubi3h8I7rBgjulllOKnIwq7mxGe6RgUK7GLPDSNAfnNShDveU+Ckn
-        i5ICt+9iZsyEWnCndwRRnZdbclY/r/GSSJCFQxtSoamonY6s1NhnI6On8BMEtq1nrxXbUqdgXnA4
-        SawqomTkMKQo5FWAcjovtnmps5Dl7w3xuyjC8Hv2ptsTinWvI8DGkPsxrcXESf7gZIlQrguZ6v+P
-        gyLJnab4y0FpytJvBaXJy9JCziLye0EpgpCrDbtp4+6gP5n0NaGCFfZCDrgBCgLEnRksNuzZtXVl
-        3DlbYFTgPrSDuFSIKlgwwBGaEN13Dxd7AZ0JlzLCxnmxIG4Q+ahQ3fM8Vkb2CGcbN3XNN6lLE9hG
-        Q7mTRFlpNTThgmk+DvfskZek1p3UlpU2xL6ENaFcygG5BKGPULwjeog1oQZkApTpPLIvylMMtcA8
-        GnEShrBldgqSDAf0BdUCEKoa0slo16AWImRD4CM4vAT6x+xAc3du4QU5gRIHPXqFdkYYIdsCjgMz
-        hBKVe/8F1bLGNr8P03e1I4lwzhfkrKlQwGhGNryAtRI3cI04+DNfme2GNfx1TCMYyiJi1w8d4VAR
-        oXAsVfjMYckLdu4tJRQF3CxEFya7nflHRIwOLspfYmW1tQ1V8Rau5f0Me8VkOBm+dqcP43dNqMAF
-        JV8bKNwQksnmKoWyYi9u5a/kEIh6cP7kyNK3MtRqB1Fq0grZoFlt0PH/i2apstT8Dc1qf9GsfycL
-        Wd5EGPtFO5VfgSssyybfDbJKl1/ayvA/SWH7V+tDfuGYd/xcbcKFLoDCAs2RS9ytX1zSa5CxSmVi
-        9xfk5yyli34xqQS1rzJQz+3sNzs8SbxriNx8ogklxsyOEwTQNMhyIy8pVYy9sMzZrOeEj2fYMmuN
-        wX4FVTnZO4QaUu4uOxZIlp8JIhdxDvEFQjbrcq8pGlPnSgjmr/1B5vQVXCPmm53HaIfgi9jmsoUh
-        RPVZRUAwNX3j6svgCixIVw39V7DGqzT3t+CCe93oX6NnWr3pvwZ/T1GKT0Th1n9V/gVJHPmwkhEA
-        AA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1768']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:26 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:16 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGJhbmRfdG9rZW4+LTEtLVExbXpRMFpXS1NlY1prOXo0V1A3WkJK
+      LUZrMVFsalJMZUg4OXh2OXNDWWU4YkVldjEzaGhGSGF5eV82WWRVYkhBR3l3RVI2U1J5blktQmVY
+      aFR3cTJhZC1jNWhBdzhaaEtwSm5tM042Mktmek0zcHlCc21QLUN3Q1VJWS1jZ3NXcXZLWTFxLUJR
+      QV9DU3dKYThIUmN0ZnZaUWlKS1g3ckZkY0ZMeXBDNmNDb0NYZ09oX29zdldjb3lRTUxaN3VJaWli
+      T1JrWXI0VXZ0SXd6XzFtaG9XM1BVV2ZEZWdTMnNaSnNXRGlxTnptcmRnbjdOWDhyOV9mYVpEaE9I
+      N2M5SmJaPC9iYW5kX3Rva2VuPjxjcnlwdG9fYmxvY2s+RTAtLUV4STUySlJDcS1nTERzdng0d25V
+      WnpaU1dTWURxcWV2SkZHdmw0cG9DaXZDcVVVZnZVTEFYZzlicDlYZzYtY2NLNUx0UUpTdlJtTGV2
+      ZXhlMTMwaTV6NVFnRVd6bjFXbUUyeVh3Z1Z4ZE5vOVNtSmZjZVh5WTdLTU50OHp1eVZKdzlhUlhP
+      U2o1eUZOcC0wd0FkdjJLQkh2cGg2Y0ZxUk9jcno5LTRsRGh1eDJYSGFBbTFGNFNibmRKMm1xd2tS
+      Z1o8L2NyeXB0b19ibG9jaz48bm9fb2ZfdGlja2V0cz4xPC9ub19vZl90aWNrZXRzPjx1c2VyX2lk
+      PmRlbW88L3VzZXJfaWQ+PGRlc3BhdGNoX3Rva2VuPmNfLS1GeUpWRGY4RHlFRGhNWVU2Zllsa29B
+      MUcxempMbnZkVndoN0tMSmticlhpaC1aeTJ4U3BTT0RkSGFIemR5YUdqLXBySGQ0N0s3dmZDUkZY
+      dU1FSnVValJLQnNHbldScW1IdDk4LXNoTHNSWklFbjlMQlczV1ZLczNQLS13Sm5RSE9fenB5WnV5
+      VWlBLVk8L2Rlc3BhdGNoX3Rva2VuPjxwdXp6bGVkPnllczwvcHV6emxlZD48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS0HvDihIg7XFxZDKMgoBCj+Tv9Jf1kHg4Je
+        O4fKzLeqlauS2GfHCeLEOWcHJvPHxbYqEfADw3V+/0R8xj9VgKO6muEcfv+0EgdY89Mf7b8xmhGo
+        buhAyfUgYgaSD4LQgm0mCBXNtWXDkcIA+JIRSIqstR2Xqb62MCACDpon+0CW0DqgzW6YajHKDBoI
+        1DaLXis+68AHOSFFGdWAcca1XEdzHSw0mWoBZvaUOkntuTGfbMlBkP+V8WUfBohSALkx5XeQsfJ3
+        2fb+Xemh7YbJq5TMDNpUusPMbQyQp0eICYDsq7pkgjhdqYriUiBJ9HLebdodeXBW8J79abKjgtdO
+        s+3cCA9gwUn30ZUtC8B8o/2nCdlOq8UrVG9BTBLCz8OeHkIZuJvT+SvHgECrjFFaoaQoqPmp+AY0
+        VJRTkQHOkgd8NckRAscR8aWJ0WQIJF92DkACjpaPU2eiHv6rQgSwsgQeBLYC/AqJE3WmWlAydghV
+        yd3vAwDbVD1Z6hktaAFQUSoFbYJukI0a/ci+GTN6jP6zbU1rJ4viLZzImXccnbTbrOOElMKyo0nQ
+        sEFKx/AWhhMi0fqNwn/D8X/ixG/JSq8n5H6fY5CNA4iS40NUalCvTOX4Z8ajTtINCv/meNTw2nfF
+        o4b+/Jl45PtPe02WjvxK7Amd3pgVmGoJzilpGKYyhDo4V7pu6DvgH0GFR9vxZdVEKSSyS/E2MYtZ
+        9mxo7fpwcLMYt/4mWSjR3TZyJ8OkZ5TBnOHJUG9X0WTMztbFlHRdLMCc+7oYBAGs3uanU/LpaIcw
+        DNqWEd3d59CNgNqvDOXqbQxjD7QDw/YsgAKGnMPbvNSSs0IvAJaF3jSAD1tkP24RPU05vIxXX/g4
+        ADc5KLnNWDI0YIhiXiM+18hWnSCoBlO9owzq5ofsEcM/Ezg64VqdRIQ7zFQLZ7ocSI6b9IN9kKrN
+        A5B0U9QRUce5t9F8yNjyRfJDx0FHkeUNQaI9fEAZG3XdF7xnlHEA0FBGeCjfkDqkOZm+zys8J4e+
+        nGhoiXZDMkKyB9e3kzacvf4HlPHcAGbi2SOECi3yTPUO3SQCSTZM2JJpt/HP+F0jyjgT6G7aVffZ
+        dtLlnjAmQHmJ6KlzcEH5gnIycVeCb5xMty8Q+I5sVURErHSTRHa0SjEjq5/0UvCq478yMCixwnyt
+        Zac/YYXlhp1Mlky1ZMhJqfulrFnARzW8QakY3Gi5lOVXkIeIFt1wAzQkIMSv6JWtFkF/e68kPmrH
+        /2s6SfZ7rmulaZ7fHZ6wpCYsw05kOM280vArLZj4ZklKkyZ7O6yDz1FS5kBuCaTICAzFyhPtGcxY
+        RePKchB1p/yiuM6nFBDzsUQfyzP5f3Zwjc8UXplPmWoBZVZdt210nSFamY6VsWy9e46ofuxBV1Is
+        VzXbUwrDvHkNEtSBlVXalIXudWeTuhutBMPhuVlgkuo4UubOUbCgNrqQvd4RP9dbR77FLk5S5F35
+        2DT7K8FuGrQ+6jkreFUipdk5cUNLBc3x3pZ74tjXvL1lDYQmO5KPVmO6dq3RwWxQxHKCNa5DsS/W
+        pS0fen2bVcXTGIZDSu1btBoC1rBFZ4L7RmdPc7EAIHccWoK4PMCVt2GbEmsv+krUeANrsyX68/gw
+        P+v6ecguW+bUtg+z/uy9f9VDq7GmG5sWL0Flya3mZ3eh0YOr1j8tsV204eaDbp/g5pG55jcTjDxv
+        V9Pu+0ggllA4jKlOIOG0wq5rltPz9my0cFW18cZe6xam6ZFKBRNtAPvyXMPm516NdJeu4hIgNiPB
+        Hg1mKuQ9TtqO3ll8Rtgrj+pq/JEfnrjxmxWc1V7EwcF+KncGrLAJ3wMruA58F9DcdQ4243ptSvOD
+        3di3CfXisFAzzoPl5djvw+OkT485stsYyjVX0YQ3BXawXXLXLJ0vo1iyg1RSKj59HCtOS+e1pfhG
+        SuuqTaHqfUQYNfR99HUVF09ZGh8UD63+ABWMvaxC189vw09gwXLC5KrbbpL1EisHC5ZnySoI2mSJ
+        k0MlDhISKYhtxbWqZRipWIa2//uf8vwCL9AiGMFDXNCNAH8IS3JFQLLt7qViAo0U7wm6+0Dfh0rg
+        WiFqO4EcoTrPpO0ZRB8ftmI4qLdRrcR+HxYvk0a5019NxNILZaG/D7NvQA19+VUSzdRkXyuRcz34
+        yu7uQ+giHWyrOIadTKzVXY/jCx5zw8b727pPDh1BdLX94rR78whpEZIUy5HN96CGMm0VXTWcvcwI
+        +mw1WHuwhz2ObACbr8VU1xodD1YwkMddthlxTTpyur6+UehtxxjESmfKc9vOarzAj9aJXkP7PD5z
+        /MzpT8QemG0Wi94+gkGzZfqboOGdotp+PhiMdmezNbXOHe1AKFdlI7sxPFIm5UbWdGlSfJeXVq7W
+        s2EX7weqUbP2FuYd9dF4PN4u+ucBuSsFIdt1KQrJZbMcpez2iVQAKSfK1VyasgFKDSd7lJ4O9IWh
+        RE4Uz/MN1LOp2iO7sJTp6Fqiy/4BtOkn9t1QYmeXZ+m1/wcjk9WfJEeyYcmJwiFF/4Ax+SVHPhQ5
+        nQrPE8ikTiUlkdsseRHrCSpzkvSsPiCFsvryGU1woHEI3TDIbwgEuo6/NKR06ELZemKWMeY56KVQ
+        PwW4FNYXwXwMYbWo/D/dA0jiSz2gxw0n/a/0gJ5uWFoF3dLBj9Y/hup/MrPtKdcbqoPpZLVRjAO2
+        ssfieL2bAKTbI3vcXGMY2Y+3w51CBCJ+4PZCPzk6QG8miq0vunWjX9eIix7hsqGe4vCs26ap2dtA
+        wSSIBHl42I07kWVKFKcvWuxA1nbS25BerhoT1msK727Ei+PT6r0xmVDXQcvvXqh+h++1LrPNynwb
+        rsH1elI9aYdhX61l4gdqOTuYb61lovldtUx9by0/+/+rlu9BeVnL1JdqOZv3C2r5i3q+FFd9lv+a
+        oi+TnxMc+FPq2UT17GPxebJddlnWqznX/ZD2uzzRiHrWfOny5mEyn7iR8z7ZHvsX8chpR65Xj+Z2
+        NI15DzojxdKN6I2bDa2Q3bwfV+pKEt6l3tCGbOOkHK52d79Vh6fNsYOu9cLaP8lig641u9dQsE7u
+        uaY3LouDyHbZCF3FLd7t4cPl2TwbyKUn7bueQY5YZbicjI6NWcemPPYwmR2c4/xiYS3K655W5D6O
+        pyuBvtRngIhtasg1AqMJTD7e94Y0JvC0EPaImo3PZuTX+wH5I/3gu7SdrP/afvDs/69+cA/K9/eD
+        bN7P7wfUF7V91pl/rRcAx3D9impA4wqcn9IS6qglDEyKmxgcTte6Y0ne4wK7D4TgeMbttdUYGWK0
+        ah6W0LlsKa+3vhr+vjmCO6G31UdGf2SbMqV350rY6h54rTkX45ALdV912bXWXEN/esa242406ZHH
+        eG1uZ4Sxj5quxQn8pkZOehoei9KFvC75GPi7S3PhHWcCCXbXGqmfSJ2iRKsf8EJwUtXjEA99bo6j
+        b3TaOknfIPfUj1zdv0vuyV8s98/+/yrve1D+RHl/We7vj0H2W2VRkrprJD8/3H+x/GAp5dvTvz3/
+        D1lRoYe8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:27 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:16 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <trolley_add_order><describe_trolley /><user_id>whitelabel-testuser</user_id><order_token>E2--5eH5_vuupAjgQcgXHwMpTe9X9qgSl2Y0lXp5covwU1ss4IWYBA-RU8_g3PLu8IKzgerz_3Hl033oI-VMEczh0ACvOMWY84zu53eWCfAgAX2v47y8gZlotLi4soNNf8tYetkXqZoP-N1hlKUJkwZdbW0CSxe6UymaEdjSXrzwO0O_DORRcWp6xIeRBq_gkx4Wu9YZJPsOK5CeE-apF_L3wCpdqKeS3P6_3QZAvRVTdRGBuSzS-XHJpV6utMn-uLK1XaipNu8tDIAOlNAM8GDGcPYYRpF_3_rHi9pUQMOLZiyBM9BhcnyLGC8TiUOTaOxTSW98HodDDCuLqymE1MWcmVXSh6xJsVunc4mtPXPNxl7-Z</order_token><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></trolley_add_order>'
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcj48Y3J5cHRvX2Jsb2NrPk0zLS1wUDV0MTNnRWFjNGthUkJ6Wm0yaG92VVJp
+      bk5IT3NrMmNLdmJQbmpSbHRkSngyQ0NqMHc2OWpOOUVRcV92cHpOeWtrRFVSbThpNGhKQ25VdHpi
+      dmI4QXFISWxjZThLZm1hQ1RLcmRwZmxsRlI4RUphamw3TVZvbEpnazczMVNMLTd6SVREVDZfWE51
+      cERtRWNUcUt0dUkzY0RsNGN1ZUVpbVRuTDByaUFmNEh5UmV0SGpJbFJUU2d0VXBXRThfRW1RRGJ2
+      N0dlVms5VHJQeWdQd2hod0lFUzlrTW1tZ09ET1lEemh1bDdWNDdXOU5fdGJTSFVQd29RZDRGemRE
+      cVMtWnZXSFBGQkQxSFB2a1ZOV0wtMndYVU1CWUpSMVN0UmdLM0FzXzA0YkVWNWxuQ3BmRXZRb2Nj
+      N0dFejZsLWRodmMzc0xkRnREYVBkLVB3QzUyb1NvYm8xZXlrdlJtSkZPY3ROcEhfWEpZRTBPMW1V
+      cDNCZE5qTklxSEtHbHN3Y0N2SHRGZk1hQUZFUld1WXNsc3pGcm9lNEh6UGVXSzY1TTRORlpLcm0x
+      Y3huRXRkaXdGU3hqRER0akxENEtIMkI3SWE1b2JkUkdidEEtWjwvY3J5cHRvX2Jsb2NrPjxkZXNw
+      YXRjaF90b2tlbj5jXy0tRnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJY
+      aWgtWnkyeFNwU09EZEhhSHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5
+      OC1zaExzUlpJRW45TEJXM1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tl
+      bj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxwdXp6bGVkPnllczwvcHV6emxlZD48ZGlzY291bnRf
+      dG9rZW4+YzAtLXFrLTlCVkt5eDB5SEk3WUdWRDJJblJUb2RmUXFaR3AxX1F1MjNFSDI4WXM1YW5r
+      VXZ6ZDBFeE8xNHdsN0VtRmZ0Q0gyN2VtTjV5M0JsSmpnbHNGYUtCRTh2SDg0dm5CcmhXYjRYQWlG
+      eWJBTU5IWEFVS1EwamxxNFZ0bXdLd0hOT25ETFRDZU9XUVFDZnZ0czg5a3JXczdwcXY1ZlBGRkpa
+      d2s5TWx3QWRnMWJ6Yldhb3l0ajNrM292bE1TazNOQk5fVW9kQ210QjBEc2NpNWxmbC1wamhKS0tL
+      WFFEd0YyWjwvZGlzY291bnRfdG9rZW4+PC9jcmVhdGVfb3JkZXI+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['706']
+      Content-Length: ['1008']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61YyZbiOBbd91fQualFN4HNTB6X6zBGkBAQASYYNj7GEth4DEsGzO/Un/SXtWzJ
-        I2R1ZnXmIgPdd5+GpzdZwh9XyyydoYd0x/79C//EfSlBW3WAbh9//7KSRuX2lz/EfwjYc0wTBrIC
-        gOx4AHqyB5FvYlFA/h44lqLbso8IrCN5rwAxgEioPBYJqhe42JH3pqMa4koul8+Ge+gY/Y67asz3
-        5aPnHACPny/q7G17qkEVnWqDLd88vRtzbru2B2dLmmhoNTgMN1d11X8JPrfmdPPibEYv3tzQ+yNN
-        rZ1qdWTNB3xzXb1tqh9zqSzZhhd0T9/aM76hv13an/DFXN/Q5DY6bIVKbk9CeErXQUjfm5AeJYck
-        1sCOAW2xWS+XdamGlY+2U61hua87DXgz24u1PaqCi2J9PtvX7jV4GV1ul+m5DgdtUJ4fpE7Dfx13
-        WvBtMzPQ+HX8MeeWo8PGOrsjvfF5Ac83/Tg4OtaQO43gDh28+lXvfszWvqoFL9bQ3pd372tzLUNi
-        JSmozdu93v6wQB/c+MOWDbDRpt3XRb87O/Dqdbp7vaKPPexIvU/34jacz8ZAA9Kwf3h2LP0KBsRQ
-        Jv/+8aENXv25Xquqp9bu1IDBYHDqtnby+HZsD/zF1Lm0x3Z9vXr+9N6Pi5GM3qA0WS6MUc/aYvXZ
-        qLfxoXY4ti4zs76a11cvcEXOic6b3vR96kp+Q7+1LEM78/K6Pmmure6u6jRWBuirE9ezTe+0rIE3
-        tf920s6X3nZX7WxXxjoYDYddaXRDw/Gnuw9UHQwnx8GmCYatjS55U74qvbQG0sUdztZcT/12la5b
-        ubpuapfn+rLz3us/j8G3YATWPe/sHSdL3ZSnr+f9rnXrgWALlU79E8tb6CxtY+bOvr2OVz17NBnM
-        p4FR3uh827QMeJPVzRyM7IVuBDO3vz+eaiCAg0bQHu93XvtdW3S0/UwbvzfLO6GSd5DEX2jkqI5v
-        Y5FPWVk49D0IZB1DS7Z9aw+9kHkPxnOKwt63QeiU9G9xjQdozESO76mQgACK8IplDBHmEo2stKAB
-        IFJFibBLywCRPZV20HOKihEpVsQOVkwyl7XXbQjEaucpXaggK6ogLNa4p8YdHeEClSzoKljVRP6O
-        nYjyGggq2PV0FYrV5t2GUmFBiZxOU7wjFGv3OolMUH3PI4k0SH9RUx73Lsk2OShlHBQVO+TCOS7D
-        YWDKYh7QrjYzrNgtEsA1FRUisZrhMCjDIVaUUWDtHbOShT3IUPE/f2b1UzxFRQHAvU52KKuao0fz
-        MyCVUIfRYGngW1ZQ6iseKA2oTKjkSImKbmN49BRMypIMFKxUUpGtWFAE4UypcoQlDBy4d4wIS4bp
-        r3TbUYyEk1BnoRvqh1Gm4tLBc6wSJkc4Q9uHoXaWlSpZEGsOyADRFffnvXlGh157ZkicOfLaPPR/
-        biUsv8Ry4mwlkfUzvFiQUiPjqHT+DDGxWfFwOmKppBDSaRTHFHrWpbQaDGcSmSoHp6xo60vsA2jj
-        Erl2mKHSY9mO7ByiqERhXssOmQzrqgGz0hgQioGeie1COGciuJKeEhJLh6nZgwrd+HBNcnIyooJo
-        m0PSSgUXDXqQEVga1I++K58V04c0urOAoOqYpQLTsYFjl32DmDIBqTyaaBrJmZBOrZoKQuwP5RPX
-        UHC4gQzG5HEgZuV0GtKcRZ0anS7qefJQaERiG9kgNYetUIksGYNhJ8iosWaC5OZLeQ+mNHSAHk9L
-        D8LkOSylRGcZKZZuBhkSPWElXbcSGy28Xo+ZOTJ6FkjEkf7KJuUXlCakMSZNbUplt+DpxNtIU3zW
-        4UV2IamAYf2NEvlDkUAiEMqeYh+hDG3Axux+/H+X+DbWSl3/6JMqW+V4kupTAuX6WCVOfkCQFMhm
-        uFARTWkIqsRxSGTUW3yj3uBy7FhI6QH5Z1mABDRZlGvzbcZMcHK5TrvJ8XIEKzYgYUZyb0gvc+0y
-        35b4ztca95Xj/sXxX8OVHiuweYsWoGOEFQ/f2aTKE2N0SeCav9IkTb7arNV/2CT1Kv9TJqmXq/zf
-        MQkzQZR6qD+GeXzR7U+GC6GSgRklMsOrgkkgXUo90oPZ8DdUmpHjeApJg94/YyVqL/pbB2JzPIol
-        ZMRwk3i5kyaSLMgYZHvYR6KpnxM5g2ICLTKVeBzVEqRbbtgtRYk51qNVhv72XQRNkyyFcG6Pw/s9
-        fm/vIT5ZZfHKg7mP0JFpETRJkxEWHrERleBkKJBkfKQ/y9wTH4oSQKik+pqCZFJvSGAfkGiTPjgH
-        hLkwLDcQJEmQDQVLucqeb9vErPT++SpxjTtUsEjOfMArooINyTcCgC7xG590aqEvRft5hDOyTzus
-        DC1GKCE8g+NZiq2y7+A7VAh7SFoT+/yiVJdmQiWB4gRPKikO2bJhiRwrwEVcQJoTpccDPQ59Qchj
-        wnc+WXLfKn/9kZL7OokaKNahdAfT4WK5Hk6nS6GSETASbVAU0ut7JKzWxJFQTGPlhTUJfysaC597
-        uQ+9nLXTjLeGgGTEVlglfn1GbJHE/xMZsXWXEb8XomFsuI5jss4tuuQCFkaMqVthtY38MjP8X4m2
-        9aOJNnIpurtyt9MlLssAJkHyWc+8/hRBykozHPVQksZYd/jBVFJIuA/gfPCG/9OLaz3VuNLbq1BJ
-        ISrVNMsiXQvfqUUFPIvR9dKYDHtbeR+eN1o9PGABynLCNSo5JD1aeCekd/n0IUoyvO0kEAS0my5S
-        BJriMxbojxf96TDcdkGQo9JWyyWnKam6p5owr8Cs8eg1ofiMQMeFr4Z7MMfLfEE8goXHzwZ37wUP
-        HwruXgh+NK+wz9JfnPoq8bNR/AjFHjLuHqdy+E+9ZFWSJ6rKd5+P/wu8uhIsgBYAAA==
+        H4sIAAAAAAAAA7VY2XLjuBV9z1ew+mHmIaG5aO9wOKW9ZVleJFmS/cLiAkm0SEICQC3+nfxJviyX
+        BChSsqbSmSSuLps491wA9+IuQBu/H8NA2iNCfRz99k27U79JKHKx50er3769Tnty/dvv5l8MlyCb
+        IQsTDxGLIBoHzDRo7Hg4tP3IiinAPrUc2zMjbCi3JYYbEwKzn/IvC5ZC5srZGsollDOWtsswMTVV
+        LXAEmLOiOHQQMet6tcASYM7aBraLqKkXOAIqcDBlFj2FDg6UIkyQQM1//qOon+M5CnrktGXYcgLs
+        bkzXkuWq7NCP+dNHMF4RJNOOcz9uPLXcZX09rB53k8dlnz1OnlvPTlUL1FPTd7a96Wr8Uhp674PP
+        jk9XnztGG97sx2uLWCffDwYrHZfr82iP3iZPM2cR9OkMP+/mnfmh5jgvGpr9mPW2sku0T//9hOy5
+        u5r1ds1P0pHfYKfF/Rn8XBneoMis6rL8flRlbRAd2/t5a9hYdtnboq82WAc1SbsfPcz6h9Wu8mPR
+        H9XR8TCddOo7/aU/6O3wptq+Xyx71n21/PBWZq1HN3Le41pVnSH/1B2w8eDw2Qg6u8FLadHc6c1h
+        975B1eWL3w3aeDhh6nTf7ez9Zs/W/U515I7eV/KijJv3R28dbYa91uKw9BalaIlaFW0zGNn68Zmw
+        oFtvfp68NVKX/rv9uWmMYxmTUml3Qp3RyDno88/jev/08sZG+DirnWrTYzir3J9au1Kz9XL/OGnY
+        4Xo/bTmd9kelNNdPVth2lg3NPtgf8vuQ6m5ra+nHwJ8ebH+kq4/DnX2oTiqzUT0s43c3Umn51WrY
+        nWnY1/36y3bufiw+P96qbzPWWw/cx2CNdtFC7i+I68z1Pn43lKLLuf9Nw0N0azN3bcGHa7ZxECCX
+        SUuCQ4mtEaRpFCNDuWTlSiFia+wVgDSR2k+tp4IOT67CkDJTu6tcMAD6L7eS5L/NbPPxdQrrF3iZ
+        IKey0xaZLp+/QEzhwvhsnE9dHEewQxeHjh8hzyw17pLSkA3PFG5rs/P6MIWJLsCck2686UE9kyiz
+        I88mXoHMzYqwhZcWhQpITc1QikMhY767QUVpBhgJbUt8F5mlSrLNfAzlk7hrm6yQWU4l52G+AdNA
+        4Gn4Y0P95Vvvzg0lH3FBus0uVPHTYY0IEgS+eddnoqQGOPJwJMcbcNYZ5PKU+pDKhVAoBzal4g/n
+        24RRoOSAEHI/glD6xQ63f5fa4NE42UpBbEAfSJsCn/aEYKZLKHEXeMHaoFO6kpI6LEOShiN4mdoZ
+        uZgs513P59mRi25Pys3JCBdgzkntaNkQrUwY2rlS4JYq+RaUzInJgRLh9vQQisBZnOq/Rj5DnjSE
+        Lgx9NKeKUyE+xBe04b2PDtYWETeJEd4gb4oML2nexI5WyEKRJ8bpZNN1/DdJo0yaoC1DSbuUdFWD
+        JppTODtmLgT2kiJmlqrJUtdoTqPIhVCCbCjX9FqlfMnOhJx+gp8w9DwzWVRtqJpgnnE4aVyvqpqV
+        wpCgkFohSumy2pBVbao1vpfU76r6V1X7nqx0W0HMe+0DPobMJ+yLVypsLY3s0//SH1W9XCupP+2P
+        ilr5j/xRgX9/xh/C/rTW8HBMCve42R52x4ZSgAUldcPIZtAJDlILxyRCv1LpEcwhNtQ9Ik27k2mm
+        yH3Gv33PrA56mQRGAg8g0LEJ09ksqRlFUDCgC6xNBZTlkK8rO+m6MpWj87oyQ5QpmX6qItTBQhZT
+        M/D35+kFlBF4Y1Kycdp/qB9uAySKeabHOxP/jrcUBQHslLILE7tfTYSv0Q+1iCs35lghbPEGGdjM
+        ZzH4vALtWW9UNa1UM5QzakA1X/FPWb3TVDjhShXutTlsKPlka5ta0JigHixpekG/AJJqmvQlaJ5Z
+        GRVDI7SPFomjCI6Cx42mgw1fUCOEqnuDd40aEUIeRMQW4g26QxqT6X5u4YIcE7AZRwVahnBCYgMm
+        YVKG+fa/oEZypefNs62NpfL00VDOUNYioOWyhG1tQlMVnfoaN+gap1V1yc1Jl7vCDApxCfR0cnSE
+        eIGYTKYrwBmH9+0jQySyA2kKRKmVBHLkSbkGz5/0HXWr4t8SGOn1jK81aXYeuuPJvPvwMDGUgkCQ
+        0uknthcgAjk8h1CkGU20MnEF+dOpD60szJ5iST0qDI2LY8pL7Bx50JW0/0cBbjS08s8XYO1rQ/qj
+        Spak1BbjQNwM09i4wpJEC/ww6e1pOBeG/6auaz/d59JI5LuTm+ozRLoAhIRae5/6TiCi9xrkrLwa
+        8sCGkidunzOhkkPG17y/zPnkNz+42l1JlZ5HhpJDXLpehyHckbQGb45FjK+Xp3Jyd7acxF5+vQf5
+        FVTkJGsoF0huWnImkDm7GNFzN4jwGUIev61fUwzeDgoeaA/G7Ydusu0rwQWVX+y2YI3k+sQN0KWC
+        8AZmdmBdPW2uQEG6epV8BS94hRfKLVhwr18r12hGu3y5XIM/XVnEs1e59b9L/wL2/DbImhIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2158']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:27 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1879']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:17 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <trolley_add_order><describe_trolley /><trolley_token>64--iT3taV8o23t_Cio5ezl8RWnF2dwamqGnxAxyHFwzwLv4eD8d-OfT95uMI97ePXNksIMIVO0SFfXmvpFi5qwdGzigDgomE0jFeZsfr4xiAVNWuchyHmEnb-ZQWlW_eYj3Ty3O8BBbfRsV0IVn_kdXhLAMRCANf1cxLZMxsVbe9TBqpwp5oq5DhdTECfGomixdD6W2l1QVVhDMuOi32cj7Zj5eyDDjA7Z_Izg8DuRLow8In4WUGqrQgRF_sPeTKSRkFBmYtcGk48tf3fg7wNl4UO4UHeUT95svXBLQLpTu5iz7mkhv1_W4K6WmAZ2o5UkdCcKprnlrjS3dPcCPjhvwBYZ29YUkWyFEEATFzsEIqpbycidEKgDX6dE7XiTrL12TH7DTwpENW0BcJxTxY_2W6hwG4S9QBCGIdJyFdWBrvrgKSil_LMvbZ7zBdyYea94qt_YeoSnkNpNJMIUBnFKDOLyk-Xi18lmkez_cXOdFnRikyNpCbgj3dyeD5y8IbZr8QhR9hbNhIQ6-Z</trolley_token><user_id>whitelabel-testuser</user_id><order_token>c1--16kut9RB3qB5vg82y8sxt1gLWHGf3I0J8vkFUdWt8Uf6Ah3eEvsLLtoyWhBF36HkmfnZ68-_xhAzEAI5Za_7iWhNCEoOQxBS6350KYOeSPgdwyX_WKvzXxYMGW0WYFYphvGKJJX-9iNDBz7KXwdvfr-enGyH80kCpkYekLaM5x8NNJPGdkIQ9pICWhOMzRrex814XKL4QtMu_AdyLCHXIRMCbSiXm9ldgnz4-TjSm_8QX3G0Tv6GwU8O0wW2RCURcddxtH02kzDOU01nkeAlipMbfb7TlSkJdOm1vj9N69J_tBdPIM6LQ---Z</order_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsUDfEXxcUCHyqYlLXHoXFHrOkiCFhc3j34smOD16W2zX2VOT-TnkryAjJ8N15iPw8qeHlWzsKzFfY</crypto_block></trolley_add_order>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48ZXZlbnRfdG9rZW5fbGlzdD42TDk8L2V2ZW50X3Rva2VuX2xpc3Q+PHJl
+      cXVlc3RfbWVkaWE+c3F1YXJlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPmxhbmRzY2Fw
+      ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X29uZTwvcmVxdWVzdF9tZWRp
+      YT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X3R3bzwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRp
+      YT50cmlwbGV0X3RocmVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZm91
+      cjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X2ZpdmU8L3JlcXVlc3RfbWVk
+      aWE+PHJlcXVlc3RfbWVkaWE+bWFycXVlZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5z
+      ZWF0aW5nX3BsYW48L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+c3VwcGxpZXI8L3JlcXVl
+      c3RfbWVkaWE+PHVzZXJfcGFzc3dkPmRlbW9wYXNzPC91c2VyX3Bhc3N3ZD48dXNlcl9pZD5kZW1v
+      PC91c2VyX2lkPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48cmVxdWVzdF9jdXN0b21fZmllbGRzIC8+
+      PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1202']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a2XLjuBV9z1cwXankIUOLoESJnHCU0m5bm63V9guLIiGJ4moClCz/Tv4kXxaQ
-        oMRFUnsZ98wklX7oFs49AIFL3IuL05T/+WJbzBb6yHCdX76BK+4bAx3N1Q1n9cu36aTNit/+Wf2T
-        jH3XsuBeUXVdcX0d+ooPUWDhqoyChe7aquEoASKwgZSFqlf3EMmF8yZZ8/cedpWF5Wpmdaqw7Nb0
-        lpLZkLypMFywK99d6gB3dtrg7nFThBraFJuPoLy5N4fc49xpbu1Jd42mzWXr4UWbNq73z49W7+Ha
-        fWhf+0PTaLTXWnFTLCF72ATlOf/6wM+GE3bimP6+trkVB0Aw7nbiM7y25q+o+9pePsqFzJzkcJWe
-        i5CxsCBdSgY5egO7JnSqpsCyr9JWN3s1sfnEiVMIGuN9fQ7YErhvLvuq7wavQ0IoLzcV31G6s93O
-        qDe0uz7UYH09GAnlRrc8mBrzAASrWVFXRCu492aGX+Gndw+7ov3Cj0WrNq4IaumpjCWuab82xIkO
-        +i8ufvC2krEY19jdrTar8Uqfrc/U3q3ptYTO9ba+l2bdYFu/hTvx2kfrvjeyR2veHqOtdG9u9VVJ
-        MpH3fF1W/buSoTutxsrabWfmo/jEKdfqi3lTGQJ3f4fb3Rq3ao+e4eBWazz2wNqaduYvN+6s0uZH
-        asln+2vX2cxuuXLT91F7NLtv3JZ8OO9PWU1y1HvVtlXH2yhwM1pgsOgr6ryxugb36lPf3Arj9lKv
-        sba+Btxy/jha4actzzeGPpjXik7fXc30KT/CrzXdacPOQ6/I1wGUhE2jvVpUhCmSysGm2+LBAnv+
-        eHIvzUf1V/QglO7d1a6CzGl77y7bbUl7aRtipzG1y/Z9gNx+WXot8Y99pTUabSpPz9P+9ImzthrH
-        KYMOr2+NxqqzHAbqwrHrTfPBkIT7WW2FsVDfDBc9czMTNT/Qur2xO6rU3Mc2HhgK3r3suj3DqN28
-        tMTmsLPnppYj1ZtF5EJ411xN6m5x1/VU/9X1+rco2LY60Jts1Xs0Kj9Yte3D+nrWft7CpgnHt56i
-        LOfi3bi4sm+lrsLa7XmR7d3MrveTXWncYP0RX+/oG/PB7ArY6WhgfuMBcLMXnm5g9zWocSz7JBey
-        m/W4d2kUa27g4CqfsNJwGAdQVwwMbcUJ7AX0Q+YpeBizKi8CRw8DhP6bGQzIhTPogYncwNcgAXVY
-        hS9YwRBh7tgjbc310CHSqhPCZsZ7RObEPEHfzXeMSIeO2MWqRcayF4YD9SovXSUPytnyXRCuFrkr
-        4YSOcI5KHuipWFtXwQn7aMr2QFAlm9fQYJUvn0woMeY6kdWtVX8Fq8XTPkebrAW+T5L6PvlFXbla
-        eCTzZaCEsVQ17PpVwHEpTgwmrHgHiHw5xTpsiyPgWaoGUbh58lCKQ7yooL29cK1CGvZhjFb//a90
-        /wRP0Kqsw4VBZqhoa9eIxo+BxEI3zBoyzcC290xD9XWmSW1yIUM6djEcDFe+iskRqegqVguJyVFt
-        WNXDkZLOEXZk4L13woiwYzP5lUw7ipFwELpZ6IQaYZRpmFn6rs1gsoQtdAIY9k6zkk42xGtXTwHR
-        K24M68NUH/raU02ymaNdm4V+5VTCUoB4rjqYTsjzU7yDIaFGztHo+Cni0Wf5xRkoTiW5kE6i+ECh
-        ax1Pps3WYEKGysAJK5r6GAc6dDBDXjtMUemyHFdxl1FUojCvpZuxDRuaCdPWAyDnAz0V27lwTkVw
-        IVklJJ4OU7MPVTrx1pzk5GOLGqJptkhZt9+toQ9jQpwGjVXgKVvVCiCN7jQgawaOU4HlOrrrsIFJ
-        XHkEqT0aqBfZYyMdWrNUhOJ/KJ9sDRWHE0hhsf0QiGk7HYYUilHVSIeL6q8sFDqR+EYxyZkTP6EQ
-        efIAhlVpTD30PCKZ8RLemSFNQ0fnh6ULie0ZLKFEa2mrtmHtUyS6wkLy3MLBaeHr9WM3R05PA0dz
-        1H/qkONXZ7qkSCcFdkKN34JvkN1GCvStAXeKB8kJGJ6/USI/a5JJBELFV50VVKCjx+34/QQ/MUDE
-        a6YWrAJyyvIcIKk+IVBugDWyyZcIkgOyHD4ojyY0BDWycUhklCpAKAlchn0wUvqe/LFtnQQ0eSgn
-        AjFmHnHycl2xzAElglVHJ2FGcm9IZzmRBeIESD8XuZ857u8c+Dl80vkO8bh5D9A2wqqPT3zCA+KM
-        Gglc6ytdUgZ8uVh6t0tKPPiQS0osDz7jktgFUeqh+zHM46Nao9sayYUUHFMiN/RVTAJpx9RJDebA
-        vyFmQJbjqyQN+n8+dKL+or8NvVq+aR8spBXjFtnlbpJI0mDMINPDAapaxvZoj6EDgR4yhUM7OkuQ
-        YXthtRQl5kM/esrQ34GHoGWRRyGcmWPrdI6X5h7i3WkaL5wZewVdhR6CFikywoOnKkRH8LEpk2S8
-        oj9Z7gqEpiMgF5L+axUp5Lwhgb1EVYfUwRkgzIXhcQP1YxKMm7Ktvih+4DjErfT9A55sjRNUtknO
-        PMPLo7IDyR1Bh+SigwNSqYV7KZrPOTwmB7TCStEOCCWEa3B9covU4jv5CSqHNSQ9ExtgxJQmA7lw
-        hA4JnpykOGQrpl3l4gM4j8to7UbpcUmXQ9WMLCZfuLJk7irfv6RkbidRARVXKLVmrzUaz1u93lgu
-        pAwxiRYoKqn1fRJWc7KR0IEWHy9xkfCpaEzf7Eh6yVz0Mt5OMt4c6iQjVsJT4uszYoUk/g9kxMpJ
-        RrwUomFseK5rxZVb9JJzWBgxlmGHp220L1PNtxJt5b2JNtpSdHZsTaqRLRsDsQUpWyOlROVBykoy
-        HN2hJI3F1eEs7pJA8mkAZ4M3/Ju+uMpVkWPu+nIhgah1vbZtUrUAqRgd4GmMPi+JybC2VRbheqOn
-        hwvMQWlO+IxCBkmWFr4TUrs8BxAdM7zjHiGo02o6T5Fpik95oHEzavRa4bRzhgyVlloeWQ2jGb5m
-        wWyH2Bvn1IS8jEDbuVvDKZjhpW4Q52D5vGxwohecFQpOFIL35pX4WvrFqa+QlY2+SD4Cn5KPhg78
-        iHokch9Sj87SL6tHp+w31aOK8An16Eyft9WjAOlfpR6VuB+vHv3l/+LRbyMeRZv2R4hHhS8ViWgo
-        XhKJSAX2lkJU0wMLM2HRqIfb4AcKRTSmzwpFwm8kFAmXZSJSMW3hSkVsgC4pRSpiZiHlf1ks0tQF
-        8R3+nl6UUL4nGTUoi/mranv/YGaqb0D8CQUJvUdBGpMKCSLGXTI1G5K9pea1pO8oQwH8iQESqflv
-        A2v/dsnP8gL/7qJflCS+/O6ivwKkD8kgFRZIE56n1Tlp/n7K0IecAnip9H657FPaEB965GNOOdWG
-        erV2q99vXRSGeirThrYNmUsqUE/6Q6hAZ2SZYvkKcHxZKF7QZgAQrkCFL1fAH0ehkf6IAs1gJkqA
-        k35rfQa885IS3QIy5X/0BUtON6+QU/EcntZy+p1+Z1QbNHuzi0oOoTAdEkw6kzoo35BzLsRQ7r/q
-        f4h287GcJfLgI3r299SbbFr40erNO8+Ho3rTk9g7sfTF6k2vNmn9Gv0GcG8IODz/Xyng3I1a7XfJ
-        N3c+XEJyv9OZcGDiondoOPRm8HtoOLTQf1PDEd7ScN7OKN8Rcj6fI486zuFjolhSOPnIKIN/6Iuk
-        wvFTo8LFTxL/A9zjHdHUKAAA
+        H4sIAAAAAAAAA+1YWW/cNhB+768QjKIvjaxjD69dRoHXF+B6HcfeOE1eBErirhRLlMzD3u2v71DU
+        ud7UMZAUQZHAQFbffBxyDpIzRG9WWWo8EMaTnL7ecXbtHYPQMI8Suny9835+ak523ni/IPJAqPA5
+        wSyMfUa4TIWHuAyiPMMJ9SUnzE+4H+DIozmytktQyNaFyP0gzcM7L/RNc2wG/POHt5/T6yUjJj8O
+        zq/3307DxST+c7y6v7lcnInLm6vpVTB2Unt9mATF6XwppsF98DEcT47k6GJ6heP3N1fX+/4R/+v2
+        04r/zW/k8XjuFkOXBkVw/Xj+bnp+cv5pdTZcH93FsYuTxX46iEaLdRDPRu9Gs8vULqZD8yOyeutD
+        UcIFpiHhPmbEf8Bpoo3bhmsHeQgQ7IP7iHfyAVntlxZEhIfeCXh7/RgTRipCiaIwEWvNTTH3H8gS
+        c1NyWFODa0rJvsDcuFWUSl6pgJG8+k8PwUIwHAqIrWK2eMUphx0+5Wh1ELUyhFrtmoC4D6EqH+7I
+        ujuTBfFvBSpLKno9ukF6OlveF9SGOAB/ie3atV0tpQe3rNKyI80yfsNZ8YdxnFBKmHET54+8M1D7
+        wGpXZdXuzbnwGaZL0JvhFcyQBQklkTexd21k9aCSAMsVBUtC4u2NakaLaYoEgzADlS2jgVCmPL4x
+        SxcqCU9m6WGasjFLD0I09zns+pQop/0/TbyXmAq1X/KiTCkPlbvXr3HPQdYGsslwn2UMnmUMnzKs
+        p0sr/e+HkjE4kIFS/9IpLXkEGdmDWsYCtkzOPMe2O5wKbFlUZgFh3mTYZVVgyypSDEedsnsT6nBU
+        vvB1FuSp1YXheNSo92t3eAsja9NK6wtp+DN0P37ouvEKc0kFayxWwg7QiMtT9j1NBImMG4EF4Ua+
+        MA4zAlsat4P0YRyBXOv3CY2q71I0l+SV4dLIOJRLyYXh2s4YLupGrqlShH6+WHAiPNMducrFm3hL
+        5CTMacQ9Z7hnu7bbZ9dCTV/DvyyLIk9Na09st2I2ONx8+WRsO34JYxr5IslISTftiWm7c9c9GNgH
+        tm3aewdqpu0DKr2bLtDfUJQw0XNKLF8ZIxEbM7z+th4ZuyN7MP5qj4zs0Ys8MoK/uavc8TKPVB7Q
+        tWqZZxeHpyez2QmyOlglr+oo45RkGakJ2jX6N1R144v9WtLUeH4Kp1PuiRguHtYM1GDFyEiUYMhx
+        XJ4HsK1i2Bhe5Dyuho+DkQyyKFnthmkuowXLqdilqmIpOSih4EgJuwxuviIlyrks9WIhigPL+lcN
+        FodLjkRWZwkWWQkftpRwrJMPFqTwynFGu5+LJXhz6zyI4kzVnxBIWDwYV36jAovYe5n+cgj6ki38
+        2xqz1RQuiyJngvtqQl1p9qE+g2+hqKKvF9EfObx7tr0a2Pbz4c0wu5fkhcHtaf/ewe1N9jO44BFn
+        COk+/IrgcihG2Atj21P+vWPbm+xnbH/nay5I5reIMiRNCPuKWFfMF0T7uem+a/Sfm/w/zgbtLrji
+        zRSbC1UFWDVPu6F684KqVHIvTR6ay76CaoIMoAbBVv0t8jtCu6WDBmrpuoDIJcpEqGDCO5ViHQla
+        klyVOLDKFENTIaFgGYx3HXsAnUeDoDSnS/3TVLegs+dC+9OCyGrVxJj70FMVhC14+XzVA9SbjGqh
+        ocWuH2Oqz7JpZ5JSqGx0reW4Vd/eQ8u2u4fsV413n0YJiaC+KqBEU1FWZVu5nG14RZYMq43aodWI
+        JigTcpaptzi9+icoUu1NWfVd3k72HRti0iD1M1P9nOffZV758LAFRzzOH0vN2hqdZH0M8VyykOgi
+        s8lxoHXgmqMfAleCMIpTYw5EY4ohGaCDaUfoYhRyQ1ajZ2ezs+vDy+OLW+hCW7iilHSgGGdQDUdG
+        54mwI6+SrdkR/RfdfwBjn1trDhYAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2754']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:27 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1447']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:18 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxldmVudF90b2tlbj42TDk8L2V2ZW50X3Rva2VuPjx1c2Vy
+      X2lkPmRlbW88L3VzZXJfaWQ+PHJlcXVlc3RfY29zdF9yYW5nZSAvPjxwdXp6bGVkPnllczwvcHV6
+      emxlZD48bGF0ZXN0X2RhdGU+MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['345']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1cW3OqShp9n19h7Zqap00EFIQ9HE8Z7/cL3uIL1UKjhJtCo5Jff5qLomZnTmKZ
+        mZgxlarI6tXd9NeL1V8jRPhzZxqpDXRczbb++EE9kD9S0JJtRbMWf/wYDSsE9+PP/D8EBSAoIc2E
+        kr1CmOpKDnQ9A+UF15srtgk0S/Jc6EiaK82BkrdsIf37EkF2/BWypblhy3qeIAmCIzfbapFUN9XN
+        aKJJW/pZevakCjUvGby5YciZ9lLY5HJlsqjy7MzhiKYxbmZ2WV6fdXdjckeInXatW2ZZMEZbr2JM
+        Os3d5HFbKTVLu36Fm/lPFW0oP4s1v9/viNMq7OUU2l/xz62e2dhW1UxPminNZq61k7denUa1HrPc
+        dEyn3lvCptjg5DpFDIbcy67OEzMhfXL+ggWhIilwBRzkOVAK4hQO/ne4sASutIKOKlnAhG7IO4ME
+        z8WRjxBDc3F84QZayR/gQCDh6YH58kRIJ0dRgQJdOV/Gs+lvl9CBMSFEBVlDfsQ1cJcbuAAu4bl4
+        OAc8ooTsFnBT44ASl8dN4Jpu/CeqAhBygBwKAjMTPOaE1QqvOVFzWBChOqJmfYiLTyHBhcCRl5IO
+        /eOe0lhaSUEgwJi+r31ATtpMeG80K4M5jhf6fevRuBLKCZywwpEVI1bqX8Bc/TtV0iwLOilxaW/d
+        o4pRDNLJWaX34bVdJDnAWuB2TbDDPZhzzYJKniMfSCF9AoUEfLpo5WgyzOeYPSPBIoqHBwQc3GTC
+        OECCGUT8rJdjKCS86uUEiyhnvZxAgmVLgbYNGATtew5x7QELBddLbJJ5YQMMTZH2eJ4S0mfIOYP+
+        W0bmbxnZ14z061ML4y/JnuNgw8eU/adI0p6rYEWeQAlDxZeM7eQpkjzixGDCsjxzDp08lz1mxWDC
+        WhlAxsZHH3Fi6IgT6MX1zbltpI9hbKwRmv/ncfUEFtLno0y/IcP71H39qTueL9n2LOQcRhwUHgGH
+        4tBlR5aGoJISEV6E3ZStpgomxJc0SCpFZhwmOVGv0FLi47Bo6MGfKdpSUgVv4bkoRZMUK6ST8ojq
+        IVmyVdWFKE/QDB2E+BxPiC6UbUtx81Q2R9IkfcreF0Z0H/+YpqLkg25JjqRj5gHHK5/NsSQVphkS
+        sJQwVQvpBMkRJD2k6V8Z8hdJEmTuV9DT7yvE7Z6HIDp2Ec5lToKy9H6mGLRMtYF/3YiwNENm2HdH
+        hCGZD0WEwb9DOgjHxyISRyBMxSKdtQqVcrtdFtJHWFwe51GpCjRNuCdEoYk+a0qebfH7EnwU4wZ2
+        JzuPlnjhcQ4VIzBmrABa5tO4MmEAQg3aT+95YVFMw6eLPDdvaJtDMzG0J+AEHSCQ3h8jfwXzrmau
+        jCDXl/Ug0TkqERbQDsID8oIBsCF5eLAZ9oEiM9i1Dohg2NYi+khQFPNA5WhsnQkopJNmguQX+3GQ
+        7SbZ8AEI8rlg+cXL8z6Riw/DBd/xLCvIlcN5ouh4zT9BwyX7BOHjRfuU9qEkPgI9BwRmfETbIxEh
+        GILtmMDCmUN49q9QIbDGUDGdMcdTJJbCAdmnqAreAgRkSTfzYdLyG1xwcWYZ7RjC0YS9nWGCa+Ms
+        BUYChTs8odBFeFqO4T0n2kTsEHQsYKSGmJh6BFgM2P2SGpGQsTa8uHa72q4OCp1Sa4xXsASOKSEd
+        U1JVfCUpqaPtxVF5LLYbW4v3J30ytTdikm8ZUbgptW0jvN7ibdQZFlychmYGC2t4DRwdXs17Q/1G
+        Z0c0s3jC9kBcgrexmqvNjVjz52DESkwuuhxsrOS8ThCE05nRTsafwU2mKTb1x7pV5mu2urUmtXrb
+        FFuk3FGZuVd6LLQL6IVlcp2VUzRMtUeU+6MGMXyKe4xajFvHPhlvzwuD1oFxQIVXZnRqROEdllAa
+        3ANJpnptIZ1AUelyaZp4m4hlQgahO8ai7hJ/+R8okqJvVJHvy49OFZm9siKBvn4qN5stVCgNtKct
+        1RCfuv1Gt4mNHCyqfb1ebz2D7gIxNZ0l9XVxgirPi3crslUYlv9GkOEq+pYiKfIh858lSWculGTF
+        0X6m2E+SJB9dKO+UJPtFJMleZpLMlSWpr3JiixgavtZQG1qvXLC345XaG+p6X31mRVfeAoOhV5nc
+        ut91st01rDDSo3X7Jvm5iuS/hCL3SfUHJHmJS7JXlmTX2Wbd6aLncoYmTunxXGeXoDdhduJgDR6n
+        lIxG66ls8Bz01/4IVYwX3268W5Jf2CVFgH6mcp+jSTbHZj+gydwXccncZS6Zu7Iktz0VJ5GDscmg
+        wuyZD75AaneHa2a07CNQaPY4k2U6DEWKgybb5p70KWv47jdwyU9VJMd8CUV+1CVzl7kkd22XbPLe
+        rLBUOL7NTDcNjsjM3AnUNpmc3ugrdrEyqLSZ9VQX9UEz24czr66OSt/CJT3rZ4r7HE3mWJr7gCa5
+        L+KS3GUuyV9Zkk90TXppkEqzWrSeHIm1fdF8YYh+pcRuTQCXT5RRqEjKo7HMKE+jDGywiup/B5f8
+        TEXmqBtV5CUmWbiyIkesXEDqNOtUV2TW9dRWdekNOoMazfWo1WasWSgr22u6xsPeKNPZ9eYsm+O+
+        g0m2bSxJ/nMkyWX593+ZxQS3vb+EJPnLTPLxypJ8eea1vtkkhiWKhbVW3WQ7uSwrit3ifKeh/q7q
+        Pta0nVEpQ3LLoc6wVX4elM3bN8lPVSTD3agiLzHJ4rU3N90mt+1SUudFqXeXs9JULkhbachMpXF2
+        5Q6L3Kqz2S4myFBpYu1XlaLU68z1b2CS4Zf+FPk5muQzzAfulFPk19AkRV7mkqVr3ykn/OmKKm+H
+        bafQ7G7GurxZl4YbkexNKzwFCupM5x0NLZwusVbVHJjx4rzzHb67+VRJZrM3KslLbLJ8ZUnq7V5r
+        O+X1PqlbPalZb7wUN9nyyC25qlwXZd/J6APbfoJD0n2ZA35tTetd9B2+vJlABWuS+hRNZsIHo96v
+        SeqLaJK6zCYrV9Zko1wvLxZPKFPssr4x7E5Xjc6cQKpX6T0afqtoVwCNx9vd9nR+1hpl++2WBW7W
+        JmUgL6Ei7Z8NdoMHOF5h98erb3eIN/Vc0P/pM7r3x6tvduqO5+u/tbxnqBtd3i9JOatXXt77sOCs
+        KnYtM7KIcRFNmmIt9yjWtc1SHGaq3tTuc9pEXFcWTmlXV9o87bNV86ZuX6bfeh3u/h7c/T24G81i
+        7onafbX/Aqv9PVG72am7vwd3fw/u/h7c/T24+3tw3/s9uEhzX3hFfusEI7MI93Vn/y7mL+x50c9w
+        RgAA
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2454']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:19 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+LTAtLTgwdndHQzBmdkd2VVdpX3cy
+      al9qdV9GMWJEbDltdjUwWml6QXY3N0UwQ2Y5NlpyOC1LbFZLM3g0OWtaT3hWMHgtU05NSE9FNjZh
+      VnR3dUZsV05LeFdCd0ZES0R4UUY4WnlZRmlUY2pTSHlRUU5TWEdlUDdkMnlwOWpMUG1Kd0dmM1Bf
+      WmRLSzdMeGN3dUkydEhQNWh2Tm1ySVBoZUtTSjhjSTEtUlQ4enhJOS1aPC9jcnlwdG9fYmxvY2s+
+      PHBlcmZfdG9rZW4+ay0tLVFlQXJwRm9IM1VuLVZDdFdLU0g3QlNJaXZoU1QzR3VYb1E4aVdTcUZn
+      ckR4SWRNOTJ5Nkdtbm1mUC1FUVVKLVRZPC9wZXJmX3Rva2VuPjxzZWxmX3ByaW50X21vZGU+aHRt
+      bDwvc2VsZl9wcmludF9tb2RlPjxwdXp6bGVkPnllczwvcHV6emxlZD48dXNlcl9pZD5kZW1vPC91
+      c2VyX2lkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['429']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VYaXPiOhb9Pr/C1TU1n9rxwmLo8fMrEpZmDSEEEr64hC3AxLaMJbP9+rm2DLYh
+        b7pf1UwqlaBzz5WluxzJ6H8ePVfY45A6xP/jm/IgfxOwbxHb8dd/fHubtsXatz+Nf+hojxwXLR3X
+        YSeTBAzY1AwxjVxm6DRa2sRDjm9GFIemQ80lsg2f6NLXFn0XIZ/lZjL0PXId27zghqJLN8gtQ/0l
+        o/RLRvmeId0vzQpPASPm0iXWp9GSRfF9XqVvXSSrmzE1/cfWqMs27WG7OfJK9XNnVZ4ptGcH73X5
+        PHuxrW1tdySdceSUtP6Ozdft/nT40nv/iPrj2tNwVi49f5Q6FTk0T+2jGZFT2wy3Zfft/DqYq+Rx
+        rg2iAXK3HnuavIzwu93uLMQX1W+hwSPDUXXx7A/xCFYsPpfXi1XH1D6r3arlNs35oaRoxOnZpWPF
+        f9I+fLunervD52S90KXCnnS8xz6kEYUYmZB6bLTmupSNuMHG1DJaUCmnwwaHOCUkqG7FAUu4LqLm
+        Hq8RFSMKj7ninJKwB4gKs5iS2tMpwJOm/7gLYixEVpIEYGZ4ykncGvccPh1UWlJ2fNoTBnMR0ilG
+        obUxP/Ep/yQJajYzxJWd0i/eV6QwZ8b7i2kttIR4sa9n5/vKKAU4YyU7e+Is4V/IC/4tNB3fx6Hw
+        uiEHmnPkMZCyVUmX8JLIZ2GakyRDeeBqTvzffIdhW3hliGEqkJXQ8HDoWChz4o+xwW6GyF9jE/t2
+        Ok5M0wh/F1TfFhrROqJMUGWlqkuZnVMjZplktaKYGaJaUWU5peTwjEixRXybGkpZk1VZLbIvRk4/
+        wY/n2bYRP1auyWrKvOKQU1KryoqZwMi3TeZ4OKGLck2U1amq/ijJP2RZlLUf8ZO+dkjnvQ0BH1OG
+        QlYIyib6LlTYRhii0/82IlW1Ipeqvx2Rilz5WxGpwO9UjcPx9yKSRiARGV5ng0a7NRy2dCmHpfZU
+        IYQ29jx8IfDQ8M+ObVQH9YsFRinuwoFFDLbBiIVXRw6mjACxjSGBs+gicRXPL114iSmlwXJZRA3X
+        2V+nSaELAc40xJB0GbNTgA3qeIGLYffWZ9zCOYu+xiQODzJ0F8HJEsFmS9UHRS7B8XNFdJf4a/5R
+        VJTKg6KpcAZmoC5l02xAY31iBjhc0eSULQCxUoHIQOteJSod6h46mmHk+xAVnidFhRTeoboHilZA
+        6jHtFtR9jG3ITQDpjUKclECynK/wlByFKNbDHO2CcEK8BRJ6yLcwX/0dqgeEsqRiRrNaXZGhFK7I
+        RXxtBzIGZPPTM+QH+Sq6eVynoJnJzHw3ydNuMJ2SKAR6Mjk+QkIxZZCWPHzh8OPxyHDoI1eYAlF4
+        RFAMoH6ZBy9kqI0o9R52hp1JY9QczOAqksEpJaEDRehAJ9lC7uDM2dNig8Dko5RJyhzb3wVF+b8I
+        TkkuKfLvC46i3AnOXzV1XNIBIW5Su+lhe4PFhe46XnxIJfWUG/5CxxTld5U9qQW+OrFf7kCtpUBq
+        gcuOQ52lm9bPLchZmWDw0gJVuOjgtJU6ZaB+36HFtov/8uQp8kNJFsZDXcowbt5sPA/Oe1UtJenJ
+        Y/yB10KxojCEC/8p+3S5HNhw0BegjLGCaw0J4flyjpOCGcuPvCUOjVo5z0rBjBW4yMI0vs/fQjkO
+        dLhJT96SuFIeBnXhqPHPvHsGZ6hReIWJwxQrdSrRAdxrMLyaxGc3WlLiRlAFFO0h6FxAbkF9mdQI
+        gf42hvBKUJePP83BYvuh+o31wcITub1WyG65c1qbWl97be5ng2oVLctkN4s+g5r56DiVl3p33p2S
+        xkvXeZxFWnM3azS3x/FMY5/bzpuiyJ9ltKfbz2BrdUwLR4v+TG6yY2VTNt0FPVRNcd9TnXNdHbMD
+        nU3eRXvqllpnszNpb8b2R98Z+wfx5/L49KI8rnfnSYAa4+OsWxlZ0Wt93jODiXbc98NIG+FZfRj6
+        Ddej/bIIrwe53cGd0Fs6PjRVLYnEdRi3H2gD5DJtPj7QfeLzj+aN5xeGHDnu6SQNhlYpsjNLng56
+        ukHhGhu37Kshx06T/fX8BaPO69NMiwV6GE7pOyxuZAukCq2zMkn66gbMFRZvoQawbqA8J+5gqYBk
+        2hGiAzjAm946IhFNNVCBK9yXhoTOCEPuDTOP6bdBz4X6JsC5sH4RzGIIpXw75fqM73c8abWvHjnZ
+        yyOJko1DDOkJ4RUkXhaEs+h1UbsM4QULbSE6b154aHX30XbF6LzXnJDo5/mMnnpnZRZafbXeOVMN
+        +vM4NKvn5lP3pWfvD1FgtZ/Debe53vq78tCcO9vpuVSbzzR1NUaPb+NOafwKZevOJh/FpaSdIhU0
+        RSrqjYV808VoD7UBW3FxeqbdwzpsDO6jcF25fgNxRTzMNsTOAUnonp4fn+FgLWB5CmVcxIpQxuDv
+        lcR1scWEVUg8Aa7RQnLFyDml14XLMCvMK8TD8Abx762qUWWi9ZbWsDo6OIvd6VzqVhSidcUaDXq7
+        Yb3xvtuO99r5fSMuTurxNXh9VmjkDtajcUU9LKohnpx3NUzEpTud7cZmI6qsO8fjqbWpPp83RN0O
+        Ve38c28Hx8Zouu+oK7P99Nw9HQOEldH2I7fuNDnZOM6OxXebp/Gk3YVauk+H9N++DPsPYdEuYlET
+        AAA=
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1997']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:19 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGJhbmRfdG9rZW4+TTAtLTkweEhfTFpqWTJuQWd3Y2VSMEZnMW9x
+      YnFpRWg4SzdTRHZWTDY2YWI0b3FWdWtwOF9CaWk1UTlJV0lUb0FRSWlCVnU3RHFWQURqeFBWN3Rr
+      akdVMTEwazRhdnNqa3BqY0dfY2V1WktWMER0eDVoNF9sWnN3Nl8tdkoyaXo5MlB0d3NWUlgtZFRs
+      M0V6X0dSRmhQZFlLaVBudy1IYnhDUTFCZ3F6UnBhQVB4Vkk1TmN1UzlXSl9wUjd4dktydTdOZVY5
+      TXJuQWxtc0s0LVo8L2JhbmRfdG9rZW4+PGNyeXB0b19ibG9jaz5FMC0tWFc2c1VJYTAyaFBzX25C
+      RU5JdGhGTUZETm0zOXpHZjRWMXNKZHBYOTB6VlFkY2o4cXhvR1B1aTM3S3F0V2dGS1RNUUpYWXVL
+      UDhDTVY0M09ZM0c1MHJfeUZ4X3VveUZfcmo0bFV6U0xXMm9CVzdMdUxhbGptdENSUU5lWGRGR1ot
+      UTJuRWFMQnRldTZaT25NZU5udGktTzRnWmZHXzdrNkk2Y2xEX1d3MzE3b2lKZDN4NW5DN1luZEoy
+      bXF3a1JnWjwvY3J5cHRvX2Jsb2NrPjxub19vZl90aWNrZXRzPjE8L25vX29mX3RpY2tldHM+PHVz
+      ZXJfaWQ+ZGVtbzwvdXNlcl9pZD48ZGVzcGF0Y2hfdG9rZW4+VV8tLUpmNnU1UjdKYmNNNk53aVpx
+      eXozSTUxbzdJLThzcEpxTTlBWHFqUHY3elhoLVp5MnhTcFNPMXN1bExnTlA1MndaNnJlUnpxOGVv
+      LWJsVFZxUF9BdTVnR3h4eUVoNk96aG8yak0yN3pIdmRweEFOVHZHMmZfRkNPSXl4cGFlMU5qWTwv
+      ZGVzcGF0Y2hfdG9rZW4+PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjwvZGlzY291bnRfb3B0aW9ucz4=
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['740']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1ZWZOiShZ+n19BdEzMU9MCbtjD5Yb7UuIuLi9EAimgLEomKv76SRYFreptbt+3
+        W1FRkt/5ziHz5FkyLeHPq2NTZ+gjy3P/+MR+YT5R0NU83XKNPz4tFx2a//Sn+C9Bt5DmBS5WvCMm
+        TKT4EAU2FgUUqLrnAMtVAgR9xUKKCnTR9YTCxxIBnqFL9IAPgULeA8X2Sihko0SgQ6SJbTKt8GJC
+        H6aEGBU0C4cJ1wZIOUMDIDpAQiHDE0rMHgJEyREllacmiCZKPxIVgLEPtHhphJnhKSdWq7/nJObI
+        0uJ1JmZDSMTPkIAg8DVTOcAw/6YCcVImiFyZ0u/aD+TJZsb7hlkNqMRf+GPryboyyhOcseKVNRMW
+        9R/gHP9LtSzXhT41N70LyikmPihksyrc3RsFjJ/uSbxDeeAhjvWXroWhTs0xwBBR3o6qO9C3NJAp
+        Ja/RiVzxgWtABbp6Oo5FiwB+pjhXp+qBESBMcQxbEQqZPKEGWFO83Q5BLNJcmWOYlJLDMyKCmufq
+        SGRLVYZjuGf2XZjQQ/LjOLouRq9leIZLmQ+c7KnHVxhWiWHg6gq2HBjTaYanGW7BcV+LzFeGoZnq
+        1+hNHyukdl9dkIwRBj5+cooZfKbK2KQkEP5ej1S4MlOs/LRHykz5lzxSJr8LLnLHr3kk9UBcZJI4
+        G9Y7bUlqC4UclsrTCkF1oOPAOyFxTfJs6WJlWLtLrHv1UmxSHT0RmxBg/6GYgCnjCLApFogybQN6
+        F9kv3HmxKKWR6eIAibZ1fphJoTuBFFGAQeE+xuERishyjjYkq9cOUQrnJIIBvcg9QBRsgC0ckMUW
+        K19YplgSCg9EsD3XSB5pli1/YascS8QPUChkZkxSY11POUJ/h+Ky/gRElYoUGZK6jxKVDgUHXBU/
+        cF3ilWSfWI5s4TtUcEhFe0JqEe0VFFwIdbI3R7K9gQ/jEIin8xGekgMfRPUwR7sjCSFaguc7wNVg
+        Mvt3qHD0EI4jZiTzNZYhofBA7sWXdEYckZWDIzJfmEfRzeMCIjUztpysJn7bCyYgL/AJPTYOr2RD
+        IcJkW/LwnZO0xyuGvgtsakGIVAOQYCDVL9NIApnERpBqS12pO6uPWkNZKOTglBLTCYXqkkzSqVzj
+        zMnTYCOOyXspKykrqH+mWPZvKThFpsgyP19wWPZdwflWUkchffQ8O47dtNm+YFGg25YTNak4nnLD
+        H9Qxlv3Zyh7HQjI7+q3UJbGWAqmEHHYsZKl2Gj+vYMLKCkYSWqQq3Ovgop0qZaDwPkOf0y76m2we
+        y3wpMtREEgoZlohN03FIv+e4Yrw9eSx54SNQND88Yk9RbU87iAeOpmELjK3FvjQaal1GXs8bfbbt
+        2q3FbVUfoR5XuprLE15N16He0FZN4srKCsD9asB7/WB8PM97i7DmVabX5hjUN7eOsh/uKkWvwwTy
+        qN73jyde6uL91ZTWvUCpn5ar1tieB3y17KoMh53TxOjSN7TU9utw0C1VPXPnsUPQm9TkcUOvdNpW
+        ebNRlzLt1LfNeq9TD/D55IWNE7tZXAYD0xjxHZve9M431VxtkYPR4TqZnFZ6WG3WimG3VNsi31I2
+        vYAcXmfuzR7KJ93g5HU1oOdjy+DW59nmML5tO5WK3Lk2T7LWo/EykNndQR5aLbXcqKnTowLNuV0a
+        2qpaDpSgP6Tru6Ba8XxpW5melcFaCfU92kEGrmx1w55rtz7gsRMCTVkRf1+a+nIEABiV9FBek/nN
+        ZkzRmNXc2pt87qiHS7derl174ap2PcxGRXisMDS9Jeeu/F4Jqg1c0myU7B7g2mEShx+LBC3wfXKT
+        yD3dD4I6Mf4EZYwdOcJ6Pok1JsdJwYzlBo4KfZEv5VkpmLGONtAgCcscJ4VyHFLNFRQ6qmcX8jDp
+        JAkq/juvnsEZKj7uRih7JMUBYTGqVU+AQBqnt1MyhSJpOi/Qwwa5CqnIswNSIxA4k5RM2ssrSM7R
+        jmq5pBDxsfwxzCYTO7neGi5y80kc/xgmFxydXOmoqG3pwNcp0ixhTiMt4T9Y4WOIPdKPxCiYgnFx
+        NLUBEwwQsnl37i9cpn5BrtuoF4cDdTpUyq3Tfnl4u/YWVrF0G9Fqba82ORO151OZxdC4VsH50A/g
+        zJKOt56xPau3cIvZLl/vMQY42JPt1NUGS23trC/20jxI6u04lxa6sQuZ1c5QtLe3vdSv9qoHsGv3
+        mpK82BjQYC/umJcXgdzcSqU1LXmN/nLYY7k32ekt6DgJXlaTW1102sqvPjl+kXJMWhgJw7RHJAOy
+        7W7yqLxs1geCHDlqPUdyC4JitfzMziR5Omn7JvANKL6yH4IcOzk9Kh/bfxIKSWop4AwsG0SthrTW
+        d1jUbzTSUYGRxWtc/l9AITaqqFHfSwKTsF6gPCcKu8ITkrU4H1yIgostI/AClLZqltw0PhTEdOxh
+        YL8w85jw6vScq18cnHPrB858dmEhy+r/O7+r7Pfye9VujDudn8rwC1SpeJ9/S4q3SYr7gdmieacI
+        p7wrn91wE6gc373yLXjbaxPXlquzRmgGvcHuNOvjozJ15Nu+UevPrbY8ldaN2nU1aW5IT7+NOwej
+        tJMPzX675dKyN2mObohuTYs9pVxWe8puwNobYGB7VYHapnJpb8ctWrtKWlm9TGvbg7KquZJOujFX
+        c1BvsNSlNcsowUEvHTqHljfD0mgAqma/XuLkboP2rvrF75k/THX2L6R6sm8/m+oV/pdSvfirqf5q
+        /59Ufzjlw1Qvfi/VE73fn+qV8vdSvTHvzn6Q6I0AEU2EKMP3guNva+XcRJo0urcNV1ttd62K1FU7
+        jh6+9fHlwJ7sA1ZqFlTftMt6jtrNSVuhw66G4GU7gCV/6xne4ozAGO+Xw/NWlv3SBDt+5W3RmXQM
+        +8ZzF9ycAdRWLnN06kzGJ2bSWHv8eL+1Znse0Tea6Q77++VyEE7xsayh8fAi6RLTaHRPHeeG1lWV
+        HYej5bxe1BwDrvTpEWpvClB+opVzfyG/K+Vfym/m723lr/b/ye+HU369lSd638zvxyNKvkTIUtL0
+        rOim8fgq4Z0kF28v/1L5Hy7T1raTGQAA
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2304']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:20 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcj48Y3J5cHRvX2Jsb2NrPmsyLS1lRGFPaVRqNE5MY0cwVlhTQkkxRW5sRFR6
+      V0FOc0gyNHhoVXF0V1FYeWRCY1dDMTFUNldhZWpXSjhvSXVPcHZTSFR5OW82UXhDT2FBWXpGX2pM
+      ZjYzb0YwdVZOQUlycHE4TUd0anhoTVhIdV9BcVVXRE9sU3U4NzVuYjAydG1xUGdHLXpzVWNqWHlK
+      RzQ3b2hmbzFMYUhQOVZPQmQ2RkVpNVlZYlVWLW1BWkNBSEZBdXR2cW95QnExWVR3SkpoZ044Rmwt
+      WUh2emJoV1pzbXRza3hQUHFXZHk3QzkzeUc0OVpzcmlfWUh1ZWFfUm56bExWcWRnMlZYN3UtU09p
+      ZzJYdlJZa096WkY2NlZGeENxVmNILXRVdVYxZmtWTGlEYjVCOWJRcF9laFNsNExsYmI1dV91SUwt
+      QWZ1NzZvck1aNlF2X0pYX3lkanNmZTBlV2xiWTF2OXpJYTh0bXlhY19Xcnlwd0NkVU5hYWFONGR5
+      Vlh4UFBSUjAzZ1I5bjlLVnZGYmt3R0E1OXhIeVc5eGtSTjNlcDYwLS1aPC9jcnlwdG9fYmxvY2s+
+      PGRlc3BhdGNoX3Rva2VuPlVfLS1KZjZ1NVI3SmJjTTZOd2lacXl6M0k1MW83SS04c3BKcU05QVhx
+      alB2N3pYaC1aeTJ4U3BTTzFzdWxMZ05QNTJ3WjZyZVJ6cThlby1ibFRWcVBfQXU1Z0d4eHlFaDZP
+      emhvMmpNMjd6SHZkcHhBTlR2RzJmX0ZDT0l5eHBhZTFOalk8L2Rlc3BhdGNoX3Rva2VuPjx1c2Vy
+      X2lkPmRlbW88L3VzZXJfaWQ+PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjxkaXNjb3VudF90b2tlbj42
+      MC0tdU8zTlFsYTB1SnNzbDhuU3JUbjBBd3NubkJBM0xKYlFMXzVEcWpVa0t4SFRpMzR6Ti1iOWpi
+      QzJoc0VTUVYxdGVneDdhdmtJdWVSaU1wekhnWnZienladDFHOEFIMGdha2xQWlFuY0pVY1htWHds
+      VWhrTWJ6cFNNVGRnZnkwV2ZnX2NLS2pNSTdIN2thZkVIQ01WVFlnZWcxd25POFZUdVZDWk00WC1N
+      b0JJVUxIMTJLVm1IVC0tLVo8L2Rpc2NvdW50X3Rva2VuPjwvY3JlYXRlX29yZGVyPg==
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['904']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VYa3PiOhL9vr/CNbW1n8bxg2dmfX0LhkcmPAIJAyRfXH4I48SywJIJ5tfftiWw
+        TXJrZ2p3U6mATp+WpVb3aTnGn0ccSgcU04BEf3zRbtQvEopc4gWR/8eXn4uB3P7yp/kPw42RzZBF
+        Yg/FVoxoEjLToInjEWwHkZVQgANqObZnRsRQPrcYbhLHMHtafLPgUchMqGcoVahgbGyXkdjUVLXE
+        EWDBihLsoNhs18ssARasXWi7iJp6iSOgEodQZtEUOyRUynCMBGr+s+xewAUKbnG6Y8RyQuK+ma4l
+        y03Zoa+rh9fw0Y+RTHvO/ePtQ9fdtLej5nH/NN0M2fRp1p05TS1U007g7AYL/3FeG3kvP069gPqn
+        PaO33vLuZze20iAIf/g6qbdX0QE9Pz0snXU4pEsy2696q/eW48w1tLxbDnayG2un4CVF9sr1l4N9
+        5xT35GdYaXl9Bj9WRt5QZLqaLNt+Ko8i1Z2z2jh6eVruJ/Epxd/99+YsGuDxpH9Mxz9O6iw9RovO
+        ZBX0t8/Nt/vmaD/dtobd1wWejzraOmztNfX07OmtetLue91nrzVfNd+n8mF1WK/fcL+h3vf7c8Zc
+        u/7cpY0Dbr5qYzS/G3ba6FXDzX3HPq2tw8+ZOgyx371/SI9TvK8/3j9OEdnP79IdbrfrzdFqP2tY
+        Dn5zHfp4bCekO1otppOn8HX/koy9Oe6+NLqz2eBOG422qIbeX/YD6stLv/f0/NqT1+vJSKVLzLSD
+        myJrYLnL2qTVpzN9G3V7t0TVbL89urP2azZ4xkt3oa4x26fh7j35cXib3J8a+PbFdw6qLL8YSjmU
+        PK6m4SG6s5m7teCLa34nYYhcJm1igiW2RVB9UYIMpcoqnDBiW+KVgLw+vj90H0o+vGZKQ8pM9Uat
+        MAD6L5eSlbXNbKUEsXSHTJfPU3LM4dL4somAuiSJYCUuwU4QIc9s5+u8DC8UvqdOb7yAeSpYQcnX
+        1/FAjSTK7MizY0+KQahKHnwLEbHIxqIgYtTUDKU8FDYWuG+obD0DRkbbxYGLzFYjW2oxBgWM3a0d
+        +8jklsuwWIBpIIgqfNggoXz9/ZWhFCNuyJfZByFO37coRoLAF+8GTKhiaFPrgHybygmFmF1wTsnZ
+        Y5tKy4wi7GIK8KTig7vYjMUgoiD7GbPABYdH9iOHTweCnqs7nzZFYK5CWdAgFtYbSstPUvLonQ1Z
+        AxH0s/cFqcxZ8P5mWtd2IF7s89n5vgpKBS5YvCI4S/qXjXf/lnpBFKFYetqSd1py5DFQilUp5/Bm
+        Bx5fmlqW1SXgYs79f0YBQ570xCBdqUQ2UgcjSCq7cBLFl/Xd2I58ZKHIE+PctEjQV0mPPKmT+All
+        kq5qTci7i51TE+ZCNm8oYqasN/Ssi17jBZEil0QeFEG9peqqXmWfjZyewg/Gnmdmj1Xbqi6YFxzO
+        lLSbqmblMBQnVBRGOV1W27KqL3T9W039pqqy2vqWPelzBzHvdQj4GKo+ZpWgbJOvUoNtpYmd/m8j
+        0tQbaq35yxFpqI3fikgDfhd6Fo7fi4iIQC4yPM/GnUF/MukbSgkTdqEQ0gBhjM4EHhr+PfDM5vj2
+        bIGRwEO4DxITWoTN4osjBwUDdH5rKuAsh7a8yeZXzrzcJGiwXJZQMwwOl2kEdCZcegwf552EBngX
+        IiHJZz/eY3xEsvDYphHaLGAJbLbWvNHUWt1QLogRksjnX2VNa9xoLR10vgANpZhmCxoLHWCH4g3N
+        L7MVIFOqrAFApzpLlBga2D5acRJFEBV+TpoOR/gBNTAoWgW5zWjXoBEh5MHZ7OB4E7hkZkeeL+cz
+        XJAT6H2ghyXaGeGEbAskxnYEvStf/QfUyG6/ecZMl+1bTYVUuCBn8YXOxjKy9Yb5HeMT3KCgmfnM
+        fDf5064wgxLol4gnKDrCgSLK4FjK8JnD2+ORoTiyQ2kBRKlrQzKA+hUePJHzOwz3ngwnw8fOtDde
+        GkoJFpScDhRpCJXkSaXGWbKLZPuFAgI5x+c3jqx0S0OjEuJCj1bI+ypp2v9FrWpqDV6ZflmtNO2D
+        Wv2dImT1sCMkFPen/GivsKxKwgBnHS5PxtLwP4igpv1qW8gTia9OHtWHkKgCEBa4KQU0cEKRfNcg
+        ZxVqw/MSJOUsoou+cCpA42N5V2s2+8sPT1Nvaqo0mxhKgXHzdosxXBZ0vZYfTxnjDyxqMbtkwpsz
+        bJnfhcF+BZU52TOUClLsLjsWeG/fJ4heBDciFwh5/Fp7TTG44pZCMHvsD7JFX8EVYr7ZWYw2CF6H
+        PSmbGEJU9RIBIcwOratXgStQkK5u8B/BCq90m/8MFtzrm/01eqZVb/nX4O/JiXgnVD77j8pfSB2H
+        3I4RAAA=
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1772']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:20 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PHN0YXJ0X3Nlc3Npb24+PHVzZXJfaWQ+ZGVtbzwvdXNlcl9pZD48dXNlcl9wYXNzd2Q+ZGVtb3Bh
+      c3M8L3VzZXJfcGFzc3dkPjwvc3RhcnRfc2Vzc2lvbj4=
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['89']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA21SXW/aMBR9369AvHuhTGIgua7GECtjgg4atvFi+eMmNSR2ajsM+utnB7ouGi+J
+        r8+x7rnnXHx3LIvOAaxTRt92b973uh3Qwkil89tu+jhFw+4deYedZ9ZTBy7yqAVXF55gV3NpSqY0
+        rR1YqhzlTBJtcHIdwcKeKm8oL4zYk5QiNEDc7X4sd8Uqt4DchH9djZZjkQ2f5oPj83qRffGL9cP4
+        gQ9uit7pk+LV9DFfff8wl9vZy0S5/OXZu5Hc3Kdju/im5HC72Y6edp/zTTWq7bL/Uez1nOdgit1h
+        uq5m5vBzdhjzdTbo6W3//vcvnLQ0YVtrHWZvZBPMmdiDljS3pq6IhNJQpT1YzQoqgSt/RnDSJmJh
+        Aktf0IRgCRkLjlFhau3tKfwlkHqPk6sAjnb1eWPk5YgthJaalUAmQYV23jIfouikQSdO3tCYlIcy
+        NpfghFVhNpvE61MBJFNHkMgz7kJEzU3MkJ6PzVcilmXoIqvJkf5L/FsGj8IWOINy0GCVuFDb9Ghi
+        6H1eAdn4h5PXKqhuef2fN21PXqs4FUm18iA78/A6rNkbtQHjaFe29Q9od30C6wIAAA==
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['448']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:20 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PHRyb2xsZXlfYWRkX29yZGVyPjxjcnlwdG9fYmxvY2s+VV8tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRnUlEzS2RaSXpEaXNnenF0czlkVkhVQnJO
+      TGlkOFpWWjloakNnVnA5dXJPMjdja25LYmdlb2xqdkZTcElvdlhJdkJiU2Y2MG5aMkh3WTwvY3J5
+      cHRvX2Jsb2NrPjxvcmRlcl90b2tlbj42Mi0tWngwLTFJbnhDdldCSzlmRXRZWEcwOXREZUFyQ0du
+      TFZHd2dxNUhYR004ZXh3VFNEOHEyUUdJRnFvazZDSlhmRl9KNjRMWTR0Qk5jbmJadTc2MFZlaXlF
+      SXRSSXd6OWxEcUlRM1hBcTJBS0VKOXMwZlFpRWxDb0tTdDBUdkVEdmlBRmEyaUQ2TWNNWmctWDRv
+      QUp4ZGhua0tGQlh3ZmRYM25mZUI1MWtJTWEyeFBydGxFOEF6eWRoZTBmaVphems5UnUtb3IzM3F5
+      ZURNTWJ3Mld6eGh2T1FZdE1veFY3eTdUeG1WNUp5QnEzQUJRSk5TOWFtaHZUQmJEQ2o1M1cyeV9t
+      Q2JmOTFhd2FqLVpLczJjQnBfMnhsaVR3YWlNMjBOS3FhdzZTNVZNOG00b1pjbjBzNFVfOWFEVG1H
+      Mmk4UXBXY2pYempZNllWdEZoSWNObGhlcW5YLUdYcmNiVzJHb1o8L29yZGVyX3Rva2VuPjxkZXNj
+      cmliZV90cm9sbGV5IC8+PHVzZXJfaWQ+ZGVtbzwvdXNlcl9pZD48cHV6emxlZD55ZXM8L3B1enps
+      ZWQ+PC90cm9sbGV5X2FkZF9vcmRlcj4=
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['650']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VY2XLqSBJ9n68g7sPMw4wsiZ07anWwGS+A2TG8KLQUIKONqhK2+J35k/6yTqkk
+        tMCNud0z7XDY0smTVZVZWZlZkn79sq3SGWFius4v38QH4VsJObprmM7+l2/LxSPX/Par/DeJYtey
+        UKCohqG42EBYwYj4FpUl4muGa6umo/gEYJMommrIjivx9yWSjgOPuopmufpR1hWOq3Ma+Vi/fViz
+        PUYc6Wkvs9ZbR981D6/1r9N8vBvQ8XzSmWh10RKCtql5j4v9bFp5NbbPl55J9pcTJS1j9bTsYCUw
+        Tet5X3arzbVzRpv520p7twZk5U5O6976s6FpUxGtnlaPHqdj8WJuA6Su9f3q8dS+4B63kfjc+qTQ
+        YM8lxNQsJAeISHwOuTqGukfkyPUKx1HltKPN4eZY/uQmY/OptqzOp4Y4OiCn2zMGtQDhz4G2Pguz
+        zVzbUkvd4O6upzoz1fQUNDY/4LF9IC+HdqX2YdSmi+eX2X4wtt6f943eevh+mXK1Chl0q4/meXS8
+        LH3zNH45dgJ62jp1vTzcfwUcev7s69MWVha2s3ndHmtvDj4/NbYNQ7QWRlM1zFdaGc0NI/CHh8eX
+        Dlcr94YeFygf/ZZm+ZfutPxWNTRjUz4tuu7r61PD7ArKhbaXA6WL/W6lhbTatvuiiFPRPVU3uvf+
+        Wf0Uh8qL3l8ZDc/ptBtH/VQdjQZ+q+NazY0uBo35YmXsyeSwmfc6fvujgrwGOl0Cd3z0a0652dOV
+        dr1RW5y1lepsyNtw2xla50V3Ig5O5TWtNN87Z63zPL+sZ+vlBW/JadhZdD/Gu7H4rin13mZbFyvT
+        WXnT2I1OC7wZzDa7yevmYz3ZzNr9CapNB8EXXZKn3mbzrgTTL6XpcX2s2YueJ3DcVuLzm3ndWxbw
+        uus7VBZTVhYO4wQZikmRrTi+rSEcMm/BZExZ0nzHCAOI/S/OcQdNmMT1sY4ANJCMvqhCEaHCVSMr
+        LWgYiOhy/4si7KhWaQFqpY6qg6VG6UY/4ib61KWqBUPamukgQ660HlJ+QVZUIVSuCg+1GzqhBSpM
+        6KlUP8jiDfsqymsQpFIPmzqSK7WbBaXCghJYd1DxHsnVW52rTNJ9jCENBukT8+he8yBB5KCUsVN1
+        6sK+C0KGE4MpKw6EZrmeYSXRcQU8S9URkcsZTgxlOOBFhQS25lp8FsYoRuXf/pPVT/EUlaUoxGQp
+        cTLb+W4YpDot7bBrl+gBQYVwfCTxeVaqZCN6cI0MELmm+9Z5y+gwd2VeIQii3c5D/+NSwqqjUlUe
+        Lxcwf4aXCFIqDTwk62z8DDGCM+9X40wSn8TCUUijP6EwW9u95XABA+XAlBMtvG1AFS0RqjqGio0M
+        mZnluIq7i6KZhGkh+xrLqAlHOCtNAKl4QDJnonAMMpHPp1Yi8HSY2TBS2dL7a0hp1zcmYEkFGojg
+        84Awigls8bpJ40NiuY7hOpx/BGddQSaPqMNIHgtjZUslJP7H+CqmUH4zQCxkfgRh6e+q7f271AWP
+        +uFSMmIJuo+oFWHDRoU8D4XuAi8oR0jO4Ux85LAECducmJeoXZHcYCmvOJ6hOjq6PygzJyHkwJQT
+        2dFRIVppbGivoMAs5dMl8IkTww3FsdujTcgCV3Gkv3SgXhmlV2gAoXtLqfGuYBPiC5q/s4k+FQ9B
+        rQgLVpTy7ookOHNIwaqzRwpUmvg9Gmxx8P9VEqEKzZEHJRISYKksiJAWUwpj+1SHwN4RROVKPZyq
+        iKY0gnQIJTgN1Ua5Uavm2YmQ0QP4sW3DkMNJhZYgxswrDjvtNuuCqEQwHFA4WjaK6JzQ4gRxIba+
+        V4TvgvBPQfweznRfIR636AP2Dicf0xuv1OihNFKD/6c/6uVqoyL8tD9qQu0P+aMGv3/GH7H9Ua5h
+        4Rgm7lm7+9qfSXwGjimRG0YqhUrwWepAs+Kgf5DSGMzBYS+DS4v+fJEoMp+xZ9OQ68+PiQTeYtyC
+        QHdlGE6lYc7IgjEDqsBB5kGZs9m8nBbNyxHOuc7LhW0Yn+hHKrE6WEh9Ilvm+Tp8DCUEVpj45D2q
+        P8S0vbAziZJ5oscqE3v2PYIsC1ZKaM7E/q2J8DR6ErI4f2eMPXIVViAtlZrUB5/XoDyXW3VRrDQk
+        /opKkM337JETHkQBdrhWh04lhSU+HeygEgUKE+SDHYmuhTkgzKZhXYLimaTR+FWy1S8F+44DW8Hi
+        RiyDDTeoZEPWvcMropKDoBc3kAfxBtUhisloPffwmOxjsNl1MrQEYYTQBhfbYRpmy79BpbBJY8Wz
+        K85K1cVY4q9QUiKg5NKQrRxtWYgrdRGXyMGNsuqOmRNNV8CkH1wNcneCn7oM5G4B0e39Xsa/J5Ci
+        9ozNNW/3hv3ZfN0fDucSnxHEpGj4uQodOIYzvIZQJAktLmVxC/Knj37hPpa7ieW2KU2xa2RAVRL/
+        igTcaonVn0/A4m1B+lEmC4+U57pW3BlGsVHAwoNmmXZY26Nwzrz+l7wu/nSdiyKRrY5rCxOI9BiI
+        JUQ5m5kPKUWQsdJsyAIbUl7cfa5ilRSSbs99/syHf9nGNR4qQmkygtv7FWLSw8G2oUcSW6w4ZjE2
+        X3qUw95Z0UJ7WXsP8gKU5YRz8DkkNS3cEzg5Jx+RazVw3CuEDNatFykSKwcZD3SfZ91hP1x2QZCj
+        ssbOA2tKuol1C+UVYm/cu+UXr/fsvXAruQVzvMwN5R4s3b/O39zj717gb27uP5tZ4mvvX5Mx+eTj
+        TvKpKP7OcPMJKYf/oe9N/PVDEv/Db7O/A9pPXdzdFQAA
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2085']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:21 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PHRyb2xsZXlfYWRkX29yZGVyPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRnUlEzS2RaSXpEaXNnenF0czlkVkhVQnJf
+      eWlpbElnMm80OFdudmVZU09WYlhsR3NWb1BxV0RXdzdiYlExZVZIVkZwLWNyMXppWnllYVdjZ1ZG
+      cUF6ckQtWTwvY3J5cHRvX2Jsb2NrPjx0cm9sbGV5X3Rva2VuPjYzLS10X3FmdDhMWWsydy1QTmlI
+      NVU0U1FkMU1oZW5DRGRHNXllcndHYld2MFJZU2JadGxhWXJDZkRhblJhaXBfZU5pamFuUkFoc0po
+      QTM1amQ1UVRJSlJnR05sWElnN0RXTFh6US01M3NHQzRGaXZNa3pVdWlxTkprQnl0cVpuNmMyTGd4
+      eS1lSXdFY1E5cl9UbW5ZS1prNU9ucnZIN1o3ZDFsVGQ4YWRpS3QzTVNkZHl1TGhGSkItNTJETHAt
+      eV9qRTlibHV6Q1EyTzRkYmRZMnFUQ29LS0g3aUMwX3p0QVVHX0NydUMzOWViNVpDSl8xUTFvcTRZ
+      Y3BYdzR3MUxfSmNFVmQ3cG5CQTdrY3E0TU1HdTlCb2w4WWMxeTdTVFZkZ3NQaFlTREJ1QWozZXA3
+      ZXF6eW9Oa3U1bjI4RGNfQTY3NVR2YlZhbllzT0xaQkxsdlRDUDFHcTJXdDM4WEJ2YkJJU3pXUldV
+      enJac3FMQlRDak5mTjFYYl82RFlaNjEzUVIyWTdmTXFUcllHUllmUEtZaldQWVJBRVBlNVFHeXh0
+      VXNIRFlZWF95UXhfOHAtRXJibVREcDAtLVo8L3Ryb2xsZXlfdG9rZW4+PG9yZGVyX3Rva2VuPmMx
+      LS1hZ3ktS24wY1F0M0xuWlNWcU1yenltQ2d3NlBuRm1MTUV4eUxJejBQeXhuVEFNV2lFaFk2a0o2
+      S3FOaDdHQmpUbVFLQTFYbDdxMTB6WWQyNzR1OEVkQllkN1FXNndOLXZXdlhYa21FNTBKRUVRdHRj
+      YTRZQnM1dm02ajFMZVFIR0E4ZWoxbTZxQWF6WF92VVAwR2xtZ0JKT3l4Tm1xNFJKUk5lb3FRSHlw
+      bTg4NDZLV3FQNV9ibWtjYnNSeDh1b0JLV1ROTVNsanFadUxkUW1CWjVCUFBGSDFLS2hlM2V3WnFG
+      c2ctVmdEU1lqRC1YWE1LMHNWbXQxdmN5ZV9GX2NWM003RXNQMmhuQkQ5bzAxYWc4S0hfcVh0Rllt
+      VmNUMFhtdHF5bHB3dUl2a01KejVtOVpnYnYwLS1aPC9vcmRlcl90b2tlbj48ZGVzY3JpYmVfdHJv
+      bGxleSAvPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjwvdHJv
+      bGxleV9hZGRfb3JkZXI+
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['1098']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA9Va23LiSBJ9369QdGzsPuzISOI+q9GEuBiwuRkwGF4UuhQgowuoJAz+nf2T/bJN
+        qSR0Adu4uz0z2+Foo1MnS6pUVmbWMfzvB9Og9sjBum399o29Yb5RyFJtTbdWv317nNzSlW+/C3/j
+        Xcc2DHSUZE2TbEdDjuQg7BmuwGNP0WxT1i3JwwDrWFJkTbBsPnd5hFed49a1JcWw1Y2gSjRdohX8
+        PBs8G6OVg2jcUO5G1UFNXVbW96XDbtxfttz+eFgbKiXWYI6irmxvJ6vRQ/5eW3ReGzpeve5cXNWm
+        7ceaIx113eisOLtQmVl7NB8PpsqT0cJTe7ibNWYvZUV5YNG0Pb3d0qrDvuqLI5Jn6mp6uxNfnQY9
+        53Op5+P9BW9tjHXFQMIRYT6XQk6Oce0NsoRegab1w6E74w67+biLR69mp2VPam3Vkuq9FduvcfPF
+        ZqHtxNakMVCOvQ43kQfLscLJ/alyV9k83KE99/K4qrgSazw7HmKfFq2nRkfE6GXXc/D4YaZtSqhr
+        qIVly+JYb+Wynj3VR+OZN/AWJeZWwXK7VdqNGsVt7WU4cegmY8o7s7hHHo0PGzS297edfCNfmy0W
+        xfZi9LqXO7v11n5e5SvifM6Iu91rrYrUVnu21Iu3zcKIvRuo7FNr9VJtcBvzxWt0lEp+Wdi8mqXh
+        qJpfOcWK0j6oD8siqitqJy/qUrvbf563W02D3mjey325PK9iufcoliWNhtfXrC2dWrEv6oMKXepM
+        x/NZkWVr2nrHaUozr89b4uuquVw91VX20Wx1HXvl2aP5cqIfjKd1/eleOtg6fmw9Y5cxufLixbg3
+        7KrcneCHiZc3bxFbGzaG00OjM8G90Z1YKIjiXVPcveZdb1eY7w4Dp/taLh674529f7zfVBvy2Kwd
+        aXtitueGOX7cNUxXHz+sFoW7UblTfzZqO8ksqs/N8fp5WHcHdlnb7/aDqvNMy8OS3VxOFvv7ti5a
+        o764OG63NbliPFb7leGsv3kdastef3CHvFKVXZfb2wWfSwfNKYbIxlJtz3IFLmYlYT8ekSbpLjIl
+        yzMV5PjMczCaU+AVz9L8QCW/U5OxfO4CGjGx7TkqAlBDAjq4kovA3SeL5GjGQkNYFZoHFzmWbFAT
+        MKNqsgor1agz+4Ab2bu2KxswpanoFtKEfPUm5mfGsibYFQrMTfGMjt0MFW64lV11LbBn7NNQ2gIj
+        2d06uoqEfPHsgeLBjBGsbi07KyQUzm1OY7zqOQ6k22P8iXh0pWwhEaWgmLGUVdd2BJZhEpwQjFlh
+        IFS4UoIVRccJ2BqyirAfQ1kowQEvSvhoKraRS8IOClHhv/9J2sd4jAp8EGICHzmZvPm6H6SqSy0d
+        26TcNYJKZHmIz6VZsZGJ3LWtJYDANfVBbZCwIe5KXEIQBG87Df3go/jVTXZlof84gfsneNFATHWP
+        WySoZP4EMYAT16fF6TjciZmtEEd/RCFrFRuP3QlMlAJjTvDgogbVmsKubGmyoyXIZFmWLdnLIJqx
+        nxaSl+GYq8MWTo5GAJ/dIIk9kdkGicjPxatE4Gk/szlIJo/enEFKO12RAZJUoFE5vqyRg0ICeXhV
+        d8NNYtiWZlu0twFnnUAyHlC7wXg4GBobMsbhL8KXHRfKfAIIB4kfYZD6h2xu/03VwaOe/yiJYR66
+        nKDlIdMGDUMa8t0FXpA2kJz9O+UCh0WI306FvMjshKQmi3nZ+TTZUtHlSclyIkIKjDnBOmoyRKsb
+        LrSRMSArzcWPkIuc6L9QJ3R78BKSwGk4sH+0oF5p1D00mtAlxtTwrTg6xBc0mXsdvUhbBLXCL1hB
+        yrs4xMOeQ5IjWyskQaUJr4PJJmvvF4qFKjRGWyiRkAApjmEhLcYUwvZcFQJ7iZEr5Ev+rbJoTMNI
+        hVCC3VAoc+ViIc2OBgn9CP9MU9ME/6ZMlWFD5gmHN21XSgwrBTBsUNhaJgroNFOlGXbCVn/NM78y
+        zL8Y9lf/TpcNwnmzPiDXsPMd98wrRXdN9eTjz/RHiSuU88zV/igyxU/5owg/3+OPcP1BriHh6Cfu
+        kVi/b474XAIOKYEberILleCFqkGzYqF/YqoPy3H8XsahJs3xJDIkPiOfdU0odW6jEbgKcQMC3RZg
+        Otn1c0YSDBlQBdZCDoxpk9yXVoL70pi2Tvel/TYsF9kHJqE5rND1sGDo+9P0IRQRSGHKRddB/cG6
+        ufU7kyCZR3akMpHP3hYjw4AnxW5qic3zJcKnXptJ4rkLc6yQLZECaciu7nrg8yKUZ65aYtl8mc+d
+        UB6y+Yp8pJkbloE3XCxBpxLDfC6ebC1jCQoT5IMlDo6fKcDPpn5dguIZpdHwkjflg+R4lgWvgsQN
+        y8EazlDehKx7gZdFeQtBL66hLcQbVIcgJoPnuYSHZM+BNdtWghYhhOCvwXZMPw2Txz9Deb9JI8Wz
+        zo6owqTP505QVCKg5Lo+W9qYAhNW6izO47UdZNUlWU5wuwzGv3E0SJ0JrjoMpE4BgUpwKeNfGuCD
+        9ozcayw2uk04ATe73TGfSwyEpGD6sQwduAN7eAahiCNaWMrCFuS7t37y6AX5PXUSS72mOMXOkAZV
+        if2KBFytsoXrEzB7XpDeymT+ltrathF2hkFsZDB/oxm66df2IJwTlx/kdfbqOhdEInk6WmSGEOkh
+        EI5gaa8nBJssSFhxNiSBDSkv7D6noUkM8ef7Pr3n/f/Jiyvf5Blq2IPT+wkio+u1aUKPxFZJcUxi
+        5H7xVvZ7Z0nx10vaexjPQEmOf49cComX5r8T2Dk7D+FTNbDsE4Q00q1nKTwpBwkP1DujerfpP3Zm
+        IEUljd0WVkOpuqMaKG0QeuPSKT97vCfXmVPJOZjiJU4ol2D+8nH+7Bx/8QB/dnK/NrOEx96vyZi5
+        tLjzk0Qe9gdFnjP790SeCvMpkeci/W2R55z9ochT/h6R54LNxyKPh7WfJfIUmK8Xef7+V9d4gpf9
+        FRpP7qdqOSSE39ZyPinlUNApoi/Sc8pv6znFP0bPgeZij1Yypj38lqQjY2rqUz5SdVwX2je/qX5H
+        3DnnfI+qE8/yU8WdxLSqrIC/3PdUnpjyns5TJ6xI6NEtC2r3GNp9/Hm9B1+j94yhw0CYspeUaCII
+        Kjmr/Lyj43joF4qDAiN6Kw/qzYc9M80VuatlHIZjOO7qrrnCcJ+SLSo0w004jrS3NFP+k2Scz3ik
+        xBWZ/PXC1ncJOZzvjs955FzI6Yq3zV6v+aaK05WpW2Sa6C21plv9AbWmW6UNmV768/8xqswF+SRf
+        umGZfOEN6YRlizdsmWP/OsJJ9a+om/SnlSrLVP9o2YT99CGAzRwCEnpHr9VrjcR+ozt9UwYBCtWC
+        naRRicL5gRZyeQNl/gb9BZrHp7JVnsmzn5Cd31U90hnhq1WPK8vCSfWAlHNfaP1k1aMrTpo/onuw
+        zAfCB8f9Xwofw1Hz9irZY+igJYKDkEb5E4OLrtA+yFHgz9A+ytdpH8WPtI+P08k7AsiP576TABJ9
+        VyY8g599hyaFf+oLN7nTN2lyb34J7n+GQWWhRicAAA==
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2653']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:21 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/BundleTests.test_string_properties.yaml
+++ b/tests/interface_objects/cassettes/BundleTests.test_string_properties.yaml
@@ -1,1051 +1,1019 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48ZXZlbnRfdG9rZW5fbGlzdD42SUY8L2V2ZW50X3Rva2VuX2xpc3Q+PHJl
+      cXVlc3RfbWVkaWE+c3F1YXJlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPmxhbmRzY2Fw
+      ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X29uZTwvcmVxdWVzdF9tZWRp
+      YT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X3R3bzwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRp
+      YT50cmlwbGV0X3RocmVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZm91
+      cjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X2ZpdmU8L3JlcXVlc3RfbWVk
+      aWE+PHJlcXVlc3RfbWVkaWE+bWFycXVlZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5z
+      ZWF0aW5nX3BsYW48L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+c3VwcGxpZXI8L3JlcXVl
+      c3RfbWVkaWE+PHVzZXJfcGFzc3dkPmRlbW9wYXNzPC91c2VyX3Bhc3N3ZD48dXNlcl9pZD5kZW1v
+      PC91c2VyX2lkPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48cmVxdWVzdF9jdXN0b21fZmllbGRzIC8+
+      PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:28 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['778']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:28 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['365']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:28 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['449']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:28 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['1148']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:29 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order><crypto_block>E7--NuwIhns8SF9pSFmOCtayGoPi5orsAykdVtQtCufnKnVXd5ijHtnqR7hewEY9Siu9mKWZXgSi50wUnsm6QPTTn5Ap3rEh2y8qt7LQOigLgEgeiLH4ylijiJOz3cCcGHfmz-mr55XI7fNrF6K5mYhYQ3qn1nCceIO3_pGh-y2ODATK_1unwgfaRcvmf9rRBGVuoIht5KuL4JvyIf1HGwjOVpnEZgHPJm7kxU7hRzZCGSznxEZHloNsR7I2pTbq40t7v2mLo1javANm8iUGKktt-5o16BpnLLteyP0yqrtW48EZlb91SwCaca-PJX0S8BvzKCatNcVD_hETlolGxPekOoYcRxyhOS0oqh4PNL4fG5MfxXXjHxpdCbQvBrDibivFS6vhbjmFeBcQYWikaldIWXGQFooHSH2dWMs_BXrsAz6-j8VMn40F2LZish9H3g6jBjVkrnayZ4NMPTq5FtXcdK_5L7WFk2ASLauJCqJowO_bV8X2sPX_At8097h3QpXw1Kh0OkgxfUXvzDHbFI_bN0XSMiJ0al9y_p-VXab83-6hG9eHDURd6DtENaA6ZdPR1b2kCR_toknr_BpFKcDNzxpBDj9-GWfRRbpiCUM9rPYDDkijx5sFQiucuV4RNL_xRMwwjtm79e8Q_Ffs_Rbj0MXC_rEfuYOIlmhROtFCXJpXG4CNo46bV1NKHU8emAOPjTy5eN5yHKnfgvMsrKq0Ix6-yFmDNxXSz4pazVchj_p8eOwdiIe_aY0Ybh9RJBrav76RZUsxDdWqMKRqoWJyL_--Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>k0--5q_Eg4_-x1Nz1FPUkY_jXomw7H7E1_PjxiUKNYUK3emm0ERjusgvnWUYFQqZHjDGEekx61hC9iIriru1LpexlQdiFWf9oohhZR3m54tmVkLEMIItGP0eGhqQULniBgRbrSIgFusujEyS0Rw91TvO3pqX8rgNeFy0FDAL-H3GFetfBUfLnD1Zi-94KcFBeU0CKwDSXAHtxFWU5WZiFJ-wMeIriNlK_uoAMR58EAI8VqC-Z</discount_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></create_order>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['1384']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61Y23arNhB971e456UPLQGM7eCzKF2O7cSJr8eX2M4LC4NsEwMiSPj2O/2TflkH
-        JAw47urpJQ8J2rMljUaaPVK0346eW9qjkDjY//WLfCd9KSHfwrbjb379Mps+CuqX3/QfNCtEJkUG
-        Dm0UGiEikUt1jUQrG3um4xsRAdghxsq09RMimnjbpFlRGMLwp+zLgLmQvlkFmliEMsbatCgOdVmS
-        chwOZiw/8lYo1NVyLcfiYMYKXNNCRC/nOBzKcTChBjl5K+yKeThEHNX/+D3fP8MzFPqFp4BiY+Vi
-        a6fPDEHY74J1fdesB7PqcCVsQry2Zfp0sAaj5buCLPKutJZy7f3bbigt535r7027WzJrrduLozVr
-        dk4fS7e36ODFYycc7pzm49ZS3pUK8YYtuTYvnxfl1+FUmPq78NR4f1EHctUZHdQP1HHnZ9I9P66X
-        4F3eJ41tJsU75OvtsiBUUadq7KMoaLxvvlmbRefQD6aovqh/bCZueSm5i6Bq4f1hJhNSeZ4vHxrC
-        eKYaG2XUi9Tn7nmDwrOhdFxJUfCz8NpvW+et1Gjuh/35Uq2co6qC5s11Y9NYlPeV+5O6eXMx7TkV
-        ggeDtUqXiO4WH294JAzkrdudvewOb/ZqLjUnR1SbnTyzbb9PFuH5MJSGRms4HlvzoHZ8RuOHD2Oz
-        O1bmUX359jIiw261idqCGTwaPeXQDOyPLpooo5qhfHtr7MevU3v89BBNzhNh0XkJXmsR7ftC1OvK
-        C9MJBpFKW8+NoTto9NWn1pM1Wi7HMJJihB0Htu5bf9h7c04P/frD1vJPvaemOnVmw6k5PE4n87ra
-        wXar1Yx6HyevLffnlve6mGxrxxfyGvlWxaOjxWhwdO+FN03Mh5/tha7ZiAQmtbYGfFh6E7susmhp
-        HWKvRLcI8tSPkCYWWVknD9EttnNAkkjN4cMw14clV65JqC7fVQsMgP6jK3H+m9TUB7MpzJ/jpYaM
-        Sk8B0i02fo6YwLn2ZXEOsXDkg4cW9laOj2y9XL+LpSFtXihsrZPprNUeTGGoApyxEtcnNLKRT0sh
-        yFyOypblYwOvDQISSHRZE/NNbqOOtUN5awpoMS0IHQvp5VrsZtYG/QytrRlukK4klkszc0DXEEQa
-        /pggwMzx9lwTsxYzJG62QcZPhy0KEScw51fOJgqMvelGiGloHtAsh3LBdbFvY8iEHYTyAjJ7MlAv
-        sXMjG9pyTUL4H8aHo2HS2IEcxu1Jl2nRzoaB6pCUCjZcUj+KUBxEiI2xQ6d0BjGJZArGpYhT054X
-        pDBexrsx5M6xye1h2UK4vYBllGQtj6bnuKccia1QzOYV06DF2xvyMCdBzwMXc9J/5jsU2aUuFGWo
-        qhmV70LowGmDqrx30MEIUGjFJ4aVy5smzY5reWj6G2Qg3+Ztvj/RLyVZpdtSI9pEhJbKkgwFNSMw
-        bkQtOORrgqiu1OKJrtGMRpAFBwcyo3IvVytVqcBOjYx+gh/PsyGhYVJJlVXOvOCwuVitSbKRwKZv
-        Q5p5KKELkirI6lSuf1Wkr5L0syR/jWe63YGPex0B1ibUDOmnmJRlCEYDEtf9P0NSk8s1pfLdIamU
-        5X8UkopQlv9NSHgIEulh5zHW8XGj2W2PNTEHc0oShr5JIZEOpQcchT76iZQGsJzQBBkMf0w7sXix
-        b8fWa8+PqQVaHHfhlONMSPIgZ4B7NCK66+wvdg6lBFZkxLSd1BLieIGLuDCn/ViVYd9RQJDrwlSE
-        Fnxsf/bxr3yP8e4sj4s3xt4gbLAi6JrUiQuPXk1K8KWpgRhv2Kcg3cmx6QJoYtZ/axID6g0k9pro
-        PtbEAhBrYVxukH0RQd7UPPNohJHvQ1jZ/stlOBqfUM0DzbzBu0Y1HyEbdjeAcxPBfTg+S4k/t3BO
-        jqDUwqMjR0sRRojXgEPP9KFUJu5/QrX4ps5qYlMelyrTgSZeoFTgoZLSmG3sPF3iBfga18gWJ/K4
-        ZsthT5giphE410BPBkdHODqI0Hi4HJxymGyAvTQ5EYq80hsK8YXKkiC5QPEbSqPVa48n83avN9HE
-        nIGT2AXFtF0UQlrN4SCRlMbLC78k/KtshNLipQ+lWB5yTa0Q7Uzx5sgGRbyPq8T/r4j3IPz/QBHv
-        PyniX6VonBsBxi6/uSWbfIXFGeM6Xlxtk3OZa/6d0N5/r9AmR4p5JzTqDTiyHOAWYuwd4qxcfgyv
-        QcbKFI6dUJAxfjt85V0ySPucwMXkjX+zjbu/U6TSqK+JGcSs263nwa1FritJAc9jbL4sJ+O7Lbz2
-        Yb3J7PECr6A8J55DLCDZ0uI9gbvLR4TIReF9fIGQzW7T1xSNSXwuAs3ncbPXjt2+MhSo7KoVwGpK
-        lhNaLip24NHA1HSNq6fHFchJV6+Gz2CBl3tB3II59/o1cY2mtOLL4hr8bl3hz1Lx1r9//gSe8Zbz
-        OxIAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1828']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:29 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['108']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:29 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6L9</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['778']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1YW2/bNhR+368QgmEvq6OL7xmrImgu6Jo0bZqkyJNAS7StWKJkXmzr3++QlCzJ
-        cecGaIdha15ifufjOTwXUodEbzZpYq0I43FGXx+5x86RRWiYRTGdvT66v7vojI7e+L8gsiJUBJxg
-        Fs4DRrhMhI+4nERZimMaSE5YEPNggiO/IBzZ+0UoZEUusmCSZOHCvw86ndUin44Xb8f5ff9m0pmx
-        bBq54nIdfvj4+NQlIX/qnj26g6dPixvn8Qs9W6V37+f8tJsHm/vl8PbqojgL+53byJ0O3i+n8vHd
-        cnZ6wW9u6bpYYufOHdz0WHCWdq/enX8qluz8aTkaJ8z7+I6Ou2eL9Sx5RHZrTSiKucA0JDzAjAQr
-        nMSRTzNk78NNVHwECA4gZsQ//4LsemQEEeGhfw4hLtZzwkhJ0CiaxDOZK22S+H1kN4cojEVh9CSY
-        Bysyw7wjIbQ1biha0xXm1oOilHKjPoSZvPxnpog5wUItooGVcj3lri03aiB7OpVGnc5vG0JlYSxI
-        UVmwoQZqUJVKSa1mbpGWvpq3R2WIJxA7sV+z8aWmtOCapT16a1jWbzjN/7AeMIuJKBpzjNt2vRi7
-        imTGRcAwnYHKFG9AeTqJKYn8kXPsILsFaQKsVOQsDok/7FeMGjMUCb5gBiprxhZCqQryjpUmpAnP
-        rLQwQ9mx0oIQzQIOOz4hKl7/TReXElOhtkaWCzjrIJl6EwcV7rvI3kF2Gd5BRvcgo3eQ0T/IGDxn
-        2M/d0zkMQskYHOhAqX6ZHSF5BFXdgmrGFIciY77rOA1OCdYsKtMJYf6o12SVYM3KEwynpordLtTg
-        qJrjRTrJErsJw0lrUP/X5vQaRvaul/ZXSvln+v8f6W/mPMwkFWzrsRI2gK1Yn/b3NBYksj4LLAi3
-        sql1mhI4WnA9yXwUIpAb/QGhUTk2n05JXlnuWMytP2VSWJ7jQqJqsWFKEQbZdMqJ8Dte31MR3sVr
-        IidhRiPuu73BaDz2Bi12JTT0Av7SNIp8ZdYZuuOSucXhu5uNBo4baBjTKBBxSjS94ww77vjO8066
-        zonjwPBEWdo/odS7GwEzhhaJiVZM5vKV5blcWKdwUCffOSiuN+453xyUnue+KCi9jufeeSoiLwtK
-        GQTTMetKuzq9OL++Pkd2AyvlZfNmXZA0JVbFMLExv6HPHFyNK8m26wwSOOSyup9rgiUjJVGMocyx
-        PhJgZ81hb/iRu9701t2+nKRRvDkOk0xGU5ZRcUxV36Q5KKYQSQkbDT7CeUJUdFniz4XIT2z7bzXY
-        HL63JLIbS7DJRgSwq4Rrn3+xPc/ZuG7/+CmfQTj32kEUp6rrhUzC4sE5PUY5FnP/Zfr1FPQ1X/j3
-        dWavK1zmecYED5TB6m7UhNoMvoei+s9WRv/N6R06zqbrOIfTm2K2lOSFyW1p/9HJbRn7mVyIiNuD
-        cu99Q3I59CPshbltKf/RuW0Z+5nb33nBBUmDGlGOJDFh35DrkvmCbB8y90Ozf8j4P1wN0C4Iyf0k
-        Xm2/4iVUEeQEugtsV2ORLQht9gQGqKRFDimJ1dqhNwkXqnYaEjQjmWpewHyC4cIgoRXpDo5dxxv0
-        4fayxVCS0Zn52VEfOHfoDYbQP9UwsmtVc8wDuHflhE25fi1rAerJR13VSbR96ymH+nGASUqhbTGd
-        lOuV7wMtVF/vW8i4vOC3aZSQCJqnHBowlULVlOnl7MNLsmRY7cIGrUIMQbmQsVQ9/ZnVP0ORur7o
-        nu7Dw2jsOpCXLVK9YlWvh8Ei9fUDxx4c8Xm21pqNN6aC2hjimWQhMS3ktoCB1oArjmnAQW591gVv
-        3VCyZZoOU7/NMrKKiTYSqtfMIVxA9+EIikiWJq4vry9vTz+cXT3AVbSGS4rWDRTrEhriyGo8TTbk
-        ZVVu90T7afkvely8kpcWAAA=
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1442']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:30 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6L9</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['365']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+2dW3OiyhqG7/evoKZ2rattBESBtVis8px41nhIvKEQOkrkJA0q+fW7oVEwOmsy
-        KacmKrmJvP3S0P21/T3dMSL8szV0Yg0cqFnm39+oO/IbAUzFUjVz/ve30bCW4b79I/5HUGUXSK5m
-        AMmyXWSFkgOgp7uiAL2ZahmyZkoeBI6kQWkmq6IPoJA9XSQojm+7ljTTLWUpQimT4V+alLtcaZWy
-        /qbAyoin8ltqxClW0ZznKJWc9gZup7Q15uZ2ts1s6YJbrFQ5Q8lvRs9tr1VZNTRKm6rbMT0kuXHB
-        topVnVXGU41dwpxJL42marxVxj2WaTjerDmBOue4/sOm9Dqo8xmlz1YfpELGyXSni+XQ7cmsXn8x
-        J93C7LWkTe38bCpkD+5ZMAFQJRXYsuN6DpCCzhFNS8ie0oWFDCUbOC+SKRsAhr53kuBB1N1Y0TWI
-        OhWsgRn/kh0gSygmQKxOhGx8hAtUABWxikLobxbAAZEhVIWZNvdsaS3rHhDzQjZ5KCia6+N6dHQ7
-        azCXYcZDUYt1bAlrasmQGAeWqBxXr6AzYfQLn+IugOwGN5HQovLwlOFhOa4GDYxwlODqwqFzKAkQ
-        yI6ykJbA310hi4ZXLAajMLLuztwrB/XFvhNVKvIM9Z17umbclthyIMeusEVl7CL+kA37L2IsOxpw
-        /cQ5uNnZ+Gayu560oCs5sjlHVRryFlVuzDQTqCJH3pFC9kAKDehOXdvRFCCy+Z0j1rDFQ22RHVRl
-        7NhLghF08rurJKXQcHSVAw1b3l3lQBJMSwqGuA6C/rrOJq482XSDt0Y0QYoCep9pqrTTRUrIvlPe
-        O+gfOnI/dDA/dOR/6CgcO7LHzQtjKCme46CEgSy7V/gd4UEVjeoDKXa8yIprOSJFkglPJMYu0zNm
-        wBE5JumKxNhl67KC5lA64YmkhCcYc9A3ZpaeTcpojsaq+N/k6bEsZN+3MvudoZyG/zbCn4y5Ynmm
-        6+xbHBQmhH1xONuPTM0FKvHoIiaAhPVCFA2AphY5PgknhRC08FWBqUbHOHV64H8ExbsLouHpPkGT
-        FApUXIydnqtI1ssLBK6YofN00MPv9dgIgWKZKhQppsDxPF04cO8Ksd1HP4ahqmJwWZKl+Mi511He
-        tbgCSYXQI8mmGtJiaM+QbIbihzT9Z478kyTR4Z/BlU6fENX7vgfwMXQRWR30ycL7H0FT0CWKaKLW
-        z9wpFM0z5Ic7haGpn+oUJkNTQzrokZ/rlKgTQjbEI61VrFXb7aqQTWhReQRvRA0YBiB2Dtw3+LWm
-        ioUWvytBR5Guo0nOinkuKUYOdCOuB0VdW+/LI2lnQPwvu3J2d+z6NhChZth6sJZQlgFHJUqEObCC
-        hsuioMtosvFQM3KFO4qkC3k08+01QbfMOX6Zoaj8HcXSBRb1fSwL2biqgLXRnB3AdQzfeyHAxSDN
-        A3XPidFhCBaOZ5oBmodRoOiILQ7UEA0OFD6Cg0PbT60ZsOg5cjDZJmw7BRuCJliOIZuIUMK7P1KF
-        YOoLx0NnzPEUieK8V3YErKIVR2CWloYYwtEJXYALa4MXKGFr8PLuUBOghWgI4OEHtiioALooLEl5
-        58FvXlROPPrQBQbRNcHeiUdnuGR0wFoD4UWUYCXEouR1ShfQIPKiS7Tr7fqg2Km0xiiNxXJkCetG
-        FqKO3kwqkVjWJMqjUXmDSX3X8IMxpMjKAo2rHXfDoK4jLV26XG4Tb26Y3yi7pkuXmw5/MuaXg9Df
-        o9RwD9Wy9Cj/hETyTgvgTteMYOEVMlTi8GxkHvIPvrtMjx0gvoqEqARKaw1qMz1ipvcidsWgjHHK
-        WgJTXGYymemSaUGz+6Y+kfdmbdCdkYUWt2yDlsqXigZV3DTL45U2oTLUtNJ0nJHNDrpVrlndep1q
-        Z2s9PUdXxDVGtSPWjnaTi4PW3rFXhSOYPQTZ8K8A4dDg7kiS6LWFbCzh0sXCMCAa2SQZxj6p4cvF
-        fJqCRgoaaaa5skyTgsZNh/+3gEaOzF0oaHxsX/QQNB7PDBrNbrn04tOD8oRcvFXHevO+Me9UWvmu
-        8zCudeubV/J5NehXVxnLtNiWBifG9rHBfxQ0WsVh9QecEW6ufQ80KPIu9++kQedS0khJIyWNW0s1
-        KWncdPhPk0bN0RBp0Kb6i0iDI5mfIA36i5AG/bktjeGZScOuPYEXuedseNvqDZoTrTRYm8/DGfko
-        kW2nP9c9huPWGzixxkqp39tun3jNZ9MtjUvMwilopJnmSjJNCho3Hf7fBBr8hYLGZ7Y0RmcGDVjp
-        yxulyikVD+btufTUnT73Wr0RszXol6bx1mOsVv2ltYD2djh1KuXKY/3B+vDfTtItjS+VhlPSSFPN
-        laSalDRuOvynSeNRdhFp5JxfRBpMocD9BGnkvghp5D63pTE+M2k496/UfaXelOwO7ysQ9EvrokQ3
-        Wv5TrU/65kSbbVZrU3l2nmsTdVV2c8pr1y+kWxqXmIVT0EgzzZVkmhQ0bjr8vwc02PyFgsZntjQm
-        ZwYNauWp5nSqdQbKpjZx+3V7CBWnsip353m5IdutjbMYFGvdwoKqVdXFU7thqV76KY3LTMMpaaSp
-        5kpSTUoaNx3+75CGZyLSYNzFryGNfD5H/wRpMF+ENJjPbWk8nZk06hV/YXpbhprlGKXo9EavtXKF
-        XmTgs7m9RzC0VceZfuu5p77de/7SWLqNjVxMP6VxkVk4BY0001xJpklB46bD/3tAo0BfKGh8Zkvj
-        +cygYTwttFGtOQNArdKzZ2744Hc37ENzPrjnR8MeM9q0VMvy9Ee6We70Vd2cPU6o9FMal5mGU9JI
-        U82VpJqUNG46/KdJo20FpJH/VaRRyPEf/44+hs5/EdLIf25LY3pm0vDX9MPMqjyNcp7mMKWq8dDM
-        PFReTW1izwZmY+2/rTv9MucuOnL5nt2wZR6Mp+l3aVxkFk5BI800V5JpUtC46fD/HtBguAsFjU9s
-        aXDkmUGjV5q0RnbLYZR5a9qfU+UaWx03h3O+tdAeuttS2TLH3JycOQtq0iFV+kWq8U76KY3LTMMp
-        aaSp5kpSTUoaNx3+73xrV/DUAbrwq0iDDZ468HHSKHwR0ih8akuDo85MGvRg3W90R8vGcgCWfoHp
-        cOrKf+23K96kCxEjDu6N+cB+vKc4FkrAl/yy/EqnWxoXmYVT0EgzzZVkmhQ0bjr8vwc0cvkLBY3P
-        bGnQZwYNza4/292F89aWDH0wWMmLHC151VKff6tlXp3VutmZF3ypMqwvqmXQf5ypPjn48MdB0y2N
-        L5WGU9JIU82VpJqUNG46/KdJYwJURBrsryINjqJ/5lu72C9CGuzntjRyZyYN6TkPR9VptWM85Tlq
-        2yObmwa/WsqMZ5Qas9fedEw9GGqJZzYdesuym1dm01+l/3hykVk4BY0001xJpklB46bD/3tAg6Yu
-        FDQ+s6XBnPvRalOFer53l29zC7RLDDTaVUt+mLIFkNkwb/P5tPSUW6mVUpfcgtLyftsl/VH+w1/a
-        9RW2NLJeMCXhJ/TqGnSjgIuC7AA54qGJkI2PcEF4reoaOP5mAYJHP8eqMNPmni2hecADwZSRPBSU
-        YCII69HRWFkHT9XNhA9F3+vYEj2Sev/g3VgUFHQmjH7hU/bPn05oUXn0UKGDclwNGgSGHOTysLrd
-        c50T0u7Rx0vg766Q3T/3OBAFNGwi6+7MvXJQX+w7UaUiz1Dfuadrxm2JLQdy7ApbVMYu4g/ZsP8i
-        xrKjAddPnBM9tTi+meyuJ68Uq1JyTNHhStAhJcebDn8y5orlma6zb3FQmBD2xeFsPzID2CIeXcRM
-        kLBeiKIB0NQixyclEBNfFZjq0R/cKB7RacPT/TPDKcfz9Mc/QsxS/BGc/htFshmK/yhFZk/2AD6G
-        ruy4B33yxR+GfK6nFmePOwHjfwSvtWq7Xd0tCfDow68jeCNqwDAAsXPgvvnecgK/0tEkZ8U8lxQj
-        B7oR14Oirq335ZG0M+xZHh8HZC1CzbB1gNqlLAOOSpQIc2AFDZdFQZfRZOOhZuQKdxRJF/Jo5ttr
-        gm6Zc/wyQ1H5u+BDaSzq+1gWsnFVwUIIzdkBVcNw6XMgBLgYpHmEATtOjA5DsDheABypIRocbUge
-        iYIJgIo63kbB89AMEwQ0vJ1TemT2HDmYbBO2nYINydVDePdHqhBMfeF46Iw5niJRnPfKjoBVtNQI
-        zNLSEEM4OqELcGFt8MokbE14tXeaAC1EQ9HSCWxRUAF0UViS8s6D37yonHj0oQsMomuCvROPTg8C
-        R3LAWgPhRZRgJcTmg0XSsS6gQeRFl2jX2/VBsVNpjVEai+XIgv8bo94m6ujNpBKJZU2iPBqVu2F7
-        5an9e43Ec064Xo001O3Q013x/6bPnrOFlAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3276']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:30 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---ZZc1YHtkzgoeMB4smMEoaIZ76e-w4zggZBX3qdDBO0xeBkHxO0yU56KExuNENxoXY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1U8coAng31d0ZPRtNBxmgnxbx-x26tADE8mc5wUYMuLDqJi1iZdxV2T08V6poAEl7cVZi7ks3n2kmKdmzDVP74JrubKWsl8rtyIwBjRG9-cQ7EI_6-r-OZhkTtPa7lGfnWO6bjBiZp5bZ</crypto_block></availability_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['449']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA7VYW3OqyBp9P7+C2nXqPA0RUFH3YZhK1BgvqMn2EvNCNdAKkYvSDRF//XzQKGAy
-        s2dXnZOHhF7f6tt3Wd0d5Y+T53IxDokT+L9/E++Ebxz2zcBy/N3v35aLR7797Q/1XwqKkeMiw3Ed
-        mujBgQKb6CEmkUtVhUSGFXjI8fWI4FB3iG4gS00wUWpfm5RjhHxaGkpVYuQ6ln7BVVGp3SC3DOmn
-        jPpPGY2fMpo/ZcifGbXP2zPD5EAD3XADc6/KAs/z00RyppoRoGlMmv0POtsZmjca787Ps7W0kbU9
-        arzoi2Qwah+Xx8PgMZp09s/+bvjRpptetK3Hyxdp4YehPNNee8t9QN+bzXexvRKDiF9MDd1+aQrD
-        53231RuOhVXvx3jqJfY67GkxHuiDjRa/R/K8P/SMsKs1z4m4eh4kq6G7eHxv6Fvz/NyU9SDW+wLv
-        1vcDe/ahNeodWPabUqvsRcEx9iEHUIiRDnmD1f5aqRUtZrAwMdU+pFnyYeMQ54QMVQxnFx108GGE
-        U3eXm4qZOjEbx0VEj/EOET6CtCpwRslGmiDCrVJKbmfDm9CT5H9YF2pjRNNFlLDcnnVZVO1sGMjc
-        LI3ZcFluVyGFYBSatr7HyWWGGuR/AaZlklMvPa9IZbyC98WQJjLAd/TrkdleCkoFLljZjrqMxf0H
-        eYf/cisUOpgmpT5s27ViMbWLJ4PIp2Hu/iwYZeBqzvovfYdii/tBEcWEC7bcvYdDx0RFJzaNBXY9
-        RP4O69i38jYLRoR/48QOtblR5CacJIhQcIWZMSNq6sF2SzBVeakpCUJOKeEFkWAz8C2iig253elI
-        coV9MTJ6Aj+eZ1lqOq3QEjs584pDJIO2LIh6BiPf0qnj4YzOCy1e7Cwk6Xtd+C4I0PyezvR1h3zc
-        Ww+wNqEopBWf2NFvnCQSyt0fQsf9HztFlDoN4R87pSGJv+SUBi+JCyn1yK85JXdCpjYs0yb3j31N
-        6yu1EpbbczngHrHnYe7CYL5h346lypPOxQKtHHfh3AsKhSiDOQMWQiOiuk58tefQhQBHHqKodmnT
-        5IBV4ngHF8O+zH1amSWLssNBunGkKi6CQyOCbdTlO1GQ5CacYFdMcQN/xz55UWzeiS1JboHvC1ip
-        FUPZIJd+oB9wuCWqHyi1CpAKEOgHlOZVefKm4qGTHka+D1tmURAlCNAnVPFAqCpIJ6XdgoqPsQWO
-        P0DwohBnAc6W8xWek6MQpYdmiXZBGCHdQhB6yDcxW/0nVDkEhGb5MF21O6IAcb4iF021HIgakPW9
-        pwp3wlVPy7hC7OAjG5ntht1oqphCgigEejY4PkFQMaEQljJ84bDiBTv3IyEUe9zMx1cmy87slhTi
-        2MHZJGZ6trbgVPwKVyCJonwKbaANXu6nvckKriMFnFOysYHCDaCYLK50UJbseVaC98quLFRljS1Q
-        nRYo8f9FddqS2PgF1Wl9Up2/Kuw08w9B4GYpnh+1N1haD67jpWdVlnal5s/ErPVPFT5LGbY6ft6G
-        m+cFyC1wvXGIY7h5mt2CjFVoC8tAEJCLGC76eacCVD4XcrU6098seKJwVxe4uabUCoyZbdvz4NiX
-        pHp2KJQxNuE1VcwoDOHtkBRflzuCBed9BSoYW2TSIIT5hRInBwuWH3kGDtV2o8zKwYJ1cJGJSfoy
-        uIVKHBACnSSeEbi1MgwixFD13+XuBVygauU1lLopFfVczaE0oJgNlJ7hyCCBG0EWEBSD05nO3IKK
-        keVIsMe+qsHDwJKNtunIx9npdd5ebHqn8UtvPenMF8fRU0RHEUYrs3nyz2Sqn8Qu3zqej45sbAbP
-        r0trlExbs5cJ3zkFcrSVR87T+2LSc9BRduPDBrurybzx2n5rSe9HtyHsRK/5oJ1nveOKLJuRM96Y
-        Oh+9bd6P+tayJ/Lrfjp4nRLtfqgPB/xZtEMzWuGeIEadIW9MzP0pjPgX/LYcnp/GmmO0x3EQTe97
-        DpmLcn3b7KaPhdLu4GroGY4PRdXOPHFtpuUH2gCxzIuPNRQ/8NmnftPzC0OJnNZ0FgZQziq7sJTp
-        IL82Cnfw+rhhXw0ldh7sr8evGBWWn3qeLFDDIJefMCVXc7Qr0iSrqxuwlFishO6BdQOVOWkF1ypI
-        oR0h+oAO8ELdRUFEcg0U4ZT50pDRaUCRe8MsY8qt00uuvnFwya1fOLPqwlq5nEp1xvY7f+k/XnuU
-        ZK+MZEo2DzGEJ4SXSLoscGe110XtCoQlrKzzfHe+HiTooWN0k3NiD8SPdpe+39NAfNB8p7Ve/RD8
-        QWdiSQ920oma79LT6r0Rx42449KuEWkyXs/Oz4OHt3q/cTqjx02M9o994zWs99c7NJjNNtWl5JVS
-        q2hKrao3JvJ1F6MYcgO24uL8TPsMK7CxA6Jwq7n+H+KKeJjagVUCMtd1Zw8zOFgrWJlCKBOxKlQw
-        2MsycF1sUm4bBh4HV2kuu2SUOuXXhUuzSMwrxNywBP83eXt9WnZJK3hyFquB6djxKG6Fohlulqv1
-        qDd2vOgcdl1t7yHNOVGUaK3+6ImGy/3aHKB1623/THtk1VxgbLq71/a4ZZuPmxOZLN3uvLt1JL8t
-        robm06KzfPIPkqXNRrHdGmvB86DRmk82pXXnwSnaaXRMttsyjQXtk6trn8NR+7v/q/0JutlajZwT
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
         AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1997']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:30 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:21 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60---Ny2iNMboaNvs5EwtOgbMmJKgzQOW2Y6Mka4R_TyGJ8qUqpGFuL9kQngIw8tYDuf3vUR2Tnrr6OMXDUkotj55j18V1ou-TNb_hR50IQkC7DIK0VDSKNmyhWrDMveG_GYMvju6PEImbrCM5zy1VQGyVIlTFj4_fczQ56_ov_E0-l3kGhOwM439---Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>M0--d6b8ci6qOxXP8TYDxKRDWL9PTqJHutJueaVc5xnzsN_x1C-7qzqi6bYGQXUdJyN7ORL-9xo6uf6JiHjTLDiaq6lvpYelVLP4X8Z72jql40g1m5BMzODqVsU5uiKYc_-uZYjq_fdhL6XkNGXNsMAI_IG-z1hrcuVeD01u9I-bLckxru-ReZUIzHKMib8KvouNADisP163f5C-Z</band_token><despatch_token>U_--5-hWxUCs7oHiTVGcihvJv7r1crYUVWJDKimuzrClMkmaMixtayM7EJHtrUkWcGaW7ZkQtDsV5TeeclgX8K7hcFYxsLUlCPCfi2n81VIcHT9UHnp2dMOJvh7KMoQG47PLY</despatch_token></discount_options>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxldmVudF90b2tlbj42SUY8L2V2ZW50X3Rva2VuPjx1c2Vy
+      X2lkPmRlbW88L3VzZXJfaWQ+PHJlcXVlc3RfY29zdF9yYW5nZSAvPjxwdXp6bGVkPnllczwvcHV6
+      emxlZD48bGF0ZXN0X2RhdGU+MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['764']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1ZWZeiSBZ+n1/BqTNnnpqSRRFqaPugoumW7usLhyUQlE0iwNRfP8GioJldVTld
-        /db5UEl897uXuDfuEmSJf7y5DhGDENq+9/sX+iv1hQCe7hu2t//9y3LRIfkvfzT+JRo21P3IQ4of
-        IMyESghg5KCGCCPN8F3V9pQIglCxoaKpRuMCoFj5WCSCGHhYUQ2BquAXgYa8FivFKhMYAOoNGe/r
-        crZACHJCioqavY8CJVadCDRqYqW8FHUbXTI7jgqVGOxVSEZ4LwWeUVJLQxUSq4SSyzPzOtaE+a9M
-        BVlARckmSlguT1UWj/LMDHY39T0zlwbkERIhUEPdUo7gcntDBQetAJPY5tSb5h15sFfwPjCpqxqO
-        HfrYcuZLQXmAC1bqUStjEf9R3eC/xEoNbYAuJZ3M7UqxmcotkknihHn408MoA3dxqr/0bAQMYo5U
-        BCDhm4TkgtDW1UIpe42B5UqoenugAM/I19lhROA3ghaQRfQj50IwFM2JlUKcMSOkK75pQoAaJFNj
-        KCqnlPCCCIHuewZs0FWOFwSGe2DfhBn9gn9c1zAayWupOi3kzDuOT9LnOYpWUlj1DAXZLkjpJFUn
-        aWHBMN9Y6htF4eW35E0fK+R2nyOQrSFSQ/QQEyv6jWBoiAgpCG3nFweFZoQq9dNBqTL0p4JSJRl6
-        wSQR+VxQ8iCk3SbLtKHUkUcjWayUsFyetwOiA1wXEDdGFpvs2TYa3FC4SexbH1Mc3Cj9okOUwZyB
-        N4Ii2HDs+C7PoRsB90kVqZXbGl0C0IC2GzgA+6Ufk8osScQ98BPH1YboqMhGEXaD5b7SFMPVWLFy
-        x0TH9/bZI0nTta90neHqOPYFLFYKUxZul56vBCA0YcPzxcoDkDQg3D9wad47T74UXfVNCSPPwy5n
-        p0Az+IDeoaKLG9UDIiS0Z1D0ADBw4AN8eFEI0gNOt/MRnpOjUE1mUol2QzJC4oIfuqqng2z371Ax
-        8CFK8+F1xQs0hc/5jtx6Kp6AKCErR7dBfaXu/bSMi9Dyz6nlzJtsDD5iIvSjENNT4+ANHyqACB9L
-        Gb5xsuLFcmJ+gQi4xNgDd2aWneloDUFsg/QlejJb63gqfoSLOImi/BWj7qg7k17bw5VYKcE5JbWN
-        KUQXF5NBlAZlSZ5nJY5eOZRFV1kDA3edOu7Ef0vX4Rm6+omuU3/Xdf6ssJPMD3zfSVM8H7VPWFIP
-        ju0msypNu9LyR82s/rMdPk2ZbHfkhK/ilMyBXIKvNza0NSdPs2cwYxW9JctA3EBuzXAh50oFKL4v
-        5MfqTP7NDo+mvrIUMRmJlQLLxJblunjsMwybDoUylr3wnip6eAmQr2iOrx8bOkOSkcG1QRNYg9n+
-        ykama15lpaZLhw4ziy+UYADNba+kriQpU3W/PJqDi7GimL7sq/rrKdDo9mq82naGEazL8fgaxq23
-        9knxHNCcO73TQvNAsJ20Iu8Fgm7NQVOjFp216eZ1epJWRvNFEQ69LVWXOmr7jNrGtXd9aQ2psen7
-        0nXNSAxfVw7NVnSa6P3I7raXHqz3qz1Gjlpc7cK0yZGm7ZmDth1WF72BFbnR8IT69mS7vJ7e1txV
-        HZDL+cZlN2Gr47b4Odl/cSb91bR5iY8tbt6q0m2dtGx+bY6DtdNCHE92urO3SKgdqpsdmB+X4/B6
-        9ujVgOxtaqhN1S5s3Rt4QF3y1qX1Eslmfc14zoykhg57cHVGbk1kwE7Hx8nEOYZW3KHdrUEJXDuE
-        LbM2V+KYXr8ue6wc2R1hO915rCW8bM87S7Cq5A5fucrnI2qO6uFZpBSfAp5zyXLvY5GoR2GIPyZK
-        T7c7oIGNP0AFw1R15Ic4v6gSJwcLlhe5GggbfLXMysGCFTiqDnAqljg5VOLgRq/Ai6v5TqUM4yGT
-        oY1/l9ULuEAb988jWDzihgBRI+lPD4CIZ6pvKoUCHtnP0N0G/hjSoO9EuC9ANcZlmE2eZxBfoV3N
-        9nDz4VP5fVlsJg2y1B4uSvvJAn9fpiUsGfirjkgmmqGGBoHnKChp5G37Bx7el8g/Aq/BUSQ5j5SR
-        AqfncGtvqxcP+ZEpLF66vYF76pt0SzpEatW92sa6PRm/rtjeUJiT8l6xBIaudc4DViLhkXK96oSL
-        2nGzZoKeJy33fIed2o6iueSaJGOJMk9H+W0x77ds2+U3Q+vN9ITZgYs3uwNcN5u1nkA3hyiYG6A7
-        l4Lq2NItfWKNoUyZ8sKZRHVjHggd863pMS3SfsX73pWcy7wpeZdcxsreZ7cz3ILx2MJpmM+FbIGP
-        3cselafD+kBQIifjBg9P3C3rtUd2ISnT8c3AUsM9/jB+Yt8FJXZ2uVQ+tv8gFLPSUtRYtR01GS/4
-        xvIOE/OLhrov8jVt+U+gmBpVtGTWZYmJWU9QmZOkXeUBKcZaqJ6xgofsfeRHMB/PNL4AfShI6chH
-        qvPELGPic9BLoX4KcCmsHwTzMYSVoqr/7/qu09+r77XcHHc6P1XhZ6AR6Tn/khKXcam0VuYS7mfW
-        YkTLihRfZ/s+V9XoQ0+Te5Mud96CmcHWdltkOhI1GITo0J6E7nbX6didF2N0ngn7Uyfsurxry9xy
-        1p+1PdRBY5c5dnb9LncyJlsJznn2KE/4/s5l+PAwjahDVdrDdbypv6L4JdS5oxAwx/YJLcmu0eTn
-        B5/bxM3leKpcKKUfU93mdG2GylGxR5MarFurMacdmvYuqGk/LHX6L5R6dm4/W+oc/6lSZz9b6s/2
-        /yn1e1A+LHX2e6We6f36Uudq3yv15rw7+0GhNyOINSEk9qEfBb9slLPGgpH7Bh25vZFkjpvHq4/2
-        B7IWTtvWLGhqgcKxMcPi+znY8BuPPbK1wcTbMGhwQY5pLqdrdT3gW8p1Uj86bWoSeEvlzI8OA46H
-        44jcAIfjgHDs7eyZ1/ZavE3RS6o+MCejJhdwF2lZDasGMuYAzHyT2bj9WWs1gay3Ri3WqK35Lge9
-        tVOvm8rSoqrjUXAebHbKT4xy5i/UN1f7VH1Tf+8of7b/T33fg/L5UZ7p/Wl93x9h9oeDoiQt306+
-        NO5/PngnKeXb0/+q/A/knyNIlhkAAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2302']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:30 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:22 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order><crypto_block>c2--ud6DeBehKRgz3ufmfzE_5cAjF2Rvy09debmDVAGAA_QagUkfKydV02JEoacNqpb1DVOVYFLus7EvOzrvCxDq_nleBSlIqTbnepYPCunHseG5ltQd5uwbQXNQqAVdBH_9jIY07AFaDwtDdzIzHCL0OfooAzW2A287_jBCuqPcJuiGDUns7J4I2EuC65y2D-Mbbg2jbYL4TIKhumuLqtJiPYUzqxW6zaK-USXm3XrCFmC8S-JHlPJVQByvkC6SC41Dc-hi8WfOpWlCt68-FGRxu95j4XZeSkUOrzwn1VK-IX5tD05y37nKneaU8hyCHuEf7W2nlR-0Ll3jmc2ECPEe3QOkPPlkrhvF1mYd096DrsCf5S_vv1WNUI3EuiF9YQZn3h9HYwZh9h4-Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>60--Su_M_sQwrYiY4yntouf9THGIKmqJf1CAjua4mzidWDPONV3IL9S-Eg_h9215FwK3A-sk0mn4P6uDvB5feInAUg8F3Qil_bm-W--vA0fqkExTSJCiim8XLhxfn9Rj6vXZjsWBB5I91BLtpSdeGSAp4OhchcPhOsE0fETlPu7dSp9FfxBn2C-iN0--Z</discount_token><despatch_token>U_--5-hWxUCs7oHiTVGcihvJv7r1crYUVWJDKimuzrClMkmaMixtayM7EJHtrUkWcGaW7ZkQtDsV5TeeclgX8K7hcFYxsLUlCPCfi2n81VIcHT9UHnp2dMOJvh7KMoQG47PLY</despatch_token></create_order>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+LTAtLTYtYnNqV09qbFJnUHdhT1Rq
+      VWNscTNnVDMyR1UtS1lxUllYZk1mbEVTa2hDdHo5RWNtTmUtTDJkM1FnRHF5dDdQcVowazZGTG8t
+      QUF6b3JPX2Z4MXIyMWRWSG5DNE5veWhoU3gyTF9qSmRPOTF1X1MwZXJxY21RV3Y4YlZldUtKZHVH
+      bDdLZ1lwckNiNW92S3NsaUc4eHVqQ3kxQXJWMzVzU1dQSHA1ZWUzNS1ZPC9jcnlwdG9fYmxvY2s+
+      PHBlcmZfdG9rZW4+ay0tLTZTWUY5WjYxLWUwOThNeGdvdlVleU1OU1pacFJQc0RsRm1sMkVLNnJp
+      R2tpaF9hMHRMODIwUWY0Z1hlRmcwTm1ZPC9wZXJmX3Rva2VuPjxzZWxmX3ByaW50X21vZGU+aHRt
+      bDwvc2VsZl9wcmludF9tb2RlPjxwdXp6bGVkPnllczwvcHV6emxlZD48dXNlcl9pZD5kZW1vPC91
+      c2VyX2lkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['924']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7VYW3OjOhJ+319BTW3t0yFcbGM8y+GU4/iSxLckdmzPC4VBNoSLGCQc41+/DcIG
-        HG/tTO1uHhL09SfRaqm/bqL9dQx87oBi4uLwz2/SnfiNQ6GFbTfc//ltuRjw6re/9L9pVoxMigwc
-        2yg2YkQSn+oaSbY2Dkw3NBICsEuMrWnrKSKacNukWUkcw/Jp+WTAu5CeEFsT6lDJ2JkWxbEuiWKF
-        U4AlK0yCLYp1tVllFWDJinzTQkSXK5wCqnAwoQZJgy32hSocowLV/16dXsIlCtPiNKLY2PrY8vSl
-        wfMHL9p1vF4nWrZmW34f450t0eGnNZ1vPhrIIh+Nh42kfLx4M3GzCh8OweLZIcuHXX99tJa9Ufpz
-        44/XI7wejOKZ5/YGjtX4aDRJMHuQlJV8WsvvswW/CL047X48qVOp5c4/1Z9o5K9O5Pk02G3Au6pP
-        GjtLij0U6pbE85LiJbTzet/4ed867FU5VcmRSvvxajTcNR7FJ/XgDZb2iqrLndJ1Gqh/IOMxxenK
-        uR80lJEX7MIfisobR6d76ncfWz9Mo+2unGmvj2cvx/s3pdESnzcz9Dbf25/p2lg9H07r42YyXImr
-        zWATOYfh89PTmu+404f7U/t5/WkfdjGPwmE6UkWvF3kb5I3NSeuoTqdP86HtPb50osfeyplNTq8x
-        OqpSc/08br7QSWJ07XTcG60fXye97Zu7Djq+vQ9PTX7x8RYY6su6MRQXB2X4uVRn4udKfu0tXy3b
-        PtKRKHunh9lSlEIPdX03mmx32/bCf/Oe7FkgHT46U6XzZNB7e/44UcYvPM//0IRqKFlcdc1GJDKp
-        5RjwYOk97PvIotwuxgFHHQQpFyZIE+qsclKAqIPtCpDnRG92P6vMYXlSGRKqi3dijQHQf+lKlsom
-        NYUKRNMI6RZbpzIxhyvjyyZcYuEkBE8sHGzdENm6mvt5GV4obE/dh/EC1qlhJSX3r2uDBHGEmqFt
-        xjYXgzpVZrAthNjAO4OAchFd0oTqsLBR1/JQ1XoGtIwWxa6F9HYrc7Ucg+zFlmPGe6Qzy2VYOqBr
-        CKIKf0zQTeZ/f6UJ5YgZcjf7oL7pp4NiVBCY81t3n0TGwfQTeI8mVIea5dJCJX2TGAe0NwmfgOqW
-        OKPkK41Nwr1nlMLOlrdgJin+sClwFUyaOVHBCns+ZVG3s2VA2HOVZ8vl0l+HskBCfAwPpec3CHk0
-        z2BWRQrqeeYFqa1X8m4saZlbiB29vTLbS0mpwSWLZQdjcf8wg+if3LsZu4imlTls20LpjHCOZHbu
-        8aWeZZe7AlzM+fxl6FJkc28Ubi3h8I7rBgjulllOKnIwq7mxGe6RgUK7GLPDSNAfnNShDveU+Ckn
-        i5ICt+9iZsyEWnCndwRRnZdbclY/r/GSSJCFQxtSoamonY6s1NhnI6On8BMEtq1nrxXbUqdgXnA4
-        SawqomTkMKQo5FWAcjovtnmps5Dl7w3xuyjC8Hv2ptsTinWvI8DGkPsxrcXESf7gZIlQrguZ6v+P
-        gyLJnab4y0FpytJvBaXJy9JCziLye0EpgpCrDbtp4+6gP5n0NaGCFfZCDrgBCgLEnRksNuzZtXVl
-        3DlbYFTgPrSDuFSIKlgwwBGaEN13Dxd7AZ0JlzLCxnmxIG4Q+ahQ3fM8Vkb2CGcbN3XNN6lLE9hG
-        Q7mTRFlpNTThgmk+DvfskZek1p3UlpU2xL6ENaFcygG5BKGPULwjeog1oQZkApTpPLIvylMMtcA8
-        GnEShrBldgqSDAf0BdUCEKoa0slo16AWImRD4CM4vAT6x+xAc3du4QU5gRIHPXqFdkYYIdsCjgMz
-        hBKVe/8F1bLGNr8P03e1I4lwzhfkrKlQwGhGNryAtRI3cI04+DNfme2GNfx1TCMYyiJi1w8d4VAR
-        oXAsVfjMYckLdu4tJRQF3CxEFya7nflHRIwOLspfYmW1tQ1V8Rau5f0Me8VkOBm+dqcP43dNqMAF
-        JV8bKNwQksnmKoWyYi9u5a/kEIh6cP7kyNK3MtRqB1Fq0grZoFlt0PH/i2apstT8Dc1qf9GsfycL
-        Wd5EGPtFO5VfgSssyybfDbJKl1/ayvA/SWH7V+tDfuGYd/xcbcKFLoDCAs2RS9ytX1zSa5CxSmVi
-        9xfk5yyli34xqQS1rzJQz+3sNzs8SbxriNx8ogklxsyOEwTQNMhyIy8pVYy9sMzZrOeEj2fYMmuN
-        wX4FVTnZO4QaUu4uOxZIlp8JIhdxDvEFQjbrcq8pGlPnSgjmr/1B5vQVXCPmm53HaIfgi9jmsoUh
-        RPVZRUAwNX3j6svgCixIVw39V7DGqzT3t+CCe93oX6NnWr3pvwZ/T1GKT0Th1n9V/gVJHPmwkhEA
-        AA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1768']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:31 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:22 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGJhbmRfdG9rZW4+LTEtLVExbXpRMFpXS1NlY1prOXo0V1A3WkJK
+      LUZrMVFsalJMZUg4OXh2OXNDWWU4YkVldjEzaGhGSGF5eV82WWRVYkhBR3l3RVI2U1J5blktQmVY
+      aFR3cTJhZC1jNWhBdzhaaEtwSm5tM042Mktmek0zcHlCc21QLUN3Q1VJWS1jZ3NXcXZLWTFxLUJR
+      QV9DU3dKYThIUmN0ZnZaUWlKS1g3ckZkY0ZMeXBDNmNDb0NYZ09oX29zdldjb3lRTUxaN3VJaWli
+      T1JrWXI0VXZ0SXd6XzFtaG9XM1BVV2ZEZWdTMnNaSnNXRGlxTnptcmRnbjdOWDhyOV9mYVpEaE9I
+      N2M5SmJaPC9iYW5kX3Rva2VuPjxjcnlwdG9fYmxvY2s+RTAtLUV4STUySlJDcS1nTERzdng0d25V
+      WnpaU1dTWURxcWV2SkZHdmw0cG9DaXZDcVVVZnZVTEFYZzlicDlYZzYtY2NLNUx0UUpTdlJtTGV2
+      ZXhlMTMwaTV6NVFnRVd6bjFXbUUyeVh3Z1Z4ZE5vOVNtSmZjZVh5WTdLTU50OHp1eVZKdzlhUlhP
+      U2o1eUZOcC0wd0FkdjJLQkh2cGg2Y0ZxUk9jcno5LTRsRGh1eDJYSGFBbTFGNFNibmRKMm1xd2tS
+      Z1o8L2NyeXB0b19ibG9jaz48bm9fb2ZfdGlja2V0cz4xPC9ub19vZl90aWNrZXRzPjx1c2VyX2lk
+      PmRlbW88L3VzZXJfaWQ+PGRlc3BhdGNoX3Rva2VuPmNfLS1GeUpWRGY4RHlFRGhNWVU2Zllsa29B
+      MUcxempMbnZkVndoN0tMSmticlhpaC1aeTJ4U3BTT0RkSGFIemR5YUdqLXBySGQ0N0s3dmZDUkZY
+      dU1FSnVValJLQnNHbldScW1IdDk4LXNoTHNSWklFbjlMQlczV1ZLczNQLS13Sm5RSE9fenB5WnV5
+      VWlBLVk8L2Rlc3BhdGNoX3Rva2VuPjxwdXp6bGVkPnllczwvcHV6emxlZD48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS0HvDihIg7XFxZDKMgoBCj+Tv9Jf1kHg4Je
+        O4fKzLeqlauS2GfHCeLEOWcHJvPHxbYqEfADw3V+/0R8xj9VgKO6muEcfv+0EgdY89Mf7b8xmhGo
+        buhAyfUgYgaSD4LQgm0mCBXNtWXDkcIA+JIRSIqstR2Xqb62MCACDpon+0CW0DqgzW6YajHKDBoI
+        1DaLXis+68AHOSFFGdWAcca1XEdzHSw0mWoBZvaUOkntuTGfbMlBkP+V8WUfBohSALkx5XeQsfJ3
+        2fb+Xemh7YbJq5TMDNpUusPMbQyQp0eICYDsq7pkgjhdqYriUiBJ9HLebdodeXBW8J79abKjgtdO
+        s+3cCA9gwUn30ZUtC8B8o/2nCdlOq8UrVG9BTBLCz8OeHkIZuJvT+SvHgECrjFFaoaQoqPmp+AY0
+        VJRTkQHOkgd8NckRAscR8aWJ0WQIJF92DkACjpaPU2eiHv6rQgSwsgQeBLYC/AqJE3WmWlAydghV
+        yd3vAwDbVD1Z6hktaAFQUSoFbYJukI0a/ci+GTN6jP6zbU1rJ4viLZzImXccnbTbrOOElMKyo0nQ
+        sEFKx/AWhhMi0fqNwn/D8X/ixG/JSq8n5H6fY5CNA4iS40NUalCvTOX4Z8ajTtINCv/meNTw2nfF
+        o4b+/Jl45PtPe02WjvxK7Amd3pgVmGoJzilpGKYyhDo4V7pu6DvgH0GFR9vxZdVEKSSyS/E2MYtZ
+        9mxo7fpwcLMYt/4mWSjR3TZyJ8OkZ5TBnOHJUG9X0WTMztbFlHRdLMCc+7oYBAGs3uanU/LpaIcw
+        DNqWEd3d59CNgNqvDOXqbQxjD7QDw/YsgAKGnMPbvNSSs0IvAJaF3jSAD1tkP24RPU05vIxXX/g4
+        ADc5KLnNWDI0YIhiXiM+18hWnSCoBlO9owzq5ofsEcM/Ezg64VqdRIQ7zFQLZ7ocSI6b9IN9kKrN
+        A5B0U9QRUce5t9F8yNjyRfJDx0FHkeUNQaI9fEAZG3XdF7xnlHEA0FBGeCjfkDqkOZm+zys8J4e+
+        nGhoiXZDMkKyB9e3kzacvf4HlPHcAGbi2SOECi3yTPUO3SQCSTZM2JJpt/HP+F0jyjgT6G7aVffZ
+        dtLlnjAmQHmJ6KlzcEH5gnIycVeCb5xMty8Q+I5sVURErHSTRHa0SjEjq5/0UvCq478yMCixwnyt
+        Zac/YYXlhp1Mlky1ZMhJqfulrFnARzW8QakY3Gi5lOVXkIeIFt1wAzQkIMSv6JWtFkF/e68kPmrH
+        /2s6SfZ7rmulaZ7fHZ6wpCYsw05kOM280vArLZj4ZklKkyZ7O6yDz1FS5kBuCaTICAzFyhPtGcxY
+        RePKchB1p/yiuM6nFBDzsUQfyzP5f3Zwjc8UXplPmWoBZVZdt210nSFamY6VsWy9e46ofuxBV1Is
+        VzXbUwrDvHkNEtSBlVXalIXudWeTuhutBMPhuVlgkuo4UubOUbCgNrqQvd4RP9dbR77FLk5S5F35
+        2DT7K8FuGrQ+6jkreFUipdk5cUNLBc3x3pZ74tjXvL1lDYQmO5KPVmO6dq3RwWxQxHKCNa5DsS/W
+        pS0fen2bVcXTGIZDSu1btBoC1rBFZ4L7RmdPc7EAIHccWoK4PMCVt2GbEmsv+krUeANrsyX68/gw
+        P+v6ecguW+bUtg+z/uy9f9VDq7GmG5sWL0Flya3mZ3eh0YOr1j8tsV204eaDbp/g5pG55jcTjDxv
+        V9Pu+0ggllA4jKlOIOG0wq5rltPz9my0cFW18cZe6xam6ZFKBRNtAPvyXMPm516NdJeu4hIgNiPB
+        Hg1mKuQ9TtqO3ll8Rtgrj+pq/JEfnrjxmxWc1V7EwcF+KncGrLAJ3wMruA58F9DcdQ4243ptSvOD
+        3di3CfXisFAzzoPl5djvw+OkT485stsYyjVX0YQ3BXawXXLXLJ0vo1iyg1RSKj59HCtOS+e1pfhG
+        SuuqTaHqfUQYNfR99HUVF09ZGh8UD63+ABWMvaxC189vw09gwXLC5KrbbpL1EisHC5ZnySoI2mSJ
+        k0MlDhISKYhtxbWqZRipWIa2//uf8vwCL9AiGMFDXNCNAH8IS3JFQLLt7qViAo0U7wm6+0Dfh0rg
+        WiFqO4EcoTrPpO0ZRB8ftmI4qLdRrcR+HxYvk0a5019NxNILZaG/D7NvQA19+VUSzdRkXyuRcz34
+        yu7uQ+giHWyrOIadTKzVXY/jCx5zw8b727pPDh1BdLX94rR78whpEZIUy5HN96CGMm0VXTWcvcwI
+        +mw1WHuwhz2ObACbr8VU1xodD1YwkMddthlxTTpyur6+UehtxxjESmfKc9vOarzAj9aJXkP7PD5z
+        /MzpT8QemG0Wi94+gkGzZfqboOGdotp+PhiMdmezNbXOHe1AKFdlI7sxPFIm5UbWdGlSfJeXVq7W
+        s2EX7weqUbP2FuYd9dF4PN4u+ucBuSsFIdt1KQrJZbMcpez2iVQAKSfK1VyasgFKDSd7lJ4O9IWh
+        RE4Uz/MN1LOp2iO7sJTp6Fqiy/4BtOkn9t1QYmeXZ+m1/wcjk9WfJEeyYcmJwiFF/4Ax+SVHPhQ5
+        nQrPE8ikTiUlkdsseRHrCSpzkvSsPiCFsvryGU1woHEI3TDIbwgEuo6/NKR06ELZemKWMeY56KVQ
+        PwW4FNYXwXwMYbWo/D/dA0jiSz2gxw0n/a/0gJ5uWFoF3dLBj9Y/hup/MrPtKdcbqoPpZLVRjAO2
+        ssfieL2bAKTbI3vcXGMY2Y+3w51CBCJ+4PZCPzk6QG8miq0vunWjX9eIix7hsqGe4vCs26ap2dtA
+        wSSIBHl42I07kWVKFKcvWuxA1nbS25BerhoT1msK727Ei+PT6r0xmVDXQcvvXqh+h++1LrPNynwb
+        rsH1elI9aYdhX61l4gdqOTuYb61lovldtUx9by0/+/+rlu9BeVnL1JdqOZv3C2r5i3q+FFd9lv+a
+        oi+TnxMc+FPq2UT17GPxebJddlnWqznX/ZD2uzzRiHrWfOny5mEyn7iR8z7ZHvsX8chpR65Xj+Z2
+        NI15DzojxdKN6I2bDa2Q3bwfV+pKEt6l3tCGbOOkHK52d79Vh6fNsYOu9cLaP8lig641u9dQsE7u
+        uaY3LouDyHbZCF3FLd7t4cPl2TwbyKUn7bueQY5YZbicjI6NWcemPPYwmR2c4/xiYS3K655W5D6O
+        pyuBvtRngIhtasg1AqMJTD7e94Y0JvC0EPaImo3PZuTX+wH5I/3gu7SdrP/afvDs/69+cA/K9/eD
+        bN7P7wfUF7V91pl/rRcAx3D9impA4wqcn9IS6qglDEyKmxgcTte6Y0ne4wK7D4TgeMbttdUYGWK0
+        ah6W0LlsKa+3vhr+vjmCO6G31UdGf2SbMqV350rY6h54rTkX45ALdV912bXWXEN/esa242406ZHH
+        eG1uZ4Sxj5quxQn8pkZOehoei9KFvC75GPi7S3PhHWcCCXbXGqmfSJ2iRKsf8EJwUtXjEA99bo6j
+        b3TaOknfIPfUj1zdv0vuyV8s98/+/yrve1D+RHl/We7vj0H2W2VRkrprJD8/3H+x/GAp5dvTvz3/
+        D1lRoYe8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:31 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:23 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <trolley_add_order><describe_trolley /><user_id>whitelabel-testuser</user_id><order_token>E2--5eH5_vuupAjgQcgXHwMpTe9X9qgSl2Y0lXp5covwU1ss4IWYBA-RU8_g3PLu8IKzgerz_3Hl033oI-VMEczh0ACvOMWY84zu53eWCfAgAX2v47y8gZlotLi4soNNf8tYetkXqZoP-N1hlKUJkwZdbW0CSxe6UymaEdjSXrzwO0O_DORRcWp6xIeRBq_gkx4Wu9YZJPsOK5CeE-apF_L3wCpdqKeS3P6_3QZAvRVTdRGBuSzS-XHJpV6utMn-uLK1XaipNu8tDIAOlNAM8GDGcPYYRpF_3_rHi9pUQMOLZiyBM9BhcnyLGC8TiUOTaOxTSW98HodDDCuLqymE1MWcmVXSh6xJsVunc4mtPXPNxl7-Z</order_token><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></trolley_add_order>'
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcj48Y3J5cHRvX2Jsb2NrPk0zLS1wUDV0MTNnRWFjNGthUkJ6Wm0yaG92VVJp
+      bk5IT3NrMmNLdmJQbmpSbHRkSngyQ0NqMHc2OWpOOUVRcV92cHpOeWtrRFVSbThpNGhKQ25VdHpi
+      dmI4QXFISWxjZThLZm1hQ1RLcmRwZmxsRlI4RUphamw3TVZvbEpnazczMVNMLTd6SVREVDZfWE51
+      cERtRWNUcUt0dUkzY0RsNGN1ZUVpbVRuTDByaUFmNEh5UmV0SGpJbFJUU2d0VXBXRThfRW1RRGJ2
+      N0dlVms5VHJQeWdQd2hod0lFUzlrTW1tZ09ET1lEemh1bDdWNDdXOU5fdGJTSFVQd29RZDRGemRE
+      cVMtWnZXSFBGQkQxSFB2a1ZOV0wtMndYVU1CWUpSMVN0UmdLM0FzXzA0YkVWNWxuQ3BmRXZRb2Nj
+      N0dFejZsLWRodmMzc0xkRnREYVBkLVB3QzUyb1NvYm8xZXlrdlJtSkZPY3ROcEhfWEpZRTBPMW1V
+      cDNCZE5qTklxSEtHbHN3Y0N2SHRGZk1hQUZFUld1WXNsc3pGcm9lNEh6UGVXSzY1TTRORlpLcm0x
+      Y3huRXRkaXdGU3hqRER0akxENEtIMkI3SWE1b2JkUkdidEEtWjwvY3J5cHRvX2Jsb2NrPjxkZXNw
+      YXRjaF90b2tlbj5jXy0tRnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJY
+      aWgtWnkyeFNwU09EZEhhSHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5
+      OC1zaExzUlpJRW45TEJXM1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tl
+      bj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxwdXp6bGVkPnllczwvcHV6emxlZD48ZGlzY291bnRf
+      dG9rZW4+YzAtLXFrLTlCVkt5eDB5SEk3WUdWRDJJblJUb2RmUXFaR3AxX1F1MjNFSDI4WXM1YW5r
+      VXZ6ZDBFeE8xNHdsN0VtRmZ0Q0gyN2VtTjV5M0JsSmpnbHNGYUtCRTh2SDg0dm5CcmhXYjRYQWlG
+      eWJBTU5IWEFVS1EwamxxNFZ0bXdLd0hOT25ETFRDZU9XUVFDZnZ0czg5a3JXczdwcXY1ZlBGRkpa
+      d2s5TWx3QWRnMWJ6Yldhb3l0ajNrM292bE1TazNOQk5fVW9kQ210QjBEc2NpNWxmbC1wamhKS0tL
+      WFFEd0YyWjwvZGlzY291bnRfdG9rZW4+PC9jcmVhdGVfb3JkZXI+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['706']
+      Content-Length: ['1008']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61YyZbiOBbd91fQualFN4HNTB6X6zBGkBAQASYYNj7GEth4DEsGzO/Un/SXtWzJ
-        I2R1ZnXmIgPdd5+GpzdZwh9XyyydoYd0x/79C//EfSlBW3WAbh9//7KSRuX2lz/EfwjYc0wTBrIC
-        gOx4AHqyB5FvYlFA/h44lqLbso8IrCN5rwAxgEioPBYJqhe42JH3pqMa4koul8+Ge+gY/Y67asz3
-        5aPnHACPny/q7G17qkEVnWqDLd88vRtzbru2B2dLmmhoNTgMN1d11X8JPrfmdPPibEYv3tzQ+yNN
-        rZ1qdWTNB3xzXb1tqh9zqSzZhhd0T9/aM76hv13an/DFXN/Q5DY6bIVKbk9CeErXQUjfm5AeJYck
-        1sCOAW2xWS+XdamGlY+2U61hua87DXgz24u1PaqCi2J9PtvX7jV4GV1ul+m5DgdtUJ4fpE7Dfx13
-        WvBtMzPQ+HX8MeeWo8PGOrsjvfF5Ac83/Tg4OtaQO43gDh28+lXvfszWvqoFL9bQ3pd372tzLUNi
-        JSmozdu93v6wQB/c+MOWDbDRpt3XRb87O/Dqdbp7vaKPPexIvU/34jacz8ZAA9Kwf3h2LP0KBsRQ
-        Jv/+8aENXv25Xquqp9bu1IDBYHDqtnby+HZsD/zF1Lm0x3Z9vXr+9N6Pi5GM3qA0WS6MUc/aYvXZ
-        qLfxoXY4ti4zs76a11cvcEXOic6b3vR96kp+Q7+1LEM78/K6Pmmure6u6jRWBuirE9ezTe+0rIE3
-        tf920s6X3nZX7WxXxjoYDYddaXRDw/Gnuw9UHQwnx8GmCYatjS55U74qvbQG0sUdztZcT/12la5b
-        ubpuapfn+rLz3us/j8G3YATWPe/sHSdL3ZSnr+f9rnXrgWALlU79E8tb6CxtY+bOvr2OVz17NBnM
-        p4FR3uh827QMeJPVzRyM7IVuBDO3vz+eaiCAg0bQHu93XvtdW3S0/UwbvzfLO6GSd5DEX2jkqI5v
-        Y5FPWVk49D0IZB1DS7Z9aw+9kHkPxnOKwt63QeiU9G9xjQdozESO76mQgACK8IplDBHmEo2stKAB
-        IFJFibBLywCRPZV20HOKihEpVsQOVkwyl7XXbQjEaucpXaggK6ogLNa4p8YdHeEClSzoKljVRP6O
-        nYjyGggq2PV0FYrV5t2GUmFBiZxOU7wjFGv3OolMUH3PI4k0SH9RUx73Lsk2OShlHBQVO+TCOS7D
-        YWDKYh7QrjYzrNgtEsA1FRUisZrhMCjDIVaUUWDtHbOShT3IUPE/f2b1UzxFRQHAvU52KKuao0fz
-        MyCVUIfRYGngW1ZQ6iseKA2oTKjkSImKbmN49BRMypIMFKxUUpGtWFAE4UypcoQlDBy4d4wIS4bp
-        r3TbUYyEk1BnoRvqh1Gm4tLBc6wSJkc4Q9uHoXaWlSpZEGsOyADRFffnvXlGh157ZkicOfLaPPR/
-        biUsv8Ry4mwlkfUzvFiQUiPjqHT+DDGxWfFwOmKppBDSaRTHFHrWpbQaDGcSmSoHp6xo60vsA2jj
-        Erl2mKHSY9mO7ByiqERhXssOmQzrqgGz0hgQioGeie1COGciuJKeEhJLh6nZgwrd+HBNcnIyooJo
-        m0PSSgUXDXqQEVga1I++K58V04c0urOAoOqYpQLTsYFjl32DmDIBqTyaaBrJmZBOrZoKQuwP5RPX
-        UHC4gQzG5HEgZuV0GtKcRZ0anS7qefJQaERiG9kgNYetUIksGYNhJ8iosWaC5OZLeQ+mNHSAHk9L
-        D8LkOSylRGcZKZZuBhkSPWElXbcSGy28Xo+ZOTJ6FkjEkf7KJuUXlCakMSZNbUplt+DpxNtIU3zW
-        4UV2IamAYf2NEvlDkUAiEMqeYh+hDG3Axux+/H+X+DbWSl3/6JMqW+V4kupTAuX6WCVOfkCQFMhm
-        uFARTWkIqsRxSGTUW3yj3uBy7FhI6QH5Z1mABDRZlGvzbcZMcHK5TrvJ8XIEKzYgYUZyb0gvc+0y
-        35b4ztca95Xj/sXxX8OVHiuweYsWoGOEFQ/f2aTKE2N0SeCav9IkTb7arNV/2CT1Kv9TJqmXq/zf
-        MQkzQZR6qD+GeXzR7U+GC6GSgRklMsOrgkkgXUo90oPZ8DdUmpHjeApJg94/YyVqL/pbB2JzPIol
-        ZMRwk3i5kyaSLMgYZHvYR6KpnxM5g2ICLTKVeBzVEqRbbtgtRYk51qNVhv72XQRNkyyFcG6Pw/s9
-        fm/vIT5ZZfHKg7mP0JFpETRJkxEWHrERleBkKJBkfKQ/y9wTH4oSQKik+pqCZFJvSGAfkGiTPjgH
-        hLkwLDcQJEmQDQVLucqeb9vErPT++SpxjTtUsEjOfMArooINyTcCgC7xG590aqEvRft5hDOyTzus
-        DC1GKCE8g+NZiq2y7+A7VAh7SFoT+/yiVJdmQiWB4gRPKikO2bJhiRwrwEVcQJoTpccDPQ59Qchj
-        wnc+WXLfKn/9kZL7OokaKNahdAfT4WK5Hk6nS6GSETASbVAU0ut7JKzWxJFQTGPlhTUJfysaC597
-        uQ+9nLXTjLeGgGTEVlglfn1GbJHE/xMZsXWXEb8XomFsuI5jss4tuuQCFkaMqVthtY38MjP8X4m2
-        9aOJNnIpurtyt9MlLssAJkHyWc+8/hRBykozHPVQksZYd/jBVFJIuA/gfPCG/9OLaz3VuNLbq1BJ
-        ISrVNMsiXQvfqUUFPIvR9dKYDHtbeR+eN1o9PGABynLCNSo5JD1aeCekd/n0IUoyvO0kEAS0my5S
-        BJriMxbojxf96TDcdkGQo9JWyyWnKam6p5owr8Cs8eg1ofiMQMeFr4Z7MMfLfEE8goXHzwZ37wUP
-        HwruXgh+NK+wz9JfnPoq8bNR/AjFHjLuHqdy+E+9ZFWSJ6rKd5+P/wu8uhIsgBYAAA==
+        H4sIAAAAAAAAA7VY2XLjuBV9z1ew+mHmIaG5aO9wOKW9ZVleJFmS/cLiAkm0SEICQC3+nfxJviyX
+        BChSsqbSmSSuLps491wA9+IuQBu/H8NA2iNCfRz99k27U79JKHKx50er3769Tnty/dvv5l8MlyCb
+        IQsTDxGLIBoHzDRo7Hg4tP3IiinAPrUc2zMjbCi3JYYbEwKzn/IvC5ZC5srZGsollDOWtsswMTVV
+        LXAEmLOiOHQQMet6tcASYM7aBraLqKkXOAIqcDBlFj2FDg6UIkyQQM1//qOon+M5CnrktGXYcgLs
+        bkzXkuWq7NCP+dNHMF4RJNOOcz9uPLXcZX09rB53k8dlnz1OnlvPTlUL1FPTd7a96Wr8Uhp674PP
+        jk9XnztGG97sx2uLWCffDwYrHZfr82iP3iZPM2cR9OkMP+/mnfmh5jgvGpr9mPW2sku0T//9hOy5
+        u5r1ds1P0pHfYKfF/Rn8XBneoMis6rL8flRlbRAd2/t5a9hYdtnboq82WAc1SbsfPcz6h9Wu8mPR
+        H9XR8TCddOo7/aU/6O3wptq+Xyx71n21/PBWZq1HN3Le41pVnSH/1B2w8eDw2Qg6u8FLadHc6c1h
+        975B1eWL3w3aeDhh6nTf7ez9Zs/W/U515I7eV/KijJv3R28dbYa91uKw9BalaIlaFW0zGNn68Zmw
+        oFtvfp68NVKX/rv9uWmMYxmTUml3Qp3RyDno88/jev/08sZG+DirnWrTYzir3J9au1Kz9XL/OGnY
+        4Xo/bTmd9kelNNdPVth2lg3NPtgf8vuQ6m5ra+nHwJ8ebH+kq4/DnX2oTiqzUT0s43c3Umn51WrY
+        nWnY1/36y3bufiw+P96qbzPWWw/cx2CNdtFC7i+I68z1Pn43lKLLuf9Nw0N0azN3bcGHa7ZxECCX
+        SUuCQ4mtEaRpFCNDuWTlSiFia+wVgDSR2k+tp4IOT67CkDJTu6tcMAD6L7eS5L/NbPPxdQrrF3iZ
+        IKey0xaZLp+/QEzhwvhsnE9dHEewQxeHjh8hzyw17pLSkA3PFG5rs/P6MIWJLsCck2686UE9kyiz
+        I88mXoHMzYqwhZcWhQpITc1QikMhY767QUVpBhgJbUt8F5mlSrLNfAzlk7hrm6yQWU4l52G+AdNA
+        4Gn4Y0P95Vvvzg0lH3FBus0uVPHTYY0IEgS+eddnoqQGOPJwJMcbcNYZ5PKU+pDKhVAoBzal4g/n
+        24RRoOSAEHI/glD6xQ63f5fa4NE42UpBbEAfSJsCn/aEYKZLKHEXeMHaoFO6kpI6LEOShiN4mdoZ
+        uZgs513P59mRi25Pys3JCBdgzkntaNkQrUwY2rlS4JYq+RaUzInJgRLh9vQQisBZnOq/Rj5DnjSE
+        Lgx9NKeKUyE+xBe04b2PDtYWETeJEd4gb4oML2nexI5WyEKRJ8bpZNN1/DdJo0yaoC1DSbuUdFWD
+        JppTODtmLgT2kiJmlqrJUtdoTqPIhVCCbCjX9FqlfMnOhJx+gp8w9DwzWVRtqJpgnnE4aVyvqpqV
+        wpCgkFohSumy2pBVbao1vpfU76r6V1X7nqx0W0HMe+0DPobMJ+yLVypsLY3s0//SH1W9XCupP+2P
+        ilr5j/xRgX9/xh/C/rTW8HBMCve42R52x4ZSgAUldcPIZtAJDlILxyRCv1LpEcwhNtQ9Ik27k2mm
+        yH3Gv33PrA56mQRGAg8g0LEJ09ksqRlFUDCgC6xNBZTlkK8rO+m6MpWj87oyQ5QpmX6qItTBQhZT
+        M/D35+kFlBF4Y1Kycdp/qB9uAySKeabHOxP/jrcUBQHslLILE7tfTYSv0Q+1iCs35lghbPEGGdjM
+        ZzH4vALtWW9UNa1UM5QzakA1X/FPWb3TVDjhShXutTlsKPlka5ta0JigHixpekG/AJJqmvQlaJ5Z
+        GRVDI7SPFomjCI6Cx42mgw1fUCOEqnuDd40aEUIeRMQW4g26QxqT6X5u4YIcE7AZRwVahnBCYgMm
+        YVKG+fa/oEZypefNs62NpfL00VDOUNYioOWyhG1tQlMVnfoaN+gap1V1yc1Jl7vCDApxCfR0cnSE
+        eIGYTKYrwBmH9+0jQySyA2kKRKmVBHLkSbkGz5/0HXWr4t8SGOn1jK81aXYeuuPJvPvwMDGUgkCQ
+        0uknthcgAjk8h1CkGU20MnEF+dOpD60szJ5iST0qDI2LY8pL7Bx50JW0/0cBbjS08s8XYO1rQ/qj
+        Spak1BbjQNwM09i4wpJEC/ww6e1pOBeG/6auaz/d59JI5LuTm+ozRLoAhIRae5/6TiCi9xrkrLwa
+        8sCGkidunzOhkkPG17y/zPnkNz+42l1JlZ5HhpJDXLpehyHckbQGb45FjK+Xp3Jyd7acxF5+vQf5
+        FVTkJGsoF0huWnImkDm7GNFzN4jwGUIev61fUwzeDgoeaA/G7Ydusu0rwQWVX+y2YI3k+sQN0KWC
+        8AZmdmBdPW2uQEG6epV8BS94hRfKLVhwr18r12hGu3y5XIM/XVnEs1e59b9L/wL2/DbImhIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2158']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:31 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1879']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:23 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <trolley_add_order><describe_trolley /><trolley_token>64--iT3taV8o23t_Cio5ezl8RWnF2dwamqGnxAxyHFwzwLv4eD8d-OfT95uMI97ePXNksIMIVO0SFfXmvpFi5qwdGzigDgomE0jFeZsfr4xiAVNWuchyHmEnb-ZQWlW_eYj3Ty3O8BBbfRsV0IVn_kdXhLAMRCANf1cxLZMxsVbe9TBqpwp5oq5DhdTECfGomixdD6W2l1QVVhDMuOi32cj7Zj5eyDDjA7Z_Izg8DuRLow8In4WUGqrQgRF_sPeTKSRkFBmYtcGk48tf3fg7wNl4UO4UHeUT95svXBLQLpTu5iz7mkhv1_W4K6WmAZ2o5UkdCcKprnlrjS3dPcCPjhvwBYZ29YUkWyFEEATFzsEIqpbycidEKgDX6dE7XiTrL12TH7DTwpENW0BcJxTxY_2W6hwG4S9QBCGIdJyFdWBrvrgKSil_LMvbZ7zBdyYea94qt_YeoSnkNpNJMIUBnFKDOLyk-Xi18lmkez_cXOdFnRikyNpCbgj3dyeD5y8IbZr8QhR9hbNhIQ6-Z</trolley_token><user_id>whitelabel-testuser</user_id><order_token>c1--16kut9RB3qB5vg82y8sxt1gLWHGf3I0J8vkFUdWt8Uf6Ah3eEvsLLtoyWhBF36HkmfnZ68-_xhAzEAI5Za_7iWhNCEoOQxBS6350KYOeSPgdwyX_WKvzXxYMGW0WYFYphvGKJJX-9iNDBz7KXwdvfr-enGyH80kCpkYekLaM5x8NNJPGdkIQ9pICWhOMzRrex814XKL4QtMu_AdyLCHXIRMCbSiXm9ldgnz4-TjSm_8QX3G0Tv6GwU8O0wW2RCURcddxtH02kzDOU01nkeAlipMbfb7TlSkJdOm1vj9N69J_tBdPIM6LQ---Z</order_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsUDfEXxcUCHyqYlLXHoXFHrOkiCFhc3j34smOD16W2zX2VOT-TnkryAjJ8N15iPw8qeHlWzsKzFfY</crypto_block></trolley_add_order>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48ZXZlbnRfdG9rZW5fbGlzdD42TDk8L2V2ZW50X3Rva2VuX2xpc3Q+PHJl
+      cXVlc3RfbWVkaWE+c3F1YXJlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPmxhbmRzY2Fw
+      ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X29uZTwvcmVxdWVzdF9tZWRp
+      YT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X3R3bzwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRp
+      YT50cmlwbGV0X3RocmVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZm91
+      cjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X2ZpdmU8L3JlcXVlc3RfbWVk
+      aWE+PHJlcXVlc3RfbWVkaWE+bWFycXVlZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5z
+      ZWF0aW5nX3BsYW48L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+c3VwcGxpZXI8L3JlcXVl
+      c3RfbWVkaWE+PHVzZXJfcGFzc3dkPmRlbW9wYXNzPC91c2VyX3Bhc3N3ZD48dXNlcl9pZD5kZW1v
+      PC91c2VyX2lkPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48cmVxdWVzdF9jdXN0b21fZmllbGRzIC8+
+      PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1202']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a2XLjuBV9z1cwXankIUOLoESJnHCU0m5bm63V9guLIiGJ4moClCz/Tv4kXxaQ
-        oMRFUnsZ98wklX7oFs49AIFL3IuL05T/+WJbzBb6yHCdX76BK+4bAx3N1Q1n9cu36aTNit/+Wf2T
-        jH3XsuBeUXVdcX0d+ooPUWDhqoyChe7aquEoASKwgZSFqlf3EMmF8yZZ8/cedpWF5Wpmdaqw7Nb0
-        lpLZkLypMFywK99d6gB3dtrg7nFThBraFJuPoLy5N4fc49xpbu1Jd42mzWXr4UWbNq73z49W7+Ha
-        fWhf+0PTaLTXWnFTLCF72ATlOf/6wM+GE3bimP6+trkVB0Aw7nbiM7y25q+o+9pePsqFzJzkcJWe
-        i5CxsCBdSgY5egO7JnSqpsCyr9JWN3s1sfnEiVMIGuN9fQ7YErhvLvuq7wavQ0IoLzcV31G6s93O
-        qDe0uz7UYH09GAnlRrc8mBrzAASrWVFXRCu492aGX+Gndw+7ov3Cj0WrNq4IaumpjCWuab82xIkO
-        +i8ufvC2krEY19jdrTar8Uqfrc/U3q3ptYTO9ba+l2bdYFu/hTvx2kfrvjeyR2veHqOtdG9u9VVJ
-        MpH3fF1W/buSoTutxsrabWfmo/jEKdfqi3lTGQJ3f4fb3Rq3ao+e4eBWazz2wNqaduYvN+6s0uZH
-        asln+2vX2cxuuXLT91F7NLtv3JZ8OO9PWU1y1HvVtlXH2yhwM1pgsOgr6ryxugb36lPf3Arj9lKv
-        sba+Btxy/jha4actzzeGPpjXik7fXc30KT/CrzXdacPOQ6/I1wGUhE2jvVpUhCmSysGm2+LBAnv+
-        eHIvzUf1V/QglO7d1a6CzGl77y7bbUl7aRtipzG1y/Z9gNx+WXot8Y99pTUabSpPz9P+9ImzthrH
-        KYMOr2+NxqqzHAbqwrHrTfPBkIT7WW2FsVDfDBc9czMTNT/Qur2xO6rU3Mc2HhgK3r3suj3DqN28
-        tMTmsLPnppYj1ZtF5EJ411xN6m5x1/VU/9X1+rco2LY60Jts1Xs0Kj9Yte3D+nrWft7CpgnHt56i
-        LOfi3bi4sm+lrsLa7XmR7d3MrveTXWncYP0RX+/oG/PB7ArY6WhgfuMBcLMXnm5g9zWocSz7JBey
-        m/W4d2kUa27g4CqfsNJwGAdQVwwMbcUJ7AX0Q+YpeBizKi8CRw8DhP6bGQzIhTPogYncwNcgAXVY
-        hS9YwRBh7tgjbc310CHSqhPCZsZ7RObEPEHfzXeMSIeO2MWqRcayF4YD9SovXSUPytnyXRCuFrkr
-        4YSOcI5KHuipWFtXwQn7aMr2QFAlm9fQYJUvn0woMeY6kdWtVX8Fq8XTPkebrAW+T5L6PvlFXbla
-        eCTzZaCEsVQ17PpVwHEpTgwmrHgHiHw5xTpsiyPgWaoGUbh58lCKQ7yooL29cK1CGvZhjFb//a90
-        /wRP0Kqsw4VBZqhoa9eIxo+BxEI3zBoyzcC290xD9XWmSW1yIUM6djEcDFe+iskRqegqVguJyVFt
-        WNXDkZLOEXZk4L13woiwYzP5lUw7ipFwELpZ6IQaYZRpmFn6rs1gsoQtdAIY9k6zkk42xGtXTwHR
-        K24M68NUH/raU02ymaNdm4V+5VTCUoB4rjqYTsjzU7yDIaFGztHo+Cni0Wf5xRkoTiW5kE6i+ECh
-        ax1Pps3WYEKGysAJK5r6GAc6dDBDXjtMUemyHFdxl1FUojCvpZuxDRuaCdPWAyDnAz0V27lwTkVw
-        IVklJJ4OU7MPVTrx1pzk5GOLGqJptkhZt9+toQ9jQpwGjVXgKVvVCiCN7jQgawaOU4HlOrrrsIFJ
-        XHkEqT0aqBfZYyMdWrNUhOJ/KJ9sDRWHE0hhsf0QiGk7HYYUilHVSIeL6q8sFDqR+EYxyZkTP6EQ
-        efIAhlVpTD30PCKZ8RLemSFNQ0fnh6ULie0ZLKFEa2mrtmHtUyS6wkLy3MLBaeHr9WM3R05PA0dz
-        1H/qkONXZ7qkSCcFdkKN34JvkN1GCvStAXeKB8kJGJ6/USI/a5JJBELFV50VVKCjx+34/QQ/MUDE
-        a6YWrAJyyvIcIKk+IVBugDWyyZcIkgOyHD4ojyY0BDWycUhklCpAKAlchn0wUvqe/LFtnQQ0eSgn
-        AjFmHnHycl2xzAElglVHJ2FGcm9IZzmRBeIESD8XuZ857u8c+Dl80vkO8bh5D9A2wqqPT3zCA+KM
-        Gglc6ytdUgZ8uVh6t0tKPPiQS0osDz7jktgFUeqh+zHM46Nao9sayYUUHFMiN/RVTAJpx9RJDebA
-        vyFmQJbjqyQN+n8+dKL+or8NvVq+aR8spBXjFtnlbpJI0mDMINPDAapaxvZoj6EDgR4yhUM7OkuQ
-        YXthtRQl5kM/esrQ34GHoGWRRyGcmWPrdI6X5h7i3WkaL5wZewVdhR6CFikywoOnKkRH8LEpk2S8
-        oj9Z7gqEpiMgF5L+axUp5Lwhgb1EVYfUwRkgzIXhcQP1YxKMm7Ktvih+4DjErfT9A55sjRNUtknO
-        PMPLo7IDyR1Bh+SigwNSqYV7KZrPOTwmB7TCStEOCCWEa3B9covU4jv5CSqHNSQ9ExtgxJQmA7lw
-        hA4JnpykOGQrpl3l4gM4j8to7UbpcUmXQ9WMLCZfuLJk7irfv6RkbidRARVXKLVmrzUaz1u93lgu
-        pAwxiRYoKqn1fRJWc7KR0IEWHy9xkfCpaEzf7Eh6yVz0Mt5OMt4c6iQjVsJT4uszYoUk/g9kxMpJ
-        RrwUomFseK5rxZVb9JJzWBgxlmGHp220L1PNtxJt5b2JNtpSdHZsTaqRLRsDsQUpWyOlROVBykoy
-        HN2hJI3F1eEs7pJA8mkAZ4M3/Ju+uMpVkWPu+nIhgah1vbZtUrUAqRgd4GmMPi+JybC2VRbheqOn
-        hwvMQWlO+IxCBkmWFr4TUrs8BxAdM7zjHiGo02o6T5Fpik95oHEzavRa4bRzhgyVlloeWQ2jGb5m
-        wWyH2Bvn1IS8jEDbuVvDKZjhpW4Q52D5vGxwohecFQpOFIL35pX4WvrFqa+QlY2+SD4Cn5KPhg78
-        iHokch9Sj87SL6tHp+w31aOK8An16Eyft9WjAOlfpR6VuB+vHv3l/+LRbyMeRZv2R4hHhS8ViWgo
-        XhKJSAX2lkJU0wMLM2HRqIfb4AcKRTSmzwpFwm8kFAmXZSJSMW3hSkVsgC4pRSpiZiHlf1ks0tQF
-        8R3+nl6UUL4nGTUoi/mranv/YGaqb0D8CQUJvUdBGpMKCSLGXTI1G5K9pea1pO8oQwH8iQESqflv
-        A2v/dsnP8gL/7qJflCS+/O6ivwKkD8kgFRZIE56n1Tlp/n7K0IecAnip9H657FPaEB965GNOOdWG
-        erV2q99vXRSGeirThrYNmUsqUE/6Q6hAZ2SZYvkKcHxZKF7QZgAQrkCFL1fAH0ehkf6IAs1gJkqA
-        k35rfQa885IS3QIy5X/0BUtON6+QU/EcntZy+p1+Z1QbNHuzi0oOoTAdEkw6kzoo35BzLsRQ7r/q
-        f4h287GcJfLgI3r299SbbFr40erNO8+Ho3rTk9g7sfTF6k2vNmn9Gv0GcG8IODz/Xyng3I1a7XfJ
-        N3c+XEJyv9OZcGDiondoOPRm8HtoOLTQf1PDEd7ScN7OKN8Rcj6fI486zuFjolhSOPnIKIN/6Iuk
-        wvFTo8LFTxL/A9zjHdHUKAAA
+        H4sIAAAAAAAAA+1YWW/cNhB+768QjKIvjaxjD69dRoHXF+B6HcfeOE1eBErirhRLlMzD3u2v71DU
+        ud7UMZAUQZHAQFbffBxyDpIzRG9WWWo8EMaTnL7ecXbtHYPQMI8Suny9835+ak523ni/IPJAqPA5
+        wSyMfUa4TIWHuAyiPMMJ9SUnzE+4H+DIozmytktQyNaFyP0gzcM7L/RNc2wG/POHt5/T6yUjJj8O
+        zq/3307DxST+c7y6v7lcnInLm6vpVTB2Unt9mATF6XwppsF98DEcT47k6GJ6heP3N1fX+/4R/+v2
+        04r/zW/k8XjuFkOXBkVw/Xj+bnp+cv5pdTZcH93FsYuTxX46iEaLdRDPRu9Gs8vULqZD8yOyeutD
+        UcIFpiHhPmbEf8Bpoo3bhmsHeQgQ7IP7iHfyAVntlxZEhIfeCXh7/RgTRipCiaIwEWvNTTH3H8gS
+        c1NyWFODa0rJvsDcuFWUSl6pgJG8+k8PwUIwHAqIrWK2eMUphx0+5Wh1ELUyhFrtmoC4D6EqH+7I
+        ujuTBfFvBSpLKno9ukF6OlveF9SGOAB/ie3atV0tpQe3rNKyI80yfsNZ8YdxnFBKmHET54+8M1D7
+        wGpXZdXuzbnwGaZL0JvhFcyQBQklkTexd21k9aCSAMsVBUtC4u2NakaLaYoEgzADlS2jgVCmPL4x
+        SxcqCU9m6WGasjFLD0I09zns+pQop/0/TbyXmAq1X/KiTCkPlbvXr3HPQdYGsslwn2UMnmUMnzKs
+        p0sr/e+HkjE4kIFS/9IpLXkEGdmDWsYCtkzOPMe2O5wKbFlUZgFh3mTYZVVgyypSDEedsnsT6nBU
+        vvB1FuSp1YXheNSo92t3eAsja9NK6wtp+DN0P37ouvEKc0kFayxWwg7QiMtT9j1NBImMG4EF4Ua+
+        MA4zAlsat4P0YRyBXOv3CY2q71I0l+SV4dLIOJRLyYXh2s4YLupGrqlShH6+WHAiPNMducrFm3hL
+        5CTMacQ9Z7hnu7bbZ9dCTV/DvyyLIk9Na09st2I2ONx8+WRsO34JYxr5IslISTftiWm7c9c9GNgH
+        tm3aewdqpu0DKr2bLtDfUJQw0XNKLF8ZIxEbM7z+th4ZuyN7MP5qj4zs0Ys8MoK/uavc8TKPVB7Q
+        tWqZZxeHpyez2QmyOlglr+oo45RkGakJ2jX6N1R144v9WtLUeH4Kp1PuiRguHtYM1GDFyEiUYMhx
+        XJ4HsK1i2Bhe5Dyuho+DkQyyKFnthmkuowXLqdilqmIpOSih4EgJuwxuviIlyrks9WIhigPL+lcN
+        FodLjkRWZwkWWQkftpRwrJMPFqTwynFGu5+LJXhz6zyI4kzVnxBIWDwYV36jAovYe5n+cgj6ki38
+        2xqz1RQuiyJngvtqQl1p9qE+g2+hqKKvF9EfObx7tr0a2Pbz4c0wu5fkhcHtaf/ewe1N9jO44BFn
+        COk+/IrgcihG2Atj21P+vWPbm+xnbH/nay5I5reIMiRNCPuKWFfMF0T7uem+a/Sfm/w/zgbtLrji
+        zRSbC1UFWDVPu6F684KqVHIvTR6ay76CaoIMoAbBVv0t8jtCu6WDBmrpuoDIJcpEqGDCO5ViHQla
+        klyVOLDKFENTIaFgGYx3HXsAnUeDoDSnS/3TVLegs+dC+9OCyGrVxJj70FMVhC14+XzVA9SbjGqh
+        ocWuH2Oqz7JpZ5JSqGx0reW4Vd/eQ8u2u4fsV413n0YJiaC+KqBEU1FWZVu5nG14RZYMq43aodWI
+        JigTcpaptzi9+icoUu1NWfVd3k72HRti0iD1M1P9nOffZV758LAFRzzOH0vN2hqdZH0M8VyykOgi
+        s8lxoHXgmqMfAleCMIpTYw5EY4ohGaCDaUfoYhRyQ1ajZ2ezs+vDy+OLW+hCW7iilHSgGGdQDUdG
+        54mwI6+SrdkR/RfdfwBjn1trDhYAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2754']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:31 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1447']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:24 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxldmVudF90b2tlbj42TDk8L2V2ZW50X3Rva2VuPjx1c2Vy
+      X2lkPmRlbW88L3VzZXJfaWQ+PHJlcXVlc3RfY29zdF9yYW5nZSAvPjxwdXp6bGVkPnllczwvcHV6
+      emxlZD48bGF0ZXN0X2RhdGU+MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['345']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1cW3OqShp9n19h7Zqap00EFIQ9HE8Z7/cL3uIL1UKjhJtCo5Jff5qLomZnTmKZ
+        mZgxlarI6tXd9NeL1V8jRPhzZxqpDXRczbb++EE9kD9S0JJtRbMWf/wYDSsE9+PP/D8EBSAoIc2E
+        kr1CmOpKDnQ9A+UF15srtgk0S/Jc6EiaK82BkrdsIf37EkF2/BWypblhy3qeIAmCIzfbapFUN9XN
+        aKJJW/pZevakCjUvGby5YciZ9lLY5HJlsqjy7MzhiKYxbmZ2WV6fdXdjckeInXatW2ZZMEZbr2JM
+        Os3d5HFbKTVLu36Fm/lPFW0oP4s1v9/viNMq7OUU2l/xz62e2dhW1UxPminNZq61k7denUa1HrPc
+        dEyn3lvCptjg5DpFDIbcy67OEzMhfXL+ggWhIilwBRzkOVAK4hQO/ne4sASutIKOKlnAhG7IO4ME
+        z8WRjxBDc3F84QZayR/gQCDh6YH58kRIJ0dRgQJdOV/Gs+lvl9CBMSFEBVlDfsQ1cJcbuAAu4bl4
+        OAc8ooTsFnBT44ASl8dN4Jpu/CeqAhBygBwKAjMTPOaE1QqvOVFzWBChOqJmfYiLTyHBhcCRl5IO
+        /eOe0lhaSUEgwJi+r31ATtpMeG80K4M5jhf6fevRuBLKCZywwpEVI1bqX8Bc/TtV0iwLOilxaW/d
+        o4pRDNLJWaX34bVdJDnAWuB2TbDDPZhzzYJKniMfSCF9AoUEfLpo5WgyzOeYPSPBIoqHBwQc3GTC
+        OECCGUT8rJdjKCS86uUEiyhnvZxAgmVLgbYNGATtew5x7QELBddLbJJ5YQMMTZH2eJ4S0mfIOYP+
+        W0bmbxnZ14z061ML4y/JnuNgw8eU/adI0p6rYEWeQAlDxZeM7eQpkjzixGDCsjxzDp08lz1mxWDC
+        WhlAxsZHH3Fi6IgT6MX1zbltpI9hbKwRmv/ncfUEFtLno0y/IcP71H39qTueL9n2LOQcRhwUHgGH
+        4tBlR5aGoJISEV6E3ZStpgomxJc0SCpFZhwmOVGv0FLi47Bo6MGfKdpSUgVv4bkoRZMUK6ST8ojq
+        IVmyVdWFKE/QDB2E+BxPiC6UbUtx81Q2R9IkfcreF0Z0H/+YpqLkg25JjqRj5gHHK5/NsSQVphkS
+        sJQwVQvpBMkRJD2k6V8Z8hdJEmTuV9DT7yvE7Z6HIDp2Ec5lToKy9H6mGLRMtYF/3YiwNENm2HdH
+        hCGZD0WEwb9DOgjHxyISRyBMxSKdtQqVcrtdFtJHWFwe51GpCjRNuCdEoYk+a0qebfH7EnwU4wZ2
+        JzuPlnjhcQ4VIzBmrABa5tO4MmEAQg3aT+95YVFMw6eLPDdvaJtDMzG0J+AEHSCQ3h8jfwXzrmau
+        jCDXl/Ug0TkqERbQDsID8oIBsCF5eLAZ9oEiM9i1Dohg2NYi+khQFPNA5WhsnQkopJNmguQX+3GQ
+        7SbZ8AEI8rlg+cXL8z6Riw/DBd/xLCvIlcN5ouh4zT9BwyX7BOHjRfuU9qEkPgI9BwRmfETbIxEh
+        GILtmMDCmUN49q9QIbDGUDGdMcdTJJbCAdmnqAreAgRkSTfzYdLyG1xwcWYZ7RjC0YS9nWGCa+Ms
+        BUYChTs8odBFeFqO4T0n2kTsEHQsYKSGmJh6BFgM2P2SGpGQsTa8uHa72q4OCp1Sa4xXsASOKSEd
+        U1JVfCUpqaPtxVF5LLYbW4v3J30ytTdikm8ZUbgptW0jvN7ibdQZFlychmYGC2t4DRwdXs17Q/1G
+        Z0c0s3jC9kBcgrexmqvNjVjz52DESkwuuhxsrOS8ThCE05nRTsafwU2mKTb1x7pV5mu2urUmtXrb
+        FFuk3FGZuVd6LLQL6IVlcp2VUzRMtUeU+6MGMXyKe4xajFvHPhlvzwuD1oFxQIVXZnRqROEdllAa
+        3ANJpnptIZ1AUelyaZp4m4hlQgahO8ai7hJ/+R8okqJvVJHvy49OFZm9siKBvn4qN5stVCgNtKct
+        1RCfuv1Gt4mNHCyqfb1ebz2D7gIxNZ0l9XVxgirPi3crslUYlv9GkOEq+pYiKfIh858lSWculGTF
+        0X6m2E+SJB9dKO+UJPtFJMleZpLMlSWpr3JiixgavtZQG1qvXLC345XaG+p6X31mRVfeAoOhV5nc
+        ut91st01rDDSo3X7Jvm5iuS/hCL3SfUHJHmJS7JXlmTX2Wbd6aLncoYmTunxXGeXoDdhduJgDR6n
+        lIxG66ls8Bz01/4IVYwX3268W5Jf2CVFgH6mcp+jSTbHZj+gydwXccncZS6Zu7Iktz0VJ5GDscmg
+        wuyZD75AaneHa2a07CNQaPY4k2U6DEWKgybb5p70KWv47jdwyU9VJMd8CUV+1CVzl7kkd22XbPLe
+        rLBUOL7NTDcNjsjM3AnUNpmc3ugrdrEyqLSZ9VQX9UEz24czr66OSt/CJT3rZ4r7HE3mWJr7gCa5
+        L+KS3GUuyV9Zkk90TXppkEqzWrSeHIm1fdF8YYh+pcRuTQCXT5RRqEjKo7HMKE+jDGywiup/B5f8
+        TEXmqBtV5CUmWbiyIkesXEDqNOtUV2TW9dRWdekNOoMazfWo1WasWSgr22u6xsPeKNPZ9eYsm+O+
+        g0m2bSxJ/nMkyWX593+ZxQS3vb+EJPnLTPLxypJ8eea1vtkkhiWKhbVW3WQ7uSwrit3ifKeh/q7q
+        Pta0nVEpQ3LLoc6wVX4elM3bN8lPVSTD3agiLzHJ4rU3N90mt+1SUudFqXeXs9JULkhbachMpXF2
+        5Q6L3Kqz2S4myFBpYu1XlaLU68z1b2CS4Zf+FPk5muQzzAfulFPk19AkRV7mkqVr3ykn/OmKKm+H
+        bafQ7G7GurxZl4YbkexNKzwFCupM5x0NLZwusVbVHJjx4rzzHb67+VRJZrM3KslLbLJ8ZUnq7V5r
+        O+X1PqlbPalZb7wUN9nyyC25qlwXZd/J6APbfoJD0n2ZA35tTetd9B2+vJlABWuS+hRNZsIHo96v
+        SeqLaJK6zCYrV9Zko1wvLxZPKFPssr4x7E5Xjc6cQKpX6T0afqtoVwCNx9vd9nR+1hpl++2WBW7W
+        JmUgL6Ei7Z8NdoMHOF5h98erb3eIN/Vc0P/pM7r3x6tvduqO5+u/tbxnqBtd3i9JOatXXt77sOCs
+        KnYtM7KIcRFNmmIt9yjWtc1SHGaq3tTuc9pEXFcWTmlXV9o87bNV86ZuX6bfeh3u/h7c/T24G81i
+        7onafbX/Aqv9PVG72am7vwd3fw/u/h7c/T24+3tw3/s9uEhzX3hFfusEI7MI93Vn/y7mL+x50c9w
+        RgAA
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2454']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:25 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+LTAtLTgwdndHQzBmdkd2VVdpX3cy
+      al9qdV9GMWJEbDltdjUwWml6QXY3N0UwQ2Y5NlpyOC1LbFZLM3g0OWtaT3hWMHgtU05NSE9FNjZh
+      VnR3dUZsV05LeFdCd0ZES0R4UUY4WnlZRmlUY2pTSHlRUU5TWEdlUDdkMnlwOWpMUG1Kd0dmM1Bf
+      WmRLSzdMeGN3dUkydEhQNWh2Tm1ySVBoZUtTSjhjSTEtUlQ4enhJOS1aPC9jcnlwdG9fYmxvY2s+
+      PHBlcmZfdG9rZW4+ay0tLVFlQXJwRm9IM1VuLVZDdFdLU0g3QlNJaXZoU1QzR3VYb1E4aVdTcUZn
+      ckR4SWRNOTJ5Nkdtbm1mUC1FUVVKLVRZPC9wZXJmX3Rva2VuPjxzZWxmX3ByaW50X21vZGU+aHRt
+      bDwvc2VsZl9wcmludF9tb2RlPjxwdXp6bGVkPnllczwvcHV6emxlZD48dXNlcl9pZD5kZW1vPC91
+      c2VyX2lkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['429']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VYaXPiOhb9Pr/C1TU1n9rxwmLo8fMrEpZmDSEEEr64hC3AxLaMJbP9+rm2DLYh
+        b7pf1UwqlaBzz5WluxzJ6H8ePVfY45A6xP/jm/IgfxOwbxHb8dd/fHubtsXatz+Nf+hojxwXLR3X
+        YSeTBAzY1AwxjVxm6DRa2sRDjm9GFIemQ80lsg2f6NLXFn0XIZ/lZjL0PXId27zghqJLN8gtQ/0l
+        o/RLRvmeId0vzQpPASPm0iXWp9GSRfF9XqVvXSSrmzE1/cfWqMs27WG7OfJK9XNnVZ4ptGcH73X5
+        PHuxrW1tdySdceSUtP6Ozdft/nT40nv/iPrj2tNwVi49f5Q6FTk0T+2jGZFT2wy3Zfft/DqYq+Rx
+        rg2iAXK3HnuavIzwu93uLMQX1W+hwSPDUXXx7A/xCFYsPpfXi1XH1D6r3arlNs35oaRoxOnZpWPF
+        f9I+fLunervD52S90KXCnnS8xz6kEYUYmZB6bLTmupSNuMHG1DJaUCmnwwaHOCUkqG7FAUu4LqLm
+        Hq8RFSMKj7ninJKwB4gKs5iS2tMpwJOm/7gLYixEVpIEYGZ4ykncGvccPh1UWlJ2fNoTBnMR0ilG
+        obUxP/Ep/yQJajYzxJWd0i/eV6QwZ8b7i2kttIR4sa9n5/vKKAU4YyU7e+Is4V/IC/4tNB3fx6Hw
+        uiEHmnPkMZCyVUmX8JLIZ2GakyRDeeBqTvzffIdhW3hliGEqkJXQ8HDoWChz4o+xwW6GyF9jE/t2
+        Ok5M0wh/F1TfFhrROqJMUGWlqkuZnVMjZplktaKYGaJaUWU5peTwjEixRXybGkpZk1VZLbIvRk4/
+        wY/n2bYRP1auyWrKvOKQU1KryoqZwMi3TeZ4OKGLck2U1amq/ijJP2RZlLUf8ZO+dkjnvQ0BH1OG
+        QlYIyib6LlTYRhii0/82IlW1Ipeqvx2Rilz5WxGpwO9UjcPx9yKSRiARGV5ng0a7NRy2dCmHpfZU
+        IYQ29jx8IfDQ8M+ObVQH9YsFRinuwoFFDLbBiIVXRw6mjACxjSGBs+gicRXPL114iSmlwXJZRA3X
+        2V+nSaELAc40xJB0GbNTgA3qeIGLYffWZ9zCOYu+xiQODzJ0F8HJEsFmS9UHRS7B8XNFdJf4a/5R
+        VJTKg6KpcAZmoC5l02xAY31iBjhc0eSULQCxUoHIQOteJSod6h46mmHk+xAVnidFhRTeoboHilZA
+        6jHtFtR9jG3ITQDpjUKclECynK/wlByFKNbDHO2CcEK8BRJ6yLcwX/0dqgeEsqRiRrNaXZGhFK7I
+        RXxtBzIGZPPTM+QH+Sq6eVynoJnJzHw3ydNuMJ2SKAR6Mjk+QkIxZZCWPHzh8OPxyHDoI1eYAlF4
+        RFAMoH6ZBy9kqI0o9R52hp1JY9QczOAqksEpJaEDRehAJ9lC7uDM2dNig8Dko5RJyhzb3wVF+b8I
+        TkkuKfLvC46i3AnOXzV1XNIBIW5Su+lhe4PFhe46XnxIJfWUG/5CxxTld5U9qQW+OrFf7kCtpUBq
+        gcuOQ52lm9bPLchZmWDw0gJVuOjgtJU6ZaB+36HFtov/8uQp8kNJFsZDXcowbt5sPA/Oe1UtJenJ
+        Y/yB10KxojCEC/8p+3S5HNhw0BegjLGCaw0J4flyjpOCGcuPvCUOjVo5z0rBjBW4yMI0vs/fQjkO
+        dLhJT96SuFIeBnXhqPHPvHsGZ6hReIWJwxQrdSrRAdxrMLyaxGc3WlLiRlAFFO0h6FxAbkF9mdQI
+        gf42hvBKUJePP83BYvuh+o31wcITub1WyG65c1qbWl97be5ng2oVLctkN4s+g5r56DiVl3p33p2S
+        xkvXeZxFWnM3azS3x/FMY5/bzpuiyJ9ltKfbz2BrdUwLR4v+TG6yY2VTNt0FPVRNcd9TnXNdHbMD
+        nU3eRXvqllpnszNpb8b2R98Z+wfx5/L49KI8rnfnSYAa4+OsWxlZ0Wt93jODiXbc98NIG+FZfRj6
+        Ddej/bIIrwe53cGd0Fs6PjRVLYnEdRi3H2gD5DJtPj7QfeLzj+aN5xeGHDnu6SQNhlYpsjNLng56
+        ukHhGhu37Kshx06T/fX8BaPO69NMiwV6GE7pOyxuZAukCq2zMkn66gbMFRZvoQawbqA8J+5gqYBk
+        2hGiAzjAm946IhFNNVCBK9yXhoTOCEPuDTOP6bdBz4X6JsC5sH4RzGIIpXw75fqM73c8abWvHjnZ
+        yyOJko1DDOkJ4RUkXhaEs+h1UbsM4QULbSE6b154aHX30XbF6LzXnJDo5/mMnnpnZRZafbXeOVMN
+        +vM4NKvn5lP3pWfvD1FgtZ/Debe53vq78tCcO9vpuVSbzzR1NUaPb+NOafwKZevOJh/FpaSdIhU0
+        RSrqjYV808VoD7UBW3FxeqbdwzpsDO6jcF25fgNxRTzMNsTOAUnonp4fn+FgLWB5CmVcxIpQxuDv
+        lcR1scWEVUg8Aa7RQnLFyDml14XLMCvMK8TD8Abx762qUWWi9ZbWsDo6OIvd6VzqVhSidcUaDXq7
+        Yb3xvtuO99r5fSMuTurxNXh9VmjkDtajcUU9LKohnpx3NUzEpTud7cZmI6qsO8fjqbWpPp83RN0O
+        Ve38c28Hx8Zouu+oK7P99Nw9HQOEldH2I7fuNDnZOM6OxXebp/Gk3YVauk+H9N++DPsPYdEuYlET
+        AAA=
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1997']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:26 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGJhbmRfdG9rZW4+TTAtLTkweEhfTFpqWTJuQWd3Y2VSMEZnMW9x
+      YnFpRWg4SzdTRHZWTDY2YWI0b3FWdWtwOF9CaWk1UTlJV0lUb0FRSWlCVnU3RHFWQURqeFBWN3Rr
+      akdVMTEwazRhdnNqa3BqY0dfY2V1WktWMER0eDVoNF9sWnN3Nl8tdkoyaXo5MlB0d3NWUlgtZFRs
+      M0V6X0dSRmhQZFlLaVBudy1IYnhDUTFCZ3F6UnBhQVB4Vkk1TmN1UzlXSl9wUjd4dktydTdOZVY5
+      TXJuQWxtc0s0LVo8L2JhbmRfdG9rZW4+PGNyeXB0b19ibG9jaz5FMC0tWFc2c1VJYTAyaFBzX25C
+      RU5JdGhGTUZETm0zOXpHZjRWMXNKZHBYOTB6VlFkY2o4cXhvR1B1aTM3S3F0V2dGS1RNUUpYWXVL
+      UDhDTVY0M09ZM0c1MHJfeUZ4X3VveUZfcmo0bFV6U0xXMm9CVzdMdUxhbGptdENSUU5lWGRGR1ot
+      UTJuRWFMQnRldTZaT25NZU5udGktTzRnWmZHXzdrNkk2Y2xEX1d3MzE3b2lKZDN4NW5DN1luZEoy
+      bXF3a1JnWjwvY3J5cHRvX2Jsb2NrPjxub19vZl90aWNrZXRzPjE8L25vX29mX3RpY2tldHM+PHVz
+      ZXJfaWQ+ZGVtbzwvdXNlcl9pZD48ZGVzcGF0Y2hfdG9rZW4+VV8tLUpmNnU1UjdKYmNNNk53aVpx
+      eXozSTUxbzdJLThzcEpxTTlBWHFqUHY3elhoLVp5MnhTcFNPMXN1bExnTlA1MndaNnJlUnpxOGVv
+      LWJsVFZxUF9BdTVnR3h4eUVoNk96aG8yak0yN3pIdmRweEFOVHZHMmZfRkNPSXl4cGFlMU5qWTwv
+      ZGVzcGF0Y2hfdG9rZW4+PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjwvZGlzY291bnRfb3B0aW9ucz4=
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['740']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1ZWZOiShZ+n19BdEzMU9MCbtjD5Yb7UuIuLi9EAimgLEomKv76SRYFreptbt+3
+        W1FRkt/5ziHz5FkyLeHPq2NTZ+gjy3P/+MR+YT5R0NU83XKNPz4tFx2a//Sn+C9Bt5DmBS5WvCMm
+        TKT4EAU2FgUUqLrnAMtVAgR9xUKKCnTR9YTCxxIBnqFL9IAPgULeA8X2Sihko0SgQ6SJbTKt8GJC
+        H6aEGBU0C4cJ1wZIOUMDIDpAQiHDE0rMHgJEyREllacmiCZKPxIVgLEPtHhphJnhKSdWq7/nJObI
+        0uJ1JmZDSMTPkIAg8DVTOcAw/6YCcVImiFyZ0u/aD+TJZsb7hlkNqMRf+GPryboyyhOcseKVNRMW
+        9R/gHP9LtSzXhT41N70LyikmPihksyrc3RsFjJ/uSbxDeeAhjvWXroWhTs0xwBBR3o6qO9C3NJAp
+        Ja/RiVzxgWtABbp6Oo5FiwB+pjhXp+qBESBMcQxbEQqZPKEGWFO83Q5BLNJcmWOYlJLDMyKCmufq
+        SGRLVYZjuGf2XZjQQ/LjOLouRq9leIZLmQ+c7KnHVxhWiWHg6gq2HBjTaYanGW7BcV+LzFeGoZnq
+        1+hNHyukdl9dkIwRBj5+cooZfKbK2KQkEP5ej1S4MlOs/LRHykz5lzxSJr8LLnLHr3kk9UBcZJI4
+        G9Y7bUlqC4UclsrTCkF1oOPAOyFxTfJs6WJlWLtLrHv1UmxSHT0RmxBg/6GYgCnjCLApFogybQN6
+        F9kv3HmxKKWR6eIAibZ1fphJoTuBFFGAQeE+xuERishyjjYkq9cOUQrnJIIBvcg9QBRsgC0ckMUW
+        K19YplgSCg9EsD3XSB5pli1/YascS8QPUChkZkxSY11POUJ/h+Ky/gRElYoUGZK6jxKVDgUHXBU/
+        cF3ilWSfWI5s4TtUcEhFe0JqEe0VFFwIdbI3R7K9gQ/jEIin8xGekgMfRPUwR7sjCSFaguc7wNVg
+        Mvt3qHD0EI4jZiTzNZYhofBA7sWXdEYckZWDIzJfmEfRzeMCIjUztpysJn7bCyYgL/AJPTYOr2RD
+        IcJkW/LwnZO0xyuGvgtsakGIVAOQYCDVL9NIApnERpBqS12pO6uPWkNZKOTglBLTCYXqkkzSqVzj
+        zMnTYCOOyXspKykrqH+mWPZvKThFpsgyP19wWPZdwflWUkchffQ8O47dtNm+YFGg25YTNak4nnLD
+        H9Qxlv3Zyh7HQjI7+q3UJbGWAqmEHHYsZKl2Gj+vYMLKCkYSWqQq3Ovgop0qZaDwPkOf0y76m2we
+        y3wpMtREEgoZlohN03FIv+e4Yrw9eSx54SNQND88Yk9RbU87iAeOpmELjK3FvjQaal1GXs8bfbbt
+        2q3FbVUfoR5XuprLE15N16He0FZN4srKCsD9asB7/WB8PM97i7DmVabX5hjUN7eOsh/uKkWvwwTy
+        qN73jyde6uL91ZTWvUCpn5ar1tieB3y17KoMh53TxOjSN7TU9utw0C1VPXPnsUPQm9TkcUOvdNpW
+        ebNRlzLt1LfNeq9TD/D55IWNE7tZXAYD0xjxHZve9M431VxtkYPR4TqZnFZ6WG3WimG3VNsi31I2
+        vYAcXmfuzR7KJ93g5HU1oOdjy+DW59nmML5tO5WK3Lk2T7LWo/EykNndQR5aLbXcqKnTowLNuV0a
+        2qpaDpSgP6Tru6Ba8XxpW5melcFaCfU92kEGrmx1w55rtz7gsRMCTVkRf1+a+nIEABiV9FBek/nN
+        ZkzRmNXc2pt87qiHS7derl174ap2PcxGRXisMDS9Jeeu/F4Jqg1c0myU7B7g2mEShx+LBC3wfXKT
+        yD3dD4I6Mf4EZYwdOcJ6Pok1JsdJwYzlBo4KfZEv5VkpmLGONtAgCcscJ4VyHFLNFRQ6qmcX8jDp
+        JAkq/juvnsEZKj7uRih7JMUBYTGqVU+AQBqnt1MyhSJpOi/Qwwa5CqnIswNSIxA4k5RM2ssrSM7R
+        jmq5pBDxsfwxzCYTO7neGi5y80kc/xgmFxydXOmoqG3pwNcp0ixhTiMt4T9Y4WOIPdKPxCiYgnFx
+        NLUBEwwQsnl37i9cpn5BrtuoF4cDdTpUyq3Tfnl4u/YWVrF0G9Fqba82ORO151OZxdC4VsH50A/g
+        zJKOt56xPau3cIvZLl/vMQY42JPt1NUGS23trC/20jxI6u04lxa6sQuZ1c5QtLe3vdSv9qoHsGv3
+        mpK82BjQYC/umJcXgdzcSqU1LXmN/nLYY7k32ekt6DgJXlaTW1102sqvPjl+kXJMWhgJw7RHJAOy
+        7W7yqLxs1geCHDlqPUdyC4JitfzMziR5Omn7JvANKL6yH4IcOzk9Kh/bfxIKSWop4AwsG0SthrTW
+        d1jUbzTSUYGRxWtc/l9AITaqqFHfSwKTsF6gPCcKu8ITkrU4H1yIgostI/AClLZqltw0PhTEdOxh
+        YL8w85jw6vScq18cnHPrB858dmEhy+r/O7+r7Pfye9VujDudn8rwC1SpeJ9/S4q3SYr7gdmieacI
+        p7wrn91wE6gc373yLXjbaxPXlquzRmgGvcHuNOvjozJ15Nu+UevPrbY8ldaN2nU1aW5IT7+NOwej
+        tJMPzX675dKyN2mObohuTYs9pVxWe8puwNobYGB7VYHapnJpb8ctWrtKWlm9TGvbg7KquZJOujFX
+        c1BvsNSlNcsowUEvHTqHljfD0mgAqma/XuLkboP2rvrF75k/THX2L6R6sm8/m+oV/pdSvfirqf5q
+        /59Ufzjlw1Qvfi/VE73fn+qV8vdSvTHvzn6Q6I0AEU2EKMP3guNva+XcRJo0urcNV1ttd62K1FU7
+        jh6+9fHlwJ7sA1ZqFlTftMt6jtrNSVuhw66G4GU7gCV/6xne4ozAGO+Xw/NWlv3SBDt+5W3RmXQM
+        +8ZzF9ycAdRWLnN06kzGJ2bSWHv8eL+1Znse0Tea6Q77++VyEE7xsayh8fAi6RLTaHRPHeeG1lWV
+        HYej5bxe1BwDrvTpEWpvClB+opVzfyG/K+Vfym/m723lr/b/ye+HU369lSd638zvxyNKvkTIUtL0
+        rOim8fgq4Z0kF28v/1L5Hy7T1raTGQAA
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2304']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:26 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcj48Y3J5cHRvX2Jsb2NrPmsyLS1lRGFPaVRqNE5MY0cwVlhTQkkxRW5sRFR6
+      V0FOc0gyNHhoVXF0V1FYeWRCY1dDMTFUNldhZWpXSjhvSXVPcHZTSFR5OW82UXhDT2FBWXpGX2pM
+      ZjYzb0YwdVZOQUlycHE4TUd0anhoTVhIdV9BcVVXRE9sU3U4NzVuYjAydG1xUGdHLXpzVWNqWHlK
+      RzQ3b2hmbzFMYUhQOVZPQmQ2RkVpNVlZYlVWLW1BWkNBSEZBdXR2cW95QnExWVR3SkpoZ044Rmwt
+      WUh2emJoV1pzbXRza3hQUHFXZHk3QzkzeUc0OVpzcmlfWUh1ZWFfUm56bExWcWRnMlZYN3UtU09p
+      ZzJYdlJZa096WkY2NlZGeENxVmNILXRVdVYxZmtWTGlEYjVCOWJRcF9laFNsNExsYmI1dV91SUwt
+      QWZ1NzZvck1aNlF2X0pYX3lkanNmZTBlV2xiWTF2OXpJYTh0bXlhY19Xcnlwd0NkVU5hYWFONGR5
+      Vlh4UFBSUjAzZ1I5bjlLVnZGYmt3R0E1OXhIeVc5eGtSTjNlcDYwLS1aPC9jcnlwdG9fYmxvY2s+
+      PGRlc3BhdGNoX3Rva2VuPlVfLS1KZjZ1NVI3SmJjTTZOd2lacXl6M0k1MW83SS04c3BKcU05QVhx
+      alB2N3pYaC1aeTJ4U3BTTzFzdWxMZ05QNTJ3WjZyZVJ6cThlby1ibFRWcVBfQXU1Z0d4eHlFaDZP
+      emhvMmpNMjd6SHZkcHhBTlR2RzJmX0ZDT0l5eHBhZTFOalk8L2Rlc3BhdGNoX3Rva2VuPjx1c2Vy
+      X2lkPmRlbW88L3VzZXJfaWQ+PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjxkaXNjb3VudF90b2tlbj42
+      MC0tdU8zTlFsYTB1SnNzbDhuU3JUbjBBd3NubkJBM0xKYlFMXzVEcWpVa0t4SFRpMzR6Ti1iOWpi
+      QzJoc0VTUVYxdGVneDdhdmtJdWVSaU1wekhnWnZienladDFHOEFIMGdha2xQWlFuY0pVY1htWHds
+      VWhrTWJ6cFNNVGRnZnkwV2ZnX2NLS2pNSTdIN2thZkVIQ01WVFlnZWcxd25POFZUdVZDWk00WC1N
+      b0JJVUxIMTJLVm1IVC0tLVo8L2Rpc2NvdW50X3Rva2VuPjwvY3JlYXRlX29yZGVyPg==
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['904']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VYa3PiOhL9vr/CNbW1n8bxg2dmfX0LhkcmPAIJAyRfXH4I48SywJIJ5tfftiWw
+        TXJrZ2p3U6mATp+WpVb3aTnGn0ccSgcU04BEf3zRbtQvEopc4gWR/8eXn4uB3P7yp/kPw42RzZBF
+        Yg/FVoxoEjLToInjEWwHkZVQgANqObZnRsRQPrcYbhLHMHtafLPgUchMqGcoVahgbGyXkdjUVLXE
+        EWDBihLsoNhs18ssARasXWi7iJp6iSOgEodQZtEUOyRUynCMBGr+s+xewAUKbnG6Y8RyQuK+ma4l
+        y03Zoa+rh9fw0Y+RTHvO/ePtQ9fdtLej5nH/NN0M2fRp1p05TS1U007g7AYL/3FeG3kvP069gPqn
+        PaO33vLuZze20iAIf/g6qbdX0QE9Pz0snXU4pEsy2696q/eW48w1tLxbDnayG2un4CVF9sr1l4N9
+        5xT35GdYaXl9Bj9WRt5QZLqaLNt+Ko8i1Z2z2jh6eVruJ/Epxd/99+YsGuDxpH9Mxz9O6iw9RovO
+        ZBX0t8/Nt/vmaD/dtobd1wWejzraOmztNfX07OmtetLue91nrzVfNd+n8mF1WK/fcL+h3vf7c8Zc
+        u/7cpY0Dbr5qYzS/G3ba6FXDzX3HPq2tw8+ZOgyx371/SI9TvK8/3j9OEdnP79IdbrfrzdFqP2tY
+        Dn5zHfp4bCekO1otppOn8HX/koy9Oe6+NLqz2eBOG422qIbeX/YD6stLv/f0/NqT1+vJSKVLzLSD
+        myJrYLnL2qTVpzN9G3V7t0TVbL89urP2azZ4xkt3oa4x26fh7j35cXib3J8a+PbFdw6qLL8YSjmU
+        PK6m4SG6s5m7teCLa34nYYhcJm1igiW2RVB9UYIMpcoqnDBiW+KVgLw+vj90H0o+vGZKQ8pM9Uat
+        MAD6L5eSlbXNbKUEsXSHTJfPU3LM4dL4somAuiSJYCUuwU4QIc9s5+u8DC8UvqdOb7yAeSpYQcnX
+        1/FAjSTK7MizY0+KQahKHnwLEbHIxqIgYtTUDKU8FDYWuG+obD0DRkbbxYGLzFYjW2oxBgWM3a0d
+        +8jklsuwWIBpIIgqfNggoXz9/ZWhFCNuyJfZByFO37coRoLAF+8GTKhiaFPrgHybygmFmF1wTsnZ
+        Y5tKy4wi7GIK8KTig7vYjMUgoiD7GbPABYdH9iOHTweCnqs7nzZFYK5CWdAgFtYbSstPUvLonQ1Z
+        AxH0s/cFqcxZ8P5mWtd2IF7s89n5vgpKBS5YvCI4S/qXjXf/lnpBFKFYetqSd1py5DFQilUp5/Bm
+        Bx5fmlqW1SXgYs79f0YBQ570xCBdqUQ2UgcjSCq7cBLFl/Xd2I58ZKHIE+PctEjQV0mPPKmT+All
+        kq5qTci7i51TE+ZCNm8oYqasN/Ssi17jBZEil0QeFEG9peqqXmWfjZyewg/Gnmdmj1Xbqi6YFxzO
+        lLSbqmblMBQnVBRGOV1W27KqL3T9W039pqqy2vqWPelzBzHvdQj4GKo+ZpWgbJOvUoNtpYmd/m8j
+        0tQbaq35yxFpqI3fikgDfhd6Fo7fi4iIQC4yPM/GnUF/MukbSgkTdqEQ0gBhjM4EHhr+PfDM5vj2
+        bIGRwEO4DxITWoTN4osjBwUDdH5rKuAsh7a8yeZXzrzcJGiwXJZQMwwOl2kEdCZcegwf552EBngX
+        IiHJZz/eY3xEsvDYphHaLGAJbLbWvNHUWt1QLogRksjnX2VNa9xoLR10vgANpZhmCxoLHWCH4g3N
+        L7MVIFOqrAFApzpLlBga2D5acRJFEBV+TpoOR/gBNTAoWgW5zWjXoBEh5MHZ7OB4E7hkZkeeL+cz
+        XJAT6H2ghyXaGeGEbAskxnYEvStf/QfUyG6/ecZMl+1bTYVUuCBn8YXOxjKy9Yb5HeMT3KCgmfnM
+        fDf5064wgxLol4gnKDrCgSLK4FjK8JnD2+ORoTiyQ2kBRKlrQzKA+hUePJHzOwz3ngwnw8fOtDde
+        GkoJFpScDhRpCJXkSaXGWbKLZPuFAgI5x+c3jqx0S0OjEuJCj1bI+ypp2v9FrWpqDV6ZflmtNO2D
+        Wv2dImT1sCMkFPen/GivsKxKwgBnHS5PxtLwP4igpv1qW8gTia9OHtWHkKgCEBa4KQU0cEKRfNcg
+        ZxVqw/MSJOUsoou+cCpA42N5V2s2+8sPT1Nvaqo0mxhKgXHzdosxXBZ0vZYfTxnjDyxqMbtkwpsz
+        bJnfhcF+BZU52TOUClLsLjsWeG/fJ4heBDciFwh5/Fp7TTG44pZCMHvsD7JFX8EVYr7ZWYw2CF6H
+        PSmbGEJU9RIBIcwOratXgStQkK5u8B/BCq90m/8MFtzrm/01eqZVb/nX4O/JiXgnVD77j8pfSB2H
+        3I4RAAA=
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1772']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:27 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PHN0YXJ0X3Nlc3Npb24+PHVzZXJfaWQ+ZGVtbzwvdXNlcl9pZD48dXNlcl9wYXNzd2Q+ZGVtb3Bh
+      c3M8L3VzZXJfcGFzc3dkPjwvc3RhcnRfc2Vzc2lvbj4=
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['89']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA21SXW/aMBR9369AvHuhTGIgua7GECtjgg4atvFi+eMmNSR2ajsM+utnB7ouGi+J
+        r8+x7rnnXHx3LIvOAaxTRt92b973uh3Qwkil89tu+jhFw+4deYedZ9ZTBy7yqAVXF55gV3NpSqY0
+        rR1YqhzlTBJtcHIdwcKeKm8oL4zYk5QiNEDc7X4sd8Uqt4DchH9djZZjkQ2f5oPj83qRffGL9cP4
+        gQ9uit7pk+LV9DFfff8wl9vZy0S5/OXZu5Hc3Kdju/im5HC72Y6edp/zTTWq7bL/Uez1nOdgit1h
+        uq5m5vBzdhjzdTbo6W3//vcvnLQ0YVtrHWZvZBPMmdiDljS3pq6IhNJQpT1YzQoqgSt/RnDSJmJh
+        Aktf0IRgCRkLjlFhau3tKfwlkHqPk6sAjnb1eWPk5YgthJaalUAmQYV23jIfouikQSdO3tCYlIcy
+        NpfghFVhNpvE61MBJFNHkMgz7kJEzU3MkJ6PzVcilmXoIqvJkf5L/FsGj8IWOINy0GCVuFDb9Ghi
+        6H1eAdn4h5PXKqhuef2fN21PXqs4FUm18iA78/A6rNkbtQHjaFe29Q9od30C6wIAAA==
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['448']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:28 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PHRyb2xsZXlfYWRkX29yZGVyPjxjcnlwdG9fYmxvY2s+VV8tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRnUlEzS2RaSXpEaXNnenF0czlkVkhVQnJO
+      TGlkOFpWWjloakNnVnA5dXJPMjdja25LYmdlb2xqdkZTcElvdlhJdkJiU2Y2MG5aMkh3WTwvY3J5
+      cHRvX2Jsb2NrPjxvcmRlcl90b2tlbj42Mi0tWngwLTFJbnhDdldCSzlmRXRZWEcwOXREZUFyQ0du
+      TFZHd2dxNUhYR004ZXh3VFNEOHEyUUdJRnFvazZDSlhmRl9KNjRMWTR0Qk5jbmJadTc2MFZlaXlF
+      SXRSSXd6OWxEcUlRM1hBcTJBS0VKOXMwZlFpRWxDb0tTdDBUdkVEdmlBRmEyaUQ2TWNNWmctWDRv
+      QUp4ZGhua0tGQlh3ZmRYM25mZUI1MWtJTWEyeFBydGxFOEF6eWRoZTBmaVphems5UnUtb3IzM3F5
+      ZURNTWJ3Mld6eGh2T1FZdE1veFY3eTdUeG1WNUp5QnEzQUJRSk5TOWFtaHZUQmJEQ2o1M1cyeV9t
+      Q2JmOTFhd2FqLVpLczJjQnBfMnhsaVR3YWlNMjBOS3FhdzZTNVZNOG00b1pjbjBzNFVfOWFEVG1H
+      Mmk4UXBXY2pYempZNllWdEZoSWNObGhlcW5YLUdYcmNiVzJHb1o8L29yZGVyX3Rva2VuPjxkZXNj
+      cmliZV90cm9sbGV5IC8+PHVzZXJfaWQ+ZGVtbzwvdXNlcl9pZD48cHV6emxlZD55ZXM8L3B1enps
+      ZWQ+PC90cm9sbGV5X2FkZF9vcmRlcj4=
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['650']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VY2XLqSBJ9n68g7sPMw4wsiZ07anWwGS+A2TG8KLQUIKONqhK2+J35k/6yTqkk
+        tMCNud0z7XDY0smTVZVZWZlZkn79sq3SGWFius4v38QH4VsJObprmM7+l2/LxSPX/Par/DeJYtey
+        UKCohqG42EBYwYj4FpUl4muGa6umo/gEYJMommrIjivx9yWSjgOPuopmufpR1hWOq3Ma+Vi/fViz
+        PUYc6Wkvs9ZbR981D6/1r9N8vBvQ8XzSmWh10RKCtql5j4v9bFp5NbbPl55J9pcTJS1j9bTsYCUw
+        Tet5X3arzbVzRpv520p7twZk5U5O6976s6FpUxGtnlaPHqdj8WJuA6Su9f3q8dS+4B63kfjc+qTQ
+        YM8lxNQsJAeISHwOuTqGukfkyPUKx1HltKPN4eZY/uQmY/OptqzOp4Y4OiCn2zMGtQDhz4G2Pguz
+        zVzbUkvd4O6upzoz1fQUNDY/4LF9IC+HdqX2YdSmi+eX2X4wtt6f943eevh+mXK1Chl0q4/meXS8
+        LH3zNH45dgJ62jp1vTzcfwUcev7s69MWVha2s3ndHmtvDj4/NbYNQ7QWRlM1zFdaGc0NI/CHh8eX
+        Dlcr94YeFygf/ZZm+ZfutPxWNTRjUz4tuu7r61PD7ArKhbaXA6WL/W6lhbTatvuiiFPRPVU3uvf+
+        Wf0Uh8qL3l8ZDc/ptBtH/VQdjQZ+q+NazY0uBo35YmXsyeSwmfc6fvujgrwGOl0Cd3z0a0652dOV
+        dr1RW5y1lepsyNtw2xla50V3Ig5O5TWtNN87Z63zPL+sZ+vlBW/JadhZdD/Gu7H4rin13mZbFyvT
+        WXnT2I1OC7wZzDa7yevmYz3ZzNr9CapNB8EXXZKn3mbzrgTTL6XpcX2s2YueJ3DcVuLzm3ndWxbw
+        uus7VBZTVhYO4wQZikmRrTi+rSEcMm/BZExZ0nzHCAOI/S/OcQdNmMT1sY4ANJCMvqhCEaHCVSMr
+        LWgYiOhy/4si7KhWaQFqpY6qg6VG6UY/4ib61KWqBUPamukgQ660HlJ+QVZUIVSuCg+1GzqhBSpM
+        6KlUP8jiDfsqymsQpFIPmzqSK7WbBaXCghJYd1DxHsnVW52rTNJ9jCENBukT8+he8yBB5KCUsVN1
+        6sK+C0KGE4MpKw6EZrmeYSXRcQU8S9URkcsZTgxlOOBFhQS25lp8FsYoRuXf/pPVT/EUlaUoxGQp
+        cTLb+W4YpDot7bBrl+gBQYVwfCTxeVaqZCN6cI0MELmm+9Z5y+gwd2VeIQii3c5D/+NSwqqjUlUe
+        Lxcwf4aXCFIqDTwk62z8DDGCM+9X40wSn8TCUUijP6EwW9u95XABA+XAlBMtvG1AFS0RqjqGio0M
+        mZnluIq7i6KZhGkh+xrLqAlHOCtNAKl4QDJnonAMMpHPp1Yi8HSY2TBS2dL7a0hp1zcmYEkFGojg
+        84Awigls8bpJ40NiuY7hOpx/BGddQSaPqMNIHgtjZUslJP7H+CqmUH4zQCxkfgRh6e+q7f271AWP
+        +uFSMmIJuo+oFWHDRoU8D4XuAi8oR0jO4Ux85LAECducmJeoXZHcYCmvOJ6hOjq6PygzJyHkwJQT
+        2dFRIVppbGivoMAs5dMl8IkTww3FsdujTcgCV3Gkv3SgXhmlV2gAoXtLqfGuYBPiC5q/s4k+FQ9B
+        rQgLVpTy7ookOHNIwaqzRwpUmvg9Gmxx8P9VEqEKzZEHJRISYKksiJAWUwpj+1SHwN4RROVKPZyq
+        iKY0gnQIJTgN1Ua5Uavm2YmQ0QP4sW3DkMNJhZYgxswrDjvtNuuCqEQwHFA4WjaK6JzQ4gRxIba+
+        V4TvgvBPQfweznRfIR636AP2Dicf0xuv1OihNFKD/6c/6uVqoyL8tD9qQu0P+aMGv3/GH7H9Ua5h
+        4Rgm7lm7+9qfSXwGjimRG0YqhUrwWepAs+Kgf5DSGMzBYS+DS4v+fJEoMp+xZ9OQ68+PiQTeYtyC
+        QHdlGE6lYc7IgjEDqsBB5kGZs9m8nBbNyxHOuc7LhW0Yn+hHKrE6WEh9Ilvm+Tp8DCUEVpj45D2q
+        P8S0vbAziZJ5oscqE3v2PYIsC1ZKaM7E/q2J8DR6ErI4f2eMPXIVViAtlZrUB5/XoDyXW3VRrDQk
+        /opKkM337JETHkQBdrhWh04lhSU+HeygEgUKE+SDHYmuhTkgzKZhXYLimaTR+FWy1S8F+44DW8Hi
+        RiyDDTeoZEPWvcMropKDoBc3kAfxBtUhisloPffwmOxjsNl1MrQEYYTQBhfbYRpmy79BpbBJY8Wz
+        K85K1cVY4q9QUiKg5NKQrRxtWYgrdRGXyMGNsuqOmRNNV8CkH1wNcneCn7oM5G4B0e39Xsa/J5Ci
+        9ozNNW/3hv3ZfN0fDucSnxHEpGj4uQodOIYzvIZQJAktLmVxC/Knj37hPpa7ieW2KU2xa2RAVRL/
+        igTcaonVn0/A4m1B+lEmC4+U57pW3BlGsVHAwoNmmXZY26Nwzrz+l7wu/nSdiyKRrY5rCxOI9BiI
+        JUQ5m5kPKUWQsdJsyAIbUl7cfa5ilRSSbs99/syHf9nGNR4qQmkygtv7FWLSw8G2oUcSW6w4ZjE2
+        X3qUw95Z0UJ7WXsP8gKU5YRz8DkkNS3cEzg5Jx+RazVw3CuEDNatFykSKwcZD3SfZ91hP1x2QZCj
+        ssbOA2tKuol1C+UVYm/cu+UXr/fsvXAruQVzvMwN5R4s3b/O39zj717gb27uP5tZ4mvvX5Mx+eTj
+        TvKpKP7OcPMJKYf/oe9N/PVDEv/Db7O/A9pPXdzdFQAA
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2085']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:28 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PHRyb2xsZXlfYWRkX29yZGVyPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRnUlEzS2RaSXpEaXNnenF0czlkVkhVQnJf
+      eWlpbElnMm80OFdudmVZU09WYlhsR3NWb1BxV0RXdzdiYlExZVZIVkZwLWNyMXppWnllYVdjZ1ZG
+      cUF6ckQtWTwvY3J5cHRvX2Jsb2NrPjx0cm9sbGV5X3Rva2VuPjYzLS10X3FmdDhMWWsydy1QTmlI
+      NVU0U1FkMU1oZW5DRGRHNXllcndHYld2MFJZU2JadGxhWXJDZkRhblJhaXBfZU5pamFuUkFoc0po
+      QTM1amQ1UVRJSlJnR05sWElnN0RXTFh6US01M3NHQzRGaXZNa3pVdWlxTkprQnl0cVpuNmMyTGd4
+      eS1lSXdFY1E5cl9UbW5ZS1prNU9ucnZIN1o3ZDFsVGQ4YWRpS3QzTVNkZHl1TGhGSkItNTJETHAt
+      eV9qRTlibHV6Q1EyTzRkYmRZMnFUQ29LS0g3aUMwX3p0QVVHX0NydUMzOWViNVpDSl8xUTFvcTRZ
+      Y3BYdzR3MUxfSmNFVmQ3cG5CQTdrY3E0TU1HdTlCb2w4WWMxeTdTVFZkZ3NQaFlTREJ1QWozZXA3
+      ZXF6eW9Oa3U1bjI4RGNfQTY3NVR2YlZhbllzT0xaQkxsdlRDUDFHcTJXdDM4WEJ2YkJJU3pXUldV
+      enJac3FMQlRDak5mTjFYYl82RFlaNjEzUVIyWTdmTXFUcllHUllmUEtZaldQWVJBRVBlNVFHeXh0
+      VXNIRFlZWF95UXhfOHAtRXJibVREcDAtLVo8L3Ryb2xsZXlfdG9rZW4+PG9yZGVyX3Rva2VuPmMx
+      LS1hZ3ktS24wY1F0M0xuWlNWcU1yenltQ2d3NlBuRm1MTUV4eUxJejBQeXhuVEFNV2lFaFk2a0o2
+      S3FOaDdHQmpUbVFLQTFYbDdxMTB6WWQyNzR1OEVkQllkN1FXNndOLXZXdlhYa21FNTBKRUVRdHRj
+      YTRZQnM1dm02ajFMZVFIR0E4ZWoxbTZxQWF6WF92VVAwR2xtZ0JKT3l4Tm1xNFJKUk5lb3FRSHlw
+      bTg4NDZLV3FQNV9ibWtjYnNSeDh1b0JLV1ROTVNsanFadUxkUW1CWjVCUFBGSDFLS2hlM2V3WnFG
+      c2ctVmdEU1lqRC1YWE1LMHNWbXQxdmN5ZV9GX2NWM003RXNQMmhuQkQ5bzAxYWc4S0hfcVh0Rllt
+      VmNUMFhtdHF5bHB3dUl2a01KejVtOVpnYnYwLS1aPC9vcmRlcl90b2tlbj48ZGVzY3JpYmVfdHJv
+      bGxleSAvPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjwvdHJv
+      bGxleV9hZGRfb3JkZXI+
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['1098']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA9Va23LiSBJ9369QdGzsPuzISOI+q9GEuBiwuRkwGF4UuhQgowuoJAz+nf2T/bJN
+        qSR0Adu4uz0z2+Foo1MnS6pUVmbWMfzvB9Og9sjBum399o29Yb5RyFJtTbdWv317nNzSlW+/C3/j
+        Xcc2DHSUZE2TbEdDjuQg7BmuwGNP0WxT1i3JwwDrWFJkTbBsPnd5hFed49a1JcWw1Y2gSjRdohX8
+        PBs8G6OVg2jcUO5G1UFNXVbW96XDbtxfttz+eFgbKiXWYI6irmxvJ6vRQ/5eW3ReGzpeve5cXNWm
+        7ceaIx113eisOLtQmVl7NB8PpsqT0cJTe7ibNWYvZUV5YNG0Pb3d0qrDvuqLI5Jn6mp6uxNfnQY9
+        53Op5+P9BW9tjHXFQMIRYT6XQk6Oce0NsoRegab1w6E74w67+biLR69mp2VPam3Vkuq9FduvcfPF
+        ZqHtxNakMVCOvQ43kQfLscLJ/alyV9k83KE99/K4qrgSazw7HmKfFq2nRkfE6GXXc/D4YaZtSqhr
+        qIVly+JYb+Wynj3VR+OZN/AWJeZWwXK7VdqNGsVt7WU4cegmY8o7s7hHHo0PGzS297edfCNfmy0W
+        xfZi9LqXO7v11n5e5SvifM6Iu91rrYrUVnu21Iu3zcKIvRuo7FNr9VJtcBvzxWt0lEp+Wdi8mqXh
+        qJpfOcWK0j6oD8siqitqJy/qUrvbf563W02D3mjey325PK9iufcoliWNhtfXrC2dWrEv6oMKXepM
+        x/NZkWVr2nrHaUozr89b4uuquVw91VX20Wx1HXvl2aP5cqIfjKd1/eleOtg6fmw9Y5cxufLixbg3
+        7KrcneCHiZc3bxFbGzaG00OjM8G90Z1YKIjiXVPcveZdb1eY7w4Dp/taLh674529f7zfVBvy2Kwd
+        aXtitueGOX7cNUxXHz+sFoW7UblTfzZqO8ksqs/N8fp5WHcHdlnb7/aDqvNMy8OS3VxOFvv7ti5a
+        o764OG63NbliPFb7leGsv3kdastef3CHvFKVXZfb2wWfSwfNKYbIxlJtz3IFLmYlYT8ekSbpLjIl
+        yzMV5PjMczCaU+AVz9L8QCW/U5OxfO4CGjGx7TkqAlBDAjq4kovA3SeL5GjGQkNYFZoHFzmWbFAT
+        MKNqsgor1agz+4Ab2bu2KxswpanoFtKEfPUm5mfGsibYFQrMTfGMjt0MFW64lV11LbBn7NNQ2gIj
+        2d06uoqEfPHsgeLBjBGsbi07KyQUzm1OY7zqOQ6k22P8iXh0pWwhEaWgmLGUVdd2BJZhEpwQjFlh
+        IFS4UoIVRccJ2BqyirAfQ1kowQEvSvhoKraRS8IOClHhv/9J2sd4jAp8EGICHzmZvPm6H6SqSy0d
+        26TcNYJKZHmIz6VZsZGJ3LWtJYDANfVBbZCwIe5KXEIQBG87Df3go/jVTXZlof84gfsneNFATHWP
+        WySoZP4EMYAT16fF6TjciZmtEEd/RCFrFRuP3QlMlAJjTvDgogbVmsKubGmyoyXIZFmWLdnLIJqx
+        nxaSl+GYq8MWTo5GAJ/dIIk9kdkGicjPxatE4Gk/szlIJo/enEFKO12RAZJUoFE5vqyRg0ICeXhV
+        d8NNYtiWZlu0twFnnUAyHlC7wXg4GBobMsbhL8KXHRfKfAIIB4kfYZD6h2xu/03VwaOe/yiJYR66
+        nKDlIdMGDUMa8t0FXpA2kJz9O+UCh0WI306FvMjshKQmi3nZ+TTZUtHlSclyIkIKjDnBOmoyRKsb
+        LrSRMSArzcWPkIuc6L9QJ3R78BKSwGk4sH+0oF5p1D00mtAlxtTwrTg6xBc0mXsdvUhbBLXCL1hB
+        yrs4xMOeQ5IjWyskQaUJr4PJJmvvF4qFKjRGWyiRkAApjmEhLcYUwvZcFQJ7iZEr5Ev+rbJoTMNI
+        hVCC3VAoc+ViIc2OBgn9CP9MU9ME/6ZMlWFD5gmHN21XSgwrBTBsUNhaJgroNFOlGXbCVn/NM78y
+        zL8Y9lf/TpcNwnmzPiDXsPMd98wrRXdN9eTjz/RHiSuU88zV/igyxU/5owg/3+OPcP1BriHh6Cfu
+        kVi/b474XAIOKYEberILleCFqkGzYqF/YqoPy3H8XsahJs3xJDIkPiOfdU0odW6jEbgKcQMC3RZg
+        Otn1c0YSDBlQBdZCDoxpk9yXVoL70pi2Tvel/TYsF9kHJqE5rND1sGDo+9P0IRQRSGHKRddB/cG6
+        ufU7kyCZR3akMpHP3hYjw4AnxW5qic3zJcKnXptJ4rkLc6yQLZECaciu7nrg8yKUZ65aYtl8mc+d
+        UB6y+Yp8pJkbloE3XCxBpxLDfC6ebC1jCQoT5IMlDo6fKcDPpn5dguIZpdHwkjflg+R4lgWvgsQN
+        y8EazlDehKx7gZdFeQtBL66hLcQbVIcgJoPnuYSHZM+BNdtWghYhhOCvwXZMPw2Txz9Deb9JI8Wz
+        zo6owqTP505QVCKg5Lo+W9qYAhNW6izO47UdZNUlWU5wuwzGv3E0SJ0JrjoMpE4BgUpwKeNfGuCD
+        9ozcayw2uk04ATe73TGfSwyEpGD6sQwduAN7eAahiCNaWMrCFuS7t37y6AX5PXUSS72mOMXOkAZV
+        if2KBFytsoXrEzB7XpDeymT+ltrathF2hkFsZDB/oxm66df2IJwTlx/kdfbqOhdEInk6WmSGEOkh
+        EI5gaa8nBJssSFhxNiSBDSkv7D6noUkM8ef7Pr3n/f/Jiyvf5Blq2IPT+wkio+u1aUKPxFZJcUxi
+        5H7xVvZ7Z0nx10vaexjPQEmOf49cComX5r8T2Dk7D+FTNbDsE4Q00q1nKTwpBwkP1DujerfpP3Zm
+        IEUljd0WVkOpuqMaKG0QeuPSKT97vCfXmVPJOZjiJU4ol2D+8nH+7Bx/8QB/dnK/NrOEx96vyZi5
+        tLjzk0Qe9gdFnjP790SeCvMpkeci/W2R55z9ochT/h6R54LNxyKPh7WfJfIUmK8Xef7+V9d4gpf9
+        FRpP7qdqOSSE39ZyPinlUNApoi/Sc8pv6znFP0bPgeZij1Yypj38lqQjY2rqUz5SdVwX2je/qX5H
+        3DnnfI+qE8/yU8WdxLSqrIC/3PdUnpjyns5TJ6xI6NEtC2r3GNp9/Hm9B1+j94yhw0CYspeUaCII
+        Kjmr/Lyj43joF4qDAiN6Kw/qzYc9M80VuatlHIZjOO7qrrnCcJ+SLSo0w004jrS3NFP+k2Scz3ik
+        xBWZ/PXC1ncJOZzvjs955FzI6Yq3zV6v+aaK05WpW2Sa6C21plv9AbWmW6UNmV768/8xqswF+SRf
+        umGZfOEN6YRlizdsmWP/OsJJ9a+om/SnlSrLVP9o2YT99CGAzRwCEnpHr9VrjcR+ozt9UwYBCtWC
+        naRRicL5gRZyeQNl/gb9BZrHp7JVnsmzn5Cd31U90hnhq1WPK8vCSfWAlHNfaP1k1aMrTpo/onuw
+        zAfCB8f9Xwofw1Hz9irZY+igJYKDkEb5E4OLrtA+yFHgz9A+ytdpH8WPtI+P08k7AsiP576TABJ9
+        VyY8g599hyaFf+oLN7nTN2lyb34J7n+GQWWhRicAAA==
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2653']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:28 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/BundleTests.test_unicode_properties.yaml
+++ b/tests/interface_objects/cassettes/BundleTests.test_unicode_properties.yaml
@@ -1,1052 +1,1019 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48ZXZlbnRfdG9rZW5fbGlzdD42SUY8L2V2ZW50X3Rva2VuX2xpc3Q+PHJl
+      cXVlc3RfbWVkaWE+c3F1YXJlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPmxhbmRzY2Fw
+      ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X29uZTwvcmVxdWVzdF9tZWRp
+      YT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X3R3bzwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRp
+      YT50cmlwbGV0X3RocmVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZm91
+      cjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X2ZpdmU8L3JlcXVlc3RfbWVk
+      aWE+PHJlcXVlc3RfbWVkaWE+bWFycXVlZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5z
+      ZWF0aW5nX3BsYW48L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+c3VwcGxpZXI8L3JlcXVl
+      c3RfbWVkaWE+PHVzZXJfcGFzc3dkPmRlbW9wYXNzPC91c2VyX3Bhc3N3ZD48dXNlcl9pZD5kZW1v
+      PC91c2VyX2lkPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48cmVxdWVzdF9jdXN0b21fZmllbGRzIC8+
+      PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u46pemFGSGGmGmAmAbTGGNeNLK1cY1l2dEF7Hx9JQPDhOZJ
-        e9PuOXsWnfYN955AqqoVJ5Mvn6cTD0TRskqUJ5Nk/cv/OTnFn5DSVGqiQLk6IkEZrjFSJmdtQytB
-        jAJJKkVyyvAACgWHU6iQQ6dbkvO2qHFBfD+ddbsyvX8yfx7iMv4K81WWL64hiWZhn8Xb4iZuskHw
-        xd1y26zvZ01vO6jLOu6q6zy9aTtT7oYN/73Y/eiTqzC9XbG7kB5P5987npFveXZ8pP3LcsrN49Vj
-        FF2E9cV6e76Eo81t35/p82o1z6XanEUqCf0HFOzhQ9IIYRcxUsAop0UNgpFStqbDWj2jYD+EilZo
-        EPrFDTBisKF2UaRojdBysC8DbGoUHEwgCZQTQRvAa1DaS/9WGryI5sC9xCJAwXuBE0RD44YxUIWs
-        LGoZuPDAAXdGgpVgtJ1IZDSDV/uD78hZ80Umhp/dVO6G+tqiMOPgt6SFsLeS/4jtE3rzHEScCNuY
-        eUv7217Ge+mYdGgPXNg/p+ZY6Z8CAAA=
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['422']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:32 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bY92t-Ig0lujJjLLHCkHTqDKe2fRxxAtDiOBbrsfALsUC-Z</crypto_block></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['778']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1a2XLjuBV9z1co/TIPE4kEd3ZhOOV4Sbrs6Z7xUl3OCwsEQIkWNwOgZX1P/iRf
-        FnATSUkeSU67xtORi1UWDw4uLu49AEEQ8OfnJB49UcajLP3pA5ioH0Y0xRmJ0ulPH+5uL8bOh5+9
-        v0D6RFPhc4oYnvmM8iIWHuRFQLIERalfcMr8iPsBIt6ScqhsL4KYLXOR+UGc4bl354/HT/M8dOen
-        bn5nfgnGU5aFBIh/LPDnX+8fdIr5g352D6yH3+Zf1Puv6dlTcns54yd67j/fPdrXVxfLM2yOrwkI
-        rcvHsLj/9Dg9ueCnSP8nughi55fwi8H8s0S/+nT+2/KRnT88Om7MtF8/pa5+Nl9M43uoDHyCJOIC
-        pZhyHzHqP6E4Il6aQWUbXkfFgxJBvowZ9c6/QqW7qwsI5dg7lyFeLmaU0YZQoTCIpkVeWiuoB1QV
-        Kn0A4kgsa0txlpIsHRdz6e4KrMsrQ1dVeVNYm8Yx4rz5V/PFjCJROtDDmvKqyu2wvDYjM1elsTZX
-        5XYIwUYUc7psW1Bk/juwlElDbWuukIG9jrfF5DwifLvZuiNN+QDrKFVfLlASxcseqe6h0rWrtEHL
-        uPAZSqfSRkDl7yohfhaGlMmsBjyLC0F9jp7kMPGAPpGZW0dhWMSx9CMJopQSz9RK0hCrKbJPImcR
-        pp5hrzgd2JAK2W/EpENmx1lhsPKsM6y7JWkNbEidZd3sWL32GmBl3OixuhZzyrAUP5quOqyZUNlE
-        paQ3Apig53VfB1BFqOsfY/6qmG8GsELW3BhiNWXowhCCSTnq276BmtGHGoLM9wtpM/bIGnB2Z63H
-        eTlr6h5ZA8Y+Weuzfidr6r5Z017I2lr0yvt1J4ZYTRk6MIRgmvlcmo8p94/T2nFa+1PH/DitHae1
-        pvnHAqWiXO1muZCvLnLRVq3J/Rb3AFTWkHWGtpOh72QYOxnmToa1yVA2u1fN2z4uGJPvZ5LS/qqX
-        utMgl6vXAdQxQoRFxuoXjHWwY6VFEsj0OJrVYzVgx8pjJF+CytitQz1OmWy+TIIsVvqwfHGqUe8/
-        /+7X73CorHdTZLlfieI4Zb5qytyIn/LCguA4oI4D6jigXjOg+qMIZ0UqWCOYarumD6yKq52HuzQS
-        lIwupV2SJR212b9hkYiwz+hTRBd+40kjua1FkCCZrjrdNCXNfbOzU/xtBBwxG50U04KLkaYCKcqO
-        UHMLgctOcSo83SobWkc7Gqc4SwmXT28bmIapDthtYU1fyr8kIcQrG1Ud4DTMFQ4jnjmWCvwKRinx
-        RZTQij5WnTFwboH7UVc/quqPKvhYtrS9QmN3PQL1PReIiY2YaEAG40SmM/6WIbGAZunG3iExNHBQ
-        SIyxBl4TkiYE9VZupcfPd7en1yenl+fXUOnBDaUKwy9IiBldjP6eFSylP/DRZ9kdhvCcsr+2lep4
-        1b8j4lmfLtqS1SapH0uVZ90WZB9sGAklEZK6R9UELee5mRxXXoVOpNznVPBFJPBsgsvBUhXCKJWB
-        LeR0J7E8pmWwWezNhMj5R0XZXlfhcsxTovRalSMqy+U4UlxdXlg1glAlmkFDnagmdUIaGgGybdUl
-        oWroBkVAx5OHfCrDvtUBmCIZ/FimgcvuyO5W9zBHYuZ90+Yri/APjsHWCPAizzMmuF86Uu2gD5Eh
-        gbdfDQYYVAbKeD8ysam8VMPBlmmGtksAoiowgItdzdBUxwIkBKYVOHq4h0wSxB4Lur9IDm78LURy
-        sBP/fyIxqbxU1Qg1MzARCqzQ0DVMbGo5uhvIgWRoxEFmCOxgt0i4XL+y/TVycNtvoZGDnXgPGiFg
-        8WwsdLMIEhI9T3CcFSRkWSomKRW7pSID9bsWtsWLPgtfUC5U5Ue+5IImfoeUHYkjyvZQSMPcqZH9
-        m9stijfs6x5i2Ez1n3vGCF15ISQftPLxa9g21lWd2E6ATaDaGKu2aZDQMSyEnd16ECwqIT+Mnvaf
-        Nw724C3mjYOdeA/zxvegFLnEPyrle3zCNPHyK6bimvIKXBwYyHVCZAcmMALDsAzVtZHq2GEQ2IEN
-        AMZof/Fk6d6zzGvdeIPH0f/o0bt4Rv3hetJMeamWSVxsEaRhy7KB7sp720YGMQzdci0MTJfoB+hJ
-        zNj+70SvdeTNFXWwR+9CUd/Bs0wssuOj7Bs+yrhAouBeXC0mB1BLKAKCBFLae5HNadrfCqyBtnSZ
-        yzeWqHTdr6O0opUlDavIOY1jP464GGwvnm9uL7607Vjil3d9XNlie0qzcuNU9jZGIhIFoZ4JJiZU
-        VrcwztJp/XOsTkBZtAKg0tWfIe6nWbknH/Iq/gOgPABZfpqgZHXysbmtTimwIk3Lsw3V1i3QmoMK
-        A7T6Mr6Ft47ClFLiE5ojJkqZlNvAlT/b8IZcMFTOAj1ai9SEsg8ZS8pTsLX7GygsP1TVB2FPwfXI
-        uP0sB0sLtac625O0/jypv+xvwSGfZdWXjbDuTq3TIQa5XK9iWm9Zr94iJa0Ht5x6x1+Wj26qt87R
-        vyjLVtR6/1rKomiq3ZycXZ1f33w9v7q6gUqvoCFVFW4QiSn7gY++SiHxltacKW1OBrdDZXBu+r8D
-        NE7ldC0AAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:32 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsCa3HaFbl8MfO4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['365']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TGGQkFgq1HRgjDc2m6Vs86IQUgIyWrBSYvud+ZP5sslN
-        C4u7sMfVQbmzoyMKnTyZyrx575XuEUbqnyvHFhbAh5bn/vFFPMt9EYBreKblTv74MuhfZkpf/qz8
-        SzX1AGiB5QDNmweICjUfwNAOKioMR6bn6JarhRD4mgW1kW5W1gCq2cNNquGv54GnjWzPmFWglslc
-        TZvDqxowFo939qxu10o3Yvvpdl1sXQUtQ2zL/cJtsdtb1mZex99I7cX4ZeM/Flr1zcXttTyR9Wm/
-        VlSsm4uXfufcuyiYoD5p3XubB3dl3zzPyh7QbOn24nxlTZ+nw7w2HuvNy4l8V26P5avLWk5T+hut
-        quQb7iq/2DQv6mKzpl08dgqj53NrOFdGQzW7NWfVBcDUTDDX/SD0gYaNU3E9NXsIV6c61ObAH2uu
-        7gBILbODqSFE9qaIbUFkVbAAbvKP7gNdQ5sCKvUHNZsc0QYTQKNSR3u4Xk6BDxiBoOrImoRzbaHb
-        IaiIuZyaTQOqYQVrOpLtuabnZsIZWmoM0nYyUJO0s0Y6tGHrELJ/KD+YAj3AE0hhrJ106W+302GQ
-        VxAXocMR62xDKgS6b0y1GVhHZ8gi30pA7IKMGvWMka3xEt6BIWeWCQ8PSxfC2rewhELWcqk7lr1O
-        kegKs8l5s5HRPBhovu5O0BgjgD6TDdG88Rj4aFdH0LNDFHBQXyC/qIj5M7Rzu6g6Dm0bzcMZWS4w
-        K4qESdsYpaA1BXPfMkBFLsacBGSkEK1b99GElIQTYyqZWTJwvoxJOyAjJSPnlYSVOh8D4sHlFCs5
-        IwoGAzm/PokXLClqdh9FLr1nQEdf7c51CyIE2p/b/F023zcgQXamsY1RyvYUtiHVwVEfrU2kjDTE
-        CGi/X9k2+YhdE0s/3rUU5/Vdyx2xa6J8zK6lWX+xa7ljd016Zdd2rIePdyexjVHK9gS2IdX1NHz1
-        sgHUeFrjae2XtjlPazytsdO/hLob4LtdVvBUVBSLlqlFeEVUszvILkP6ISP/Q4b8Q4byQ0Zhn5Hd
-        Xx7J25oR+j4qABEl+kRvdSejObp73YISxlg3As+nBcYumLDc0Bmh7SlJhRSLgQlrbusGKomkFIdB
-        KQ7ebLh2Rp6dTcOo5qJo5b//SfdPcDW7u8zAm2vEKXjKfFfK3LNf9pUbAh5QPKB4QL0noNJRZHih
-        G/jMYYhckwbiZqI8DFwrAKbQQOOanpNQmX7jW4FlaD5YWGCpsZkwlzvYREVAut3ANdkxU3bCr4JY
-        CqZCNZyEMBCknIicMiFQbhgYeFEQBJV8AZ9oF01oEBiea0J09S6KiqzktthRI6Wv0X+OY5oVfNJc
-        SSwxZoyrFvRKhZxIBDlNd02iZBJ6JlfKiKW+WP6Wz33L5f6dE7/hMx3uwMbdtQA9hoHuB3s2kURk
-        jCraTvsjTVIQpUJePtoksiS+ySRyRhLfYxJmAiJaUn9sD/q1brXWqHfVbApmFGKGlh4EU7AUzr3Q
-        d8HvUGij5fi6MQP+b1Enai/62TIrhZvLqAUdMdxGXu4lEmQaZAw0vSCEFdtaxO0MigjhCK1Gz0bH
-        wXoOKtBy5jbWvtGMgqgfaWGscA4Byi4p3ZbOsb4/x9fmjvHGII1nD4w9AR62vl5RbR1daUJkSEU8
-        Q1kkPlRtz53Qj5ncmYibYkDNJv2x/Iyu0lhvhkS43gKwiorzGzBj+ZQdklLHD10XF0hk/0WJVTtb
-        KLm9PsDbRd8mpFMw9HV8fU3RIoQS8Bo839FdlJvJ9PdQFV/tqJpeE7uC3G+jRBxBkTRsIpNjtjZz
-        aHlwAFfh1FtS1Z4shz702MZUiPwa0cngYIVcB5X1eLgUHHFo2kDtQm8NA+AIQ+B7MZUGAXKLkHXr
-        VS+a9W7vod5s9tANSdLASKRDTzdt4KOwekCOBCMaE6bZ44V/3J1ZtPAtrzB0Y4o8JSruIR5rD+PK
-        PZe4fm2b/y0SV+HtEpdyxK5J4gdJXPljJK7CB0pc0rG7Jv8kiUviyj1Pa5/Y5jyt8bTGlXsuNPKU
-        yZV7HlA8oE4joNJR9Ksow69JleQ7q55nMyUk+R5rgmHl0LYc/NSB6HOpww8TnIm0RmeXqZbpfQUB
-        WAvUFha0RjaT43ZBykqUXqrUeTPgVmaZTGYs9wu69VR+vmk3bou9m6L7UlsOFhc198K8uptY3XvR
-        Dy+7MrwCxWK7MR3dZVqNdfm+f9nJD5SbzRM7Ix2Rjb6eM2Gu/j1qjiF1XybdlkjJl66JWxTP8jnh
-        roX8LIZo63TqOBDtfjlPHpOkMXq+RPnkghevDP9hNueVIa8MueDF09onszlPazytccGL1+c8ZXLB
-        iwcUD6jTCKjDgtelb30VJMk1f4bglZfLpTcIXtKJCF7S+wQv5YMFr5ze2CiTx/5z59kbwoIUrr1M
-        /r66Aue9h3zrGl7mG5uhv4GuaMidbnFlmjfN6oYLXjxD8MrwRG3OK0NeGXLBi6e1T2ZzntZ4WuOC
-        F6/PecrkghcPKB5QpxFQhwWvXuh+FSQZ/z30xwteiiQV3iB4yScieMnvE7yKHyx49aqTfvulcN0M
-        Z4NC63YcrF25bzxlnGuQaQ360Gop63JwacJ8Z/L4vdsLwOQGLrngxTMErwxP1Oa8MuSVIRe8eFr7
-        ZDbnaY2nNS548fqcp0wuePGA4gF1GgF1WPBqeVjwUn6O4FXIlY///T8ZL+UkBC/lfYJX6aO/4aVd
-        FqxGZ7xqfVfOV8WZ0r0pNduFIJx/72W0gaYMpE4xb25qC2XdnA5bL53O/Tn/hhfPELwyPFWb88qQ
-        V4Zc8OJp7ZPZnKc1nta44MXrc54yueDFA4oH1GkE1Cu/4RWCr4JU+EmCV1l5y294FU5E8Cq8T/Aq
-        v0/wwq/Ordy4hh3ilxULI92YCRBvpjDXYdSLkH4gkLUmGaPRWRaX3x/zhV71WgFP7U5u7M3cy1Kh
-        2x7fiu6tPhQByNxfPN5fLdb3U/16xQUynlF4JXmiNueVJK8kuUDG09onszlPazytcYGM1/M8ZXKB
-        jAcUD6jTCKjDAtkDML8KUvHnCGTFkviW3/wqnohAVnyfQFb94G+EOcvhpt+9Ph8+3Vve00VnY41f
-        TPAd6sv89FbRrkp3hntx1RIHS/G5E95kOsPy/eDX+RPIbIjzO30HZ+qtrCjSfaCzOT6gCI+PaAM5
-        V30B/PVyCvArZBNUHVmTcE6rHZr10oBq4LxKRrKRE3puhryXOQZpOxmoSdpZI3sNs63jJZB/KD9+
-        h20KY+3s9RFb7XQYtPuOjm80yXDRe1tTUPRi0xlYR2fIxm81xaCK/IVRo54xsjVewjsw5Mwy4eFh
-        6UJY+xaWUOivBeqOZa9TJPa20uS82chovKDnBf2vbPO/paCPC8zjC3r5iF1LFev/X0GfO6agl4/Z
-        tSML+tyxuyb9pII+x3VKntY+sc15WuNpjeuUXFbhKZPrlDygeECdRkClo8jwQjfwmcMQuSYNxM1E
-        eRi4WNwTGmhc03MSKtNvfCuwDM0HCwssNTYT5nIHm6hESbcbuObei0HFEtZMw0kIg48UTYuiIivH
-        /xltSSztiaZ/pW6WMmLpWHUze9AC9BgGuh/8Oi9L/ai3mmb3TUBFaeKP7UG/1q3WGvVupFVTN6Wf
-        6R9g60EwBUvh3At9F/wOhTZajq8bM+D/FnWi9npN+qafbOTlXiJBpkHGQNMLQlixrUXczqCIEOvO
-        9BjrwBVoOXMboNWiGQVRP9LCWOEcApRdUoItnWN9f46vzR3jjUEazx4YewI8bH29oto6utKEyJCK
-        eIaySHyo2p47oR8zuTMRN8WAmk364wcD6CqNhWZIHgVsAVhFxfkN5cBIPmWHpNTZl8T3UHJ7fYC3
-        i6ouACba3TnymxBdU7Avkfkcwhk59HV8fU3RIoQS0oo6mf4equKrHVXTa2JXkPttlIgjKJKGTWRy
-        zNZmDi0PDuAqnHpLKteT5ZDT7WAqRH5tsMcJYIVcB5X1eLgUHHFo2kDtQm8NA+AIQ+B7MZUGAXKL
-        kHXrVS+a9W7vod5s9tANSdLASPQHPXXTBj4KqwfkSDCiMWGaPV6gvvbJ789eW6Th2TYwAvqMDO3O
-        KkgwctQAayGY+gA/t0jj+yzP/WtOf2pBAf0PPQcI6B7McgWM7/bJHpoSzbPk4RGbOro8w9AOKv8D
-        AUDbhgqnAAA=
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3143']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:32 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--GhLZGCecvXPlkElC8I1NYJy7MGtMc1N4T6J7RSwCkoOrz2NvfqzrX6MEzDJH4g4ahTC75iIDqTOBoD6deEgMQozWnxlIjk9oe_l2JDBxihjhZ3_ffaLFg4P9Nf4GFC0_5Tz_A53Knx3vzLDE1LC_DXO6bjBiZp5bZ</crypto_block></availability_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['449']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimoQQAkkgxCDEC8YkQMyz4Hfun9wvu2iI
-        kCIycjqV51S1dVpapnz5csd9u++1t7vE+D9OcfTUuEUZpMnf/wL9Bv7lyU3s1AkS7+9/UeQ5QP7l
-        P17+x9hszCAyrSAKqs5Is2pgl0bhlnVUvYzL2nLS2AwSoy7dwghKwzKdl84tx8+fV43z2kyqh65e
-        xo0ZBY7xir9A4+cPyEcG/F0G8l0G+l0G9l0G/iXj+cvp2WkUuXZllK5ZlUblnqo7dikt3e6p8gvX
-        HT+/w79kpcm3ObIflE/D3zKN3acsGmz/dMY/tnn+dEhFl1WpYUWpHb7gIAAAfAcH/NpKTaeoZy2+
-        atZlEG0t7Mh4pqD50MyZrFEradGt1SWpLOXrNDsCEA3vzZXDlgfQDFZpdtjrjUg3fYifYLFfBlog
-        szMB3yOwricqg7EZ1+K+5lhzK2c41Rr1vDMDPSSXd0d0Wk5d2yA2PEntd/UKwRIMABCeo0qxTUkn
-        JPJJXlQq7k4pq6EdnhrGrQ/ze5zL2G3cZJigWbimMWxv94XejZ/vpWuF45b2Cz14Q9f6buHeCBd0
-        bAVenRnDUtfuCwSC4+dHYGyfV/vSU5QmTpoAdTiM4A281l86Wl3qb5XXru3ILMvbf1d+5Q+Lch7A
-        A3arvzSR39dfuxmc6+Jp1+4u7vceGg9LXdi+Ebrd6xOeBxe9g2dPvlFfW74h7/q78z7pMgyc8vNu
-        rxO51b/D7pTLXOZmHETdA+k6w+f7c59fjZbWSVXczHwx+iPwVn1pryRB5TpPy0HbBlG6U2+rUARV
-        YA+i1gRua2RuYZ93zGWpP68aO2blGoWZeK7hJs6tfFuf+v88QWTlP01qry6rJxiEBqG4E67curKN
-        9HAo3eoFwc8P+ojeaaVrDxunfIFQAsJQDHzHfq280rvhTxw7zsv5oSAJkTfmGz4sbkriIGRcYDNx
-        jCqI3QsdAEkAImVo9DcE/BsI/jsI/e38pM8b3Pr9aIFruazMovrCJjA0GGOSFUH0K02CQzCOoD9s
-        EhSGfsokKABDv8ckNxNcpOe6H3lFprYTaklvx88P8I1yMcParAZHap+maV0k7v8un/hhOoVph27x
-        P18bXe11/Rw4Lzg7f60ZSjc8GnZ5eheSR/DGGIZX1eVLFDRv9TfolTAEb7Myn1/LVZe5L2UQZ5E7
-        zHYYUfXa7lJzY9VZ6UbR8KiyejdG+ssxfm3sZ3ypPOLPn/TtuenZ+ubLODKHaFsPhsSg34aI/VYc
-        D2LsXT8C4G/QueoNGD/f2/tmaSTp2bEP5UuSjp/fAWctPAdJ13kTwVtxHJsno6iTZDDrdf0heNga
-        X6DjeNDMT3gf0XHius6wutmwb+rCveyty3g+w2/kujDPOcYD7RW5Es5zSIvYTGz3Ovwv0HGWltU1
-        JlLQ9gmV+fHzG/Qq8M5g8jPbCOMX8DfwTd8f8XHppxd5PFync80A32PjctjXA/3S+ZBzDIlHWZ27
-        e4BfOVfZGOqfpK6s3PhJd4v0jXp1gmFb1Ldm0mS2orfSjl6tpCEpu1fcSJcGkulEbjG41W7YSOUr
-        7RZebknCO+PcBWrnOoOAEWdR//UCRgw6/RMCRnwhYF/zqPNWztI0uuZ51zX5gJ03eBTE5+B42UYP
-        xe/pIvGjunjZAdfRAZPRZNhhN+BWUxpNUAZWdNs1H8Er6y5I1w01qM4tmVNvTe7Q+Et/e+9r53+v
-        C0f8hoBPm/X4+Q5da30/jockAxohl3j7iF2f97ZL7LoohnNTd/90HYVnZUP68A66Mw6mXaXFLcX4
-        AN5ZSR1bbvFCwvgD6wbeWUOib7vl+VT0EXrgDE5tlF1spdHzIzwoyhV9+a//fGx/x+/oy7uj4NlO
-        5zhwCwCDWwyOaZnnVMC0yjSqhz1Qms1g9GGWZ9X4iI6tyxZJQzd5CdHhvGGiIm8v6ANONNPT1Ik5
-        4Dj1PRqXuQY48TW2IqXjrnCwPN5TRngqeM85MZkbac1osYfwTNwTOHNC7XC3UZeqBR6zqDFOo1KP
-        C3xdz4N6sm0EiFTwhkI99jg5MJlZHpI8gmhTg2rLR8PVOhpsKyXtASyBiu2cA76PaX1wtEids8P0
-        TZkLy3m0TZHUQE+wgmQUsW75+URvpjwKBLzJ+VrIz1l5z27IwGZJt6ZPyayxO0Dlig1vTvgqm0xH
-        G33d83wSY+Z8vgqP6xKnjyjEBqsEJ4HDvEs7zqViWEsHLSacvQgIGlbt9QzKdyzNLfdyyu7iA3/I
-        M5tyWULts/1sOQvn2xFsxZNW1qBwtnWjpo0XKG4fDUefF+xMLANcCpZHE1+owciSZcxZ7A+hY9C2
-        wa8kYAGXUB2zS1HxCkBV+Z1psoGPMysOxj1kbh73zm5vZdNVRbZHC6w3PpB2ookL3FqM5pAigDvi
-        wI8OB28NrIAojrzliGpH6zWtodzWlSfVFDetxtRPix3tzjycOfZzgQgIP+UPZMWqesT0VpbsNraE
-        DMHF3SD0IiNLqhSg4NjnUFgdkBhLNJC3GtVv0tN2TYasKMahMZz7HnbUkP7HVpAMOgaPzrvvrTge
-        wtYl+79FDlmZ0bw8aOo7+M66ho5z3pBUT0N4dR+ob4evQd8Hl3xNEa6lcZIm14/G28ORy1g+qXgg
-        n4X54k0vCPaefa95pA8R0TcLz31BP7DfKh7YN5/9vP93leOrzhg3nx+EeBChL7Dx7URkem9+fRar
-        L9EHgbha+BwHPkCPnLNpn98h9whQmO3QIKmGU3hal7dIBg1x8dOKC71KKzP6wHzExnfbwvgtx3m1
-        9d2QyKXmbtd3Bru2e2/D50dZ/JZEflchFRgARNV0tikjC5OJtckiH7GO0xEjMeJSkJWRh4mmu+H0
-        ql4d1LZHipQcrajZFtr7TuWDzqmhWVzyIGeVusvsqB4W5mqD2jaxMzTeKWGIBTCG8imvkHZqkrHr
-        WYWB1QmyJI/dH7AGpER7KU3Z2TwFw0WM9huFiTJntSigSdfQ9CyDvDWx0dUDxqG7HTixNUg+Jd2q
-        KBdbVFuFe3W9mZQNSfF7zWsoQlNN8rglYp7dArK2Ecs0lPr2SMYrkzH2I2eW2izY4NvTjsKVPEKT
-        mN7IEH6EI4Ur13I2tSBG0ZJTTmCmngToLkgZk0/Xg9QF7iiSG60F975hTOmdxgpwGC9zN8rNCa2A
-        /AzxklXVSrPKs2RxOdnlLMFbnJi3gD63SzxxvU7e88GIJglht9B2FdgzX1MYBH2vMG8ScMuovqEH
-        6E/pAfgH6wH4R+gB+ENyMP3FcjD6UTUYfVMMEPCrYoB+Swyu7X6nGBA/ki7VOlhOt6REzlg2pYTl
-        HFHDiYNzjl7kApDOJVWG6qUvEmTmmSd4daA6ysEPEshM5NLhhHbFHipE32gG5CkLLULybjvkJNqc
-        TTlaqFqiaLIEqQV/H1tEvYwhNuLCQ4psIt5Q6RLn3NoaSd38hACusIRiTO55DAC2x+Fcu5B5hcP0
-        Ba/XGupz6ipnayODR+EyRzvEWLjSKF+j3REWmn4ithrFBb18ADCA4RFoe8JkLfNwP9hWsMeetKmp
-        w51iW0wW5ICWHNYAnwNlf/TQACYa3CImXr8rc9qls06O3QzfrmF7f6gSfF/OjSof5K5cSMn2RKt6
-        ZZtaVidox404OVz3+igNSjbL6Vlkc8Zpxk9wXqNLGYi5ZQ5NljGLTCOcQaexxM9bnkuPBYu0+JIW
-        UN7Y1Qy8c0fFwRGMoGKcTJ0R6iG02q2TNYFg61CLzikPqVXM7qfHZGrSuQHF9SgHkyXFThWYI1os
-        6YhVf4AnAb3ZMwE/V1Ta2hMcVlp8EizozjsSlg9t3Wx9yqCiVQRoNaUk0CAsOudVbNZiYcz2JC6I
-        Ekn7URhBnO00dUg58BTECkRtE7UjxJhMN66IuuvD3DWhevrVdAn+g9Ml92RerpFeD6DOy3SFkuig
-        lM5bCXotDW2qQVuuX6Ocz4wX5u3z+FBHlw+3Dl6LZwEu3LIaXGw4yBrnm9tXKf4Ij4u0vfYwyMD1
-        48X7L1+KXOb2fAYyc5hKWgyfnx/H9On4oM/HB/0Txvf8wdbvioY5HPIK14wuz/5K1c8kt/BPJbfw
-        H5zcfuz/FyW36A9FM+pXJ7fwDye38DfjGTT6fcnttd034tnDZcDNBOyWWtFvbR5uZx6R65cz2WDS
-        Jzso7Mh93+D1QuaOXOUKNwCgQNyFvpTYkR3U+zjDIMAognIGwUPYiVd6m7JUqPNSFUnKFJoxuSFl
-        20Qp9A3ujvyEW4xqjsH3jCH5gkNzCcc5HTWvlM1kZVkmJaL790O56eTzu1uPH74Cwb8X0sshpBtx
-        Nw1imO31rIfjIR5CvqJS1CyLIuSY6zEepXPOMlVNwTsugjmPlwIENvboBBUmhCIvtkGtcthe0/uA
-        52pr3Ul4PNpbQTs/qNyJZEKGqABqxbICPV+xe8UwRIDegEuxX6DI3uppKd+HwFINWGk9JPc5Ih9I
-        CdSyrKkOmdLHjH0KJrgt+nPMmJ02rRoqmqCOJF5oeb0/hOwujavUB0g2AVQ865Xj1kiXTTyCF+xE
-        LFqXntiVL/LFxq6KVoRrGp3NugpniQXPnGhOmi+P8OzEJfNYECguW8mIqBc0SysTMWqXB1k4tQs5
-        L2IDm5kdA5U8kRmSDC9EST3tS4hAsIPqwKt4LTJHEGG0eNsddVFjJynGum7C9j48TzgS0ILezjoW
-        nLAdGB+HaUCCUHox4ONqzOgCW2A2WwwBN8ndlT0zAIXskF1kjoxDvuvkZYhT2rExeAgwwQLmjnOG
-        cvnNaGb3ScpJoaNOJt6W2+muAtmKeqpAozal0Wpp+9aRmhZ5FCOEuEUwhdAIa42WUsx64hH3xLp2
-        Sqk+IfKcnCFHZkb7y9Y5ghPQPdVAOjg0rTWYBkiTxs32p6lc8vg6mJx6AVsMqR572nAjm3A3BAp8
-        LbxD5J8e3nUWO9+W38L7uUR8NbxfmB/D562DfyB86uwvCu+XsX82PuKfML4/Obz/1FkVhn4qvCM/
-        Hd6hPyS8Y/+cu6tfFt6/fncFfzO8/6F3VyE8RGvfFOgTWzedMCF3EhJvYXJfLRhv7qQkK8/oOaGe
-        QuOAx8AkdcBD5i2l0URLJx4XDLF4o1i0jemNUefJVDJBcz1frlaIMIcku0t3ZAGE9r5Xp7J7srq5
-        pk0b2+0UMSwwitkSCgiGEzLAMhQqxAilve3CbsQ6gJXpVMmwpSmgPcNisk/pqWYedk5a1K3I6eyR
-        cJNcOCo9sTm1EDgLyyTU/CmL0Et/u04jL5DBZOExK2U9SlcatAjrXC/QaBYdPM+vduAiPqxGHgKS
-        eDTP11uMLwLB8qdq7623a1WNo4mzrOvlcGKjRiyn2XrjI8b6sJJ5ANhYC0N3ASCe1yI5hbUVhVQx
-        TgZHaY05UDHyIpd1gjU14nAsjg3aavYzve8zgEi0uPUKMkD2G7mudaVfIgVHE4XcotZOYbrVtGCx
-        VtOvv5b6/BgI/d47rY+e+W2duMajP04nPvb/HZ1A/pXvtJAfVQnk2yJB/s4zAPkPiAT2Iwlwx6t+
-        xQgLwKf3zZID+Z2iKri3WpwKFDvR1WFXhYM3x57r1EF0SNhAxSNS3ojT2CUEv5DBrpAxk1mwg6vY
-        jG0RgO7C4nyJSBl9vuqi4BY1soTbqlSEAyuKXPj9sslQYVuJXL1NemFmKgWetYROc96yE08tOleH
-        rNxY7OPmhMMky6CAsKXWp+FEH+72arhsGIM87FN7Z4nbmTUlSPu0YYTDTp/0kXVIjhnQVzwJd3MA
-        NtGsmiknfodoWTRSjzaLgMcRvUUsu1xjorgT+bCF5mYMeHlgOLoYDnmkmHT9BtNglJ5XKgGmKzLs
-        kbJwohCYS7S5XgSnhIq3E2RHb5RVJSrRfD6jGLcLZzOOiOiqKeBZlKdZzZMj3j4tG13oDErt28yW
-        jozhMSFwkEOEEsp6W+BOjG17ZEF3BdTNSaVDmSOJyAvaPxh7xbMNemkLWaiu430iqWo9szQQsuyQ
-        w6d2Wu28Wdd4MSbI6UQHyzXEUNws32FlyuVBpcNizeJ2LRkjdBkNxzQUIY4bJHWEExmpx5CBs20b
-        EpRQgZICHCSoSODFqCQnFpvMWO3QrLQjgXhEX291zDSz8rTYLgVR0IzIQllgAebsytjOD5IbEF9P
-        gPE/PQFeCCj2lvKeSzj49fst7JME89bBP5BgLoRfdb+Fg5+O7wz/6eP7kxPg/w8C2z/pfutXRTb0
-        d6a/6M/ebkny5PJTsx+43ZJ990kahhs9/Vvitk/V2fR//bFrrrUBAJkjbtzRqFoZkS40i6gYNXsL
-        XS7LBjJ1guLqsIE4Kkj642m6aRGnhaVgH0SbSF5bHsG2ZMms5Hw/m3CbIy2yYd+LTcjN6nhkEKTC
-        9sja55d8HDV5bOPLrVvbLNoMz/2l118Q8r3wTw/h3yGZjG6FdXnQHGtXel2QLZppY3LsvPBXNAnk
-        uVXlvp6fkL70YmYHtUInez1HSbNjkrhwrinEqD+qtAeutabhlskizHPyEObTuIT8vZKAO4c062MO
-        LxfKBGbtzQmebyttRMIzVI0WxIHFUhOc8RoCTTlw7ihbCLLLLLfsRb5fB4i+UgOZO+5B1AqdEbvj
-        VxmrN+06Llu1Xy2PSejjfhmKZjdjCoaiDQ2X91m/lmRu157SIl17dqK4CxZvewg9MN5GDESmEhx0
-        YSgTtQ/YtdS18m4UqMEQ7e1+r/ReuO0Jsae7BIC4kiUZmV1hiLtfy7NIl8LKY912tMlop0OAMiJj
-        gpi7UnlkzPVUyo8MgZqF2Puoa3RSwbGelCez2G9Fuan84jTr2YQbGWAvlt3aAa01UMWM2mxXgrJo
-        +h0Tk7Iwy/vddNbm+4XuU2sIIHo/w5JKSmQWoOEc4HgsFbt92XFSDzrGaNHRMZUQHuCIal3JDpj5
-        sgXpWddR5VYi8+KgZOA6brY7Pna2wD7xfNBBZ8BKmqIxKEMlxGYB4xI0k5Y99PUzCvIv9MseDP6Z
-        4IASPxUcPn5V8t3g8LH//6dvRzDoR6PDK/NrX+Zjv/PLfOxnw8N0sqIEfv9D8WFqRsPMup/44uOY
-        8l7WCGGrUxq2LRf7BcsubRrztMQNVtspaAQBsSL4BTBaxlgAGsuFPq/gjqBPkV9O3ZUyCNMMWPd+
-        jdgQG0JALmsCbh2ngZ5h1o8o//P7n4LaZmJErtkMm2LYEpF7+7Hxl/B4mFhmVrZ/fz/uDYndyk+d
-        B+CaagjTITd8jz1Syurl8sv/99CdcbEkdX3h7elQpPFTNQTky2+/HxrdfsX9WrztyMtLG8L0gfda
-        cadezWMP6wIuD4as52C2tJdMUfunOBSJabTZa3TdnBY2CIHKgmJCHkvMdXCqzG5N0NtZlEBTPZ9t
-        EjziZ5Zp630lyYbG4nqPqsThCIwI9cDFp/i4hyMjdgSGSmbLkkomm2ChBzwfV/x0tbIXdWlHdu/6
-        eGeco/eHET6M+LyCt1cAH2nXhf36cny+PhtBkr+zPsh312czYE//piyf/teQpf/fJ7Zwo8GxntIk
-        6v76Q6s0jOIHVikcVum4EJU6Wc8tjtyS5THYCgersTJPXiHHFvN2u7L121G40RRWbkG7FUAmnqha
-        QZ5MhEaoidHQUjVfkjBa7jYppVUgAwihTVoO1tDakVFGmbJ0ZbQ/HltfzqeIDloGR8KA45B7jOOB
-        cpeqk0RN96Cril1eLpeyCALfX7HzT7i/WK5BjuOgOh+nrm+0Be79xbgPb8gF7jffkLvZ/OOrcc9v
-        nT1/+qwv98sdeXPx52+9Q/zfG42TO4g8AAA=
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5840']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:33 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60---Ny2iNMboadruDw6LvMsilRb5jGgaOXh1DdAM4bnw4RbynoTSqMopj-1E2YaLdIsf0aiLopfYZvQEvzk6x2QzKiXiTIDO6Y32ZZnVG5IpJw6hXdbFbqGJVb9zNdD0g3qTWj4BsBec_7PN8CYWuL35n5--3NJCsQwo8dk7qAqrtV6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['1148']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1ZSZajSBLd9ymic9OLblLMkupRqqcQoBmNIIkNj8EFiEnCQQhdp2/SJ2tHEJoi
-        KqOyMmtXucjEv3133A2zb+ZK7rdT4L8cQQzdKPz1C/EV//ICQjOy3ND+9Yu8FLHGl99a/+AsF5pR
-        GiZatE8QE2oxgKmftDiYGlYU6G6opRDEmgs1Q7daOYBc7WMTB44gRBP1GOgaehFoCSuudhuVBgtA
-        syWgfeWZA2JQES4oZ7h2uteOup+CFoHjXO0e4Ew3ycuV/Ci0ohBLPa52A0v7ZaHRxV4Zy6VNX4ew
-        +qfkJw7Qk2IDd1hlv0xZPtrLZdBRL+cul7s44xHiINBj09E8kL+9oYYcdgMLv1bUt5lX5GG9G++D
-        JT3Xgh8vWx6ksj9gN8rlLKIeuH5+RypPWLu9t/bmtCI+4srNF6ffA1fzZb4cugmwXoYoylCI3KjV
-        V4jdxDVRiB1dkGl7EJtFxFw+9ccmztIToMV6aAMNhFY1rr5P+p8XopE4L+3UTmHyQuIEy9VuhJKb
-        JqYWbbcQJC2KLV70jN5oEJgocGCLoOsEQzP4A/vNWNJz9CcILKtVvBRvEI2KecXRx40aLE5oF1gP
-        LS1xA3ChY3gDIxpLovkLhf+C4//GiV+KN308oVr32QPlGCZ6nLzzCUkgZ7T3sev/TJewBMlS9B92
-        CU0S3+USGiOJP+OSygUX6SnjUZKXnXm7MxTmXO0OrigXN4z1BCVS9vIapXEI/gVfJHScWDc9EP/z
-        bVLpr/LZtVpsX3yzuG9Sp/koyqObkNyDFQNtL0lhy3ePV3sFvRGQlOqJXnsbJ/ketKAb7H2ATot2
-        lLzNu1gqVrqHwPfRq2DysEfh/R5/b+8FPpTv8doHa9sgKryvtzhfT9wkRY5kiK8MV7sOOSTGdvmI
-        4V+JwnQFuNptvqNDLYyKxN7CVhhxtQeg0EKkZkg6riJYDblAP2lxGobIreX3J0gUGu9QLkCa+QHv
-        GeVCACz0dfcobtIYXGLrsp+P8IqcxnpRG+9ob0hJKM4QxYEemqDc/juU20cwKWtih5i/0EuJq12h
-        N4FHpTgp2JoXtPCv+FXf73EOOtFFHrflccp6/IhxEMU1ol8WBycUOgAmxXJ38BunlA1kf1nkMAHB
-        iwri6EotkwCFRVpNW7T5kTBfrITRaMHV7gwV6TJhoVs+iFFarVAgwTdaVV6qJuHBOTeBWgELCVi9
-        EPWfL2B1pNPfIWD1dwL2exlVhPI+ivxLzFZl/AkrAtx3g6I4XsLobviZLtb/qC5eIqDcHdZutlGE
-        VUBlgdrRha7hV1HzDJasmyCVAYVUp2rmlGrKDeLe59tjrhV/lx+u/pXCX6ZjrnaDSqvjBAFqMogm
-        dam391j5vmuUmHG+TyLN8CPTawl1DJPSrO+EsLEQp7o1cpSOk0r4ZsDsI1qk5tKEbIwoEAB9vJxb
-        m2VXHdH7cEc6sh/O+f1W3k8Y/7hZNlQy9LrdAIad0SQyVioZTHq6Erb5IUXHWVNcGhR1Muu53IkJ
-        qRl1QA+d3XZZfzPM60F3DwRjLeL4ZtawBufoyMq6RG9OItlJMpmKdmG2S/CZrMnngTTdmKy3nnfP
-        gm/41oA342wIeaW+khNnlREsG9BdTacSzJ7QDB8MTn2PHMwpOJ02X40+GDRnekcS1J1k9JQVOWgm
-        zHo8jfqeNun73nZ7grrXtI51UbbOYRpJh/72aHVEyHrWDjti2XrRSBYbvrODwfw4bqoyfmC33TUe
-        Y5rYlS2xf2q2p9R+2RaU7dwQASQ9yhieHDiZ714VXWPay0P7RCmyuXbQ/cF2dHunrmjNnLv1jTzp
-        zLPRxNMhc5LgGN8Ozk3GHbDd0Xq5kkRT7vGZed6a/aFk84vNaZbPXhmsL5zAKz5VUl2O1LaImkC6
-        d2jWvbRHdaY4e+4vsrWpTZkzPSIss0m4r6R3ggu9ZzJLrOHxkoanCbliU/N4yOUugT7mbnje6lKo
-        pFNyvumfX/FZV37d9dQki7e7NIn3ct8XGm5ibglW7h6d1ZxQex1FXp9zZcwwPVzpTzcNg2K8dDMb
-        rM72IsJn01koQtPN012WeFEdW7R1ycgEuj97leLdOIsO3R4tnzcBm/fC2I8bK9jBFP/ENv2esiM9
-        zD4GTM/gN5uBl9ZXS3JyUk+duUU4zGtbGZ28/SyZQLUjwUlwXk/4V69nMGexKcTM2dsdz6o5Tx2j
-        P5G6mYLFWoxNByzln019s5NGEb6dJy6tdLZKXcMwteim73KFM3w9RJ2EdrvrhX5+kaGPLbdL4UWj
-        WhRSwkeEM9M4RtfJ/PZUSoJt7NHbH6AbY6ubSRRX/f4TeGOFaWCAuNUg2TtWBd5Ye183AWyRd5wK
-        uuOgCqvBPDAiv3YPo/Jeoq3//fd+/g2/oTdnwAe/oO4If3BL0S6hfibaarcJNGoFnqDrGug+bMDI
-        T5GEQ/2INLOs+c8gul4FhhuiOkE2C/t1eNtMWZmXMi9Iy7stlc6/DsvSXPRlYfKC2hdwR61q6yen
-        uw6TyANhy8MxjDlogk1r2ImQzoQ4lb2NtltHQVbv1QVCm+5OrjyUNvIQ6XCAC/NdCu1juJI34uyg
-        9nZ8VwDeiSWcTtPtx26cEqM9OPkzyxVX22YUOY46pwKGTgLFGwnjfj/pTnHQdQ4zeRS6r/bciBd9
-        W0xhuhPyBT7PmsTyOKH2h3UjtiUg5rjIt0dYj+qKINm+yttRyBOqizXpoSm+AhnvDDN+sW73kpO4
-        kpmV6ooDLBsDtBfJH2pp1B7PmYbQ7jeUQ6dIqycP3HmkaM7vPVZ266i6oo4ExW1V8ssBCpOwfNSe
-        Pu4Hhjty0UmgrgjVQpJ9ZN8s93TUwjl6bIMW9cS+Gu7Y5WVD+3j9ByNX5qKmH3XX14vOAV313mFc
-        dYXX7Vt8Xwr6E8hdFtWMoo25RGzRtzxB95wiVGsPyK1jifUMTQgT106jFFadF4H6uA8NF3oSJbr/
-        xLzHuGen37n6ycF3bv3AmY8urN1U4E/rAfVNPWjz8ugzNWhbqZ+8FJcLS4+tH9UDE+mB4McbnBVC
-        SAWpO85WZMMYnbv8zpOE+ebk2bpAqPtO5LU7DrVaeoMeu5qFetMfL5i6nW8ayXqAd5XdCWRif0vQ
-        XfmsWGsRAmeAHxWBb/viAgx6+7BzIKjE7alGEmIinZ8bgrJap3VvyK741YBe521qOiInTvcYm+Mk
-        tPC2TNky6e3ZdD+HR6q+MMexrKuNtrrPcfZQd3aZg5+lOB72Zr5NZ6sgTzrEmd6ZpD2xo8Vs1j5l
-        kv6pBhA/oAHUd2kAxXyXBtDfqwHP6/+tAVenfKgB9Lc0oJz38zWAJL6lAZ1ef8R/ogEdx/Wtn9IP
-        YCj/6fPIXsc4nEV26MZZaKgHXOr3Jma+11hvOdho9anM4w1+Oz+FvWy5NgN7H6fkkR074hEjD6pE
-        BwGDr1TTw8YzbMmfQrwxUFxrtFrtfTfJJ9qAtrykd+K9dJd6lrum++o6HG9pl5HdtaVoxjqQdBG1
-        Jl297jZmTbYB/LHCepk6JWBPn8gbSZnP+M/rOfkj9Zz4nlwmGn9tPX9e/+9cvjrl++t5Oe8vqOff
-        zOVJe/pZbw9CN4pfTDdxzyD8KSnNopQetEe6TXXVhZBOe/H0KA2CILK3s4PCOGCqQMKR0tX6MF3y
-        PDvMuprkNCcdNtdVgXAlcr2WWazb9VfaWcjXmTjXw/zY72KHmeWr2xhX6aVy7hFMxxBZRpF1Zjgb
-        O2vQNc6RM7F4b9Pj1wq95zv5jhha7O6gjF0jPqu96NVd51EeHyTx9ezOHOWgsCNMyoROAiCBYZ+n
-        N/Ujpfq70pv8i9P7ef2/0/vqlD/Rrn87va+PsPzd95aSTuQWPz9cf/19Z7mLt6f/bP8/J8Lkqq0f
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
         AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2909']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:33 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:29 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order><crypto_block>E7--NuwIhns8SFPadLhVChuN0YJ5po4F3RNO28L3emeaMTRdYTGZL4pnj2hUlnRDpfUpO5lvYT8Z2nkGGmsnCLOobWZ2mOHaVnADK34rw9FTb33xc7yUCr1N9oCeHodegi6lYKy7mGpeEbXF00YQ8dJzov6UaN4YxF2CtwU3ojnwjt0QU_UzJNPYc6kXRGzElbldJDcrwKsDV7WUthWw166m4G_a3t-gO45DmJxIk2JR3sPP9BbIeJ9QaCNEZjNbHVW2J9t5XMPoIk_OIlkffxsak9dv7FUdznuoNqIfvdCFs6kdj-v-wXS8tSYDCjsmRvM9ZU0q6fGX0r-_FGUdFIx9AP3pTAEVfRbFes2k3bKxhsORjBVa_5ATqAx3VUcXhF-8ghagjZW4_cRi7YUOCRwLOkas5xNsM0fJz95iJ6GLXTWNFcUHDwczfcIKNgDSYxQyQB5-IExeB0PVuaUoZAFrit4Hq97kuH3CP06zISwXc_P5z4L1dc91iB2kxsSaHc5T-8kDN_0ut2W6ucvqyUG1Z2njKzfaNnVuP2RYIzB0QGUBjHZtwrfjutrpUIlE8itcf16UGvhWR1ZHCVUXzyVM55H0VIPY8b35kuYQJWzgSo0QPQnFsciyujwtko7-SAaNbwE4IQBNrjMwoqGH4UzYm6yHnrlr8WsC-Vlx69lHVj2k-gvm5HbDYYJku7WT2OxZxCRd1h5BAVLxkpQtOsZCNsOmzXODBkHb5zF9Er5zkjvzZcRuhbIONGwV-r_r-PJ63lzcaYjNLo0fRti4VCfV7_--Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>k0--5q_Eg4_-x1Nz1FPUkY_jXomw7H7E1_PjxiUKNYUK3emm0ERjusgvnWUYFQqZHjDGEekx61hC9iIriru1LpexlQdiFWf9oohhZR3m54tmVkLEMIItGP0eGhqQULniBgRbrSIgFusujEyS0Rw91TvO3pqX8rgNeFy0FDAL-H3GFetfBUfLnD1Zi-94KcFBeU0CKwDSXAHtxFWU5WZiFJ-wMeIriNlK_uoAMR58EAI8VqC-Z</discount_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></create_order>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxldmVudF90b2tlbj42SUY8L2V2ZW50X3Rva2VuPjx1c2Vy
+      X2lkPmRlbW88L3VzZXJfaWQ+PHJlcXVlc3RfY29zdF9yYW5nZSAvPjxwdXp6bGVkPnllczwvcHV6
+      emxlZD48bGF0ZXN0X2RhdGU+MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1384']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61Y23arOBJ9n6/wnJd+mCGAb8Fn0fRybCdOfD2+xHZeWBhkmxgQkYQv+Z35k/my
-        LpAw4LjXnO7pPCRo15ZUKql2SdF/O/le6YAIdXHw6zf1TvlWQoGNHTfY/vptPnuUtG+/Gf/QbYIs
-        hkxMHERMgmjkMUOn0drBvuUGZkQBdqm5thzjjKgu3zbpdkQIDH/OvkyYCxnbdajLRShjbCybYWKo
-        ipLjCDBjBZG/RsTQyvUcS4AZK/QsG1GjnOMIKMfBlJn07K+xJ+dhggRq/Pc/+f4ZnqHQj5xDhs21
-        h+29MTcl6bAPN419qxHOa6O1tCV446js6WgPx6v3CrLpe6W9UuvvP/YjZbUI2gd/1tvReXvTWZ7s
-        eat7/lh5/WUXLx+7ZLR3W487u/JeGZGh8rhsd99H/fLraCbNgj05N99ftKFac8dH7QN1vcUn7X0+
-        blbgXd4nnW8mw3sUGJ2yJNVQt2Yeoihsvm9/2Ntl9zgIZ6ixbHxsp155pXjLsGbjw3GuUlp9Xqwe
-        mtJkrpnbyrgfac+9zy0in2al6ymVCn6WXgcd+3OnNFuH0WCx0qqfUa2CFq1Nc9tclg/V+7O2ffMw
-        67tViofDjcZWiO2XH294LA3Vndebv+yPb856obSmJ1Sfn32r47xPl+TzOFJGZns0mdiLsH56RpOH
-        D3O7P1UXUWP19jKmo16thTqSFT6a/cqxFTofPTStjOtm5cdb8zB5nTmTp4do+jmVlt2X8LUesUEg
-        Rf2eurTccBhprP3cHHnD5kB7aj/Z49VqAiNVTNJ1Yet+DEb9N/f8MGg87Ozg3H9qaTN3PppZo9Ns
-        umhoXey0262o/3H2O+pgYfuvy+mufnqhr1FgV302Xo6HJ+9eetPlfPj5Xhi6g2hoMXtnwodttLDn
-        IZuVNgT7JbZDkKdBhHS5yMo6+YjtsJMDkkRqjR5GuT48uXJNygz1rlZgAPR/uhLnv8UsYzifwfw5
-        XmrIqOwcIsPm4+eICZxrXxbnUhtHAXhoY3/tBsgxyo27WBrS5oXC1zqdzdud4QyGKsAZK3F9yiIH
-        BaxEQOZyVL6sAJt4Y1KQQGqoupxvChtz7T3KW1NAj2khcW1klOuxm1kb9JPYO4tskVFJLJdm5oCh
-        I4g0/LFAgLnjnYUuZy1uSNzsgIyfjztEkCBw59fuNgrNg+VFiGtoHtBtlwnB9XDgYMiEPYTyAnJ7
-        MlA/sQsjH9r2LErFH86Ho2Gx2IEcJuxJl1nRzoeB6pCUCj5cUj+KUBxEiI25R+d0BjmJZArGpUhQ
-        054XpDBexrsx5N516O1h+UKEvYBllGQtj5bveuccia9QzuaV06DF20tEmJOg54GLOek/D1yGnFIP
-        ijJU1YwqdoG4cNqgKh9cdDRDROz4xPByedOkO3EtJ1awRSYKHNEW+xP9u6RqbFdqRtuIslJZUaGg
-        ZgTOjZgNh3xDETMq9XiiazSjUWTDwYHMqN6rtWpNKbBTI6ef4cf3HUhomFTRVE0wLzhsLtbqimom
-        sBU4kGY+SuiSokmqNlMb3yvKd0X5l6J+j2e63UGMex0B3qbMIuxLTMoqBKMJiev9nSGpq+V6pfrT
-        IamW1T8VkqpUVv9KSEQIEunh5zHW8Umz1etMdDkHC0oShoHFIJGOpQcckQD9QktDWA6xQAbJP9NO
-        PF7823WM+vNjaoGWwD045TgTkjwoGOAei6jhuYeLXUApgRcZOW0ntYS6fughIcxpP15l+HcUUuR5
-        MBVlBR87X338I99jvDfP4/KNsbcIm7wIehZz48Jj1JISfGnqIMZb/ikpd2psugC6nPXfWdSEegOJ
-        vaFGgHW5AMRaGJcb5FxEUDR13zqZJAoCCCvff7UMR+MLqvugmTd416geIOTA7oZwbiK4D8dnKfHn
-        Fi7IEZRaeHTkaCnCCfEaMPGtAEpl4v4XVI9v6rwmttRJqTob6vIFSgUeKimL2ebeNxRRgK9xne5w
-        Io8bvhz+hCliOoVzDfRkcHSCo4Moi4fLwSmHywbYS9MzZcgvvSGCL1SeBMkFStxQmu1+ZzJddPr9
-        qS7nDILELyiW4yECabWAg0RTmigv4pLwl7IRSoufPpRiecg19UK0M8VbIAcU8T6uEn+/It6D8P8J
-        Rbz/ooh/lKJxboQYe+LmlmzyFRZnjOf6cbVNzmWu+b+E9v5nhTY5Utw7qdlowpEVgLBQ8+BSd+2J
-        Y3gNclamcPyEgoyJ2+Gr6JJB+tcELiZv/Jtv3P1dRSmNB7qcQdy62/k+3FrURiUp4HmMz5flZHy3
-        hdc+rDeZPV7gFZTnxHPIBSRbWrwncHf5iBC9KHyALxBy+G36mqJzic9FoPU8afU7sdtXhgKVX7VC
-        WE3JdontoWIHEQ3MLM+8enpcgYJ09Wr4ChZ4uRfELVhwr18T12hKK74srsGf1hXxLJVv/fvnd9nS
-        /Ew7EgAA
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1830']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:34 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:29 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+LTAtLTYtYnNqV09qbFJnUHdhT1Rq
+      VWNscTNnVDMyR1UtS1lxUllYZk1mbEVTa2hDdHo5RWNtTmUtTDJkM1FnRHF5dDdQcVowazZGTG8t
+      QUF6b3JPX2Z4MXIyMWRWSG5DNE5veWhoU3gyTF9qSmRPOTF1X1MwZXJxY21RV3Y4YlZldUtKZHVH
+      bDdLZ1lwckNiNW92S3NsaUc4eHVqQ3kxQXJWMzVzU1dQSHA1ZWUzNS1ZPC9jcnlwdG9fYmxvY2s+
+      PHBlcmZfdG9rZW4+ay0tLTZTWUY5WjYxLWUwOThNeGdvdlVleU1OU1pacFJQc0RsRm1sMkVLNnJp
+      R2tpaF9hMHRMODIwUWY0Z1hlRmcwTm1ZPC9wZXJmX3Rva2VuPjxzZWxmX3ByaW50X21vZGU+aHRt
+      bDwvc2VsZl9wcmludF9tb2RlPjxwdXp6bGVkPnllczwvcHV6emxlZD48dXNlcl9pZD5kZW1vPC91
+      c2VyX2lkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u46pemFGSGGmGmAmAbTGGNeNLK1cY1l2dEF7Hx9JQPDhOZJ
-        e9PuOXsWnfYN955AqqoVJ5Mvn6cTD0TRskqUJ5Nk/cv/OTnFn5DSVGqiQLk6IkEZrjFSJmdtQytB
-        jAJJKkVyyvAACgWHU6iQQ6dbkvO2qHFBfD+ddbsyvX8yfx7iMv4K81WWL64hiWZhn8Xb4iZuskHw
-        xd1y26zvZ01vO6jLOu6q6zy9aTtT7oYN/73Y/eiTqzC9XbG7kB5P5987npFveXZ8pP3LcsrN49Vj
-        FF2E9cV6e76Eo81t35/p82o1z6XanEUqCf0HFOzhQ9IIYRcxUsAop0UNgpFStqbDWj2jYD+EilZo
-        EPrFDTBisKF2UaRojdBysC8DbGoUHEwgCZQTQRvAa1DaS/9WGryI5sC9xCJAwXuBE0RD44YxUIWs
-        LGoZuPDAAXdGgpVgtJ1IZDSDV/uD78hZ80Umhp/dVO6G+tqiMOPgt6SFsLeS/4jtE3rzHEScCNuY
-        eUv7217Ge+mYdGgPXNg/p+ZY6Z8CAAA=
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['422']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:34 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:30 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6L9</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bY92t-Ig0lujJjLLHCkHTqDKe2fRxxAtDiOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGJhbmRfdG9rZW4+LTEtLVExbXpRMFpXS1NlY1prOXo0V1A3WkJK
+      LUZrMVFsalJMZUg4OXh2OXNDWWU4YkVldjEzaGhGSGF5eV82WWRVYkhBR3l3RVI2U1J5blktQmVY
+      aFR3cTJhZC1jNWhBdzhaaEtwSm5tM042Mktmek0zcHlCc21QLUN3Q1VJWS1jZ3NXcXZLWTFxLUJR
+      QV9DU3dKYThIUmN0ZnZaUWlKS1g3ckZkY0ZMeXBDNmNDb0NYZ09oX29zdldjb3lRTUxaN3VJaWli
+      T1JrWXI0VXZ0SXd6XzFtaG9XM1BVV2ZEZWdTMnNaSnNXRGlxTnptcmRnbjdOWDhyOV9mYVpEaE9I
+      N2M5SmJaPC9iYW5kX3Rva2VuPjxjcnlwdG9fYmxvY2s+RTAtLUV4STUySlJDcS1nTERzdng0d25V
+      WnpaU1dTWURxcWV2SkZHdmw0cG9DaXZDcVVVZnZVTEFYZzlicDlYZzYtY2NLNUx0UUpTdlJtTGV2
+      ZXhlMTMwaTV6NVFnRVd6bjFXbUUyeVh3Z1Z4ZE5vOVNtSmZjZVh5WTdLTU50OHp1eVZKdzlhUlhP
+      U2o1eUZOcC0wd0FkdjJLQkh2cGg2Y0ZxUk9jcno5LTRsRGh1eDJYSGFBbTFGNFNibmRKMm1xd2tS
+      Z1o8L2NyeXB0b19ibG9jaz48bm9fb2ZfdGlja2V0cz4xPC9ub19vZl90aWNrZXRzPjx1c2VyX2lk
+      PmRlbW88L3VzZXJfaWQ+PGRlc3BhdGNoX3Rva2VuPmNfLS1GeUpWRGY4RHlFRGhNWVU2Zllsa29B
+      MUcxempMbnZkVndoN0tMSmticlhpaC1aeTJ4U3BTT0RkSGFIemR5YUdqLXBySGQ0N0s3dmZDUkZY
+      dU1FSnVValJLQnNHbldScW1IdDk4LXNoTHNSWklFbjlMQlczV1ZLczNQLS13Sm5RSE9fenB5WnV5
+      VWlBLVk8L2Rlc3BhdGNoX3Rva2VuPjxwdXp6bGVkPnllczwvcHV6emxlZD48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1YWXPbNhB+76/geDp9aWQeOukizHhi2UljxzlsZ/zEgUhIokWCFA5Z+vddAKRI
-        ykoVzySdThu/WPj2wy72ALgAerXOUmtFGE9y+vLIPXaOLEKjPE7o7OXR7c15Z3T0KvgFkRWhIuQE
-        s2geMsJlKgLE5STOM5zQUHLCwoSHExwHG8KRvV+EIrYpRB5O0jxaBLdhp7NaFFN/8dovbvvXk86M
-        5dPYFReP0fsP9w9dEvGH7tm9O3j4uLh27r/Qs1V2827OT7tFuL5dDj9dnm/Oon7nU+xOB++WU3n/
-        djk7PeevcfcNPp+ko6vpdY+FZ1n38u3442bJxg/LkZ8y78Nb6nfPFo+z9B7ZrTWhOOEC04jwEDMS
-        rnCaxAHNkb0PN1EJECA4hJiRYPwF2fXICGLCo2AMId48zgkjJUGjaJLMZKG0SRL0kd0coigRG6Mn
-        xTxckRnmHQmhrXFD0ZouMbfuFKWUG/URzOTlPzNFzAkWahENrJTrKTdtuVED2dOpNOp0ftsQKgtj
-        QTaVBRtqoAZVqZTUauYWaemreXtURngCsRP7NRtfakoLrlnao9eGZf2Gs+IP6w6zhIhNY45x264X
-        Y1eRzLkIGaYzUJnhNSjPJgklcTByjh1ktyBNgJWKgiURCYb9ilFjhiLBF8xAZc3YQihTQd6x0oQ0
-        4YmVFmYoO1ZaEKJ5yGHHp0TF67/p4lJiKtTWyAsBZx0kU2/isMIDF9k7yC7DO8joHmT0DjL6BxmD
-        pwz7qXs6h2EkGYMDHSjVL7MjJI+hqltQzZjiSOQscB2nwSnBmkVlNiEsGPWarBKsWUWK4dRUsduF
-        GhxVc3yTTfLUbsJw0ho0+LU5vYaRveul/ZVS/pn+/0f6mzmPckkF23qshA1gK9an/S1NBImtzwIL
-        wq18ap1mBI4WXE8yH4UY5EZ/SGhcjs2nU5IXluuLufWnTDeW57iQqFpsmFJEYT6dciKCjtf3VIR3
-        8ZrISZTTmAdubzDyfW/QYldCQ9/AX5bFcaDMOkPXL5lbHL67+WjguKGGMY1DkWRE0zvOsOP6N553
-        0nVOHAeGJ8rS/gml3t0ImDG0SEy0YjKXLyzP5cI6hYM6/c5BcT2/53xzUHqe+6yg9Dqee+OpiDwv
-        KGUQTMesK+3y9Hx8dTVGdgMr5WXzZp2TLCNWxTCxMb+hzxxc+pVk23WGKRxyed3PNcGSkZE4wVDm
-        WB8JsLPmsDeC2H1c9x67fTnJ4mR9HKW5jKcsp+KYqr5Jc1BCIZISNhp8hIuUqOiyNJgLUZzY9t9q
-        sDl8b0lsN5Zgk7UIYVcJ1x5/sT3PWbtu//ihmEE499pBFGeq64VMwuLBOT1GBRbz4Hn69RT0NV/4
-        93VmrytcFkXOBA+Vwepu1ITaDL6HovrPVkb/zekdOs666ziH05thtpTkmcltaf/RyW0Z+5lciIjb
-        g3LvfUNyOfQj7Jm5bSn/0bltGfuZ29/5hguShTWiHEkTwr4h1yXzGdk+ZO6HZv+Q8X+4GqBdEJIH
-        abLafsVLqCLICXQX2K7GIl8Q2uwJDFBJNwWkJFFrh94kWqjaaUjQjOSqeQHzKYYLg4RWpDs4dh1v
-        0IfbyxZDaU5n5mdHfeDcoTcYQv9Uw8iuVc0xD+HeVRA25fq1rAWoJx91VSfx9q2nHOrHASYphbbF
-        dFKuV74PtFB9vW8hfnnBb9MoITE0TwU0YCqFqinTy9mHl2TJsNqFDVqFGIJyIWeZevozq3+CInV9
-        0T3d+7uR7zqQly1SvWJVr4fhIgv0A8ceHPF5/qg1G29MBbUxxHPJImJayG0BA60BVxzTgIPc+qwL
-        3rqmZMs0HaZ+m2VklRBtJFKvmUO4gO7DERSRLE1cXVxdfDp9f3Z5B1fRGi4pWjdQrAtoiGOr8TTZ
-        kJdVud0T7aflvwCNC5tQlxYAAA==
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS0HvDihIg7XFxZDKMgoBCj+Tv9Jf1kHg4Je
+        O4fKzLeqlauS2GfHCeLEOWcHJvPHxbYqEfADw3V+/0R8xj9VgKO6muEcfv+0EgdY89Mf7b8xmhGo
+        buhAyfUgYgaSD4LQgm0mCBXNtWXDkcIA+JIRSIqstR2Xqb62MCACDpon+0CW0DqgzW6YajHKDBoI
+        1DaLXis+68AHOSFFGdWAcca1XEdzHSw0mWoBZvaUOkntuTGfbMlBkP+V8WUfBohSALkx5XeQsfJ3
+        2fb+Xemh7YbJq5TMDNpUusPMbQyQp0eICYDsq7pkgjhdqYriUiBJ9HLebdodeXBW8J79abKjgtdO
+        s+3cCA9gwUn30ZUtC8B8o/2nCdlOq8UrVG9BTBLCz8OeHkIZuJvT+SvHgECrjFFaoaQoqPmp+AY0
+        VJRTkQHOkgd8NckRAscR8aWJ0WQIJF92DkACjpaPU2eiHv6rQgSwsgQeBLYC/AqJE3WmWlAydghV
+        yd3vAwDbVD1Z6hktaAFQUSoFbYJukI0a/ci+GTN6jP6zbU1rJ4viLZzImXccnbTbrOOElMKyo0nQ
+        sEFKx/AWhhMi0fqNwn/D8X/ixG/JSq8n5H6fY5CNA4iS40NUalCvTOX4Z8ajTtINCv/meNTw2nfF
+        o4b+/Jl45PtPe02WjvxK7Amd3pgVmGoJzilpGKYyhDo4V7pu6DvgH0GFR9vxZdVEKSSyS/E2MYtZ
+        9mxo7fpwcLMYt/4mWSjR3TZyJ8OkZ5TBnOHJUG9X0WTMztbFlHRdLMCc+7oYBAGs3uanU/LpaIcw
+        DNqWEd3d59CNgNqvDOXqbQxjD7QDw/YsgAKGnMPbvNSSs0IvAJaF3jSAD1tkP24RPU05vIxXX/g4
+        ADc5KLnNWDI0YIhiXiM+18hWnSCoBlO9owzq5ofsEcM/Ezg64VqdRIQ7zFQLZ7ocSI6b9IN9kKrN
+        A5B0U9QRUce5t9F8yNjyRfJDx0FHkeUNQaI9fEAZG3XdF7xnlHEA0FBGeCjfkDqkOZm+zys8J4e+
+        nGhoiXZDMkKyB9e3kzacvf4HlPHcAGbi2SOECi3yTPUO3SQCSTZM2JJpt/HP+F0jyjgT6G7aVffZ
+        dtLlnjAmQHmJ6KlzcEH5gnIycVeCb5xMty8Q+I5sVURErHSTRHa0SjEjq5/0UvCq478yMCixwnyt
+        Zac/YYXlhp1Mlky1ZMhJqfulrFnARzW8QakY3Gi5lOVXkIeIFt1wAzQkIMSv6JWtFkF/e68kPmrH
+        /2s6SfZ7rmulaZ7fHZ6wpCYsw05kOM280vArLZj4ZklKkyZ7O6yDz1FS5kBuCaTICAzFyhPtGcxY
+        RePKchB1p/yiuM6nFBDzsUQfyzP5f3Zwjc8UXplPmWoBZVZdt210nSFamY6VsWy9e46ofuxBV1Is
+        VzXbUwrDvHkNEtSBlVXalIXudWeTuhutBMPhuVlgkuo4UubOUbCgNrqQvd4RP9dbR77FLk5S5F35
+        2DT7K8FuGrQ+6jkreFUipdk5cUNLBc3x3pZ74tjXvL1lDYQmO5KPVmO6dq3RwWxQxHKCNa5DsS/W
+        pS0fen2bVcXTGIZDSu1btBoC1rBFZ4L7RmdPc7EAIHccWoK4PMCVt2GbEmsv+krUeANrsyX68/gw
+        P+v6ecguW+bUtg+z/uy9f9VDq7GmG5sWL0Flya3mZ3eh0YOr1j8tsV204eaDbp/g5pG55jcTjDxv
+        V9Pu+0ggllA4jKlOIOG0wq5rltPz9my0cFW18cZe6xam6ZFKBRNtAPvyXMPm516NdJeu4hIgNiPB
+        Hg1mKuQ9TtqO3ll8Rtgrj+pq/JEfnrjxmxWc1V7EwcF+KncGrLAJ3wMruA58F9DcdQ4243ptSvOD
+        3di3CfXisFAzzoPl5djvw+OkT485stsYyjVX0YQ3BXawXXLXLJ0vo1iyg1RSKj59HCtOS+e1pfhG
+        SuuqTaHqfUQYNfR99HUVF09ZGh8UD63+ABWMvaxC189vw09gwXLC5KrbbpL1EisHC5ZnySoI2mSJ
+        k0MlDhISKYhtxbWqZRipWIa2//uf8vwCL9AiGMFDXNCNAH8IS3JFQLLt7qViAo0U7wm6+0Dfh0rg
+        WiFqO4EcoTrPpO0ZRB8ftmI4qLdRrcR+HxYvk0a5019NxNILZaG/D7NvQA19+VUSzdRkXyuRcz34
+        yu7uQ+giHWyrOIadTKzVXY/jCx5zw8b727pPDh1BdLX94rR78whpEZIUy5HN96CGMm0VXTWcvcwI
+        +mw1WHuwhz2ObACbr8VU1xodD1YwkMddthlxTTpyur6+UehtxxjESmfKc9vOarzAj9aJXkP7PD5z
+        /MzpT8QemG0Wi94+gkGzZfqboOGdotp+PhiMdmezNbXOHe1AKFdlI7sxPFIm5UbWdGlSfJeXVq7W
+        s2EX7weqUbP2FuYd9dF4PN4u+ucBuSsFIdt1KQrJZbMcpez2iVQAKSfK1VyasgFKDSd7lJ4O9IWh
+        RE4Uz/MN1LOp2iO7sJTp6Fqiy/4BtOkn9t1QYmeXZ+m1/wcjk9WfJEeyYcmJwiFF/4Ax+SVHPhQ5
+        nQrPE8ikTiUlkdsseRHrCSpzkvSsPiCFsvryGU1woHEI3TDIbwgEuo6/NKR06ELZemKWMeY56KVQ
+        PwW4FNYXwXwMYbWo/D/dA0jiSz2gxw0n/a/0gJ5uWFoF3dLBj9Y/hup/MrPtKdcbqoPpZLVRjAO2
+        ssfieL2bAKTbI3vcXGMY2Y+3w51CBCJ+4PZCPzk6QG8miq0vunWjX9eIix7hsqGe4vCs26ap2dtA
+        wSSIBHl42I07kWVKFKcvWuxA1nbS25BerhoT1msK727Ei+PT6r0xmVDXQcvvXqh+h++1LrPNynwb
+        rsH1elI9aYdhX61l4gdqOTuYb61lovldtUx9by0/+/+rlu9BeVnL1JdqOZv3C2r5i3q+FFd9lv+a
+        oi+TnxMc+FPq2UT17GPxebJddlnWqznX/ZD2uzzRiHrWfOny5mEyn7iR8z7ZHvsX8chpR65Xj+Z2
+        NI15DzojxdKN6I2bDa2Q3bwfV+pKEt6l3tCGbOOkHK52d79Vh6fNsYOu9cLaP8lig641u9dQsE7u
+        uaY3LouDyHbZCF3FLd7t4cPl2TwbyKUn7bueQY5YZbicjI6NWcemPPYwmR2c4/xiYS3K655W5D6O
+        pyuBvtRngIhtasg1AqMJTD7e94Y0JvC0EPaImo3PZuTX+wH5I/3gu7SdrP/afvDs/69+cA/K9/eD
+        bN7P7wfUF7V91pl/rRcAx3D9impA4wqcn9IS6qglDEyKmxgcTte6Y0ne4wK7D4TgeMbttdUYGWK0
+        ah6W0LlsKa+3vhr+vjmCO6G31UdGf2SbMqV350rY6h54rTkX45ALdV912bXWXEN/esa242406ZHH
+        eG1uZ4Sxj5quxQn8pkZOehoei9KFvC75GPi7S3PhHWcCCXbXGqmfSJ2iRKsf8EJwUtXjEA99bo6j
+        b3TaOknfIPfUj1zdv0vuyV8s98/+/yrve1D+RHl/We7vj0H2W2VRkrprJD8/3H+x/GAp5dvTvz3/
+        D1lRoYe8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1444']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:34 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:30 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6L9</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsCa3HaFbl8MfO4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcj48Y3J5cHRvX2Jsb2NrPk0zLS1wUDV0MTNnRWFjNGthUkJ6Wm0yaG92VVJp
+      bk5IT3NrMmNLdmJQbmpSbHRkSngyQ0NqMHc2OWpOOUVRcV92cHpOeWtrRFVSbThpNGhKQ25VdHpi
+      dmI4QXFISWxjZThLZm1hQ1RLcmRwZmxsRlI4RUphamw3TVZvbEpnazczMVNMLTd6SVREVDZfWE51
+      cERtRWNUcUt0dUkzY0RsNGN1ZUVpbVRuTDByaUFmNEh5UmV0SGpJbFJUU2d0VXBXRThfRW1RRGJ2
+      N0dlVms5VHJQeWdQd2hod0lFUzlrTW1tZ09ET1lEemh1bDdWNDdXOU5fdGJTSFVQd29RZDRGemRE
+      cVMtWnZXSFBGQkQxSFB2a1ZOV0wtMndYVU1CWUpSMVN0UmdLM0FzXzA0YkVWNWxuQ3BmRXZRb2Nj
+      N0dFejZsLWRodmMzc0xkRnREYVBkLVB3QzUyb1NvYm8xZXlrdlJtSkZPY3ROcEhfWEpZRTBPMW1V
+      cDNCZE5qTklxSEtHbHN3Y0N2SHRGZk1hQUZFUld1WXNsc3pGcm9lNEh6UGVXSzY1TTRORlpLcm0x
+      Y3huRXRkaXdGU3hqRER0akxENEtIMkI3SWE1b2JkUkdidEEtWjwvY3J5cHRvX2Jsb2NrPjxkZXNw
+      YXRjaF90b2tlbj5jXy0tRnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJY
+      aWgtWnkyeFNwU09EZEhhSHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5
+      OC1zaExzUlpJRW45TEJXM1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tl
+      bj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxwdXp6bGVkPnllczwvcHV6emxlZD48ZGlzY291bnRf
+      dG9rZW4+YzAtLXFrLTlCVkt5eDB5SEk3WUdWRDJJblJUb2RmUXFaR3AxX1F1MjNFSDI4WXM1YW5r
+      VXZ6ZDBFeE8xNHdsN0VtRmZ0Q0gyN2VtTjV5M0JsSmpnbHNGYUtCRTh2SDg0dm5CcmhXYjRYQWlG
+      eWJBTU5IWEFVS1EwamxxNFZ0bXdLd0hOT25ETFRDZU9XUVFDZnZ0czg5a3JXczdwcXY1ZlBGRkpa
+      d2s5TWx3QWRnMWJ6Yldhb3l0ajNrM292bE1TazNOQk5fVW9kQ210QjBEc2NpNWxmbC1wamhKS0tL
+      WFFEd0YyWjwvZGlzY291bnRfdG9rZW4+PC9jcmVhdGVfb3JkZXI+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['1008']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+2dW3OqyBqG7/evoFbtmqttBDwywzDlOYnnc/SGQugIkZM0qOTX74YGwWhmJSlX
-        rajkJvL2S0P31/b3dMcI+89OU4kNsKBi6H//oO7IHwTQRUNS9OXfP8ajeqr44x/uP6wk2IC3FQ3w
-        hmkjK+QtAB3V5ljoLCRDExSddyCweAXyC0HiXADZ9OkiVrRc0zb4hWqIKw7yqZQ9pUZz977ZsDfF
-        F1l0KlWzulrLD/x42tUyLceE60G77MzqPaVnwFQmb46GgJkshV6tX24MdpPcky1UJ/lNZ11iBmtq
-        +Uy5O4meSpL1UJOYF+Z58kSWBybdtPJDo0ItJmS/BDbiI1jKjdV21qcn97mF20nNmaJQLZEpaNvK
-        pJtfvJSVuZlbzNn0wT2zOgASLwFTsGzHArzXOZxusOlTOisLkDeB9czrggag73sjsQ5E3Y0VVYGo
-        U8EG6NEvwQICj2ICuNqUTUdHuEACUORqKITuVgYWCAy+yi6UpWPyG0F1AJdj0/FDVlRsF9ejotvZ
-        gKUAUw6KWqRji19TS4DExLME5bh6EZ0Jg1/4FFsGgu3dREwLyv1TRofluBo0MPxRgqvzh86hxEIg
-        WKLMr4AbXiGNhlckeqMwsIZn7pWD+iLfiSpFYYH6zj5dM25LZDmQI5ffogp2EX8ImvkXMREsBdhu
-        7Bzc7HR0M+mwJw1o85agL1GVmrBDlWsLRQcSVyTvSDZ9IPkGdKe2aSki4Aq50BFp2OKgtggWqjJy
-        7CVW8zr5zVXikm84usqBhi1vrnIgsbrBe0NcBV5/XWcT146g295bI5ggORa9zxSJD3WOYtNvlLcO
-        +qeOzE8d2Z86cj915I8d6ePm+THkRceyUMJAlvAVfkc4UEKj+kCKHM+CaBsWR5FkzBOIkUt3tAWw
-        uGI27grEyGWqgojmUDrmCaSYxxtz0NUWhpqOy2iOxir33/jpkcym37Yy/c5QTsJ/G+GPx1w0HN22
-        9i32CmPCvtif7ce6YgOJGNqICSBhPBMlDaCpRYhOwknBBy18VaBLwTFOnQ74H0Extkw8OqpL0CSF
-        AhUVY6dji7zx/AyBzaXoHO318Fs9MkIgGroEOSqbLzIMnT9wh4XY7qIfTZMkzrssWaCYwLnXUd41
-        inmS8qGHF3TJp0XfniILKYoZ0fSfGfJPkkSHf3pXOn1CUO/bHsDH0EZkddAnsvM/gqagTZTQRK2e
-        uVMomsmSH+6ULE19qlOyKZoa0V6PfK5Tgk7w2RCPtFapXmu3a2w6pgXlAbwRdaBpgAgduG/wa0Xi
-        8i0mLEFHga6iSc6IeC4uBg50I7YDOVXZ7MsDKTQg/hdsIR0e264JOKhopuqtJcSVx1GxEnYJDK/h
-        AseqAppsHNSMTP6OIul8Ds18e41VDX2JX6YoKndHFeh8AfV9JLPpqCqPtdGc7cF1BN97wcNFL80D
-        ac+JwaEPFpaj6x6a+1Gg6IAtDlQfDQ4UJoCDQ9un1gxYdCzBm2xjtlDBBq8JhqUJOiIU/+6PVNab
-        +vzx0JkUGYpEcd4rIQFLaMXhmfmVxvlwdEJnoWxs8QLFbw1e3h1qLDQQDQE8/MAOBRVAG4UlLoce
-        /OZF5cTQhTbQiK4O9k48Ov0lowU2CvAvInoroQJKXqd0Fg0iJ7hEu9FuDEqdamuC0lgkBxa/bmQh
-        GujNJBGxZU2sPBiVN5jUw4YfjCFREGU0rkLuhl5dR1qydLncJt7cML9Rdk2WLjcd/njMLweh36NU
-        fw/VMNQg//hE8kbz4E5VNG/h5TNU7PBsZO7zD767VK8wQHwVCEEJ5DcKVBZqwExvReyKQBnjlLEC
-        OrdKpVLzVbYF9e6r9ETe6/VBd0HmW8VVG7QkplzSqNK2WZmslSmVoubVpmWNzcKgWys2azunU+vs
-        jKdZcEVcY1A7Yu1gN7k0aO0de5U9gtlDkPX/CuAPjeIdSRK9NpuOJFwqy5oG0cgmST/2cQ1fLuLT
-        BDQS0EgyzZVlmgQ0bjr8vwU0MmTmQkHjY/uih6AxPDNoNLuV8rNLDypTUn6tTdTm/eOyU23lutbD
-        pN5tbF/I2XrQr61Thm4UWgqcarvhI/NR0GiVRrWfcIa/ufYeaFDkXebfSYPOJKSRkEZCGreWahLS
-        uOnwnyaNuqUg0qB16ReRRpHMfoI06G9CGvTXtjRGZyYNs/4EnoWetWVMozdoTpXyYKPPRgtyyJNt
-        q79UnWyxuNnCqTERy/3ebvfEKG4h2dK4xCycgEaSaa4k0ySgcdPh/02gwVwoaHxlS2N8ZtCA1b6w
-        FWtFserAnLnkn7rzWa/VG2d3Gv3c1F57WaPVeG7J0NyN5la1Uh02HowP/+0k2dL4Vmk4IY0k1VxJ
-        qklI46bDf5o0hoKNSCNj/SLSyObzxU+QRuabkEbma1sakzOThnX/Qt1XG03e7DCuCEG/vCnx9GPL
-        far3SVefKovteqOLM2tWn0rrip0RX7puPtnSuMQsnIBGkmmuJNMkoHHT4f89oFHIXShofGVLY3pm
-        0KDWjqTP50pnIG7rU7vfMEdQtKrrSneZEx4Fs7W15EGp3s3LVL0myU/tR0Nykk9pXGYaTkgjSTVX
-        kmoS0rjp8L9DGo6OSCNry7+GNHK5DP0J0sh+E9LIfm1L4+nMpNGourLu7LLUIpMVS1Zv/FKvVGk5
-        BWf67h7B0E6apPqtWU96vXfclbayH7dCKfmUxkVm4QQ0kkxzJZkmAY2bDv/vAY08faGg8ZUtjdmZ
-        QUN7kpVxvbkAQKrRi1lx9OB2t4WH5nJwz4xHvex425IMw1GHdLPS6UuqvhhOqeRTGpeZhhPSSFLN
-        laSahDRuOvynSaNteKSR+1Wkkc8wH/+Oviyd+yakkfvalsb8zKThbuiHhVF9GmccxcqWa9pDM/VQ
-        fdGVqbkY6I8b93XT6VeKttwRKveFbaHCgMk8+S6Ni8zCCWgkmeZKMk0CGjcd/t8DGtnihYLGF7Y0
-        iuSZQaNXnrbGZsvKisvWvL+kKvVCbdIcLZmWrDx0d+WKoU+KS3JhydS0Q0r0M19nrORTGpeZhhPS
-        SFLNlaSahDRuOvzvfGuX99QBOv+rSKPgPXXg46SR/yakkf/SlkaROjNp0INN/7E7Xj2uBmDl5rOd
-        orR2X/rtqjPtQsSIg3ttOTCH91SxAHng8m5FeKGTLY2LzMIJaCSZ5koyTQIaNx3+3wMamdyFgsZX
-        tjToM4OGYjZmZle2Xtu8pg4Ga0HO0LxTK/eZ13rqxVpvmp1l3uWro4Zcq4D+cCG55ODDHwdNtjS+
-        VRpOSCNJNVeSahLSuOnwnyaNKZAQaRR+FWkUKfoz39pV+CakUfjalkbmzKTBz3JwXJvXOtpTrkjt
-        emRz+8isV0LW0cqPi5fefEI9aFKZyW479K5Q2L5kt/118o8nF5mFE9BIMs2VZJoENG46/L8HNGjq
-        QkHjK1sa2XM/Wm0uUrN7e/W6NEC7nIVau2YID/NCHqS22dflcl5+yqylarlL7kB5db/rku449+Ev
-        7foOWxppx5uS8BN6VQXaQcA5VrCAEPDQlE1HR7jAv1ZtAyx3KwPv0c+Ryi6UpWPyaB5wgDdlxA9Z
-        0ZsI/HpUNFY23lN1U/5D0fc6tgSPpN4/eDcSWRGdCYNf+JT986djWlAePFTooBxXgwaBJni53K8u
-        fK5zTAoffbwCbniF9P65x57IomETWMMz98pBfZHvRJWisEB9Z5+uGbclshzIkctvUQW7iD8EzfyL
-        mAiWAmw3dk7w1OLoZtJhT14pViXkmKDDlaBDQo43Hf54zEXD0W1r32KvMCbsi/3Zfqx7sEUMbcRM
-        kDCeiZIG0NQiRCfFEBNfFejS0R/cKAbR6aOjumeG0yLD0B//CHGBYo7g9N8ospCimI9SZPpkD+Bj
-        aAuWfdAn3/xhyOd6anH6uBMw/gfwWq+127VwSYBHH34dwBtRB5oGiNCB++a95QR+paJJzoh4Li4G
-        DnQjtgM5VdnsywMpNOxZHh97ZM1BRTNVgNolrjyOipWwS2B4DRc4VhXQZOOgZmTydxRJ53No5ttr
-        rGroS/wyRVG5O+9DaQXU95HMpqOqvIUQmrM9qob+0udA8HDRS/MIA0JODA59sDheABypPhocbUge
-        iawOgIQ63kTBc9AM4wXUv51TemB2LMGbbGO2UMGG+OrBv/sjlfWmPn88dCZFhiJRnPdKSMASWmp4
-        Zn6lcT4cndBZKBtbvDLxW+Nf7Y3GQgPRULB0AjsUVABtFJa4HHrwmxeVE0MX2kAjujrYO/HodCCw
-        eAtsFOBfRPRWQoWct0g61lk0iJzgEu1GuzEodaqtCUpjkRxY8H9jNNpEA72ZJCK2rImVB6MyHLZX
-        ntrfaySec/z1aqChboeOanP/ByXXDveFlAAA
+        H4sIAAAAAAAAA7VY2XLjuBV9z1ew+mHmIaG5aO9wOKW9ZVleJFmS/cLiAkm0SEICQC3+nfxJviyX
+        BChSsqbSmSSuLps491wA9+IuQBu/H8NA2iNCfRz99k27U79JKHKx50er3769Tnty/dvv5l8MlyCb
+        IQsTDxGLIBoHzDRo7Hg4tP3IiinAPrUc2zMjbCi3JYYbEwKzn/IvC5ZC5srZGsollDOWtsswMTVV
+        LXAEmLOiOHQQMet6tcASYM7aBraLqKkXOAIqcDBlFj2FDg6UIkyQQM1//qOon+M5CnrktGXYcgLs
+        bkzXkuWq7NCP+dNHMF4RJNOOcz9uPLXcZX09rB53k8dlnz1OnlvPTlUL1FPTd7a96Wr8Uhp674PP
+        jk9XnztGG97sx2uLWCffDwYrHZfr82iP3iZPM2cR9OkMP+/mnfmh5jgvGpr9mPW2sku0T//9hOy5
+        u5r1ds1P0pHfYKfF/Rn8XBneoMis6rL8flRlbRAd2/t5a9hYdtnboq82WAc1SbsfPcz6h9Wu8mPR
+        H9XR8TCddOo7/aU/6O3wptq+Xyx71n21/PBWZq1HN3Le41pVnSH/1B2w8eDw2Qg6u8FLadHc6c1h
+        975B1eWL3w3aeDhh6nTf7ez9Zs/W/U515I7eV/KijJv3R28dbYa91uKw9BalaIlaFW0zGNn68Zmw
+        oFtvfp68NVKX/rv9uWmMYxmTUml3Qp3RyDno88/jev/08sZG+DirnWrTYzir3J9au1Kz9XL/OGnY
+        4Xo/bTmd9kelNNdPVth2lg3NPtgf8vuQ6m5ra+nHwJ8ebH+kq4/DnX2oTiqzUT0s43c3Umn51WrY
+        nWnY1/36y3bufiw+P96qbzPWWw/cx2CNdtFC7i+I68z1Pn43lKLLuf9Nw0N0azN3bcGHa7ZxECCX
+        SUuCQ4mtEaRpFCNDuWTlSiFia+wVgDSR2k+tp4IOT67CkDJTu6tcMAD6L7eS5L/NbPPxdQrrF3iZ
+        IKey0xaZLp+/QEzhwvhsnE9dHEewQxeHjh8hzyw17pLSkA3PFG5rs/P6MIWJLsCck2686UE9kyiz
+        I88mXoHMzYqwhZcWhQpITc1QikMhY767QUVpBhgJbUt8F5mlSrLNfAzlk7hrm6yQWU4l52G+AdNA
+        4Gn4Y0P95Vvvzg0lH3FBus0uVPHTYY0IEgS+eddnoqQGOPJwJMcbcNYZ5PKU+pDKhVAoBzal4g/n
+        24RRoOSAEHI/glD6xQ63f5fa4NE42UpBbEAfSJsCn/aEYKZLKHEXeMHaoFO6kpI6LEOShiN4mdoZ
+        uZgs513P59mRi25Pys3JCBdgzkntaNkQrUwY2rlS4JYq+RaUzInJgRLh9vQQisBZnOq/Rj5DnjSE
+        Lgx9NKeKUyE+xBe04b2PDtYWETeJEd4gb4oML2nexI5WyEKRJ8bpZNN1/DdJo0yaoC1DSbuUdFWD
+        JppTODtmLgT2kiJmlqrJUtdoTqPIhVCCbCjX9FqlfMnOhJx+gp8w9DwzWVRtqJpgnnE4aVyvqpqV
+        wpCgkFohSumy2pBVbao1vpfU76r6V1X7nqx0W0HMe+0DPobMJ+yLVypsLY3s0//SH1W9XCupP+2P
+        ilr5j/xRgX9/xh/C/rTW8HBMCve42R52x4ZSgAUldcPIZtAJDlILxyRCv1LpEcwhNtQ9Ik27k2mm
+        yH3Gv33PrA56mQRGAg8g0LEJ09ksqRlFUDCgC6xNBZTlkK8rO+m6MpWj87oyQ5QpmX6qItTBQhZT
+        M/D35+kFlBF4Y1Kycdp/qB9uAySKeabHOxP/jrcUBQHslLILE7tfTYSv0Q+1iCs35lghbPEGGdjM
+        ZzH4vALtWW9UNa1UM5QzakA1X/FPWb3TVDjhShXutTlsKPlka5ta0JigHixpekG/AJJqmvQlaJ5Z
+        GRVDI7SPFomjCI6Cx42mgw1fUCOEqnuDd40aEUIeRMQW4g26QxqT6X5u4YIcE7AZRwVahnBCYgMm
+        YVKG+fa/oEZypefNs62NpfL00VDOUNYioOWyhG1tQlMVnfoaN+gap1V1yc1Jl7vCDApxCfR0cnSE
+        eIGYTKYrwBmH9+0jQySyA2kKRKmVBHLkSbkGz5/0HXWr4t8SGOn1jK81aXYeuuPJvPvwMDGUgkCQ
+        0uknthcgAjk8h1CkGU20MnEF+dOpD60szJ5iST0qDI2LY8pL7Bx50JW0/0cBbjS08s8XYO1rQ/qj
+        Spak1BbjQNwM09i4wpJEC/ww6e1pOBeG/6auaz/d59JI5LuTm+ozRLoAhIRae5/6TiCi9xrkrLwa
+        8sCGkidunzOhkkPG17y/zPnkNz+42l1JlZ5HhpJDXLpehyHckbQGb45FjK+Xp3Jyd7acxF5+vQf5
+        FVTkJGsoF0huWnImkDm7GNFzN4jwGUIev61fUwzeDgoeaA/G7Ydusu0rwQWVX+y2YI3k+sQN0KWC
+        8AZmdmBdPW2uQEG6epV8BS94hRfKLVhwr18r12hGu3y5XIM/XVnEs1e59b9L/wL2/DbImhIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3276']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:34 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1879']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:30 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---ZZc1YHtkzgoeMB4smMEoaIZ76e-w4zggZBX3qdDBO0xeBkHxO0yU56KExuNENxoXY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--tW1TZyHKGtv8jhcuCDpDkqhI_UWOm3LupsqRMBuYFPiPos-36pTSe9VgaPEQBGRxV5XtaDV6vNqA9Rq1gf1yxd2WddrIEd9j9fVX0BRp2Kr6SoC1bV0QAevcJeghGkwYQ2VH5byN-Z98aDA0-sttiVO6bjBiZp5bZ</crypto_block></availability_options>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48ZXZlbnRfdG9rZW5fbGlzdD42TDk8L2V2ZW50X3Rva2VuX2xpc3Q+PHJl
+      cXVlc3RfbWVkaWE+c3F1YXJlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPmxhbmRzY2Fw
+      ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X29uZTwvcmVxdWVzdF9tZWRp
+      YT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X3R3bzwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRp
+      YT50cmlwbGV0X3RocmVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZm91
+      cjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X2ZpdmU8L3JlcXVlc3RfbWVk
+      aWE+PHJlcXVlc3RfbWVkaWE+bWFycXVlZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5z
+      ZWF0aW5nX3BsYW48L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+c3VwcGxpZXI8L3JlcXVl
+      c3RfbWVkaWE+PHVzZXJfcGFzc3dkPmRlbW9wYXNzPC91c2VyX3Bhc3N3ZD48dXNlcl9pZD5kZW1v
+      PC91c2VyX2lkPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48cmVxdWVzdF9jdXN0b21fZmllbGRzIC8+
+      PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['449']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7VYWXOrOBp9n19B3Zqap+Ya8IJ9h6bL8ZZ4j6+3+IUSIBtiQDYSju1f3x8IG3Ay
-        c7urZvKQoPMdbd9yJEX74+x7wgmH1CXB79/k79I3AQcWsd1g9/u3xbwr1r/9of9DQyfkesh0PZdd
-        DHJgwKZGiGnkMV2jkWkTH7mBEVEcGi41TGTrF0y10tcm7RihgOWG0rUT8lzbuOG6rJUekEeG8ktG
-        +ZeMyi8Z1V8yap8Zpc/bs8LLgRHD9Ii112uSKIrji+KORyZBqjEYjFd1IzjOZpOmRVrG7KS8tvxz
-        d7XvBLQrufVD892Zbw/Vo8J+ksOVdmbt+YcvfnT26wE2xzNrMw63s3XL6JGg3ZhuprgcBOtLNA/C
-        2WRaX63n4ar92sWSGfofT+r7OzYqTwNSvXb9V9Pa1F7l/oYtTCJvXIa2Z/k06vdX7qLftNrKS1De
-        95zJx6hSbsCyN1qpsBcNn3AAOYBCjAzIG6x3Vlopa3GDjamldyDNLh8ODnFKSFDNdHfRwQAfRjh2
-        d76pWbETk3E8RI0T3iEqRpBWGc4pyUhDRIVlTEntfHgLetL0D+/CHIxYvIgcltqTLvOinQ8DmZuk
-        MR8uye0ipFGMQssx9vhym6EE+Z+BcZmk1FvPO1IYL+N9MaSFTPAd+3pkvpeMUoAzVrKjFmcJ/0L+
-        4d/CEoUuZpdcH77tUraY0s2TJApYmLo/CUYeuJuT/ovAZdgWfjLEMBXIVmj6OHQtlHXi09hgN0IU
-        7LCBAztt82BE+DdBbjBH6EfeRVAkGQouM3NmxCyDbLcUM11UqookpZQcnhEptkhgU12u1OqNhlIr
-        sG9GTr/Aj+/bth5PK6lyI2XecYgkqdck2UhgFNgGc32c0EVJFeXGXFF+lKUfkgTNH/FMX3dIx330
-        AG9ThkJW8IkT/SYoMmVC8xC63v/YKbLSqEh/2SkVRf5bTqmIijxXYo/8PaekTkjUhmfasNntjEYd
-        rZTDUnsqB0IX+z4WbgzuG/7t2npt2LhZoJXiHpx7JFOIPJgyYCEsorrnnu72FLoR4MhDDJVubXY5
-        YJ26/sHDsC9rH1dmzqLtMIk3jnTNQ3BoRLCNcu27LCm1Kpxgd0zzSLDjn6IsV7/LqlJTwfcZrJWy
-        oRyQy4AYBxxuqR4QrVQAYgEC/YDSvCtP2tR8dDbCKAhgyzwKsgIB+oRqPghVAWnEtEdQCzC2wfEH
-        CF4U4iTAyXK+wlNyFKL40MzRbggnxFsgoY8CC/PVf0K1A6EsyYfxst6QJYjzHblpqu1C1IBs7H1d
-        +i7d9TSPa9QhH8nIfDf8RlPENEqiEOjJ4PgMQcWUQVjy8I3Dixfsws8LZdgXJgG+M3l2JrekEJ9c
-        nExixWerCqfiV7gGSRSlU4x6o96sOW4Pl3AdyeCUkowNFKEHxWQLuYMyZ0+zEryXd2WmKitsg+qo
-        oMT/F9WpK3Llb6iO+kl1/lNhx5l/IMRLUjw9ah+wuB4814/PqiTtcs1fiZn6VxU+SRm+OnFah5vn
-        DUgtcL1xqWt6aZo9gpyVaQvPQBCQmxjOO2mnDNQ+F3KxOuPfPHiy9L0sCdORVsowbnYc34djX1HK
-        yaGQx/iE91SxojCEt8Ml+7rdEWw47wtQxtgii5EQ5pdynBTMWEHkmzjU65U8KwUz1sFDFqbxy+AR
-        ynFACAx68U3ilfIwiBBH9X/mu2dwhuqF11DspljUUzWH0oBiNlF8hiOTEi+CLKDoBE7nOvMIamaS
-        I2SPA30EDwO7ZtYtt3acnNfT+vytfR7M2qthYzo/9p8j1o8wWlrVc3ClY+Mst0T1eD26NfOt97pe
-        2P3LWJ3MhmLjTGrRttZ3n9/nw7aLjjXvdHjD3nI4razrG1V5P3oVaSf71afRddI+LumiGrmDN8sQ
-        o83b+9HY2s6wtt6Pe+sxHTVfjJeeeJWd0IqWuC3JUeNFNIfW/hxG4gxvFi/X58HINeuDE4nGzbZL
-        p3KtvK224sdCbndwNfRNN4CiqieeuDfj8gNtgFimxccbWkAC/mk89PzCkCPHNZ2EAZSzyM4seTrI
-        r4PCHbw+Hth3Q46dBvvr8QtGjeenkSYL1DDI5SdMS9Uc7bI0SerqAcwlFi+hJrAeoDwnruBSAcm0
-        I0Qf0AFeqLuIRDTVQBlOmS8NCZ0RhrwHZh7THp2ec/WDg3Nu/cKZRReW8uWUqzO+3+ms0733yMle
-        HkmUbBpiCE8IL5F4WeDOYq+b2mUIT9iaIYqt6ap3QU8Ns3W5Xpye/FFvsfcmI/LTKHDV1fKnFPQa
-        Q1t5ci6NqPquPC/fK6dT5dTwWMuMRjW8mlxfe0+bcqdyvqLu2wntux1zHZY7qx3qTSZvxaWklVIq
-        aEqpqDcWCgwPoxPkBmzFw+mZ9hnWYGMHxOBWc/8/xB3xMXOInQMS17UmTxM4WAtYnkIZF7EilDH4
-        y5J4HraYsA2JL8BVWkguGblO6XXh1swS8w5xNyzA/1XRWZ0XLaqSZ3e+7Fmuc+qf1FC2wrfFctVv
-        D1w/uoYtb7T30cg9M3QZqZ3+MwsX+5XVQyt1s39lbbqszjG2vN26PlAdq/t2psOF15q2tq4S1OXl
-        i/U8byyeg4Nijyb9k6MORuS1V1Gnw7fcutPgZO04OhbfbZ7Gg/bJ1aXP4Sj9t/+r/QnkcvdUnBMA
-        AA==
+        H4sIAAAAAAAAA+1YWW/cNhB+768QjKIvjaxjD69dRoHXF+B6HcfeOE1eBErirhRLlMzD3u2v71DU
+        ud7UMZAUQZHAQFbffBxyDpIzRG9WWWo8EMaTnL7ecXbtHYPQMI8Suny9835+ak523ni/IPJAqPA5
+        wSyMfUa4TIWHuAyiPMMJ9SUnzE+4H+DIozmytktQyNaFyP0gzcM7L/RNc2wG/POHt5/T6yUjJj8O
+        zq/3307DxST+c7y6v7lcnInLm6vpVTB2Unt9mATF6XwppsF98DEcT47k6GJ6heP3N1fX+/4R/+v2
+        04r/zW/k8XjuFkOXBkVw/Xj+bnp+cv5pdTZcH93FsYuTxX46iEaLdRDPRu9Gs8vULqZD8yOyeutD
+        UcIFpiHhPmbEf8Bpoo3bhmsHeQgQ7IP7iHfyAVntlxZEhIfeCXh7/RgTRipCiaIwEWvNTTH3H8gS
+        c1NyWFODa0rJvsDcuFWUSl6pgJG8+k8PwUIwHAqIrWK2eMUphx0+5Wh1ELUyhFrtmoC4D6EqH+7I
+        ujuTBfFvBSpLKno9ukF6OlveF9SGOAB/ie3atV0tpQe3rNKyI80yfsNZ8YdxnFBKmHET54+8M1D7
+        wGpXZdXuzbnwGaZL0JvhFcyQBQklkTexd21k9aCSAMsVBUtC4u2NakaLaYoEgzADlS2jgVCmPL4x
+        SxcqCU9m6WGasjFLD0I09zns+pQop/0/TbyXmAq1X/KiTCkPlbvXr3HPQdYGsslwn2UMnmUMnzKs
+        p0sr/e+HkjE4kIFS/9IpLXkEGdmDWsYCtkzOPMe2O5wKbFlUZgFh3mTYZVVgyypSDEedsnsT6nBU
+        vvB1FuSp1YXheNSo92t3eAsja9NK6wtp+DN0P37ouvEKc0kFayxWwg7QiMtT9j1NBImMG4EF4Ua+
+        MA4zAlsat4P0YRyBXOv3CY2q71I0l+SV4dLIOJRLyYXh2s4YLupGrqlShH6+WHAiPNMducrFm3hL
+        5CTMacQ9Z7hnu7bbZ9dCTV/DvyyLIk9Na09st2I2ONx8+WRsO34JYxr5IslISTftiWm7c9c9GNgH
+        tm3aewdqpu0DKr2bLtDfUJQw0XNKLF8ZIxEbM7z+th4ZuyN7MP5qj4zs0Ys8MoK/uavc8TKPVB7Q
+        tWqZZxeHpyez2QmyOlglr+oo45RkGakJ2jX6N1R144v9WtLUeH4Kp1PuiRguHtYM1GDFyEiUYMhx
+        XJ4HsK1i2Bhe5Dyuho+DkQyyKFnthmkuowXLqdilqmIpOSih4EgJuwxuviIlyrks9WIhigPL+lcN
+        FodLjkRWZwkWWQkftpRwrJMPFqTwynFGu5+LJXhz6zyI4kzVnxBIWDwYV36jAovYe5n+cgj6ki38
+        2xqz1RQuiyJngvtqQl1p9qE+g2+hqKKvF9EfObx7tr0a2Pbz4c0wu5fkhcHtaf/ewe1N9jO44BFn
+        COk+/IrgcihG2Atj21P+vWPbm+xnbH/nay5I5reIMiRNCPuKWFfMF0T7uem+a/Sfm/w/zgbtLrji
+        zRSbC1UFWDVPu6F684KqVHIvTR6ay76CaoIMoAbBVv0t8jtCu6WDBmrpuoDIJcpEqGDCO5ViHQla
+        klyVOLDKFENTIaFgGYx3HXsAnUeDoDSnS/3TVLegs+dC+9OCyGrVxJj70FMVhC14+XzVA9SbjGqh
+        ocWuH2Oqz7JpZ5JSqGx0reW4Vd/eQ8u2u4fsV413n0YJiaC+KqBEU1FWZVu5nG14RZYMq43aodWI
+        JigTcpaptzi9+icoUu1NWfVd3k72HRti0iD1M1P9nOffZV758LAFRzzOH0vN2hqdZH0M8VyykOgi
+        s8lxoHXgmqMfAleCMIpTYw5EY4ohGaCDaUfoYhRyQ1ajZ2ezs+vDy+OLW+hCW7iilHSgGGdQDUdG
+        54mwI6+SrdkR/RfdfwBjn1trDhYAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1996']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:35 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1447']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:31 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60---Ny2iNMboa7_KKNW8_nqRROAcoC_Rv2QCmxFWkEnsF0i8pAjhTfp5q2tSopzsERDTwm-wEkXKebNRcZNrfRXC_GonD9PZPe3nnXyuTnrROP8WXTrWDQFe0brmwB7jje_4BKo5zFmQbcZ6Q1JZtUbo1Zitafx1vMJJWiUJAcD2In3kGhOwM439---Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>M0--d6b8ci6qOxXP8TYDxKRDWL9PTqJHutJueaVc5xnzsN_x1C-7qzqi6bYGQXUdJyN7ORL-9xo6uf6JiHjTLDiaq6lvpYelVLP4X8Z72jql40g1m5BMzODqVsU5uiKYc_-uZYjq_fdhL6XkNGXNsMAI_IG-z1hrcuVeD01u9I-bLckxru-ReZUIzHKMib8KvouNADisP163f5C-Z</band_token><despatch_token>U_--5-hWxUCs7oHiTVGcihvJv7r1crYUVWJDKimuzrClMkmaMixtayM7EJHtrUkWcGaW7ZkQtDsV5TeeclgX8K7hcFYxsLUlCPCfi2n81VIcHT9UHnp2dMOJvh7KMoQG47PLY</despatch_token></discount_options>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxldmVudF90b2tlbj42TDk8L2V2ZW50X3Rva2VuPjx1c2Vy
+      X2lkPmRlbW88L3VzZXJfaWQ+PHJlcXVlc3RfY29zdF9yYW5nZSAvPjxwdXp6bGVkPnllczwvcHV6
+      emxlZD48bGF0ZXN0X2RhdGU+MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['764']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1Z2ZajOBJ9n6/g1JkzT02ZxcZQQ7uPSS/pLb2vLzoYhMFmMxI47a8fsdhgp7uq
-        crr6rfOhEt24CqRQ3AiRJf/x7thUBANkee7vX9ivzBcKupqnW+7u9y/zWYsWv/xR+5esW0jzQhcD
-        z8eEiUAAUWjjmozCre45quWCEMEAWAhsVb12hkguPTfJMIIumagGUAXkRbDWXMqlfJQadIi0WpOs
-        63wyYQAzQoLKW2sX+iBS7RDWKnKpOJQ1C59TP7aKQAR3KqJDspYcTymJp76KqEVMyeype43MRNmv
-        dAo2oYrjRRSwzJ5Mmd3bUzdku8neU3dJQO4hGUE10ExwgOfrG0okaDkYxzajXmfekDt/Oe+JS03d
-        ktjh557TveSUOzhnJTt6SVnUf1TH/y+1UAML4nNhTrrtUr6Y0jWSceIEWfiTwygCN3Myf+5aGOrU
-        FKsYIsozqLoDA0tT80npa3RiB4Hq7iCArp6N08MI4W8UK2GT6ob2meIYVpBLuTllhlgDnmEgiGs0
-        V+EYJqMU8JyIoOa5OqqxZUGUJE64Y1+NKf1MfhxH12vxa5kqK2XMG05O0hMFhgUJrLo6wJYDEzrN
-        VGlWmnHcN575xjBk+C1+0/MJmd/HCKRjhNUA38XEDH+jOBZhqu4Hlv2Lg8JyUpn56aCUOfZTQSnT
-        HDvj4oh8LihZEJJqk2Zav95qDgZNuVTAMntWDqgWdBxIXRlpbNJnS68Jfelqsa51DNikUHp5hSiC
-        GYMsBIeoZlvRzZ5BVwKpkypWS9cxPvuwhizHtyHZl3aIlVmwyDvoxRtXa7KtYguHZBu88JVlOKHC
-        y6UbJtueu0sfaZatfGWrnFAlsc9huZS7Mkm5dD3gw8BANdeTS3dAXIBI/SDSvFWebCg76jsIQtcl
-        W05PgeXIAX1AZYcUqjtEimmPoOxCqJPA++TwwgAmB5ws5xmekcNAjXtSgXZFUkK8BS9wVFeD6eo/
-        oLLvIZzkw9tClFiGnPMNudZU0gFxTAYHp8Z8ZW71tIjLyPROied0N2kbvMdk5IUBoSfO4Ts5VIgw
-        OZYifOWk4iV2anpGGDrU0IU3ZpqdSWsNYGTB5CVa3FurpCs+w2WSRGH2ikF70J7U3xr9hVwqwBkl
-        8U0oVJuISacKjbJgz7KSRK8YyryqLKFOqk6VVOK/peqIHFv+RNWpfqg6fybsOPN9z7OTFM9a7QMW
-        68G2nLhXJWlXGP6omFV/tsInKZOujh6JZZKSGZBZyPXGQtbWztLsEUxZeW1JM5AUkGsxnDWzSTko
-        fxTyvTrjf9PDY5mvPEONBnIpx1KzaToOafscxydNoYilL7ylihacfeyBre1ph5rG0XSoCw2oQLM3
-        2V2aE85+dVd6x+lP6Y4nRKLUQHi9PpNELJsjdTc/GL2zvmA6E3vvNfXTpWWeFQ0tV/3pwPEGu9al
-        y5xfR43QQKgVHZkNcOsSHzhmRbej/bDzNvRxvbx5vYyqmwHipTl/xG/aZq33DBWU6xpa4DIIfe3Q
-        PKHBeYOk7qY93eAJJ+1mirAKwClu8A53qXDzaDuwj/aFbq2qQpVTe6/MrEs3OkavN9wK/UPTar3a
-        g5HRmoFpS6s05k0FMUgEU6Gsr3dVGtb3vUb/dUzkyi8ESTc99I6OXS06TmxFubx1xnA9bg3t03Hc
-        3oC6Iqq9fjRB1ebJiaRdtKho6tBpnNjXeWs1BuFxNQe+trIWU1sLNmvfumwWOw9KE+61/9YGQFRY
-        TSwPvItDs6Pl+3is0Hgh2H2ON6XX9WljSmaZ3pArV/F85K2tuqQXgfxTwLXPae49N8laGATkY6Lw
-        dL0D6sT5HZQzDFXDXkDyiylwMjBnuaGzhUFNLBdZGZizfFvVIEnFAieDChxS6AE6O1vPLhVh0mRS
-        tPbv4vQcztHa7fMI5Y+kICBci+vTHSCTnuoZIJ9AWvYjdPNBPoa2yLNDUheQGhEZpp3nESRXaGdr
-        uaT4iIn9NswXkwS53ujPCutJA38bJhKu6+Srjoo7mq4GOkX6KCzMyMr2D3Z4G2LvAN2awND0NAQD
-        gManYG2ty2cXe6EhzV7bnZ5z7BrsS30fqmXnYunLxmj4tuA7fWlKN3fAlDi20jr1+DqNDozjlkdC
-        2IiUigE7bn2+E1v82LLB1qGXNB3VGeN4aL7Ppt0Xy3LEVd98N1xpshei1WaPlopS6Uis0sf+VIft
-        ad0vD03N1EbmEDUZozmzR2FVn/pSy3hXXO6Ftt7IujeFzaW7KewuvowVd5/ezkgJJm2LpGHWF9IB
-        OXY3fQQPh/XEUCDH7YY0T1Itq5V7dm4p0snNwFSDHfkwfmDfDAV2erkEz/3fGeVUWkCNVMtW4/ZC
-        biwfMDm7aKi7PF+Tkv8AyolTsI17XZqYhPUAFTlx2pXukLytBeqJTHCxtQu9EGXtmSUXoKeGhI49
-        rNoPzCImPwa9EOqHABfC+iSY9yEs5ar+v/VdZb+n72VTGbZaP6XwE9xSyTn/Eok3iVReFsYc7Sbm
-        bMA2QT26THZdobxl951tszNqC6c1nOh8ZbPGhl1ner0A7xujwFlvWi3SHPXBaSLtjq2g7YiO1RTm
-        k+6k4eIWHjrcobXptoWjPlrX0VTkD82R2N04nBjsxyGzL9d3aBmtqm84eg004SD53KFxxHO6rSvi
-        dO8Jq0iZD8fgzIBuxLSV8dIIwAFYg1EFVc3FUNjuFWvjV7Y/lDr7F6SentvPSl0QPyV1/rNSf/T/
-        j9RvQXkqdf57Uk/n/XqpC5XvSV2Ztic/ELoSIjITIWoXeKH/y1o5r8+4ZldnQ6czqBtD5XDx8G5P
-        V4Jxw5z4ytYHAh9xPLmfw5W4cvkDX+mN3BWHe2dsG8Z8vFSXPfEFkGv3wW4wI9+dg5M42PcEEQ1D
-        egVtQYDSobOxJm7DfREthp0z1Z4xGiiCL5zr83JQ1rE+hXDiGdzK6U5eFiPEu0v8wuuVpdgWkLu0
-        q1UDzE2mPBz4p95qA36ilXN/Qd9C5VP6Zv7eVv7o/x9934Ly+VaezvtTfd8eUfqHg1ySpmfFXxq3
-        Px98sBTy7eF/Vf4HbiK/f5YZAAA=
+        H4sIAAAAAAAAA+1cW3OqShp9n19h7Zqap00EFIQ9HE8Z7/cL3uIL1UKjhJtCo5Jff5qLomZnTmKZ
+        mZgxlarI6tXd9NeL1V8jRPhzZxqpDXRczbb++EE9kD9S0JJtRbMWf/wYDSsE9+PP/D8EBSAoIc2E
+        kr1CmOpKDnQ9A+UF15srtgk0S/Jc6EiaK82BkrdsIf37EkF2/BWypblhy3qeIAmCIzfbapFUN9XN
+        aKJJW/pZevakCjUvGby5YciZ9lLY5HJlsqjy7MzhiKYxbmZ2WV6fdXdjckeInXatW2ZZMEZbr2JM
+        Os3d5HFbKTVLu36Fm/lPFW0oP4s1v9/viNMq7OUU2l/xz62e2dhW1UxPminNZq61k7denUa1HrPc
+        dEyn3lvCptjg5DpFDIbcy67OEzMhfXL+ggWhIilwBRzkOVAK4hQO/ne4sASutIKOKlnAhG7IO4ME
+        z8WRjxBDc3F84QZayR/gQCDh6YH58kRIJ0dRgQJdOV/Gs+lvl9CBMSFEBVlDfsQ1cJcbuAAu4bl4
+        OAc8ooTsFnBT44ASl8dN4Jpu/CeqAhBygBwKAjMTPOaE1QqvOVFzWBChOqJmfYiLTyHBhcCRl5IO
+        /eOe0lhaSUEgwJi+r31ATtpMeG80K4M5jhf6fevRuBLKCZywwpEVI1bqX8Bc/TtV0iwLOilxaW/d
+        o4pRDNLJWaX34bVdJDnAWuB2TbDDPZhzzYJKniMfSCF9AoUEfLpo5WgyzOeYPSPBIoqHBwQc3GTC
+        OECCGUT8rJdjKCS86uUEiyhnvZxAgmVLgbYNGATtew5x7QELBddLbJJ5YQMMTZH2eJ4S0mfIOYP+
+        W0bmbxnZ14z061ML4y/JnuNgw8eU/adI0p6rYEWeQAlDxZeM7eQpkjzixGDCsjxzDp08lz1mxWDC
+        WhlAxsZHH3Fi6IgT6MX1zbltpI9hbKwRmv/ncfUEFtLno0y/IcP71H39qTueL9n2LOQcRhwUHgGH
+        4tBlR5aGoJISEV6E3ZStpgomxJc0SCpFZhwmOVGv0FLi47Bo6MGfKdpSUgVv4bkoRZMUK6ST8ojq
+        IVmyVdWFKE/QDB2E+BxPiC6UbUtx81Q2R9IkfcreF0Z0H/+YpqLkg25JjqRj5gHHK5/NsSQVphkS
+        sJQwVQvpBMkRJD2k6V8Z8hdJEmTuV9DT7yvE7Z6HIDp2Ec5lToKy9H6mGLRMtYF/3YiwNENm2HdH
+        hCGZD0WEwb9DOgjHxyISRyBMxSKdtQqVcrtdFtJHWFwe51GpCjRNuCdEoYk+a0qebfH7EnwU4wZ2
+        JzuPlnjhcQ4VIzBmrABa5tO4MmEAQg3aT+95YVFMw6eLPDdvaJtDMzG0J+AEHSCQ3h8jfwXzrmau
+        jCDXl/Ug0TkqERbQDsID8oIBsCF5eLAZ9oEiM9i1Dohg2NYi+khQFPNA5WhsnQkopJNmguQX+3GQ
+        7SbZ8AEI8rlg+cXL8z6Riw/DBd/xLCvIlcN5ouh4zT9BwyX7BOHjRfuU9qEkPgI9BwRmfETbIxEh
+        GILtmMDCmUN49q9QIbDGUDGdMcdTJJbCAdmnqAreAgRkSTfzYdLyG1xwcWYZ7RjC0YS9nWGCa+Ms
+        BUYChTs8odBFeFqO4T0n2kTsEHQsYKSGmJh6BFgM2P2SGpGQsTa8uHa72q4OCp1Sa4xXsASOKSEd
+        U1JVfCUpqaPtxVF5LLYbW4v3J30ytTdikm8ZUbgptW0jvN7ibdQZFlychmYGC2t4DRwdXs17Q/1G
+        Z0c0s3jC9kBcgrexmqvNjVjz52DESkwuuhxsrOS8ThCE05nRTsafwU2mKTb1x7pV5mu2urUmtXrb
+        FFuk3FGZuVd6LLQL6IVlcp2VUzRMtUeU+6MGMXyKe4xajFvHPhlvzwuD1oFxQIVXZnRqROEdllAa
+        3ANJpnptIZ1AUelyaZp4m4hlQgahO8ai7hJ/+R8okqJvVJHvy49OFZm9siKBvn4qN5stVCgNtKct
+        1RCfuv1Gt4mNHCyqfb1ebz2D7gIxNZ0l9XVxgirPi3crslUYlv9GkOEq+pYiKfIh858lSWculGTF
+        0X6m2E+SJB9dKO+UJPtFJMleZpLMlSWpr3JiixgavtZQG1qvXLC345XaG+p6X31mRVfeAoOhV5nc
+        ut91st01rDDSo3X7Jvm5iuS/hCL3SfUHJHmJS7JXlmTX2Wbd6aLncoYmTunxXGeXoDdhduJgDR6n
+        lIxG66ls8Bz01/4IVYwX3268W5Jf2CVFgH6mcp+jSTbHZj+gydwXccncZS6Zu7Iktz0VJ5GDscmg
+        wuyZD75AaneHa2a07CNQaPY4k2U6DEWKgybb5p70KWv47jdwyU9VJMd8CUV+1CVzl7kkd22XbPLe
+        rLBUOL7NTDcNjsjM3AnUNpmc3ugrdrEyqLSZ9VQX9UEz24czr66OSt/CJT3rZ4r7HE3mWJr7gCa5
+        L+KS3GUuyV9Zkk90TXppkEqzWrSeHIm1fdF8YYh+pcRuTQCXT5RRqEjKo7HMKE+jDGywiup/B5f8
+        TEXmqBtV5CUmWbiyIkesXEDqNOtUV2TW9dRWdekNOoMazfWo1WasWSgr22u6xsPeKNPZ9eYsm+O+
+        g0m2bSxJ/nMkyWX593+ZxQS3vb+EJPnLTPLxypJ8eea1vtkkhiWKhbVW3WQ7uSwrit3ifKeh/q7q
+        Pta0nVEpQ3LLoc6wVX4elM3bN8lPVSTD3agiLzHJ4rU3N90mt+1SUudFqXeXs9JULkhbachMpXF2
+        5Q6L3Kqz2S4myFBpYu1XlaLU68z1b2CS4Zf+FPk5muQzzAfulFPk19AkRV7mkqVr3ykn/OmKKm+H
+        bafQ7G7GurxZl4YbkexNKzwFCupM5x0NLZwusVbVHJjx4rzzHb67+VRJZrM3KslLbLJ8ZUnq7V5r
+        O+X1PqlbPalZb7wUN9nyyC25qlwXZd/J6APbfoJD0n2ZA35tTetd9B2+vJlABWuS+hRNZsIHo96v
+        SeqLaJK6zCYrV9Zko1wvLxZPKFPssr4x7E5Xjc6cQKpX6T0afqtoVwCNx9vd9nR+1hpl++2WBW7W
+        JmUgL6Ei7Z8NdoMHOF5h98erb3eIN/Vc0P/pM7r3x6tvduqO5+u/tbxnqBtd3i9JOatXXt77sOCs
+        KnYtM7KIcRFNmmIt9yjWtc1SHGaq3tTuc9pEXFcWTmlXV9o87bNV86ZuX6bfeh3u/h7c/T24G81i
+        7onafbX/Aqv9PVG72am7vwd3fw/u/h7c/T24+3tw3/s9uEhzX3hFfusEI7MI93Vn/y7mL+x50c9w
+        RgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2300']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:35 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2454']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:31 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order><crypto_block>c2--ud6DeBehKRgzER2lHnXdImLS-Io6v89DstYYyVeg4hPagUkfKydV0IRljoEdwzFhyBcsWXLSMmoMgFzJ0yHPDufssFvq0Z_nA93rmh5dlvjOINOptA4ZHzP7ZMs39U3qtNcZYdKfa_4AcsVt4_upckEwsMyZs9JZGSZtR29gTB6Xr_w0719m2z52UvbMlqlz-FX7672aKH0TJ-DIfKKOb6LkEiFHlMPfFT_SFc5DUEBs0s8_S64dYg7-eAjKDLHQevi3V69dhosxsqJcvqRlBBzNIQeYQFOlwqQGZ_AB8aKLvRs7Ewmv9gvV5caOmDw1HUFXQ_uqXU_pcXiVSlcrZYpizZVgoe9R2HLNG__8B1c84Mozm-1PWxQQB-tV6lL23h9HYwZh9h4-Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>60--Su_M_sQwrYiY4yntouf9THGIKmqJf1CAjua4mzidWDPONV3IL9S-Eg_h9215FwK3A-sk0mn4P6uDvB5feInAUg8F3Qil_bm-W--vA0fqkExTSJCiim8XLhxfn9Rj6vXZjsWBB5I91BLtpSdeGSAp4OhchcPhOsE0fETlPu7dSp9FfxBn2C-iN0--Z</discount_token><despatch_token>U_--5-hWxUCs7oHiTVGcihvJv7r1crYUVWJDKimuzrClMkmaMixtayM7EJHtrUkWcGaW7ZkQtDsV5TeeclgX8K7hcFYxsLUlCPCfi2n81VIcHT9UHnp2dMOJvh7KMoQG47PLY</despatch_token></create_order>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+LTAtLTgwdndHQzBmdkd2VVdpX3cy
+      al9qdV9GMWJEbDltdjUwWml6QXY3N0UwQ2Y5NlpyOC1LbFZLM3g0OWtaT3hWMHgtU05NSE9FNjZh
+      VnR3dUZsV05LeFdCd0ZES0R4UUY4WnlZRmlUY2pTSHlRUU5TWEdlUDdkMnlwOWpMUG1Kd0dmM1Bf
+      WmRLSzdMeGN3dUkydEhQNWh2Tm1ySVBoZUtTSjhjSTEtUlQ4enhJOS1aPC9jcnlwdG9fYmxvY2s+
+      PHBlcmZfdG9rZW4+ay0tLVFlQXJwRm9IM1VuLVZDdFdLU0g3QlNJaXZoU1QzR3VYb1E4aVdTcUZn
+      ckR4SWRNOTJ5Nkdtbm1mUC1FUVVKLVRZPC9wZXJmX3Rva2VuPjxzZWxmX3ByaW50X21vZGU+aHRt
+      bDwvc2VsZl9wcmludF9tb2RlPjxwdXp6bGVkPnllczwvcHV6emxlZD48dXNlcl9pZD5kZW1vPC91
+      c2VyX2lkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['924']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7VYW3OjuBJ+319BTW3t0xIuvuE5DFuO40sS35LYsT0vFAbZEC7yIOGY/PptkGzA
-        8amdqXM2Dwn6+pNotdRfN9H/OoaBcEAx8XD07YtyI38RUGRjx4t2374s5n1R+/KX8Ztux8iiyMSx
-        g2IzRiQJqKGTZOPg0PIiMyEAe8TcWI6RIqJL1026ncQxLJ8WTya8CxkJcXSpChWMrWVTHBuKLJc4
-        HCxYURJuUGxo9TKLgwVrH1g2IoZa4nCoxMGEmiQNNziQynCMOGr8Xp5ewAUK0+J0T7G5CbDtGwtT
-        FA/+ftv2u+39ojHdiLsYbx2FDt7tyWz9VkM2eavdrZXm25M/ldfL6O4Qzh9dsrjb9lZHe9Edpj/W
-        wWg1xKv+MJ76Xrfv2rW32jSeyP3V3fBtOlJfp3NxHvlx2nl70CZKw5u9az/QMFh+kMeP/nYN3pV9
-        0tlZUuyjyLAVUVSafkLbz7e1H7eNw05TU40cqbIbLYeDbe1eftAOfn/hLKm22DY7bg31DmQ0ojhd
-        urf9WnPoh9voe1MTzaPb+eh17hvfLbPlLd1Jt4enT8fbl2atIT+up+hltnPe05W5fDx8rI7r8WAp
-        L9f99d49DB4fHlZi25vc3X60HlfvzmEbiygapENN9rt7f438kTVuHLXJ5GE2cPz7p/b+vrt0p+OP
-        5xgdNaW+ehzVn+g4MTtOOuoOV/fP4+7mxVuF7cDZRR91cf72Epra06o2kOeH5uB9oU3l96X63F08
-        245zpENZ9T/upgtZiXzUCbz9eLPdtObBi//gTEPl8NaeNNsPJr11Zvfj5uhJFMXvulQOJYuroTuI
-        7C1quyY82EYXBwGyqbCNcShQF0HKRQnSpSqrmBQi6mKnBOQ50Z3eTktzWJ6UhoQa8o1cYQD0P7qS
-        pbJFLakE0XSPDJutU5qYw6XxeRMesXESgSc2DjdehBxDy/08D88UtqfO3WgO61SwgpL713FAggRC
-        rcixYkeIQZ1KM9gWImzirUlAuYih6FJ5yG3Us31Utp4APaPtY89GRquRuVqMQfZi27XiHTKY5Tws
-        HDB0BFGFPxboJvO/t9SlYsQMuZs9UN/03UUx4gTm/MbbJXvzYAUJvEeXykPd9ihXycAi5gHtLCIm
-        oLoFzij5SiOLCK8ZhdvZ8jbMJPwPmwJXwaKZEyWM2/Mp86qdLQPCnqs8Wy6X/iqUBRLiY/ooPb1B
-        yqN5ArMqwqmnmWeksl7Bu7KkbW0gdvT6ymwvBaUCFyyWHYwl/GGF+/8Ir1bsIZqW5rBtS4Uz0imS
-        2bnH53qWXe4ScDbn8xeRR5EjvFC4tUTAW6ETIrhbVjGJ52BWc2Mr2iETRQ4fs8NI0J+C0qau8JAE
-        qaDKShNu39nMmAm14U5vCaKGqDbUrH5e4gWRIBtHDqRCvam122qzwj4ZGT2FnzB0HCN7rdxS2px5
-        xuEksdaUFTOHIUUhr0KU00W5JSrtuap+rclfZRmGX7M3XZ/A172MABtD7se0EhM3+VNQFUKFDmRq
-        8H8OiqK26/JPB6WuKr8UlLqoKnM1i8ivBYUHIVcbdtNGnX5vPO7pUgnjdi4HQh+FIRJODBYb9uw5
-        RnPUPllgxPEA2kFcKEQZ5AxwhCbECLzD2c6hE+FcRtg4LxbEC/cB4qp7msfKyA7hbOOWoQcW9WgC
-        26g1bxRZbTZqunTG9ABHO/YoKkrjRmmpzRbEvoB1qVjKBbkEod+jeEuMCOtSBcgEKNN55JyVhw/1
-        0DqacRJFsGV2CooKB/QJ1UMQqgrSzmiXoB4h5EDg93B4CfSP2YHm7lzDOTmBEgc9eol2Qhgh2wKO
-        QyuCEpV7/wnVs8Y2vw+TV62tyHDOZ+SkqVDAaEY2/ZC1Eldwnbj4PV+Z7YY1/FVMJxjKImLXDx3h
-        UBGhcCxl+MRhyQt24SUlFIXCNEJnJrud+UdEjA4eyl9iZ7W1BVXxGq7n/Qx7xXgwHjx3JnejV10q
-        wZySrw0UYQDJ5AilQlmy81v5MzkEoh6ePjmy9C0N9cpBFJq0RA5oVgt0/F/RLE1V6r+gWa1PmvXf
-        ZCHLmz3GAW+n8itwgWXZFHhhVunyS1sa/pMUtn62PuQXjnknzrQ6XGgOcAs0Rx7xNgG/pJcgYxXK
-        xO4vyM9JSuc9PqkA9c8yUM3t7Dc7PEW+qcnCbKxLBcbMrhuG0DSoai0vKWWMvbDI2aznhI9n2DJr
-        jcF+AZU52TukClLsLjsWSJYfCSJncY7wGUIO63IvKTpT51IIZs+9fub0BVwh5pudxWiL4IvYEbKF
-        IUTVWTwgmFqBefFlcAFy0kVD/xms8ErN/TWYcy8b/Uv0RKs2/ZfgrykK/0SUrv1X5W96lYPlkhEA
-        AA==
+        H4sIAAAAAAAAA7VYaXPiOhb9Pr/C1TU1n9rxwmLo8fMrEpZmDSEEEr64hC3AxLaMJbP9+rm2DLYh
+        b7pf1UwqlaBzz5WluxzJ6H8ePVfY45A6xP/jm/IgfxOwbxHb8dd/fHubtsXatz+Nf+hojxwXLR3X
+        YSeTBAzY1AwxjVxm6DRa2sRDjm9GFIemQ80lsg2f6NLXFn0XIZ/lZjL0PXId27zghqJLN8gtQ/0l
+        o/RLRvmeId0vzQpPASPm0iXWp9GSRfF9XqVvXSSrmzE1/cfWqMs27WG7OfJK9XNnVZ4ptGcH73X5
+        PHuxrW1tdySdceSUtP6Ozdft/nT40nv/iPrj2tNwVi49f5Q6FTk0T+2jGZFT2wy3Zfft/DqYq+Rx
+        rg2iAXK3HnuavIzwu93uLMQX1W+hwSPDUXXx7A/xCFYsPpfXi1XH1D6r3arlNs35oaRoxOnZpWPF
+        f9I+fLunervD52S90KXCnnS8xz6kEYUYmZB6bLTmupSNuMHG1DJaUCmnwwaHOCUkqG7FAUu4LqLm
+        Hq8RFSMKj7ninJKwB4gKs5iS2tMpwJOm/7gLYixEVpIEYGZ4ykncGvccPh1UWlJ2fNoTBnMR0ilG
+        obUxP/Ep/yQJajYzxJWd0i/eV6QwZ8b7i2kttIR4sa9n5/vKKAU4YyU7e+Is4V/IC/4tNB3fx6Hw
+        uiEHmnPkMZCyVUmX8JLIZ2GakyRDeeBqTvzffIdhW3hliGEqkJXQ8HDoWChz4o+xwW6GyF9jE/t2
+        Ok5M0wh/F1TfFhrROqJMUGWlqkuZnVMjZplktaKYGaJaUWU5peTwjEixRXybGkpZk1VZLbIvRk4/
+        wY/n2bYRP1auyWrKvOKQU1KryoqZwMi3TeZ4OKGLck2U1amq/ijJP2RZlLUf8ZO+dkjnvQ0BH1OG
+        QlYIyib6LlTYRhii0/82IlW1Ipeqvx2Rilz5WxGpwO9UjcPx9yKSRiARGV5ng0a7NRy2dCmHpfZU
+        IYQ29jx8IfDQ8M+ObVQH9YsFRinuwoFFDLbBiIVXRw6mjACxjSGBs+gicRXPL114iSmlwXJZRA3X
+        2V+nSaELAc40xJB0GbNTgA3qeIGLYffWZ9zCOYu+xiQODzJ0F8HJEsFmS9UHRS7B8XNFdJf4a/5R
+        VJTKg6KpcAZmoC5l02xAY31iBjhc0eSULQCxUoHIQOteJSod6h46mmHk+xAVnidFhRTeoboHilZA
+        6jHtFtR9jG3ITQDpjUKclECynK/wlByFKNbDHO2CcEK8BRJ6yLcwX/0dqgeEsqRiRrNaXZGhFK7I
+        RXxtBzIGZPPTM+QH+Sq6eVynoJnJzHw3ydNuMJ2SKAR6Mjk+QkIxZZCWPHzh8OPxyHDoI1eYAlF4
+        RFAMoH6ZBy9kqI0o9R52hp1JY9QczOAqksEpJaEDRehAJ9lC7uDM2dNig8Dko5RJyhzb3wVF+b8I
+        TkkuKfLvC46i3AnOXzV1XNIBIW5Su+lhe4PFhe46XnxIJfWUG/5CxxTld5U9qQW+OrFf7kCtpUBq
+        gcuOQ52lm9bPLchZmWDw0gJVuOjgtJU6ZaB+36HFtov/8uQp8kNJFsZDXcowbt5sPA/Oe1UtJenJ
+        Y/yB10KxojCEC/8p+3S5HNhw0BegjLGCaw0J4flyjpOCGcuPvCUOjVo5z0rBjBW4yMI0vs/fQjkO
+        dLhJT96SuFIeBnXhqPHPvHsGZ6hReIWJwxQrdSrRAdxrMLyaxGc3WlLiRlAFFO0h6FxAbkF9mdQI
+        gf42hvBKUJePP83BYvuh+o31wcITub1WyG65c1qbWl97be5ng2oVLctkN4s+g5r56DiVl3p33p2S
+        xkvXeZxFWnM3azS3x/FMY5/bzpuiyJ9ltKfbz2BrdUwLR4v+TG6yY2VTNt0FPVRNcd9TnXNdHbMD
+        nU3eRXvqllpnszNpb8b2R98Z+wfx5/L49KI8rnfnSYAa4+OsWxlZ0Wt93jODiXbc98NIG+FZfRj6
+        Ddej/bIIrwe53cGd0Fs6PjRVLYnEdRi3H2gD5DJtPj7QfeLzj+aN5xeGHDnu6SQNhlYpsjNLng56
+        ukHhGhu37Kshx06T/fX8BaPO69NMiwV6GE7pOyxuZAukCq2zMkn66gbMFRZvoQawbqA8J+5gqYBk
+        2hGiAzjAm946IhFNNVCBK9yXhoTOCEPuDTOP6bdBz4X6JsC5sH4RzGIIpXw75fqM73c8abWvHjnZ
+        yyOJko1DDOkJ4RUkXhaEs+h1UbsM4QULbSE6b154aHX30XbF6LzXnJDo5/mMnnpnZRZafbXeOVMN
+        +vM4NKvn5lP3pWfvD1FgtZ/Debe53vq78tCcO9vpuVSbzzR1NUaPb+NOafwKZevOJh/FpaSdIhU0
+        RSrqjYV808VoD7UBW3FxeqbdwzpsDO6jcF25fgNxRTzMNsTOAUnonp4fn+FgLWB5CmVcxIpQxuDv
+        lcR1scWEVUg8Aa7RQnLFyDml14XLMCvMK8TD8Abx762qUWWi9ZbWsDo6OIvd6VzqVhSidcUaDXq7
+        Yb3xvtuO99r5fSMuTurxNXh9VmjkDtajcUU9LKohnpx3NUzEpTud7cZmI6qsO8fjqbWpPp83RN0O
+        Ve38c28Hx8Zouu+oK7P99Nw9HQOEldH2I7fuNDnZOM6OxXebp/Gk3YVauk+H9N++DPsPYdEuYlET
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1768']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:35 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1997']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:31 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGJhbmRfdG9rZW4+TTAtLTkweEhfTFpqWTJuQWd3Y2VSMEZnMW9x
+      YnFpRWg4SzdTRHZWTDY2YWI0b3FWdWtwOF9CaWk1UTlJV0lUb0FRSWlCVnU3RHFWQURqeFBWN3Rr
+      akdVMTEwazRhdnNqa3BqY0dfY2V1WktWMER0eDVoNF9sWnN3Nl8tdkoyaXo5MlB0d3NWUlgtZFRs
+      M0V6X0dSRmhQZFlLaVBudy1IYnhDUTFCZ3F6UnBhQVB4Vkk1TmN1UzlXSl9wUjd4dktydTdOZVY5
+      TXJuQWxtc0s0LVo8L2JhbmRfdG9rZW4+PGNyeXB0b19ibG9jaz5FMC0tWFc2c1VJYTAyaFBzX25C
+      RU5JdGhGTUZETm0zOXpHZjRWMXNKZHBYOTB6VlFkY2o4cXhvR1B1aTM3S3F0V2dGS1RNUUpYWXVL
+      UDhDTVY0M09ZM0c1MHJfeUZ4X3VveUZfcmo0bFV6U0xXMm9CVzdMdUxhbGptdENSUU5lWGRGR1ot
+      UTJuRWFMQnRldTZaT25NZU5udGktTzRnWmZHXzdrNkk2Y2xEX1d3MzE3b2lKZDN4NW5DN1luZEoy
+      bXF3a1JnWjwvY3J5cHRvX2Jsb2NrPjxub19vZl90aWNrZXRzPjE8L25vX29mX3RpY2tldHM+PHVz
+      ZXJfaWQ+ZGVtbzwvdXNlcl9pZD48ZGVzcGF0Y2hfdG9rZW4+VV8tLUpmNnU1UjdKYmNNNk53aVpx
+      eXozSTUxbzdJLThzcEpxTTlBWHFqUHY3elhoLVp5MnhTcFNPMXN1bExnTlA1MndaNnJlUnpxOGVv
+      LWJsVFZxUF9BdTVnR3h4eUVoNk96aG8yak0yN3pIdmRweEFOVHZHMmZfRkNPSXl4cGFlMU5qWTwv
+      ZGVzcGF0Y2hfdG9rZW4+PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjwvZGlzY291bnRfb3B0aW9ucz4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['740']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u46pemFGSGGmGmAmAbTGGNeNLK1cY1l2dEF7Hx9JQPDhOZJ
-        e9PuOXsWnfYN955AqqoVJ5Mvn6cTD0TRskqUJ5Nk/cv/OTnFn5DSVGqiQLk6IkEZrjFSJmdtQytB
-        jAJJKkVyyvAACgWHU6iQQ6dbkvO2qHFBfD+ddbsyvX8yfx7iMv4K81WWL64hiWZhn8Xb4iZuskHw
-        xd1y26zvZ01vO6jLOu6q6zy9aTtT7oYN/73Y/eiTqzC9XbG7kB5P5987npFveXZ8pP3LcsrN49Vj
-        FF2E9cV6e76Eo81t35/p82o1z6XanEUqCf0HFOzhQ9IIYRcxUsAop0UNgpFStqbDWj2jYD+EilZo
-        EPrFDTBisKF2UaRojdBysC8DbGoUHEwgCZQTQRvAa1DaS/9WGryI5sC9xCJAwXuBE0RD44YxUIWs
-        LGoZuPDAAXdGgpVgtJ1IZDSDV/uD78hZ80Umhp/dVO6G+tqiMOPgt6SFsLeS/4jtE3rzHEScCNuY
-        eUv7217Ge+mYdGgPXNg/p+ZY6Z8CAAA=
+        H4sIAAAAAAAAA+1ZWZOiShZ+n19BdEzMU9MCbtjD5Yb7UuIuLi9EAimgLEomKv76SRYFreptbt+3
+        W1FRkt/5ziHz5FkyLeHPq2NTZ+gjy3P/+MR+YT5R0NU83XKNPz4tFx2a//Sn+C9Bt5DmBS5WvCMm
+        TKT4EAU2FgUUqLrnAMtVAgR9xUKKCnTR9YTCxxIBnqFL9IAPgULeA8X2Sihko0SgQ6SJbTKt8GJC
+        H6aEGBU0C4cJ1wZIOUMDIDpAQiHDE0rMHgJEyREllacmiCZKPxIVgLEPtHhphJnhKSdWq7/nJObI
+        0uJ1JmZDSMTPkIAg8DVTOcAw/6YCcVImiFyZ0u/aD+TJZsb7hlkNqMRf+GPryboyyhOcseKVNRMW
+        9R/gHP9LtSzXhT41N70LyikmPihksyrc3RsFjJ/uSbxDeeAhjvWXroWhTs0xwBBR3o6qO9C3NJAp
+        Ja/RiVzxgWtABbp6Oo5FiwB+pjhXp+qBESBMcQxbEQqZPKEGWFO83Q5BLNJcmWOYlJLDMyKCmufq
+        SGRLVYZjuGf2XZjQQ/LjOLouRq9leIZLmQ+c7KnHVxhWiWHg6gq2HBjTaYanGW7BcV+LzFeGoZnq
+        1+hNHyukdl9dkIwRBj5+cooZfKbK2KQkEP5ej1S4MlOs/LRHykz5lzxSJr8LLnLHr3kk9UBcZJI4
+        G9Y7bUlqC4UclsrTCkF1oOPAOyFxTfJs6WJlWLtLrHv1UmxSHT0RmxBg/6GYgCnjCLApFogybQN6
+        F9kv3HmxKKWR6eIAibZ1fphJoTuBFFGAQeE+xuERishyjjYkq9cOUQrnJIIBvcg9QBRsgC0ckMUW
+        K19YplgSCg9EsD3XSB5pli1/YascS8QPUChkZkxSY11POUJ/h+Ky/gRElYoUGZK6jxKVDgUHXBU/
+        cF3ilWSfWI5s4TtUcEhFe0JqEe0VFFwIdbI3R7K9gQ/jEIin8xGekgMfRPUwR7sjCSFaguc7wNVg
+        Mvt3qHD0EI4jZiTzNZYhofBA7sWXdEYckZWDIzJfmEfRzeMCIjUztpysJn7bCyYgL/AJPTYOr2RD
+        IcJkW/LwnZO0xyuGvgtsakGIVAOQYCDVL9NIApnERpBqS12pO6uPWkNZKOTglBLTCYXqkkzSqVzj
+        zMnTYCOOyXspKykrqH+mWPZvKThFpsgyP19wWPZdwflWUkchffQ8O47dtNm+YFGg25YTNak4nnLD
+        H9Qxlv3Zyh7HQjI7+q3UJbGWAqmEHHYsZKl2Gj+vYMLKCkYSWqQq3Ovgop0qZaDwPkOf0y76m2we
+        y3wpMtREEgoZlohN03FIv+e4Yrw9eSx54SNQND88Yk9RbU87iAeOpmELjK3FvjQaal1GXs8bfbbt
+        2q3FbVUfoR5XuprLE15N16He0FZN4srKCsD9asB7/WB8PM97i7DmVabX5hjUN7eOsh/uKkWvwwTy
+        qN73jyde6uL91ZTWvUCpn5ar1tieB3y17KoMh53TxOjSN7TU9utw0C1VPXPnsUPQm9TkcUOvdNpW
+        ebNRlzLt1LfNeq9TD/D55IWNE7tZXAYD0xjxHZve9M431VxtkYPR4TqZnFZ6WG3WimG3VNsi31I2
+        vYAcXmfuzR7KJ93g5HU1oOdjy+DW59nmML5tO5WK3Lk2T7LWo/EykNndQR5aLbXcqKnTowLNuV0a
+        2qpaDpSgP6Tru6Ba8XxpW5melcFaCfU92kEGrmx1w55rtz7gsRMCTVkRf1+a+nIEABiV9FBek/nN
+        ZkzRmNXc2pt87qiHS7derl174ap2PcxGRXisMDS9Jeeu/F4Jqg1c0myU7B7g2mEShx+LBC3wfXKT
+        yD3dD4I6Mf4EZYwdOcJ6Pok1JsdJwYzlBo4KfZEv5VkpmLGONtAgCcscJ4VyHFLNFRQ6qmcX8jDp
+        JAkq/juvnsEZKj7uRih7JMUBYTGqVU+AQBqnt1MyhSJpOi/Qwwa5CqnIswNSIxA4k5RM2ssrSM7R
+        jmq5pBDxsfwxzCYTO7neGi5y80kc/xgmFxydXOmoqG3pwNcp0ixhTiMt4T9Y4WOIPdKPxCiYgnFx
+        NLUBEwwQsnl37i9cpn5BrtuoF4cDdTpUyq3Tfnl4u/YWVrF0G9Fqba82ORO151OZxdC4VsH50A/g
+        zJKOt56xPau3cIvZLl/vMQY42JPt1NUGS23trC/20jxI6u04lxa6sQuZ1c5QtLe3vdSv9qoHsGv3
+        mpK82BjQYC/umJcXgdzcSqU1LXmN/nLYY7k32ekt6DgJXlaTW1102sqvPjl+kXJMWhgJw7RHJAOy
+        7W7yqLxs1geCHDlqPUdyC4JitfzMziR5Omn7JvANKL6yH4IcOzk9Kh/bfxIKSWop4AwsG0SthrTW
+        d1jUbzTSUYGRxWtc/l9AITaqqFHfSwKTsF6gPCcKu8ITkrU4H1yIgostI/AClLZqltw0PhTEdOxh
+        YL8w85jw6vScq18cnHPrB858dmEhy+r/O7+r7Pfye9VujDudn8rwC1SpeJ9/S4q3SYr7gdmieacI
+        p7wrn91wE6gc373yLXjbaxPXlquzRmgGvcHuNOvjozJ15Nu+UevPrbY8ldaN2nU1aW5IT7+NOwej
+        tJMPzX675dKyN2mObohuTYs9pVxWe8puwNobYGB7VYHapnJpb8ctWrtKWlm9TGvbg7KquZJOujFX
+        c1BvsNSlNcsowUEvHTqHljfD0mgAqma/XuLkboP2rvrF75k/THX2L6R6sm8/m+oV/pdSvfirqf5q
+        /59Ufzjlw1Qvfi/VE73fn+qV8vdSvTHvzn6Q6I0AEU2EKMP3guNva+XcRJo0urcNV1ttd62K1FU7
+        jh6+9fHlwJ7sA1ZqFlTftMt6jtrNSVuhw66G4GU7gCV/6xne4ozAGO+Xw/NWlv3SBDt+5W3RmXQM
+        +8ZzF9ycAdRWLnN06kzGJ2bSWHv8eL+1Znse0Tea6Q77++VyEE7xsayh8fAi6RLTaHRPHeeG1lWV
+        HYej5bxe1BwDrvTpEWpvClB+opVzfyG/K+Vfym/m723lr/b/ye+HU369lSd638zvxyNKvkTIUtL0
+        rOim8fgq4Z0kF28v/1L5Hy7T1raTGQAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['422']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:36 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2304']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:32 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <trolley_add_order><describe_trolley /><user_id>whitelabel-testuser</user_id><order_token>E2--5eH5_vuupAjgQcgXHwMpTe9X9qgSl2Y0lXp5covwU1ss4IWYBA-RU8_g3PLu8IKzgerz_3Hl033oI-VMEczh0ACvOMWY84zu53eWCfAgAX2v47y8gZlotLi4soNNf8tYetkXqZoP-N1hlKUJkwZdbW0CSxe6UymaEdjSXrzwO0O_DORRcWp6xIeRBq_gkx4Wu9YZJPsOK5CeE-apF_L3wCpdqKeS3P6_3QZAvRVTdRGBuSzS-XHJpV6utMn-uLK1XaipNu8tDIAOlNAM8GDGcPYYRpF_3_rHi9pUQMOLZiyBM9BhcnyLGC8TiUOTaOxTSW98HodDDCuLqymE1MWcmVXSh6xJsVunc4mtPXPNxl7-Z</order_token><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bY92t-Ig0lujJjLLHCkHTqDKe2fRxxAtDiOBbrsfALsUC-Z</crypto_block></trolley_add_order>'
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcj48Y3J5cHRvX2Jsb2NrPmsyLS1lRGFPaVRqNE5MY0cwVlhTQkkxRW5sRFR6
+      V0FOc0gyNHhoVXF0V1FYeWRCY1dDMTFUNldhZWpXSjhvSXVPcHZTSFR5OW82UXhDT2FBWXpGX2pM
+      ZjYzb0YwdVZOQUlycHE4TUd0anhoTVhIdV9BcVVXRE9sU3U4NzVuYjAydG1xUGdHLXpzVWNqWHlK
+      RzQ3b2hmbzFMYUhQOVZPQmQ2RkVpNVlZYlVWLW1BWkNBSEZBdXR2cW95QnExWVR3SkpoZ044Rmwt
+      WUh2emJoV1pzbXRza3hQUHFXZHk3QzkzeUc0OVpzcmlfWUh1ZWFfUm56bExWcWRnMlZYN3UtU09p
+      ZzJYdlJZa096WkY2NlZGeENxVmNILXRVdVYxZmtWTGlEYjVCOWJRcF9laFNsNExsYmI1dV91SUwt
+      QWZ1NzZvck1aNlF2X0pYX3lkanNmZTBlV2xiWTF2OXpJYTh0bXlhY19Xcnlwd0NkVU5hYWFONGR5
+      Vlh4UFBSUjAzZ1I5bjlLVnZGYmt3R0E1OXhIeVc5eGtSTjNlcDYwLS1aPC9jcnlwdG9fYmxvY2s+
+      PGRlc3BhdGNoX3Rva2VuPlVfLS1KZjZ1NVI3SmJjTTZOd2lacXl6M0k1MW83SS04c3BKcU05QVhx
+      alB2N3pYaC1aeTJ4U3BTTzFzdWxMZ05QNTJ3WjZyZVJ6cThlby1ibFRWcVBfQXU1Z0d4eHlFaDZP
+      emhvMmpNMjd6SHZkcHhBTlR2RzJmX0ZDT0l5eHBhZTFOalk8L2Rlc3BhdGNoX3Rva2VuPjx1c2Vy
+      X2lkPmRlbW88L3VzZXJfaWQ+PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjxkaXNjb3VudF90b2tlbj42
+      MC0tdU8zTlFsYTB1SnNzbDhuU3JUbjBBd3NubkJBM0xKYlFMXzVEcWpVa0t4SFRpMzR6Ti1iOWpi
+      QzJoc0VTUVYxdGVneDdhdmtJdWVSaU1wekhnWnZienladDFHOEFIMGdha2xQWlFuY0pVY1htWHds
+      VWhrTWJ6cFNNVGRnZnkwV2ZnX2NLS2pNSTdIN2thZkVIQ01WVFlnZWcxd25POFZUdVZDWk00WC1N
+      b0JJVUxIMTJLVm1IVC0tLVo8L2Rpc2NvdW50X3Rva2VuPjwvY3JlYXRlX29yZGVyPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['706']
+      Content-Length: ['904']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61YyZbiOBbd91fQuelFN2mbmTwu12GMICEgAkwwbHyMJbDxGJYMOH6n/qS/rGVL
-        HiG7M6srFxnovvs0PL3JEn+/2VblAn1kuM5vX4Sv/JcKdDQXGM7pty9reVztfPld+puIfdeyYKio
-        ACiuD6Cv+BAFFpZEFByAa6uGowSIwAZSDiqQQohE7rFI1PzQw65ysFzNlNZKtXoxvWPXHHS9dXNx
-        qJ589wgE/HTV5q+7cx1q6Fwf7oTW+c1c8LuNM7zY8lRH6+FxtL1p68Fz+LGzZttndzt+9hemMRjr
-        Wv1cX/hzfrwdPp8Xs9r7Qq7KjumHvfP3zlxoGq/Xzgd8tjafaPo5Pu5ErrAnMTql5yJkHCxIj1JA
-        Umtg14SO1GpUq4Zcx+p7x63VsTIw3Cb8tDrLjTOugatqfzw5t94tfB5fP6+zSwMOO6C6OMrdZvAy
-        6bbh63ZuosnL5H3Br8bHrX3xxkbz4wqePo3T8OTaI/48hnt09Bs3o/c+3wSaHj7bI+dQ3b9trI0C
-        iZXksL7o9PuH4xK985N3RzHBVp/1XpaD3vwoaLfZ/uWG3g+wK/c/vKvXdD+aQx3Io8HxybWNGxi2
-        NjVLeHt/14cvwcKo17Rze39uwnA4PPfae2XyeeoMg+XMvXYmTmOzfvrw307LsYJeoTxdLc1x395h
-        7clsdPCxfjy1r3OrsV401s9wTc6JLtv+7G3myUHT+Gzbpn4RlE1j2trYvX3Nba5NMNCmnu9Y/nlV
-        B6/a4PWsX6793b7W3a3NTTgejXry+BONJh/eIdQMMJqehtsWGLW3huzPhJr83B7KV2803/B97ftN
-        vu2U2qalX58aq+5bf/A0Ad/DMdj0/Yt/mq4MS5m9XA779mcfhDuodhsfWNlBd+WYc2/+/WWy7jvj
-        6XAxC83q1hA6lm3CT0XbLsDYWRpmOPcGh9O5DkI4bIadyWHvd970ZVc/zPXJW6u6F7mig6T+QiNH
-        cwMHS0LGysOR70GgGBjaihPYB+hHzHswmVMSD4EDIqekf8trPEATJnIDX4MEBFCCN6xgiDCfauSl
-        JQ0AkSbJhF1ZhYjsqbKHvltWjEmJInaxapG57IPhQCDVul+zhUqysgrCUp3/2ryjI1yikgU9FWu6
-        JNyxU1FRA0EVe76hQanWuttQJiwpkdPpqn+CUv1eJ5WJWuD7JJGG2S9qytPBI9mmAGWMo6phl1w4
-        z+c4DMxYzAM6tVaOlbhFCniWqkEk1XIcBuU4xIoKCu2Da3F52IcMlf79R14/wzNUEgE8GGSHiqa7
-        Rjw/AzIJdRgdVoaBbYeVgeqDypDKRK5ASlUMB8OTr2JSlhSgYpXLRI5qQwlEM2XKMZYycOjdMWIs
-        HWa/sm3HMRJNQp2FbmgQRZmGK0fftSuYHOECnQBG2nlWpmRDrLsgB8RXPFj0Fzkdeu25IXHm2GuL
-        0P+5laj8EstJ87VM1s/xEkFGjY2j0flzxNRm5cMZiKWSUkhnUZxQ6FlX8no4mstkqgKcseKtr3AA
-        oIMr5NphjkqP5biKe4yjEkV5LT9kMmxoJsxLE0AsB3outkvhnItgLjslJJaOUrMPVbrx0Ybk5HRE
-        BfE2R6SVCq869CEjsDRonAJPuahWAGl05wFRMzBLBZbrANepBiYxZQpSeTzRLJYzIZ1as1SE2B/K
-        J66h4mgDOYzJk0DMy+k0pDmLOzU6XdzzFKHIiMQ2iklqDluBiy2ZgFEnyKiJZooU5st4D6Y0DYAe
-        T0sPwuQFLKPEZxmrtmGFORI9IZetyyVGi67XZ2aOjZ4HUnGsv3ZI+QWVKWmMSVObUdkt+AbxNtIU
-        Xwx4VTxIKmBUf+NE/lAkkgiEiq86J6hAB7Axu5/gXxWhg/VKLzgFpMrWeIGk+oxAuQHWiJMfESQF
-        shUtVEYzGoIacRwSGY220Gw0+QI7EVJ6SP7ZNiABTRblO0KHMVOcXK7bafGCEsOqA0iYkdwb0at8
-        pyp0ZKH7rc5/4/l/8sK3aKXHCmzesgXoGGHVx3c2qQnEGD0SuNZfaZKWUGvVGz9tkkZN+CWTNKo1
-        4c+YhJkgTj3UH6M8vuwNpqOlyOVgRonN8KJiEkjXSp/0YA78B6rMyXF8laRB/++JErUX/W0AqTUZ
-        JxIyYrhFvNzNEkkeZAyyPRwgyTIuqZxBCYEWGS4Zx7UEGbYXdUtxYk70aJWhvwMPQcsiSyFc2OPo
-        fo8/2nuET9d5nHsw9wm6Ci2CFmkyosIjNeMSnA5FkoxP9GeV/ypEohQQuUxfV5FC6g0J7COSHNIH
-        F4AoF0blBoI0CbKhaKs3xQ8ch5iV3r9QI65xh4o2yZkPeGVUdCD5RgDQI34TkE4t8qV4P49wRg5o
-        h5WjJQglRGdwfVt1NPYdfIeKUQ9Ja+JAWFYa8lzkUihJ8KSS4oitmLbEswJcxkWku3F6PNLj0BeE
-        Iib+4JOl8K3y3z9SCl8ncQPFOpTecDZarjaj2WwlcjkBI9EGRSW9vk/CakMcCSU0Vl5Yk/CnorH0
-        uVf40CtYO8t4GwhIRmxHVeKvz4htkvh/ISO27zLij0I0ig3PdS3WucWXXMKiiLEMO6q2sV/mhv8r
-        0bZ/NtHGLkV3V+11e8RlGcAkSLkYudefMkhZWYajHkrSGOsO35lKBon3AVwM3uh/enHtr3W+8voi
-        chlEpbpu26RrEbr1uIDnMbpeFpNRb6scovPGq0cHLEF5TrQGV0Cyo0V3QnqXjwCiNMM7bgpBQLvp
-        MkWkKT5ngcFkOZiNom2XBAUqbbU8cpqKZviaBYsKzBqPXhPKzwh0XPpquAcLvNwXxCNYfPxscPde
-        8PCh4O6F4GfzCvss/YtTH5c8GyWPUOwh4+5xqoD/0ksWlz5RcT98Pv4PdFBrFoAWAAA=
+        H4sIAAAAAAAAA7VYa3PiOhL9vr/CNbW1n8bxg2dmfX0LhkcmPAIJAyRfXH4I48SywJIJ5tfftiWw
+        TXJrZ2p3U6mATp+WpVb3aTnGn0ccSgcU04BEf3zRbtQvEopc4gWR/8eXn4uB3P7yp/kPw42RzZBF
+        Yg/FVoxoEjLToInjEWwHkZVQgANqObZnRsRQPrcYbhLHMHtafLPgUchMqGcoVahgbGyXkdjUVLXE
+        EWDBihLsoNhs18ssARasXWi7iJp6iSOgEodQZtEUOyRUynCMBGr+s+xewAUKbnG6Y8RyQuK+ma4l
+        y03Zoa+rh9fw0Y+RTHvO/ePtQ9fdtLej5nH/NN0M2fRp1p05TS1U007g7AYL/3FeG3kvP069gPqn
+        PaO33vLuZze20iAIf/g6qbdX0QE9Pz0snXU4pEsy2696q/eW48w1tLxbDnayG2un4CVF9sr1l4N9
+        5xT35GdYaXl9Bj9WRt5QZLqaLNt+Ko8i1Z2z2jh6eVruJ/Epxd/99+YsGuDxpH9Mxz9O6iw9RovO
+        ZBX0t8/Nt/vmaD/dtobd1wWejzraOmztNfX07OmtetLue91nrzVfNd+n8mF1WK/fcL+h3vf7c8Zc
+        u/7cpY0Dbr5qYzS/G3ba6FXDzX3HPq2tw8+ZOgyx371/SI9TvK8/3j9OEdnP79IdbrfrzdFqP2tY
+        Dn5zHfp4bCekO1otppOn8HX/koy9Oe6+NLqz2eBOG422qIbeX/YD6stLv/f0/NqT1+vJSKVLzLSD
+        myJrYLnL2qTVpzN9G3V7t0TVbL89urP2azZ4xkt3oa4x26fh7j35cXib3J8a+PbFdw6qLL8YSjmU
+        PK6m4SG6s5m7teCLa34nYYhcJm1igiW2RVB9UYIMpcoqnDBiW+KVgLw+vj90H0o+vGZKQ8pM9Uat
+        MAD6L5eSlbXNbKUEsXSHTJfPU3LM4dL4somAuiSJYCUuwU4QIc9s5+u8DC8UvqdOb7yAeSpYQcnX
+        1/FAjSTK7MizY0+KQahKHnwLEbHIxqIgYtTUDKU8FDYWuG+obD0DRkbbxYGLzFYjW2oxBgWM3a0d
+        +8jklsuwWIBpIIgqfNggoXz9/ZWhFCNuyJfZByFO37coRoLAF+8GTKhiaFPrgHybygmFmF1wTsnZ
+        Y5tKy4wi7GIK8KTig7vYjMUgoiD7GbPABYdH9iOHTweCnqs7nzZFYK5CWdAgFtYbSstPUvLonQ1Z
+        AxH0s/cFqcxZ8P5mWtd2IF7s89n5vgpKBS5YvCI4S/qXjXf/lnpBFKFYetqSd1py5DFQilUp5/Bm
+        Bx5fmlqW1SXgYs79f0YBQ570xCBdqUQ2UgcjSCq7cBLFl/Xd2I58ZKHIE+PctEjQV0mPPKmT+All
+        kq5qTci7i51TE+ZCNm8oYqasN/Ssi17jBZEil0QeFEG9peqqXmWfjZyewg/Gnmdmj1Xbqi6YFxzO
+        lLSbqmblMBQnVBRGOV1W27KqL3T9W039pqqy2vqWPelzBzHvdQj4GKo+ZpWgbJOvUoNtpYmd/m8j
+        0tQbaq35yxFpqI3fikgDfhd6Fo7fi4iIQC4yPM/GnUF/MukbSgkTdqEQ0gBhjM4EHhr+PfDM5vj2
+        bIGRwEO4DxITWoTN4osjBwUDdH5rKuAsh7a8yeZXzrzcJGiwXJZQMwwOl2kEdCZcegwf552EBngX
+        IiHJZz/eY3xEsvDYphHaLGAJbLbWvNHUWt1QLogRksjnX2VNa9xoLR10vgANpZhmCxoLHWCH4g3N
+        L7MVIFOqrAFApzpLlBga2D5acRJFEBV+TpoOR/gBNTAoWgW5zWjXoBEh5MHZ7OB4E7hkZkeeL+cz
+        XJAT6H2ghyXaGeGEbAskxnYEvStf/QfUyG6/ecZMl+1bTYVUuCBn8YXOxjKy9Yb5HeMT3KCgmfnM
+        fDf5064wgxLol4gnKDrCgSLK4FjK8JnD2+ORoTiyQ2kBRKlrQzKA+hUePJHzOwz3ngwnw8fOtDde
+        GkoJFpScDhRpCJXkSaXGWbKLZPuFAgI5x+c3jqx0S0OjEuJCj1bI+ypp2v9FrWpqDV6ZflmtNO2D
+        Wv2dImT1sCMkFPen/GivsKxKwgBnHS5PxtLwP4igpv1qW8gTia9OHtWHkKgCEBa4KQU0cEKRfNcg
+        ZxVqw/MSJOUsoou+cCpA42N5V2s2+8sPT1Nvaqo0mxhKgXHzdosxXBZ0vZYfTxnjDyxqMbtkwpsz
+        bJnfhcF+BZU52TOUClLsLjsWeG/fJ4heBDciFwh5/Fp7TTG44pZCMHvsD7JFX8EVYr7ZWYw2CF6H
+        PSmbGEJU9RIBIcwOratXgStQkK5u8B/BCq90m/8MFtzrm/01eqZVb/nX4O/JiXgnVD77j8pfSB2H
+        3I4RAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2159']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:36 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1772']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:33 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <trolley_add_order><describe_trolley /><trolley_token>64--iT3taV8o23t_Cio5ezl8RWnF2dwamqGnxAxyHFwzwLv4eD8d-OfT95uMI97ePXNksIMIVO0SFfXmvpFi5qwdGzigDgomE0jFeZsfr4xiAVNWuchyHmEnb-ZQWlW_eYj3Ty3O8BBbfRsV0IVn_kdXhLAMRCANf1cxLZMxsVbe9TBqpwp5oq5DhdTECfGomixdD6W2l1QVVhDMuOi32cj7Zj5eyDDjA7Z_Izg8DuRLow8In4WUGqrQgRF_sPeTKSRkFBmYtcGk48tf3fg7wNl4UO4UHeUT95svXBLQLpTu5iz7mkhv1_W4K6WmAZ2o5UkdCcKprnlrjS3dPcCPjhvwBYZ29YUkWyFEEATFzsEIqpbycidEKgDX6dE7XiTrL12TH7DTwpENW0BcJxTxY_2W6hwG4S9QBCGIdJyFdWBrvrgKSil_LMvbZ7zBdyYea94qt_YeoSnkNpNJMIUBnFKDOLyk-Xi18lmkez_cXOdFnRikyNpCbgj3dyeD5y8IbZr8QhR9hbNhIQ6-Z</trolley_token><user_id>whitelabel-testuser</user_id><order_token>c1--16kut9RB3qB5vg82y8sxt1gLWHGf3I0J8vkFUdWt8Uf6Ah3eEvsLLtoyWhBF36HkmfnZ68-_xhAzEAI5Za_7iWhNCEoOQxBS6350KYOeSPgdwyX_WKvzXxYMGW0WYFYphvGKJJX-9iNDBz7KXwdvfr-enGyH80kCpkYekLaM5x8NNJPGdkIQ9pICWhOMzRrex814XKL4QtMu_AdyLCHXIRMCbSiXm9ldgnz4-TjSm_8QX3G0Tv6GwU8O0wW2RCURcddxtH02kzDOU01nkeAlipMbfb7TlSkJdOm1vj9N69J_tBdPIM6LQ---Z</order_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsUDfEXxcUCHyqYlLXHoXFHrOkiCFhc3j3OrN0FXDHjOL2VOT-TnkryAjJ8N15iPw8qeHlWzsKzFfY</crypto_block></trolley_add_order>'
+    body: !!binary |
+      PHN0YXJ0X3Nlc3Npb24+PHVzZXJfaWQ+ZGVtbzwvdXNlcl9pZD48dXNlcl9wYXNzd2Q+ZGVtb3Bh
+      c3M8L3VzZXJfcGFzc3dkPjwvc3RhcnRfc2Vzc2lvbj4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1202']
+      Content-Length: ['89']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a2XLjuBV9z1cwXankIUOLoESJnHCU0m5bm63V9guLIiGJ4moClCz/Tv4kXxaQ
-        oMRFUnsZ98wklX7oFs49AIFL3IuL05T/+WJbzBb6yHCdX76BK+4bAx3N1Q1n9cu36aTNit/+Wf2T
-        jH3XsuBeUXVdcX0d+ooPUWDhqoyChe7aquEoASKwgZSFqlf3EMmF8yZZ8/cedpWF5Wpmdaqw7Nb0
-        lpLZkLypMFywK99d6gB3dtrg7nFThBraFJuPoLy5N4fc49xpbu1Jd42mzWXr4UWbNq73z49W7+Ha
-        fWhf+0PTaLTXWnFTHPoDrv3QvN4Me/xsOGEnjunva5tbcQAE424nPsNra/6Kuq/t5aNcyMxJDlfp
-        uQgZCwvSpWSQozewa0Knagos+yptdbNXE5tPnDiFoDHe1+eALYH75rKv+m7wOiSE8nJT8R2lO9vt
-        jHpDu+tDDdbXg5FQbnTLg6kxD0CwmhV1RbSCe29m+BV+evewK9ov/Fi0auOKoJaeyljimvZrQ5zo
-        oP/i4gdvKxmLcY3d3WqzGq/02fpM7d2aXkvoXG/re2nWDbb1W7gTr3207nsje7Tm7THaSvfmVl+V
-        JBN5z9dl1b8rGbrTaqys3XZmPopPnHKtvpg3lSFw93e43a1xq/boGQ5utcZjD6ytaWf+cuPOKm1+
-        pJZ8tr92nc3slis3fR+1R7P7xm3Jh/P+lNUkR71XbVt1vI0CN6MFBou+os4bq2twrz71za0wbi/1
-        Gmvra8At54+jFX7a8nxj6IN5rej03dVMn/Ij/FrTnTbsPPSKfB1ASdg02qtFRZgiqRxsui0eLLDn
-        jyf30nxUf0UPQuneXe0qyJy29+6y3Za0l7YhdhpTu2zfB8jtl6XXEv/YV1qj0aby9DztT584a6tx
-        nDLo8PrWaKw6y2GgLhy73jQfDEm4n9VWGAv1zXDRMzczUfMDrdsbu6NKzX1s44Gh4N3LrtszjNrN
-        S0tsDjt7bmo5Ur1ZRC6Ed83VpO4Wd11P9V9dr3+Lgm2rA73JVr1Ho/KDVds+rK9n7ectbJpwfOsp
-        ynIu3o2LK/tW6iqs3Z4X2d7N7Ho/2ZXGDdYf8fWOvjEfzK6AnY4G5jceADd74ekGdl+DGseyT3Ih
-        u1mPe5dGseYGDq7yCSsNh3EAdcXA0FacwF5AP2Segocxq/IicPQwQOi/mcGAXDiDHpjIDXwNElCH
-        VfiCFQwR5o490tZcDx0irTohbGa8R2ROzBP03XzHiHToiF2sWmQse2E4UK/y0lXyoJwt3wXhapG7
-        Ek7oCOeo5IGeirV1FZywj6ZsDwRVsnkNDVb58smEEmOuE1ndWvVXsFo87XO0yVrg+ySp75Nf1JWr
-        hUcyXwZKGEtVw65fBRyX4sRgwop3gMiXU6zDtjgCnqVqEIWbJw+lOMSLCtrbC9cqpGEfxmj13/9K
-        90/wBK3KOlwYZIaKtnaNaPwYSCx0w6wh0wxse880VF9nmtQmFzKkYxfDwXDlq5gckYquYrWQmBzV
-        hlU9HCnpHGFHBt57J4wIOzaTX8m0oxgJB6GbhU6oEUaZhpml79oMJkvYQieAYe80K+lkQ7x29RQQ
-        veLGsD5M9aGvPdUkmznatVnoV04lLAWI56qD6YQ8P8U7GBJq5ByNjp8iHn2WX5yB4lSSC+kkig8U
-        utbxZNpsDSZkqAycsKKpj3GgQwcz5LXDFJUuy3EVdxlFJQrzWroZ27ChmTBtPQByPtBTsZ0L51QE
-        F5JVQuLpMDX7UKUTb81JTj62qCGaZouUdfvdGvowJsRp0FgFnrJVrQDS6E4DsmbgOBVYrqO7DhuY
-        xJVHkNqjgXqRPTbSoTVLRSj+h/LJ1lBxOIEUFtsPgZi202FIoRhVjXS4qP7KQqETiW8Uk5w58RMK
-        kScPYFiVxtRDzyOSGS/hnRnSNHR0fli6kNiewRJKtJa2ahvWPkWiKywkzy0cnBa+Xj92c+T0NHA0
-        R/2nDjl+daZLinRSYCfU+C34BtltpEDfGnCneJCcgOH5GyXysyaZRCBUfNVZQQU6etyO30/wEwNE
-        vGZqwSogpyzPAZLqEwLlBlgjm3yJIDkgy+GD8mhCQ1AjG4dERqkChJLAZdgHI6XvyR/b1klAk4dy
-        IhBj5hEnL9cVyxxQIlh1dBJmJPeGdJYTWSBOgPRzkfuZ4/7OgZ/DJ53vEI+b9wBtI6z6+MQnPCDO
-        qJHAtb7SJWXAl4uld7ukxIMPuaTE8uAzLoldEKUeuh/DPD6qNbqtkVxIwTElckNfxSSQdkyd1GAO
-        /BtiBmQ5vkrSoP/nQyfqL/rb0Kvlm/bBQloxbpFd7iaJJA3GDDI9HKCqZWyP9hg6EOghUzi0o7ME
-        GbYXVktRYj70o6cM/R14CFoWeRTCmTm2Tud4ae4h3p2m8cKZsVfQVeghaJEiIzx4qkJ0BB+bMknG
-        K/qT5a5AaDoCciHpv1aRQs4bEthLVHVIHZwBwlwYHjdQPybBuCnb6oviB45D3ErfP+DJ1jhBZZvk
-        zDO8PCo7kNwRdEguOjgglVq4l6L5nMNjckArrBTtgFBCuAbXJ7dILb6Tn6ByWEPSM7EBRkxpMpAL
-        R+iQ4MlJikO2YtpVLj6A87iM1m6UHpd0OVTNyGLyhStL5q7y/UtK5nYSFVBxhVJr9lqj8bzV643l
-        QsoQk2iBopJa3ydhNScbCR1o8fESFwmfisb0zY6kl8xFL+PtJOPNoU4yYiU8Jb4+I1ZI4v9ARqyc
-        ZMRLIRrGhue6Vly5RS85h4URYxl2eNpG+zLVfCvRVt6baKMtRWfH1qQa2bIxEFuQsjVSSlQepKwk
-        w9EdStJYXB3O4i4JJJ8GcDZ4w7/pi6tcFTnmri8XEoha12vbJlULkIrRAZ7G6POSmAxrW2URrjd6
-        erjAHJTmhM8oZJBkaeE7IbXLcwDRMcM77hGCOq2m8xSZpviUBxo3o0avFU47Z8hQaanlkdUwmuFr
-        Fsx2iL1xTk3Iywi0nbs1nIIZXuoGcQ6Wz8sGJ3rBWaHgRCF4b16Jr6VfnPoKWdnoi+Qj8Cn5aOjA
-        j6hHIvch9egs/bJ6dMp+Uz2qCJ9Qj870eVs9CpD+VepRifvx6tFf/i8e/TbiUbRpf4R4VPhSkYiG
-        4iWRiFRgbylENT2wMBMWjXq4DX6gUERj+qxQJPxGQpFwWSYiFdMWrlTEBuiSUqQiZhZS/pfFIk1d
-        EN/h7+lFCeV7klGDspi/qrb3D2am+gbEn1CQ0HsUpDGpkCBi3CVTsyHZW2peS/qOMhTAnxggkZr/
-        NrD2b5f8LC/w7y76RUniy+8u+itA+pAMUmGBNOF5Wp2T5u+nDH3IKYCXSu+Xyz6lDfGhRz7mlFNt
-        qFdrt/r91kVhqKcybWjbkLmkAvWkP4QKdEaWKZavAMeXheIFbQYA4QpU+HIF/HEUGumPKNAMZqIE
-        OOm31mfAOy8p0S0gU/5HX7DkdPMKORXP4Wktp9/pd0a1QbM3u6jkEArTIcGkM6mD8g0550IM5f6r
-        /odoNx/LWSIPPqJnf0+9yaaFH63evPN8OKo3PYm9E0tfrN70apPWr9FvAPeGgMPz/5UCzt2o1X6X
-        fHPnwyUk9zudCQcmLnqHhkNvBr+HhkML/Tc1HOEtDeftjPIdIefzOfKo4xw+JoolhZOPjDL4h75I
-        Khw/NSpc/CTxP3WSxqfUKAAA
+        H4sIAAAAAAAAA21SXW/aMBR9369AvHuhTGIgua7GECtjgg4atvFi+eMmNSR2ajsM+utnB7ouGi+J
+        r8+x7rnnXHx3LIvOAaxTRt92b973uh3Qwkil89tu+jhFw+4deYedZ9ZTBy7yqAVXF55gV3NpSqY0
+        rR1YqhzlTBJtcHIdwcKeKm8oL4zYk5QiNEDc7X4sd8Uqt4DchH9djZZjkQ2f5oPj83qRffGL9cP4
+        gQ9uit7pk+LV9DFfff8wl9vZy0S5/OXZu5Hc3Kdju/im5HC72Y6edp/zTTWq7bL/Uez1nOdgit1h
+        uq5m5vBzdhjzdTbo6W3//vcvnLQ0YVtrHWZvZBPMmdiDljS3pq6IhNJQpT1YzQoqgSt/RnDSJmJh
+        Aktf0IRgCRkLjlFhau3tKfwlkHqPk6sAjnb1eWPk5YgthJaalUAmQYV23jIfouikQSdO3tCYlIcy
+        NpfghFVhNpvE61MBJFNHkMgz7kJEzU3MkJ6PzVcilmXoIqvJkf5L/FsGj8IWOINy0GCVuFDb9Ghi
+        6H1eAdn4h5PXKqhuef2fN21PXqs4FUm18iA78/A6rNkbtQHjaFe29Q9od30C6wIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2754']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:36 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['448']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:33 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PHRyb2xsZXlfYWRkX29yZGVyPjxjcnlwdG9fYmxvY2s+VV8tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRnUlEzS2RaSXpEaXNnenF0czlkVkhVQnJO
+      TGlkOFpWWjloakNnVnA5dXJPMjdja25LYmdlb2xqdkZTcElvdlhJdkJiU2Y2MG5aMkh3WTwvY3J5
+      cHRvX2Jsb2NrPjxvcmRlcl90b2tlbj42Mi0tWngwLTFJbnhDdldCSzlmRXRZWEcwOXREZUFyQ0du
+      TFZHd2dxNUhYR004ZXh3VFNEOHEyUUdJRnFvazZDSlhmRl9KNjRMWTR0Qk5jbmJadTc2MFZlaXlF
+      SXRSSXd6OWxEcUlRM1hBcTJBS0VKOXMwZlFpRWxDb0tTdDBUdkVEdmlBRmEyaUQ2TWNNWmctWDRv
+      QUp4ZGhua0tGQlh3ZmRYM25mZUI1MWtJTWEyeFBydGxFOEF6eWRoZTBmaVphems5UnUtb3IzM3F5
+      ZURNTWJ3Mld6eGh2T1FZdE1veFY3eTdUeG1WNUp5QnEzQUJRSk5TOWFtaHZUQmJEQ2o1M1cyeV9t
+      Q2JmOTFhd2FqLVpLczJjQnBfMnhsaVR3YWlNMjBOS3FhdzZTNVZNOG00b1pjbjBzNFVfOWFEVG1H
+      Mmk4UXBXY2pYempZNllWdEZoSWNObGhlcW5YLUdYcmNiVzJHb1o8L29yZGVyX3Rva2VuPjxkZXNj
+      cmliZV90cm9sbGV5IC8+PHVzZXJfaWQ+ZGVtbzwvdXNlcl9pZD48cHV6emxlZD55ZXM8L3B1enps
+      ZWQ+PC90cm9sbGV5X2FkZF9vcmRlcj4=
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['650']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VY2XLqSBJ9n68g7sPMw4wsiZ07anWwGS+A2TG8KLQUIKONqhK2+J35k/6yTqkk
+        tMCNud0z7XDY0smTVZVZWZlZkn79sq3SGWFius4v38QH4VsJObprmM7+l2/LxSPX/Par/DeJYtey
+        UKCohqG42EBYwYj4FpUl4muGa6umo/gEYJMommrIjivx9yWSjgOPuopmufpR1hWOq3Ma+Vi/fViz
+        PUYc6Wkvs9ZbR981D6/1r9N8vBvQ8XzSmWh10RKCtql5j4v9bFp5NbbPl55J9pcTJS1j9bTsYCUw
+        Tet5X3arzbVzRpv520p7twZk5U5O6976s6FpUxGtnlaPHqdj8WJuA6Su9f3q8dS+4B63kfjc+qTQ
+        YM8lxNQsJAeISHwOuTqGukfkyPUKx1HltKPN4eZY/uQmY/OptqzOp4Y4OiCn2zMGtQDhz4G2Pguz
+        zVzbUkvd4O6upzoz1fQUNDY/4LF9IC+HdqX2YdSmi+eX2X4wtt6f943eevh+mXK1Chl0q4/meXS8
+        LH3zNH45dgJ62jp1vTzcfwUcev7s69MWVha2s3ndHmtvDj4/NbYNQ7QWRlM1zFdaGc0NI/CHh8eX
+        Dlcr94YeFygf/ZZm+ZfutPxWNTRjUz4tuu7r61PD7ArKhbaXA6WL/W6lhbTatvuiiFPRPVU3uvf+
+        Wf0Uh8qL3l8ZDc/ptBtH/VQdjQZ+q+NazY0uBo35YmXsyeSwmfc6fvujgrwGOl0Cd3z0a0652dOV
+        dr1RW5y1lepsyNtw2xla50V3Ig5O5TWtNN87Z63zPL+sZ+vlBW/JadhZdD/Gu7H4rin13mZbFyvT
+        WXnT2I1OC7wZzDa7yevmYz3ZzNr9CapNB8EXXZKn3mbzrgTTL6XpcX2s2YueJ3DcVuLzm3ndWxbw
+        uus7VBZTVhYO4wQZikmRrTi+rSEcMm/BZExZ0nzHCAOI/S/OcQdNmMT1sY4ANJCMvqhCEaHCVSMr
+        LWgYiOhy/4si7KhWaQFqpY6qg6VG6UY/4ib61KWqBUPamukgQ660HlJ+QVZUIVSuCg+1GzqhBSpM
+        6KlUP8jiDfsqymsQpFIPmzqSK7WbBaXCghJYd1DxHsnVW52rTNJ9jCENBukT8+he8yBB5KCUsVN1
+        6sK+C0KGE4MpKw6EZrmeYSXRcQU8S9URkcsZTgxlOOBFhQS25lp8FsYoRuXf/pPVT/EUlaUoxGQp
+        cTLb+W4YpDot7bBrl+gBQYVwfCTxeVaqZCN6cI0MELmm+9Z5y+gwd2VeIQii3c5D/+NSwqqjUlUe
+        Lxcwf4aXCFIqDTwk62z8DDGCM+9X40wSn8TCUUijP6EwW9u95XABA+XAlBMtvG1AFS0RqjqGio0M
+        mZnluIq7i6KZhGkh+xrLqAlHOCtNAKl4QDJnonAMMpHPp1Yi8HSY2TBS2dL7a0hp1zcmYEkFGojg
+        84Awigls8bpJ40NiuY7hOpx/BGddQSaPqMNIHgtjZUslJP7H+CqmUH4zQCxkfgRh6e+q7f271AWP
+        +uFSMmIJuo+oFWHDRoU8D4XuAi8oR0jO4Ux85LAECducmJeoXZHcYCmvOJ6hOjq6PygzJyHkwJQT
+        2dFRIVppbGivoMAs5dMl8IkTww3FsdujTcgCV3Gkv3SgXhmlV2gAoXtLqfGuYBPiC5q/s4k+FQ9B
+        rQgLVpTy7ookOHNIwaqzRwpUmvg9Gmxx8P9VEqEKzZEHJRISYKksiJAWUwpj+1SHwN4RROVKPZyq
+        iKY0gnQIJTgN1Ua5Uavm2YmQ0QP4sW3DkMNJhZYgxswrDjvtNuuCqEQwHFA4WjaK6JzQ4gRxIba+
+        V4TvgvBPQfweznRfIR636AP2Dicf0xuv1OihNFKD/6c/6uVqoyL8tD9qQu0P+aMGv3/GH7H9Ua5h
+        4Rgm7lm7+9qfSXwGjimRG0YqhUrwWepAs+Kgf5DSGMzBYS+DS4v+fJEoMp+xZ9OQ68+PiQTeYtyC
+        QHdlGE6lYc7IgjEDqsBB5kGZs9m8nBbNyxHOuc7LhW0Yn+hHKrE6WEh9Ilvm+Tp8DCUEVpj45D2q
+        P8S0vbAziZJ5oscqE3v2PYIsC1ZKaM7E/q2J8DR6ErI4f2eMPXIVViAtlZrUB5/XoDyXW3VRrDQk
+        /opKkM337JETHkQBdrhWh04lhSU+HeygEgUKE+SDHYmuhTkgzKZhXYLimaTR+FWy1S8F+44DW8Hi
+        RiyDDTeoZEPWvcMropKDoBc3kAfxBtUhisloPffwmOxjsNl1MrQEYYTQBhfbYRpmy79BpbBJY8Wz
+        K85K1cVY4q9QUiKg5NKQrRxtWYgrdRGXyMGNsuqOmRNNV8CkH1wNcneCn7oM5G4B0e39Xsa/J5Ci
+        9ozNNW/3hv3ZfN0fDucSnxHEpGj4uQodOIYzvIZQJAktLmVxC/Knj37hPpa7ieW2KU2xa2RAVRL/
+        igTcaonVn0/A4m1B+lEmC4+U57pW3BlGsVHAwoNmmXZY26Nwzrz+l7wu/nSdiyKRrY5rCxOI9BiI
+        JUQ5m5kPKUWQsdJsyAIbUl7cfa5ilRSSbs99/syHf9nGNR4qQmkygtv7FWLSw8G2oUcSW6w4ZjE2
+        X3qUw95Z0UJ7WXsP8gKU5YRz8DkkNS3cEzg5Jx+RazVw3CuEDNatFykSKwcZD3SfZ91hP1x2QZCj
+        ssbOA2tKuol1C+UVYm/cu+UXr/fsvXAruQVzvMwN5R4s3b/O39zj717gb27uP5tZ4mvvX5Mx+eTj
+        TvKpKP7OcPMJKYf/oe9N/PVDEv/Db7O/A9pPXdzdFQAA
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2085']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:34 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PHRyb2xsZXlfYWRkX29yZGVyPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRnUlEzS2RaSXpEaXNnenF0czlkVkhVQnJf
+      eWlpbElnMm80OFdudmVZU09WYlhsR3NWb1BxV0RXdzdiYlExZVZIVkZwLWNyMXppWnllYVdjZ1ZG
+      cUF6ckQtWTwvY3J5cHRvX2Jsb2NrPjx0cm9sbGV5X3Rva2VuPjYzLS10X3FmdDhMWWsydy1QTmlI
+      NVU0U1FkMU1oZW5DRGRHNXllcndHYld2MFJZU2JadGxhWXJDZkRhblJhaXBfZU5pamFuUkFoc0po
+      QTM1amQ1UVRJSlJnR05sWElnN0RXTFh6US01M3NHQzRGaXZNa3pVdWlxTkprQnl0cVpuNmMyTGd4
+      eS1lSXdFY1E5cl9UbW5ZS1prNU9ucnZIN1o3ZDFsVGQ4YWRpS3QzTVNkZHl1TGhGSkItNTJETHAt
+      eV9qRTlibHV6Q1EyTzRkYmRZMnFUQ29LS0g3aUMwX3p0QVVHX0NydUMzOWViNVpDSl8xUTFvcTRZ
+      Y3BYdzR3MUxfSmNFVmQ3cG5CQTdrY3E0TU1HdTlCb2w4WWMxeTdTVFZkZ3NQaFlTREJ1QWozZXA3
+      ZXF6eW9Oa3U1bjI4RGNfQTY3NVR2YlZhbllzT0xaQkxsdlRDUDFHcTJXdDM4WEJ2YkJJU3pXUldV
+      enJac3FMQlRDak5mTjFYYl82RFlaNjEzUVIyWTdmTXFUcllHUllmUEtZaldQWVJBRVBlNVFHeXh0
+      VXNIRFlZWF95UXhfOHAtRXJibVREcDAtLVo8L3Ryb2xsZXlfdG9rZW4+PG9yZGVyX3Rva2VuPmMx
+      LS1hZ3ktS24wY1F0M0xuWlNWcU1yenltQ2d3NlBuRm1MTUV4eUxJejBQeXhuVEFNV2lFaFk2a0o2
+      S3FOaDdHQmpUbVFLQTFYbDdxMTB6WWQyNzR1OEVkQllkN1FXNndOLXZXdlhYa21FNTBKRUVRdHRj
+      YTRZQnM1dm02ajFMZVFIR0E4ZWoxbTZxQWF6WF92VVAwR2xtZ0JKT3l4Tm1xNFJKUk5lb3FRSHlw
+      bTg4NDZLV3FQNV9ibWtjYnNSeDh1b0JLV1ROTVNsanFadUxkUW1CWjVCUFBGSDFLS2hlM2V3WnFG
+      c2ctVmdEU1lqRC1YWE1LMHNWbXQxdmN5ZV9GX2NWM003RXNQMmhuQkQ5bzAxYWc4S0hfcVh0Rllt
+      VmNUMFhtdHF5bHB3dUl2a01KejVtOVpnYnYwLS1aPC9vcmRlcl90b2tlbj48ZGVzY3JpYmVfdHJv
+      bGxleSAvPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjwvdHJv
+      bGxleV9hZGRfb3JkZXI+
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['1098']
+      Content-Type: [text/xml]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA9Va23LiSBJ9369QdGzsPuzISOI+q9GEuBiwuRkwGF4UuhQgowuoJAz+nf2T/bJN
+        qSR0Adu4uz0z2+Foo1MnS6pUVmbWMfzvB9Og9sjBum399o29Yb5RyFJtTbdWv317nNzSlW+/C3/j
+        Xcc2DHSUZE2TbEdDjuQg7BmuwGNP0WxT1i3JwwDrWFJkTbBsPnd5hFed49a1JcWw1Y2gSjRdohX8
+        PBs8G6OVg2jcUO5G1UFNXVbW96XDbtxfttz+eFgbKiXWYI6irmxvJ6vRQ/5eW3ReGzpeve5cXNWm
+        7ceaIx113eisOLtQmVl7NB8PpsqT0cJTe7ibNWYvZUV5YNG0Pb3d0qrDvuqLI5Jn6mp6uxNfnQY9
+        53Op5+P9BW9tjHXFQMIRYT6XQk6Oce0NsoRegab1w6E74w67+biLR69mp2VPam3Vkuq9FduvcfPF
+        ZqHtxNakMVCOvQ43kQfLscLJ/alyV9k83KE99/K4qrgSazw7HmKfFq2nRkfE6GXXc/D4YaZtSqhr
+        qIVly+JYb+Wynj3VR+OZN/AWJeZWwXK7VdqNGsVt7WU4cegmY8o7s7hHHo0PGzS297edfCNfmy0W
+        xfZi9LqXO7v11n5e5SvifM6Iu91rrYrUVnu21Iu3zcKIvRuo7FNr9VJtcBvzxWt0lEp+Wdi8mqXh
+        qJpfOcWK0j6oD8siqitqJy/qUrvbf563W02D3mjey325PK9iufcoliWNhtfXrC2dWrEv6oMKXepM
+        x/NZkWVr2nrHaUozr89b4uuquVw91VX20Wx1HXvl2aP5cqIfjKd1/eleOtg6fmw9Y5cxufLixbg3
+        7KrcneCHiZc3bxFbGzaG00OjM8G90Z1YKIjiXVPcveZdb1eY7w4Dp/taLh674529f7zfVBvy2Kwd
+        aXtitueGOX7cNUxXHz+sFoW7UblTfzZqO8ksqs/N8fp5WHcHdlnb7/aDqvNMy8OS3VxOFvv7ti5a
+        o764OG63NbliPFb7leGsv3kdastef3CHvFKVXZfb2wWfSwfNKYbIxlJtz3IFLmYlYT8ekSbpLjIl
+        yzMV5PjMczCaU+AVz9L8QCW/U5OxfO4CGjGx7TkqAlBDAjq4kovA3SeL5GjGQkNYFZoHFzmWbFAT
+        MKNqsgor1agz+4Ab2bu2KxswpanoFtKEfPUm5mfGsibYFQrMTfGMjt0MFW64lV11LbBn7NNQ2gIj
+        2d06uoqEfPHsgeLBjBGsbi07KyQUzm1OY7zqOQ6k22P8iXh0pWwhEaWgmLGUVdd2BJZhEpwQjFlh
+        IFS4UoIVRccJ2BqyirAfQ1kowQEvSvhoKraRS8IOClHhv/9J2sd4jAp8EGICHzmZvPm6H6SqSy0d
+        26TcNYJKZHmIz6VZsZGJ3LWtJYDANfVBbZCwIe5KXEIQBG87Df3go/jVTXZlof84gfsneNFATHWP
+        WySoZP4EMYAT16fF6TjciZmtEEd/RCFrFRuP3QlMlAJjTvDgogbVmsKubGmyoyXIZFmWLdnLIJqx
+        nxaSl+GYq8MWTo5GAJ/dIIk9kdkGicjPxatE4Gk/szlIJo/enEFKO12RAZJUoFE5vqyRg0ICeXhV
+        d8NNYtiWZlu0twFnnUAyHlC7wXg4GBobMsbhL8KXHRfKfAIIB4kfYZD6h2xu/03VwaOe/yiJYR66
+        nKDlIdMGDUMa8t0FXpA2kJz9O+UCh0WI306FvMjshKQmi3nZ+TTZUtHlSclyIkIKjDnBOmoyRKsb
+        LrSRMSArzcWPkIuc6L9QJ3R78BKSwGk4sH+0oF5p1D00mtAlxtTwrTg6xBc0mXsdvUhbBLXCL1hB
+        yrs4xMOeQ5IjWyskQaUJr4PJJmvvF4qFKjRGWyiRkAApjmEhLcYUwvZcFQJ7iZEr5Ev+rbJoTMNI
+        hVCC3VAoc+ViIc2OBgn9CP9MU9ME/6ZMlWFD5gmHN21XSgwrBTBsUNhaJgroNFOlGXbCVn/NM78y
+        zL8Y9lf/TpcNwnmzPiDXsPMd98wrRXdN9eTjz/RHiSuU88zV/igyxU/5owg/3+OPcP1BriHh6Cfu
+        kVi/b474XAIOKYEberILleCFqkGzYqF/YqoPy3H8XsahJs3xJDIkPiOfdU0odW6jEbgKcQMC3RZg
+        Otn1c0YSDBlQBdZCDoxpk9yXVoL70pi2Tvel/TYsF9kHJqE5rND1sGDo+9P0IRQRSGHKRddB/cG6
+        ufU7kyCZR3akMpHP3hYjw4AnxW5qic3zJcKnXptJ4rkLc6yQLZECaciu7nrg8yKUZ65aYtl8mc+d
+        UB6y+Yp8pJkbloE3XCxBpxLDfC6ebC1jCQoT5IMlDo6fKcDPpn5dguIZpdHwkjflg+R4lgWvgsQN
+        y8EazlDehKx7gZdFeQtBL66hLcQbVIcgJoPnuYSHZM+BNdtWghYhhOCvwXZMPw2Txz9Deb9JI8Wz
+        zo6owqTP505QVCKg5Lo+W9qYAhNW6izO47UdZNUlWU5wuwzGv3E0SJ0JrjoMpE4BgUpwKeNfGuCD
+        9ozcayw2uk04ATe73TGfSwyEpGD6sQwduAN7eAahiCNaWMrCFuS7t37y6AX5PXUSS72mOMXOkAZV
+        if2KBFytsoXrEzB7XpDeymT+ltrathF2hkFsZDB/oxm66df2IJwTlx/kdfbqOhdEInk6WmSGEOkh
+        EI5gaa8nBJssSFhxNiSBDSkv7D6noUkM8ef7Pr3n/f/Jiyvf5Blq2IPT+wkio+u1aUKPxFZJcUxi
+        5H7xVvZ7Z0nx10vaexjPQEmOf49cComX5r8T2Dk7D+FTNbDsE4Q00q1nKTwpBwkP1DujerfpP3Zm
+        IEUljd0WVkOpuqMaKG0QeuPSKT97vCfXmVPJOZjiJU4ol2D+8nH+7Bx/8QB/dnK/NrOEx96vyZi5
+        tLjzk0Qe9gdFnjP790SeCvMpkeci/W2R55z9ochT/h6R54LNxyKPh7WfJfIUmK8Xef7+V9d4gpf9
+        FRpP7qdqOSSE39ZyPinlUNApoi/Sc8pv6znFP0bPgeZij1Yypj38lqQjY2rqUz5SdVwX2je/qX5H
+        3DnnfI+qE8/yU8WdxLSqrIC/3PdUnpjyns5TJ6xI6NEtC2r3GNp9/Hm9B1+j94yhw0CYspeUaCII
+        Kjmr/Lyj43joF4qDAiN6Kw/qzYc9M80VuatlHIZjOO7qrrnCcJ+SLSo0w004jrS3NFP+k2Scz3ik
+        xBWZ/PXC1ncJOZzvjs955FzI6Yq3zV6v+aaK05WpW2Sa6C21plv9AbWmW6UNmV768/8xqswF+SRf
+        umGZfOEN6YRlizdsmWP/OsJJ9a+om/SnlSrLVP9o2YT99CGAzRwCEnpHr9VrjcR+ozt9UwYBCtWC
+        naRRicL5gRZyeQNl/gb9BZrHp7JVnsmzn5Cd31U90hnhq1WPK8vCSfWAlHNfaP1k1aMrTpo/onuw
+        zAfCB8f9Xwofw1Hz9irZY+igJYKDkEb5E4OLrtA+yFHgz9A+ytdpH8WPtI+P08k7AsiP576TABJ9
+        VyY8g599hyaFf+oLN7nTN2lyb34J7n+GQWWhRicAAA==
+    headers:
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2653']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:35 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+          IND PHY ONL UNI PUR COM NAV DEM STA"']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/CombinedOrderReservationTests.test_bool_properties.yaml
+++ b/tests/interface_objects/cassettes/CombinedOrderReservationTests.test_bool_properties.yaml
@@ -1,495 +1,446 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:35 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:08 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:35 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:08 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:35 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:09 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGNyeXB0b19ibG9jaz5FMC0tRXhJNTJKUkNxLWdMRHN2eDR3blVa
+      elpTV1NZRHFxZXZKRkd2bDRwb0NpdkNxVVVmdlVMQVhnOWJwOVhnNi1jY0s1THRRSlN2Um1MZXZl
+      eGUxMzBpNXo1UWdFV3puMVdtRTJ5WHdnVnhkTm85U21KZmNlWHlZN0tNTnQ4enV5Vkp3OWFSWE9T
+      ajV5Rk5wLTB3QWR2MktCSHZwaDZjRnFST2NyejktNGxEaHV4MlhIYUFtMUY0U2JuZEoybXF3a1Jn
+      WjwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bm9fb2ZfdGlja2V0cz4xPC9u
+      b19vZl90aWNrZXRzPjxiYW5kX3Rva2VuPi0xLS1RMW16UTBaV0tTZWNaazl6NFdQN1pCSi1GazFR
+      bGpSTGVIODl4djlzQ1llOGJFZXYxM2hoRkhheXlfNllkVWJIQUd5d0VSNlNSeW5ZLUJlWGhUd3Ey
+      YWQtYzVoQXc4WmhLcEpubTNONjJLZnpNM3B5QnNtUC1Dd0NVSVktY2dzV3F2S1kxcS1CUUFfQ1N3
+      SmE4SFJjdGZ2WlFpSktYN3JGZGNGTHlwQzZjQ29DWGdPaF9vc3ZXY295UU1MWjd1SWlpYk9Sa1ly
+      NFV2dEl3el8xbWhvVzNQVVdmRGVnUzJzWkpzV0RpcU56bXJkZ243Tlg4cjlfZmFaRGhPSDdjOUpi
+      WjwvYmFuZF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkZXNwYXRjaF90b2tlbj5jXy0t
+      RnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJYaWgtWnkyeFNwU09EZEhh
+      SHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5OC1zaExzUlpJRW45TEJX
+      M1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tlbj48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['449']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS0HvDihIg7XFxZDKMgoBCj+Tv9Jf1kHg4Je
+        O4fKzLeqlauS2GfHCeLEOWcHJvPHxbYqEfADw3V+/0R8xj9VgKO6muEcfv+0EgdY89Mf7b8xmhGo
+        buhAyfUgYgaSD4LQgm0mCBXNtWXDkcIA+JIRSIqstR2Xqb62MCACDpon+0CW0DqgzW6YajHKDBoI
+        1DaLXis+68AHOSFFGdWAcca1XEdzHSw0mWoBZvaUOkntuTGfbMlBkP+V8WUfBohSALkx5XeQsfJ3
+        2fb+Xemh7YbJq5TMDNpUusPMbQyQp0eICYDsq7pkgjhdqYriUiBJ9HLebdodeXBW8J79abKjgtdO
+        s+3cCA9gwUn30ZUtC8B8o/2nCdlOq8UrVG9BTBLCz8OeHkIZuJvT+SvHgECrjFFaoaQoqPmp+AY0
+        VJRTkQHOkgd8NckRAscR8aWJ0WQIJF92DkACjpaPU2eiHv6rQgSwsgQeBLYC/AqJE3WmWlAydghV
+        yd3vAwDbVD1Z6hktaAFQUSoFbYJukI0a/ci+GTN6jP6zbU1rJ4viLZzImXccnbTbrOOElMKyo0nQ
+        sEFKx/AWhhMi0fqNwn/D8X/ixG/JSq8n5H6fY5CNA4iS40NUalCvTOX4Z8ajTtINCv/meNTw2nfF
+        o4b+/Jl45PtPe02WjvxK7Amd3pgVmGoJzilpGKYyhDo4V7pu6DvgH0GFR9vxZdVEKSSyS/E2MYtZ
+        9mxo7fpwcLMYt/4mWSjR3TZyJ8OkZ5TBnOHJUG9X0WTMztbFlHRdLMCc+7oYBAGs3uanU/LpaIcw
+        DNqWEd3d59CNgNqvDOXqbQxjD7QDw/YsgAKGnMPbvNSSs0IvAJaF3jSAD1tkP24RPU05vIxXX/g4
+        ADc5KLnNWDI0YIhiXiM+18hWnSCoBlO9owzq5ofsEcM/Ezg64VqdRIQ7zFQLZ7ocSI6b9IN9kKrN
+        A5B0U9QRUce5t9F8yNjyRfJDx0FHkeUNQaI9fEAZG3XdF7xnlHEA0FBGeCjfkDqkOZm+zys8J4e+
+        nGhoiXZDMkKyB9e3kzacvf4HlPHcAGbi2SOECi3yTPUO3SQCSTZM2JJpt/HP+F0jyjgT6G7aVffZ
+        dtLlnjAmQHmJ6KlzcEH5gnIycVeCb5xMty8Q+I5sVURErHSTRHa0SjEjq5/0UvCq478yMCixwnyt
+        Zac/YYXlhp1Mlky1ZMhJqfulrFnARzW8QakY3Gi5lOVXkIeIFt1wAzQkIMSv6JWtFkF/e68kPmrH
+        /2s6SfZ7rmulaZ7fHZ6wpCYsw05kOM280vArLZj4ZklKkyZ7O6yDz1FS5kBuCaTICAzFyhPtGcxY
+        RePKchB1p/yiuM6nFBDzsUQfyzP5f3Zwjc8UXplPmWoBZVZdt210nSFamY6VsWy9e46ofuxBV1Is
+        VzXbUwrDvHkNEtSBlVXalIXudWeTuhutBMPhuVlgkuo4UubOUbCgNrqQvd4RP9dbR77FLk5S5F35
+        2DT7K8FuGrQ+6jkreFUipdk5cUNLBc3x3pZ74tjXvL1lDYQmO5KPVmO6dq3RwWxQxHKCNa5DsS/W
+        pS0fen2bVcXTGIZDSu1btBoC1rBFZ4L7RmdPc7EAIHccWoK4PMCVt2GbEmsv+krUeANrsyX68/gw
+        P+v6ecguW+bUtg+z/uy9f9VDq7GmG5sWL0Flya3mZ3eh0YOr1j8tsV204eaDbp/g5pG55jcTjDxv
+        V9Pu+0ggllA4jKlOIOG0wq5rltPz9my0cFW18cZe6xam6ZFKBRNtAPvyXMPm516NdJeu4hIgNiPB
+        Hg1mKuQ9TtqO3ll8Rtgrj+pq/JEfnrjxmxWc1V7EwcF+KncGrLAJ3wMruA58F9DcdQ4243ptSvOD
+        3di3CfXisFAzzoPl5djvw+OkT485stsYyjVX0YQ3BXawXXLXLJ0vo1iyg1RSKj59HCtOS+e1pfhG
+        SuuqTaHqfUQYNfR99HUVF09ZGh8UD63+ABWMvaxC189vw09gwXLC5KrbbpL1EisHC5ZnySoI2mSJ
+        k0MlDhISKYhtxbWqZRipWIa2//uf8vwCL9AiGMFDXNCNAH8IS3JFQLLt7qViAo0U7wm6+0Dfh0rg
+        WiFqO4EcoTrPpO0ZRB8ftmI4qLdRrcR+HxYvk0a5019NxNILZaG/D7NvQA19+VUSzdRkXyuRcz34
+        yu7uQ+giHWyrOIadTKzVXY/jCx5zw8b727pPDh1BdLX94rR78whpEZIUy5HN96CGMm0VXTWcvcwI
+        +mw1WHuwhz2ObACbr8VU1xodD1YwkMddthlxTTpyur6+UehtxxjESmfKc9vOarzAj9aJXkP7PD5z
+        /MzpT8QemG0Wi94+gkGzZfqboOGdotp+PhiMdmezNbXOHe1AKFdlI7sxPFIm5UbWdGlSfJeXVq7W
+        s2EX7weqUbP2FuYd9dF4PN4u+ucBuSsFIdt1KQrJZbMcpez2iVQAKSfK1VyasgFKDSd7lJ4O9IWh
+        RE4Uz/MN1LOp2iO7sJTp6Fqiy/4BtOkn9t1QYmeXZ+m1/wcjk9WfJEeyYcmJwiFF/4Ax+SVHPhQ5
+        nQrPE8ikTiUlkdsseRHrCSpzkvSsPiCFsvryGU1woHEI3TDIbwgEuo6/NKR06ELZemKWMeY56KVQ
+        PwW4FNYXwXwMYbWo/D/dA0jiSz2gxw0n/a/0gJ5uWFoF3dLBj9Y/hup/MrPtKdcbqoPpZLVRjAO2
+        ssfieL2bAKTbI3vcXGMY2Y+3w51CBCJ+4PZCPzk6QG8miq0vunWjX9eIix7hsqGe4vCs26ap2dtA
+        wSSIBHl42I07kWVKFKcvWuxA1nbS25BerhoT1msK727Ei+PT6r0xmVDXQcvvXqh+h++1LrPNynwb
+        rsH1elI9aYdhX61l4gdqOTuYb61lovldtUx9by0/+/+rlu9BeVnL1JdqOZv3C2r5i3q+FFd9lv+a
+        oi+TnxMc+FPq2UT17GPxebJddlnWqznX/ZD2uzzRiHrWfOny5mEyn7iR8z7ZHvsX8chpR65Xj+Z2
+        NI15DzojxdKN6I2bDa2Q3bwfV+pKEt6l3tCGbOOkHK52d79Vh6fNsYOu9cLaP8lig641u9dQsE7u
+        uaY3LouDyHbZCF3FLd7t4cPl2TwbyKUn7bueQY5YZbicjI6NWcemPPYwmR2c4/xiYS3K655W5D6O
+        pyuBvtRngIhtasg1AqMJTD7e94Y0JvC0EPaImo3PZuTX+wH5I/3gu7SdrP/afvDs/69+cA/K9/eD
+        bN7P7wfUF7V91pl/rRcAx3D9impA4wqcn9IS6qglDEyKmxgcTte6Y0ne4wK7D4TgeMbttdUYGWK0
+        ah6W0LlsKa+3vhr+vjmCO6G31UdGf2SbMqV350rY6h54rTkX45ALdV912bXWXEN/esa242406ZHH
+        eG1uZ4Sxj5quxQn8pkZOehoei9KFvC75GPi7S3PhHWcCCXbXGqmfSJ2iRKsf8EJwUtXjEA99bo6j
+        b3TaOknfIPfUj1zdv0vuyV8s98/+/yrve1D+RHl/We7vj0H2W2VRkrprJD8/3H+x/GAp5dvTvz3/
+        D1lRoYe8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:36 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:09 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcl9hbmRfcmVzZXJ2ZT48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkaXNjb3Vu
+      dF90b2tlbj5jMC0tcWstOUJWS3l4MHlISTdZR1ZEMkluUlRvZGZRcVpHcDFfUXUyM0VIMjhZczVh
+      bmtVdnpkMEV4TzE0d2w3RW1GZnRDSDI3ZW1ONXkzQmxKamdsc0ZhS0JFOHZIODR2bkJyaFdiNFhB
+      aUZ5YkFNTkhYQVVLUTBqbHE0VnRtd0t3SE5PbkRMVENlT1dRUUNmdnRzODlrcldzN3BxdjVmUEZG
+      Slp3azlNbHdBZGcxYnpiV2FveXRqM2szb3ZsTVNrM05CTl9Vb2RDbXRCMERzY2k1bGZsLXBqaEpL
+      S0tYUUR3RjJaPC9kaXNjb3VudF90b2tlbj48cHV6emxlZD55ZXM8L3B1enpsZWQ+PGRlc3BhdGNo
+      X3Rva2VuPmNfLS1GeUpWRGY4RHlFRGhNWVU2Zllsa29BMUcxempMbnZkVndoN0tMSmticlhpaC1a
+      eTJ4U3BTT0RkSGFIemR5YUdqLXBySGQ0N0s3dmZDUkZYdU1FSnVValJLQnNHbldScW1IdDk4LXNo
+      THNSWklFbjlMQlczV1ZLczNQLS13Sm5RSE9fenB5WnV5VWlBLVk8L2Rlc3BhdGNoX3Rva2VuPjxj
+      cnlwdG9fYmxvY2s+TTMtLXBQNXQxM2dFYWM0a2FSQnpabTJob3ZVUmluTkhPc2syY0t2YlBualJs
+      dGRKeDJDQ2owdzY5ak45RVFxX3Zwek55a2tEVVJtOGk0aEpDblV0emJ2YjhBcUhJbGNlOEtmbWFD
+      VEtyZHBmbGxGUjhFSmFqbDdNVm9sSmdrNzMxU0wtN3pJVERUNl9YTnVwRG1FY1RxS3R1STNjRGw0
+      Y3VlRWltVG5MMHJpQWY0SHlSZXRIaklsUlRTZ3RVcFdFOF9FbVFEYnY3R2VWazlUclB5Z1B3aGh3
+      SUVTOWtNbW1nT0RPWUR6aHVsN1Y0N1c5Tl90YlNIVVB3b1FkNEZ6ZERxUy1adldIUEZCRDFIUHZr
+      Vk5XTC0yd1hVTUJZSlIxU3RSZ0szQXNfMDRiRVY1bG5DcGZFdlFvY2M3R0V6NmwtZGh2YzNzTGRG
+      dERhUGQtUHdDNTJvU29ibzFleWt2Um1KRk9jdE5wSF9YSllFME8xbVVwM0JkTmpOSXFIS0dsc3dj
+      Q3ZIdEZmTWFBRkVSV3VZc2xzekZyb2U0SHpQZVdLNjVNNE5GWktybTFjeG5FdGRpd0ZTeGpERHRq
+      TEQ0S0gyQjdJYTVvYmRSR2J0QS1aPC9jcnlwdG9fYmxvY2s+PC9jcmVhdGVfb3JkZXJfYW5kX3Jl
+      c2VydmU+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1148']
+      Content-Length: ['1032']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
+        H4sIAAAAAAAAA+VZ2ZaqSBZ9769w3Yfuh26uoIJaTVHLAU0VZ9TUFxZDKMgoESj6O/0n/WUdTIJD
+        Vt2q7nrqXHdlwj77RBAnTpwhLvtLaFulM/Ch4To/f6O+k99KwFFdzXAOP39biT2i8e0X7i+s6gMZ
+        Acn1NeBLsqNJPoDAP4Pob2AhjoWBorm2bDhSgAWSASVF1jjHZcvvJawa+D6e6Zo/SXhawB0Ujy0/
+        QjljL6vI9TmKJAucFMxZTmArwOcaFabASsGc5VmyCiBXKXBSqMBxIZLg1VZcq1yEfZCi3L//VdTP
+        8RzFev7VQ66kWK5qciZNEGdgroQeQv3m5tS2qH2jK0yqonzYUdZUJrtB1+ip/pEeVQRD+JAOs+4n
+        8+mNbrJ0XrdW61OldjppfYkfjvahLoD+jd5bVN0bXPldsAk86iTRPfLAaIfmuFfnG4zduoRjVzLU
+        k+vtjQZ+HJ+BRlNVxVyZlZYmAeZDlId0072ZlZ7ZbhCj1rSuHrYzas+0J3Wh20PeRjl1jKHn1l1f
+        B5fdZrCrteVKs9/aXlWvclyr/rYWQmEWQi1YmPpU453jbt0K5wovSJ2t5bTFhk+F4h74inc6CIo5
+        WO0vwmhv+daRmdA9T56rF6vZ6jTq19amKSyW5KizCVTlGK6n4kqZE8DQp17V5VFTPTnt2rRvAsEy
+        60FFpy3aGStzw92gCi/UtfWyYS0FWFUbNfsD9quMU/dNXqgA97za3Cw66Mj8/uMQ+spmSptCZT2x
+        zyuiY4aSeq7YzU1rretHSTdWN6M1m1aqZq0qjXY88cn7TLcC6NNKOCmTBiSNTmcxqPmhNRsRZ6Rs
+        agBu591W156ur615h94z3lDq7y7z6e1CzAin1xNHg2B53m07whJ+zis8udX6sN5oneU+mns3Nagb
+        9Hmtb1todmyCT4JGY+rK2MfmkBzuTuKJMvd+cG5AdFlj+bC5VtSOuV+vqdltPLrAG6UZNVozrE8i
+        bPSMzfTjLBGGuSUVYTgRndXqyNuUMLxWlnBr98PqdnM7koPabklLBLHDXlv0VRb5sgPx8cLBQTI0
+        TiRJkiCjX3Vm1CCGlSo+h08c1jacAAEoWWCPJIylkYKj6O9kdG6/kuPJXMsCVwm5JnA4vkbgH2si
+        NwatRrsxWcxuvOLWp1TF7mEf/FgiGw6ERUMlj8KE7HaYEb3znL452vM7giCPYXXcPVWVK9i0P4+7
+        8+CDl+Cyt5s6HxVwU4j11Fy6+xVJX4eftswENY/crhhzvKEG9aErL6iwpzGd1gFN/PbKmNZsF9JA
+        UNYeJTF6dztR9ZvUWQddMD8eXLFNO9JS8vR5t9380MTbraLUttbAp8SBQ2xJwXeP1G7iilV6TaHm
+        SByt9/bc3Q6UW08MqRkVwuVU4fva1if8hiUSdG229HsoPDAzYN7qZq9arx+I9sr8NHbGYhgOpxuV
+        2rasemVxMkTeDquW3jAq28XHSm53Lx8kKSo3UJXabTQamgjSnR21Cj+YJrm+9OeXedX+bAN542yb
+        vWVtfmwzl2q7Lu2uc56/TIO5tutemr1TVTiCQ21/GlXx0fJbtn4LNe2ThJC6hpu5t+73mp57vfiN
+        zwbc6dW+sXNFXVW3feq6IwOx6zWCaVg1hP7yFoZ03RoTR0bjRa2lNxc9snk64WVsNBUYO00/uAF9
+        OuBRQMAch4PrbFlVmM/WTb12pJl0YBoewfuKjQclYz99dJa77yQJSnUDB3FUzirCGZdjlcDRLJD9
+        fdZ9g2ZM6Aa+CpLkBEIkYXdG5F2jKH3S0ABUOT5EwHdkqyRitVJbVvEKtNKLfszN9JGLZAsPaSuG
+        AzSu2vye859kzyoQcTXyO/1Ch+iJiif0ZKTqHPXCvoseNSAuCjzfUAFXpV8+KBc+KeHV6bJ/AFzt
+        Vecu+3+qD2IX49jMyMnOdyInVVFp77t2CekAF2lOANjyIytXsgHSXa0AxKbpTNvTgk5irsIrdoJ4
+        tx+h//JToopPRjI3WYl4/gIvE+RUdPUApybjF4gxXHi/L86A6Ul8Ogq592eUZK2t7koQ8UAPYM6J
+        P7yl4Qq2BBEua2VfK5CTZTmu5O5jb4ZRWCi+pjJk4CNclGYA+3xACmciHQFnzMFnjaqz5Sh3Ghqe
+        FMmGFTmZa0X5NJalz+w+sOKHVCV7ZXFRjdMowiMjoElnA1zi0vsNzPruJRmBLaeP8afgGBYm5ilH
+        gCf7Mj40+Llc/KZy+tVPZ7hwbMv5FgHsJviPjFuHxO78hi3nb4kgiYi4AbledOCDlJBYXjVQesIt
+        19FchwhMbIo7mMhjqhDLU2GqbMkQpn8SvuwjiCk5kAoTJ8DC0l9l2/tnqYPdIYg+pSCOLBz3MMmw
+        VwBj6xagyIrYCpKJM0s0Uzk2VoZE/VHKy9TuyMNgOe95PE12VPB+0GQ5GeEBzDnxOtoyPmooXWj3
+        SSFZaTn/hHJmxGhD/dTs8SYUgbs41l85Bna20gg3kLjty6nprvgGPhzYKyNnlDyAE12UbeN4/VbE
+        alHfiUvMA5Bwmkzf48FEPfhHicIpdAk8BKLoXaqQFI7pOSVhB0jFp3IPAeKqTDTVM5rTIFCxK+Gj
+        XKtX6nTtkZ0JE/oV/9i2pnHRpGSTpFLmHcc77TYYkpJiOGqakWGDmE6QTYKkRKr5U5X8iST/TlI/
+        RTO9V0jHfbZB8o7Dlo9erEIjvTSWr/9LezCVWr1K/rA9aJL+Xfag8b8/Yo90/XGsSdwxyjqLVmfE
+        L9hyAU4psRnGMsJp7FJq40rLAX+DpQlejh8VYn5J5JdippjYLHnGgZIZ9DJJFDaTJws7usvh4WQU
+        xYwimDJwCtO5MlYm7GReQonnJSDh3OclohqynOnHKqk6XiEKIGcZ5/vwKZQRkqxazt7j5AkN24vK
+        qjgTZXpJWk2eAw8CnD0sA6KHJfKvS8RP4w+yiJffjHEArpRkd0tGBgqwzWlcW1SaDEVVcbK6oyyO
+        5ofkkSC/UyTeYZrBZVYOs+V8MF2GEs6qOB7sYZzUHoAomkY5CWf+LIymr6wth5IfOA7eisRvqErU
+        fT6jUb/6jveMsg4AUSbEmTHKDrFPxt/zDk/JAU6iuC0u0DIkIURrcH07CsPJ57+gbFRhJsmzQy1K
+        NXHClu9QliJwykURWzJtjkzLjGechbobR9V9spx4uieM/aKveWhofqiTeWhh4mu/dxH/nYCNa8tk
+        rmWrK/CL5YYXhCVbLghSUjz8Usbtg4/P8Aa7IsxoaSpLS5A/fPRxKrOzzgDH9+Ir+7BNeYjdAA1n
+        JerPCMDNJlX78QBMvSakryJZdKQ817XSsjb2jScsOmiWYUe5PSsts9ffiOvUD+e52BOTryNa5Ax7
+        egqkEohLWGgoVuq9z2DCyqNh4tg45KXV5zpVySH29dw/nvnod7Jx9e9VsjQbs+UcSqS6btu4RqKa
+        SXIsYsl8+VGOCn9Jidab9CZY/gQVOdEc5QckX1pcsfvgFAB4zwaOe4eAllTqzxQ2SQcFC3QGi47A
+        R5/9JHigJoWdh1dTUg1ftcCjQmqNd1cUz3cTyftTS/UKPvAK7dU7mH1/F/FyCfH29uHl2uFHI0va
+        s/85EbOc3Uz9kfvX7M4rvVh5uQt7wH/XxVn5fnO2x+0gzlSxFJazbCZf7bjcwl10MZ0VYVZWVVyt
+        y0r0BRiImosYj34n9YlsgxB3A/f3RJQ0aTbAeyk7JT70cGMLU1pqtHyg4nC2HHXA7hcjjh+kvzEQ
+        Pli+Gl8RfDHWE+FXh8NRS/5ioHUuehii/Go8GHiei7tDSTGsqOiUZE2LLJP+z9sXwni/oARwx2k9
+        aLzDU7J8iDbRB3sQ3VqBAv1ZErVyv/6/hf8BlzZwwHYcAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:36 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2885']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:10 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order_and_reserve><crypto_block>E7--NuwIhns8SF9pSFmOCtayGoPi5orsAykdVtQtCufnKnVXd5ijHtnqR7hewEY9Siu9mKWZXgSi50wUnsm6QPTTn5Ap3rEh2y8qt7LQOigLgEgeiLH4ylijiJOz3cCcGHfmz-mr55XI7fNrF6K5mYhYQ3qn1nCceIO3_pGh-y2ODATK_1unwgfaRcvmf9rRBGVuoIht5KuL4JvyIf1HGwjOVpnEZgHPJm7kxU7hRzZCGSznxEZHloNsR7I2pTbq40t7v2mLo1javANm8iUGKktt-5o16BpnLLteyP0yqrtW48EZlb91SwCaca-PJX0S8BvzKCatNcVD_hETlolGxPekOoYcRxyhOS0oqh4PNL4fG5MfxXXjHxpdCbQvBrDibivFS6vhbjmFeBcQYWikaldIWXGQFooHSH2dWMs_BXrsAz6-j8VMn40F2LZish9H3g6jBjVkrnayZ4NMPTq5FtXcdK_5L7WFk2ASLauJCqJowO_bV8X2sPX_At8097h3QpXw1Kh0OkgxfUXvzDHbFI_bN0XSMiJ0al9y_p-VXab83-6hG9eHDURd6DtENaA6ZdPR1b2kCR_toknr_BpFKcDNzxpBDj9-GWfRRbpiCUM9rPYDDkijx5sFQiucuV4RNL_xRMwwjtm79e8Q_Ffs_Rbj0MXC_rEfuYOIlmhROtFCXJpXG4CNo46bV1NKHU8emAOPjTy5eN5yHKnfgvMsrKq0Ix6-yFmDNxXSz4pazVchj_p8eOwdiIe_aY0Ybh9RJBrav76RZUsxDdWqMKRqoWJyL_--Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>k0--5q_Eg4_-x1Nz1FPUkY_jXomw7H7E1_PjxiUKNYUK3emm0ERjusgvnWUYFQqZHjDGEekx61hC9iIriru1LpexlQdiFWf9oohhZR3m54tmVkLEMIItGP0eGhqQULniBgRbrSIgFusujEyS0Rw91TvO3pqX8rgNeFy0FDAL-H3GFetfBUfLnD1Zi-94KcFBeU0CKwDSXAHtxFWU5WZiFJ-wMeIriNlK_uoAMR58EAI8VqC-Z</discount_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></create_order_and_reserve>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['1408']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+VZybaqSBad11dYb1KDKp40KpKLNJcNtihee52wAggapRMCFX8n/6S+rIJGQe99
-        WZlZOas3uBL77OhOxOni8b/cHLtygUFoee7P36jv5LcKdFVPs1zj52/rVZ9ofvul9TdeDSBAUPYC
-        DQYycDU5gCEMLjD5jWzU4sNI0TwHWK4cYYFshbICtFYMQ776tYhXoyDAU8XFl4znhS1D8fnqK1Qw
-        dKAiL2hRJFni5GDBciNHgUGrSTdKrBwsWL4NVBi26BInh0ocL0RyGDuKZ1fLcABztPXvX8v9C7xA
-        cb8g9pEnK7annlqnBkHYHx9UjfNE0ROVETQ33oUj2Z1Xa0ekOfkYBsEVsM6oOXAInTRvnXtnOFbR
-        raefFgTTXZ9icvVxn172wW710dRmTC2YCo4/g00p1uSZ4eucdL6jXoeLqQHbX69VIO5mw2P9FtMj
-        RhGVztBAw31dlXeW0xXr7Ljug/2+02EZS/H66p04cxerdrHnaDqOGGrEXC/2qX/sWxOrpk0Nai7V
-        2sapzgK9w0Sbm9U+Q5ab1+k+PbMl8mMfiQ2KNCVtr2sLbnZ2jy7THwmNczAf1SeN4K5NJWu2Zoad
-        ycXZntQluzfpnQgYPF0fegHd9Wants40Not4fFrpSodbsRxVa14nmgagd5UaArVzx0CozzoRV5/b
-        gn63pZkiToRFdBqN58i8LINR94PrNr3p+DhvtGvU5sa03Q51tm+wdhp2DHrXZXxBA0eHWi5r4ZoT
-        JtNeNCK6m/YmmiwpXVPbp7oWzIRz34/UWMOH67LzTk/6EP2LUQOsfe1zg7Ec7Pc9VSKVS7057w/i
-        eNZFqlkDp4k0kWlzQMyMWa83O0LAuFxvJ4n+cTQdCGeG3BjqDXbbbcK9f+zXm6FNQqkd16UucuaO
-        LI78yblN3hc7bry8DifnXXPSaEzm8UW52ZzWtWrU/DJfX4m2o+/jM6t47nErRtzgcB1dWH2o76g+
-        Y4yO6s3gDovpbkyf6rAnoTnHUQOiwzZc/yz1rNH2qnicT82X1/6Yibz2Zt/Xb53zGdpzdsqcGGvV
-        3X44x9lVITpy+zCtOYP9db4V4HpbN9jhYBFrB7VOUPPDdc+KkXU25YUkxmNd1eYe2yAO2BLK959H
-        AXBDbLLY48iW1jqQJEmQyR+GZReEWKfrfPWNwzuWGyEYyjbUkYyx3P20GuR3MvEFP5LjyTzbhrGM
-        vBN0W0KdIDoDAbK32qrfWElNtI2VrXmHm7UkorFJOOwxHNfci6vYN+ZYEzczcG4OT+AoXJRF43gd
-        sh6g5vFcCAa3Mb1otAVfuw29FdXcNC+N6RhQhq7Gw+mcW/V64odhOubJ3B9Ii2lQymm47RmEIo+E
-        yYfBNueeYu+9vem4S3AgNrdJZELUMz1d3QtzNjLljXJAnW482e/u1EAPGTleLM+osRpG11uDXE5I
-        tDLjnnd2OmM7QJA8BAM64Nbz/gpNa837dNDoLKZBI9qPaHZ1jPcMNkqL0G+LsSX1iOaobjDt8/gS
-        9hbSNDn85vC4PTS7FDfiRG+1sg8BuM8sari9j8wNWO6Jrb/Srjtq2enKPcfrb/079OURez1TZLjl
-        mL3SHVma2Lx1hFpTHjdopkbXAtk4ebOdIFM3PVZP0551glCdLpfhIa6FhDSm9abcvA6n28OOnKtA
-        OlnGxh/vhUvtCCzN9QRnJGn3zmRLcFeV8Y7ihQmc5ng3upjGZrbfdshVfXPF1gdjOqCPNIXEc0eq
-        x47vkRvCtrue0Y4GJ2hsjoIDSOm8HV4XUQxvwPrYUfRFUwxCbY83GiFtZfZM2zQpdfyQIewFYC8W
-        EsnQ2k6XjrhqqNp5Tjo7+iqY9Cq6WH777NTX0sdc9+t1awBM/bQ/39p9kTv7h5vbSe7+6wV83scs
-        kqpe5KIWVbDK8IPb4pXI1Wz4+H3v+wX6YIZeFKgwC6LwhmRsIoh89ihL33poMFRbK8yuLOMQQady
-        gIH33jElPToiDwEbj+Uolgu1Fs19LyZ6k713CVGLIb/XP9FD9EbFE/oAO9cW9Yn9FL32CHHa4geW
-        Clt049OCCuFbJ7w7EwQGbDGf+zxl/08JjAYVC69QVk3PSsfPgUKSXRgTVnqR48SVLgi0Si+T8dUX
-        0rOL5SJoBCD18RpAoFqIXODAlpaMVHROsScDxf4nRoo9m8VXsezURpJBssuSLaibWJmKKnrgORWE
-        t3CBbgST3mVW0cmByPS0EpAecVfqSKU+2bGXmvgyp7f2Ffofl5Kk1lhzrdl6hecv8R6CgpoqR83G
-        LxGfOnvfnBXmruTNpAsrflCyvS5X654wW+GhXuCClS59iSINuqiCjx2WqNm2XE/29NQqw8SvlZu5
-        DFnqCZalD4B/N/SSbecj4DRij7NuLEsSCkvDkyJg2YmxeHaSZKSy/JvXIzv9yLs8mjyuXnBugfDI
-        CGryxYLXlosd4xcwH3jXbAS+mn+mS8FO+JYpp5oAPsC68AL8XS2vqZqv+s0XldxPtTgiiK8J/gG4
-        SMu0Lmz5atHKBKmOBVzqxVcTBjAn5D7cMiJfvgA7gplrKgO8aqHcj9meq3kuEZ2wop5gJk8HElN5
-        LsyGVm0QhvlPxsf3GqBkASUslz+8SFmeDYMVnJaQ2XBpXfkKJbrFupFPOGDmM1RTLT7ApETNqY+e
-        T+RlvIL3xZAnSwu/HjbbSC5/wQpKupc+cCw7LpGyHVaLeasPpSXHG+RqTpVeBp7itP/atfDVq0xw
-        4Y6r7YKan0JgYVPBdzS5mrIPcfhOkoc0Cn0p4rWk3sdZuAFl6Gp5Oz+f6F8VqonMSjsyIpwi0CSF
-        41RByLgRUrGF6iHE0b2RTPSOFrQQqvjiYLOusVS9Vidf2A9hRo/xP8fRsDfCk5JNqpkznzg+XK/Z
-        ICk5hZOnCmThwJHQCbJJUM0Vxf3EkD+R5D9J6qdkpq875OO+ayBrhwgE6JNOaAoro429jv1XqqRB
-        0Q2m9rtVUqOpP6SSGkFTf0YluQpS15PdxyQILdpdXIPz1RKcU1I1TAHChnStdHAC6cJ/hJUZ3k4A
-        sA8P/v7olOkr+8Y+szHqPySJB82+bHzLvcKRlMGcgZeHorBlW5enPIcehCxCVh/tNBCGluMnqV4a
-        VR79shCZfUd+CHEksK0QvaxR+LzGH609wSfrMl79YmwDenIWwW2cISVRs1VP84dnk8fO2Mg+CfI7
-        lYieAF8t+psglHGwxIath2msegESX5iEGqg9nWDe5B1wk4PIdbFas/On6KTSfkeT2vwr3jvKuxAm
-        AQ4HPBThNDO5S+l6vsJzcpSlhyXaA8kIyR68wAEujvPp8j+hfJIAZzGxSy0qtdWMrz6hh4PHkRQl
-        bPnktMg8e3jH+dD0UveoZ9vJnjZfMf4H9dZLofXbFdZLaZVmf3l61e6JwmK5FURxyVdLgpyUZVcA
-        FyoBNqstvkjhg5aHlzxJ+FPWiEOL86g/sHspN/kXbRcebws17BHZJEr89R6RxY7/D3hE9pNH/JGJ
-        Jrbhe56dp53pIb9hicXYlpNE20fq92j+N0fL/l5Hm16pbHVEm2vjK5sDuSTEKWZoKXZ+Dd/BjFV4
-        uOyGYjeWZ4ebvEsB8Z8N+NV4k7/ZwbHfGbIyn/LVAsqkpuk4OGuhOCYN4GUsm6+wySQxl5Vkv+ns
-        yQbfoDInmaP6ghRbSzPqAJ4jGD49vOs9IahlmfQ7hc9cfEkD3dGiKwrJst8EL9Qs1fLxbiqqFag2
-        fO2Qa+Orp5D3N5Cs/VbyfAZfeKXy5yuY//rN49Njx5evHJ+eN36vX8lr6r/Y9VUfb15/5rX48ZqW
-        v9x8emV7wf/Qk1z1+San4zoNx5pUGlYf8QjETpr4gEArB6QyzANVhT4CSrICDCR5foonf7NkwwFJ
-        LYlVUkCZNHfbZWmurmKI14GwfoOk/cOx3gi/ORz2L+AHA20K0csQ1c+7DSPf9wIUyoplJzmbDDQN
-        F8/h438LfyBNNRzKENdo9hN8JAbveE4GRqL2AOoweciCJfq7JKmDfvu/OP8DD0u6YisdAAA=
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3017']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:37 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/CombinedOrderReservationTests.test_get_details.yaml
+++ b/tests/interface_objects/cassettes/CombinedOrderReservationTests.test_get_details.yaml
@@ -1,598 +1,514 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:37 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:10 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:37 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:10 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:37 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:11 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGNyeXB0b19ibG9jaz5FMC0tRXhJNTJKUkNxLWdMRHN2eDR3blVa
+      elpTV1NZRHFxZXZKRkd2bDRwb0NpdkNxVVVmdlVMQVhnOWJwOVhnNi1jY0s1THRRSlN2Um1MZXZl
+      eGUxMzBpNXo1UWdFV3puMVdtRTJ5WHdnVnhkTm85U21KZmNlWHlZN0tNTnQ4enV5Vkp3OWFSWE9T
+      ajV5Rk5wLTB3QWR2MktCSHZwaDZjRnFST2NyejktNGxEaHV4MlhIYUFtMUY0U2JuZEoybXF3a1Jn
+      WjwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bm9fb2ZfdGlja2V0cz4xPC9u
+      b19vZl90aWNrZXRzPjxiYW5kX3Rva2VuPi0xLS1RMW16UTBaV0tTZWNaazl6NFdQN1pCSi1GazFR
+      bGpSTGVIODl4djlzQ1llOGJFZXYxM2hoRkhheXlfNllkVWJIQUd5d0VSNlNSeW5ZLUJlWGhUd3Ey
+      YWQtYzVoQXc4WmhLcEpubTNONjJLZnpNM3B5QnNtUC1Dd0NVSVktY2dzV3F2S1kxcS1CUUFfQ1N3
+      SmE4SFJjdGZ2WlFpSktYN3JGZGNGTHlwQzZjQ29DWGdPaF9vc3ZXY295UU1MWjd1SWlpYk9Sa1ly
+      NFV2dEl3el8xbWhvVzNQVVdmRGVnUzJzWkpzV0RpcU56bXJkZ243Tlg4cjlfZmFaRGhPSDdjOUpi
+      WjwvYmFuZF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkZXNwYXRjaF90b2tlbj5jXy0t
+      RnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJYaWgtWnkyeFNwU09EZEhh
+      SHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5OC1zaExzUlpJRW45TEJX
+      M1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tlbj48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['449']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS0HvDihIg7XFxZDKMgoBCj+Tv9Jf1kHg4Je
+        O4fKzLeqlauS2GfHCeLEOWcHJvPHxbYqEfADw3V+/0R8xj9VgKO6muEcfv+0EgdY89Mf7b8xmhGo
+        buhAyfUgYgaSD4LQgm0mCBXNtWXDkcIA+JIRSIqstR2Xqb62MCACDpon+0CW0DqgzW6YajHKDBoI
+        1DaLXis+68AHOSFFGdWAcca1XEdzHSw0mWoBZvaUOkntuTGfbMlBkP+V8WUfBohSALkx5XeQsfJ3
+        2fb+Xemh7YbJq5TMDNpUusPMbQyQp0eICYDsq7pkgjhdqYriUiBJ9HLebdodeXBW8J79abKjgtdO
+        s+3cCA9gwUn30ZUtC8B8o/2nCdlOq8UrVG9BTBLCz8OeHkIZuJvT+SvHgECrjFFaoaQoqPmp+AY0
+        VJRTkQHOkgd8NckRAscR8aWJ0WQIJF92DkACjpaPU2eiHv6rQgSwsgQeBLYC/AqJE3WmWlAydghV
+        yd3vAwDbVD1Z6hktaAFQUSoFbYJukI0a/ci+GTN6jP6zbU1rJ4viLZzImXccnbTbrOOElMKyo0nQ
+        sEFKx/AWhhMi0fqNwn/D8X/ixG/JSq8n5H6fY5CNA4iS40NUalCvTOX4Z8ajTtINCv/meNTw2nfF
+        o4b+/Jl45PtPe02WjvxK7Amd3pgVmGoJzilpGKYyhDo4V7pu6DvgH0GFR9vxZdVEKSSyS/E2MYtZ
+        9mxo7fpwcLMYt/4mWSjR3TZyJ8OkZ5TBnOHJUG9X0WTMztbFlHRdLMCc+7oYBAGs3uanU/LpaIcw
+        DNqWEd3d59CNgNqvDOXqbQxjD7QDw/YsgAKGnMPbvNSSs0IvAJaF3jSAD1tkP24RPU05vIxXX/g4
+        ADc5KLnNWDI0YIhiXiM+18hWnSCoBlO9owzq5ofsEcM/Ezg64VqdRIQ7zFQLZ7ocSI6b9IN9kKrN
+        A5B0U9QRUce5t9F8yNjyRfJDx0FHkeUNQaI9fEAZG3XdF7xnlHEA0FBGeCjfkDqkOZm+zys8J4e+
+        nGhoiXZDMkKyB9e3kzacvf4HlPHcAGbi2SOECi3yTPUO3SQCSTZM2JJpt/HP+F0jyjgT6G7aVffZ
+        dtLlnjAmQHmJ6KlzcEH5gnIycVeCb5xMty8Q+I5sVURErHSTRHa0SjEjq5/0UvCq478yMCixwnyt
+        Zac/YYXlhp1Mlky1ZMhJqfulrFnARzW8QakY3Gi5lOVXkIeIFt1wAzQkIMSv6JWtFkF/e68kPmrH
+        /2s6SfZ7rmulaZ7fHZ6wpCYsw05kOM280vArLZj4ZklKkyZ7O6yDz1FS5kBuCaTICAzFyhPtGcxY
+        RePKchB1p/yiuM6nFBDzsUQfyzP5f3Zwjc8UXplPmWoBZVZdt210nSFamY6VsWy9e46ofuxBV1Is
+        VzXbUwrDvHkNEtSBlVXalIXudWeTuhutBMPhuVlgkuo4UubOUbCgNrqQvd4RP9dbR77FLk5S5F35
+        2DT7K8FuGrQ+6jkreFUipdk5cUNLBc3x3pZ74tjXvL1lDYQmO5KPVmO6dq3RwWxQxHKCNa5DsS/W
+        pS0fen2bVcXTGIZDSu1btBoC1rBFZ4L7RmdPc7EAIHccWoK4PMCVt2GbEmsv+krUeANrsyX68/gw
+        P+v6ecguW+bUtg+z/uy9f9VDq7GmG5sWL0Flya3mZ3eh0YOr1j8tsV204eaDbp/g5pG55jcTjDxv
+        V9Pu+0ggllA4jKlOIOG0wq5rltPz9my0cFW18cZe6xam6ZFKBRNtAPvyXMPm516NdJeu4hIgNiPB
+        Hg1mKuQ9TtqO3ll8Rtgrj+pq/JEfnrjxmxWc1V7EwcF+KncGrLAJ3wMruA58F9DcdQ4243ptSvOD
+        3di3CfXisFAzzoPl5djvw+OkT485stsYyjVX0YQ3BXawXXLXLJ0vo1iyg1RSKj59HCtOS+e1pfhG
+        SuuqTaHqfUQYNfR99HUVF09ZGh8UD63+ABWMvaxC189vw09gwXLC5KrbbpL1EisHC5ZnySoI2mSJ
+        k0MlDhISKYhtxbWqZRipWIa2//uf8vwCL9AiGMFDXNCNAH8IS3JFQLLt7qViAo0U7wm6+0Dfh0rg
+        WiFqO4EcoTrPpO0ZRB8ftmI4qLdRrcR+HxYvk0a5019NxNILZaG/D7NvQA19+VUSzdRkXyuRcz34
+        yu7uQ+giHWyrOIadTKzVXY/jCx5zw8b727pPDh1BdLX94rR78whpEZIUy5HN96CGMm0VXTWcvcwI
+        +mw1WHuwhz2ObACbr8VU1xodD1YwkMddthlxTTpyur6+UehtxxjESmfKc9vOarzAj9aJXkP7PD5z
+        /MzpT8QemG0Wi94+gkGzZfqboOGdotp+PhiMdmezNbXOHe1AKFdlI7sxPFIm5UbWdGlSfJeXVq7W
+        s2EX7weqUbP2FuYd9dF4PN4u+ucBuSsFIdt1KQrJZbMcpez2iVQAKSfK1VyasgFKDSd7lJ4O9IWh
+        RE4Uz/MN1LOp2iO7sJTp6Fqiy/4BtOkn9t1QYmeXZ+m1/wcjk9WfJEeyYcmJwiFF/4Ax+SVHPhQ5
+        nQrPE8ikTiUlkdsseRHrCSpzkvSsPiCFsvryGU1woHEI3TDIbwgEuo6/NKR06ELZemKWMeY56KVQ
+        PwW4FNYXwXwMYbWo/D/dA0jiSz2gxw0n/a/0gJ5uWFoF3dLBj9Y/hup/MrPtKdcbqoPpZLVRjAO2
+        ssfieL2bAKTbI3vcXGMY2Y+3w51CBCJ+4PZCPzk6QG8miq0vunWjX9eIix7hsqGe4vCs26ap2dtA
+        wSSIBHl42I07kWVKFKcvWuxA1nbS25BerhoT1msK727Ei+PT6r0xmVDXQcvvXqh+h++1LrPNynwb
+        rsH1elI9aYdhX61l4gdqOTuYb61lovldtUx9by0/+/+rlu9BeVnL1JdqOZv3C2r5i3q+FFd9lv+a
+        oi+TnxMc+FPq2UT17GPxebJddlnWqznX/ZD2uzzRiHrWfOny5mEyn7iR8z7ZHvsX8chpR65Xj+Z2
+        NI15DzojxdKN6I2bDa2Q3bwfV+pKEt6l3tCGbOOkHK52d79Vh6fNsYOu9cLaP8lig641u9dQsE7u
+        uaY3LouDyHbZCF3FLd7t4cPl2TwbyKUn7bueQY5YZbicjI6NWcemPPYwmR2c4/xiYS3K655W5D6O
+        pyuBvtRngIhtasg1AqMJTD7e94Y0JvC0EPaImo3PZuTX+wH5I/3gu7SdrP/afvDs/69+cA/K9/eD
+        bN7P7wfUF7V91pl/rRcAx3D9impA4wqcn9IS6qglDEyKmxgcTte6Y0ne4wK7D4TgeMbttdUYGWK0
+        ah6W0LlsKa+3vhr+vjmCO6G31UdGf2SbMqV350rY6h54rTkX45ALdV912bXWXEN/esa242406ZHH
+        eG1uZ4Sxj5quxQn8pkZOehoei9KFvC75GPi7S3PhHWcCCXbXGqmfSJ2iRKsf8EJwUtXjEA99bo6j
+        b3TaOknfIPfUj1zdv0vuyV8s98/+/yrve1D+RHl/We7vj0H2W2VRkrprJD8/3H+x/GAp5dvTvz3/
+        D1lRoYe8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:38 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:11 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcl9hbmRfcmVzZXJ2ZT48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkaXNjb3Vu
+      dF90b2tlbj5jMC0tcWstOUJWS3l4MHlISTdZR1ZEMkluUlRvZGZRcVpHcDFfUXUyM0VIMjhZczVh
+      bmtVdnpkMEV4TzE0d2w3RW1GZnRDSDI3ZW1ONXkzQmxKamdsc0ZhS0JFOHZIODR2bkJyaFdiNFhB
+      aUZ5YkFNTkhYQVVLUTBqbHE0VnRtd0t3SE5PbkRMVENlT1dRUUNmdnRzODlrcldzN3BxdjVmUEZG
+      Slp3azlNbHdBZGcxYnpiV2FveXRqM2szb3ZsTVNrM05CTl9Vb2RDbXRCMERzY2k1bGZsLXBqaEpL
+      S0tYUUR3RjJaPC9kaXNjb3VudF90b2tlbj48cHV6emxlZD55ZXM8L3B1enpsZWQ+PGRlc3BhdGNo
+      X3Rva2VuPmNfLS1GeUpWRGY4RHlFRGhNWVU2Zllsa29BMUcxempMbnZkVndoN0tMSmticlhpaC1a
+      eTJ4U3BTT0RkSGFIemR5YUdqLXBySGQ0N0s3dmZDUkZYdU1FSnVValJLQnNHbldScW1IdDk4LXNo
+      THNSWklFbjlMQlczV1ZLczNQLS13Sm5RSE9fenB5WnV5VWlBLVk8L2Rlc3BhdGNoX3Rva2VuPjxj
+      cnlwdG9fYmxvY2s+TTMtLXBQNXQxM2dFYWM0a2FSQnpabTJob3ZVUmluTkhPc2syY0t2YlBualJs
+      dGRKeDJDQ2owdzY5ak45RVFxX3Zwek55a2tEVVJtOGk0aEpDblV0emJ2YjhBcUhJbGNlOEtmbWFD
+      VEtyZHBmbGxGUjhFSmFqbDdNVm9sSmdrNzMxU0wtN3pJVERUNl9YTnVwRG1FY1RxS3R1STNjRGw0
+      Y3VlRWltVG5MMHJpQWY0SHlSZXRIaklsUlRTZ3RVcFdFOF9FbVFEYnY3R2VWazlUclB5Z1B3aGh3
+      SUVTOWtNbW1nT0RPWUR6aHVsN1Y0N1c5Tl90YlNIVVB3b1FkNEZ6ZERxUy1adldIUEZCRDFIUHZr
+      Vk5XTC0yd1hVTUJZSlIxU3RSZ0szQXNfMDRiRVY1bG5DcGZFdlFvY2M3R0V6NmwtZGh2YzNzTGRG
+      dERhUGQtUHdDNTJvU29ibzFleWt2Um1KRk9jdE5wSF9YSllFME8xbVVwM0JkTmpOSXFIS0dsc3dj
+      Q3ZIdEZmTWFBRkVSV3VZc2xzekZyb2U0SHpQZVdLNjVNNE5GWktybTFjeG5FdGRpd0ZTeGpERHRq
+      TEQ0S0gyQjdJYTVvYmRSR2J0QS1aPC9jcnlwdG9fYmxvY2s+PC9jcmVhdGVfb3JkZXJfYW5kX3Jl
+      c2VydmU+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1148']
+      Content-Length: ['1032']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
+        H4sIAAAAAAAAA+VZ17ajyBV991do9YP9YNMEBaQxo1nKOaP4wiIUAhEFhZD0O/4Tf5mrCAKFO9Mz
+        9jy5V697YZ99qqhTp06oy/1ytczCBXi+7tg/f6O/U98KwJYdRbePP39b812i+u2X+l842QMiBILj
+        KcATRFsRPOAD7wLw78CEdc4PJMWxRN0WAiQQdF+QRKVuOxz5WcLJgeehmW7Zk4CmBfWj5HLkM5Qx
+        VFGGjlenKSrHScCMZQeWBLx6lankWAmYsVxTlIFfZ3KcBMpxHB8K/s2SHJPMwx5I0Pq//5XXz/AM
+        RXrezYWOIJmObNTlMkGMx8F9tGC3yuwK5pdLU+h5203jBKqh1mncFopzFgN2rPQDaIVTs9UWNvNu
+        tVZU2ufLaDi1z7f7hT37Gh9SE3U708rnbnNbYdeHnjNtzRYKc2YMvTYutTZMRWFah54+Hvglmi+C
+        U2MClVCpabwx54fDYul6HlVX1Znfu87XcMtcq5I+X+z208voaHeV4LbvnipsX5mMlUWgiFp7dPU2
+        F99aTXuarFw6zaMvMNfmRaLuodmG/kATjBMDBTMcXLviwlitbcIxGkLr0mDay03nrp9uKr3SS6Zi
+        WToav1aV3F2vZNw3l925NC0ptbPXnw/7/mofKo31WDx5PFgQfmuvUhWrtueVfYuwNoNJ96o0q/v2
+        sKhf+BKzd1Sg9GeVAS0tpYpNEaotTQNfWAUXgt21R/q9O580aaO9HILdoVPiJydRN1Qb+H3jtO1Y
+        YmvWMVc3dVWkTNbfAPNYnTGjKhXOO3pb7rmn7r4nHITbedHptOSFYSuji3K+Lc/hhhiyUFgOwv1+
+        zlLwxM9D394Q1V5fa9ityU7zWYdyl5NGWThOpdVQ8DpEv1Nsm/bu0K+W+y1QrSqsXi022s5e2A1a
+        Xb6jVCRVW57WZmviEneleltr4bAxoGmeFpf0kArCsC/3mLLsXtTN0ZKD06g1GbgGtHivt2+v5MWk
+        NFmzdOdwP5zO+3l4mbbvzqQHZ1WhTbSvxeqUmI/O5dbUpokD8tS8f3LQE20fHSkUEARdqfMURREU
+        /sFWRlViVKw2OfKFw1m6HUDgCyZQoYCwJDrU6fJ3Cp/Vr+RoMsc0wU2AjgHseqVEEP27IDSJmckb
+        zHR7atOHEeSX/c1xWbaMhWK3dsXQGajHav+2ht4UltmefiixoSfeukOeOVINW7Ya1dAkJGU3sMRF
+        cbnv9lfMsegu7hq1XTScqw/95j2w1H5jB2tMs7+CJRXuakEwIhhmvrwT7WFHde1+Q1q3LrviIqyu
+        ZuXixLLt9VzbsMydnkwIdVRrVpmpivZJvs7lNrGywopRawwtYW5VZ7bPrnZ9eRxuhgFgz0I4lw61
+        ibAMN8vL3agsNcVmxb28uFXhYNSytzPeFk53dkbcbxXPkIbu9tYxRg3Q2Hpqk2m29t37cgvPZ7dd
+        CYKDN92HpcNpTI+ac3agnsz7djE4NAmjGHqUeRN5e8j2jxq76SmUtJgEJ+CMmsKFUadiaQHkWx+u
+        GUazZn1BagwG+oyhwntb0ip3Fq3xQBlHcaCJ5/XxZBGn1rkCjMNe6YNJrbRqK3vGaDfNsNGaUaqz
+        O8zZ4q43pv25MgEOTw/ma6M/4I3JUppAum3b+pJZr3buQCn1N5AQyxfobEHp6k7b4Yy2aubtdl/D
+        hnoxYANFs8Fa8hb9S42hy8si9s1nB3n4S5yIZCewYZ3OWHk45dY5KbAVE6S/X3U/oCnTdwJPBnES
+        AlcoIBeG1EMjL33RUIAv1ztXCDxbNAs8Uis0RRmtQCm86UfcVB86UDTRkJak20CpF2vfM/6L7FXF
+        h/US9b38RvfhCxVN6IpQ1ur0G/shetbwUfJ3PV0G9WL57YMy4YsSWp0mekdQL73rPGT/T3VA5GJ1
+        LjVyvPMt7KQyLKieYxWgBlAxZgeAI59ZmZIFoOYoOSAyTWvWnOV0YnPlXpETRLv9DP2Xn4IrOxGK
+        9emaR/PneKkgo8KbC+pyPH6OGMG598fidD85iS9HIfP+lBKvtdFej3k00BOYcaIPbyioUi34EJWv
+        oqfkyPGybEdw1MibfRwW8q+JDOroCOelKcC9HpDcmUhGQFmywRcrNY7E+VJX0KRQ1E3sZI6Jc2gk
+        S545NTCjh0QlfeVQ8YxSJ0QjQ6AIFx2EUYn9AeY8J4xH4MjkMfoUFMOusXlIDLiiJ6JDg57J/DeR
+        yVe/nOHcsSWzLQLITdAvEbUIsd07W47M3mJBHBFRo3ELNeCBhBBbXtZhcsJNx1YcmwgMZIoHGMsj
+        6jiSJ8JE2RR9P/kV80UP+oiSAYkwdgIkLPxVtNx/FlrIHQL8KTkxtnDUq8TD3oAfWTcHYSsiKwgG
+        yix4JjIyVorgPijhpWoP5GmwjPc6niLaMvg8aLyclPAEZpxoHU0RHTWYLLT9ohCvlMw+gUyNiDfU
+        S8webUIeeIgj/bWtI2crjFCjiNq7jJrsiqejw4G8Ejuj4AKU6HC2jeL1RxGn4P4SlZVHIKA0mbxH
+        g/Fa8I8CjVLoCrgQ4OhdYCgaxfSMErMDKKNTqfoAotOEp3pFM5oPZORK6CiXWIYtl57ZqTCm39A/
+        y1KUOp6UqlF0wnzgaKedaoWihQjGzTHULRDRCapGUKhsr/1UpH6iqL9T9E94ps8KybivNojfUdjy
+        4JtVylArTMTb/9IeFabEFqkftkeZKv8ue5TR/z9ij2T9UayJ3RFnnWWjNeosOTIHJ5TIDBMRojQW
+        Fpqo0rLB3/zCFC3Hw4WYV+A7Kz5VjG0WP6NAWRl0UwkOm/GTiRzdqaPhRIhjRh5MGCiFaXUSKRNW
+        PC8hRfMSPmE/5iVwDUmm+pFKoo5WCAO/buqXx/AJlBLirEqm71Hy9HXLxWVVlIlSvTitxs+B6wOU
+        PUzdh09L7LwvET1N+lQeJz+McQSOEGd3U4Q6DJDNy6i2YGoVmi6yHPlAORTNj/EjQX2nKbTD5Qoq
+        szKYI7PBNNEXUFZF8UD1o6T2BOBoinMSyvxpGE1eOUu8Cl6AGg37GPsNzeCO8xXFPeon3ivK2QDg
+        TIgyI84OkU9G3/MJT8gBSqKoFc7RUiQm4DU4noXDcPz5byiHK8w4ebboZaHETznyAaUpAqVciNmC
+        YdWppMx4xTlfc6KoqsbLiaZ7wbgv+pqnhuaHOpmnFia63vsU8T8JuKi2jOdaNdrjznK17YzHK47M
+        CRJSNPxKRO2Dh87wFrmin9KSVJaUIH/46KNUZqWdAYrv+VfuaZuyELsFCspK9J8RgGs1uvTjAZh+
+        T0hfRTJ8pFzHMZOyNvKNFwwfNFO3cG5PS8v09TfiOv3DeS7yxPjriAY1R56eAInERyWsr0tm4r2v
+        YMzKomHs2CjkJdXnJlHJIO793D+fefwz3jj2e5EqzCccmUGxVNMsC9VIdC1Ojnksni87yrjwFyS8
+        3rg3QfIXKM/Bc5BPSLa0qGL3wDkA/iMb2M4DAkpcqb9SuDgd5CzQGixb4w7+7BfBEzUu7Fy0moKs
+        e7IJnhUSa3y6oni9m4jfX1qqd/CJl2uvPsHc57uIt0uIj7cPb9cOPxpZkp79z4mYZHoz9UfuXNM7
+        r+Ri5e0u7An/XRdn5OPmTEXtIMpUkdQn02wm3qyo3EJddD6d5WFOlGVUrYsS/gIE4OYiwvHPuD4R
+        LXBF3cDjPRbFTZoF0F6KdqFzdVFj6ye0xGjZQPnhLBF3wM4XI06epL8xEDpYnhxdEXwx1gvhV4dD
+        UUv8YqBNJnoagnw3nh+4roO6Q0HSTVx0CqKiYMskf2H7Qhjtly8A1HGaTxqf8IQsHvEmekAF+NYK
+        5OivEtzK/fpfBf8DL8tf9l4cAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:38 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2870']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:12 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order_and_reserve><crypto_block>E7--NuwIhns8SF9pSFmOCtayGoPi5orsAykdVtQtCufnKnVXd5ijHtnqR7hewEY9Siu9mKWZXgSi50wUnsm6QPTTn5Ap3rEh2y8qt7LQOigLgEgeiLH4ylijiJOz3cCcGHfmz-mr55XI7fNrF6K5mYhYQ3qn1nCceIO3_pGh-y2ODATK_1unwgfaRcvmf9rRBGVuoIht5KuL4JvyIf1HGwjOVpnEZgHPJm7kxU7hRzZCGSznxEZHloNsR7I2pTbq40t7v2mLo1javANm8iUGKktt-5o16BpnLLteyP0yqrtW48EZlb91SwCaca-PJX0S8BvzKCatNcVD_hETlolGxPekOoYcRxyhOS0oqh4PNL4fG5MfxXXjHxpdCbQvBrDibivFS6vhbjmFeBcQYWikaldIWXGQFooHSH2dWMs_BXrsAz6-j8VMn40F2LZish9H3g6jBjVkrnayZ4NMPTq5FtXcdK_5L7WFk2ASLauJCqJowO_bV8X2sPX_At8097h3QpXw1Kh0OkgxfUXvzDHbFI_bN0XSMiJ0al9y_p-VXab83-6hG9eHDURd6DtENaA6ZdPR1b2kCR_toknr_BpFKcDNzxpBDj9-GWfRRbpiCUM9rPYDDkijx5sFQiucuV4RNL_xRMwwjtm79e8Q_Ffs_Rbj0MXC_rEfuYOIlmhROtFCXJpXG4CNo46bV1NKHU8emAOPjTy5eN5yHKnfgvMsrKq0Ix6-yFmDNxXSz4pazVchj_p8eOwdiIe_aY0Ybh9RJBrav76RZUsxDdWqMKRqoWJyL_--Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>k0--5q_Eg4_-x1Nz1FPUkY_jXomw7H7E1_PjxiUKNYUK3emm0ERjusgvnWUYFQqZHjDGEekx61hC9iIriru1LpexlQdiFWf9oohhZR3m54tmVkLEMIItGP0eGhqQULniBgRbrSIgFusujEyS0Rw91TvO3pqX8rgNeFy0FDAL-H3GFetfBUfLnD1Zi-94KcFBeU0CKwDSXAHtxFWU5WZiFJ-wMeIriNlK_uoAMR58EAI8VqC-Z</discount_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></create_order_and_reserve>'
+    body: !!binary |
+      PHRyYW5zYWN0aW9uX2luZm8+PHVzZXJfcGFzc3dkPmRlbW9wYXNzPC91c2VyX3Bhc3N3ZD48ZGVz
+      Y3JpYmVfdHJvbGxleSAvPjxwdXp6bGVkPnllczwvcHV6emxlZD48ZGVzY3JpYmVfY3VzdG9tZXIg
+      Lz48ZGVzY3JpYmVfZXh0ZXJuYWxfc2FsZV9wYWdlIC8+PHVzZXJfaWQ+ZGVtbzwvdXNlcl9pZD48
+      dHJhbnNhY3Rpb25faWQ+VDAwMC0wMDAwLTc2SzgtSzM4QjwvdHJhbnNhY3Rpb25faWQ+PC90cmFu
+      c2FjdGlvbl9pbmZvPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1408']
+      Content-Length: ['241']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VZx7aryBWd+yvkN/HA5gmEAKkXrV6gxL3KOUxYhCKIKKpQ+p3+E3+ZiyCBpPva
-        3e2e+Q2uqH12pVN1Uj3+l4vnVk4ggnbg//yN+k5+qwBfC3TbN3/+tlr2iMa3X1p/47UIKAjIQaSD
-        SFZ8XY4ABNEJJL+xi1o8jFU98BTbl2MskG0oq4reugLIV78W8VocRXiqa/El43lBy1RDvvoMFQxD
-        0VAQtSiSLHFysGD5saeCqNWosSVWDhas0FU0AFu1EieHSpwAIhlePTVwq2U4Ajna+vev5f4FXqC4
-        X3QNUSCrbqA5LYcliFsf0MOONF2y8ajX767bO7G537nRlp2TXU8OHQj3XExwJG13h6TQJqzzp3Oy
-        tIu/C4P1wAnq0pCiO0M0qYmzro8GhxHSu9apsVPbn1fTDM/yfi1s42Ub6aoEN7eAblI7eTwR9rVP
-        B5FIVZk+iM89fXo2dTBiA8jqZjwOBI2lJhQRxENtq82Yy3HLjgmd2sQ1t386mhdiTxsTGHbM5bre
-        2zXOqv8hxtv6bsEsaqf9pX+Y13audfxcMQNoBKdlx2ksHCN0hp8fxmrLMKFI0pt+kxFpUjf69cGn
-        06DbrG8yt01nILnMTnXlkT+NApk5dNwtOYhuoWRfrL0+qgPlAvrrXs84TdzZDB5d/wI/l9xxIx6Z
-        WIKi8kl8bJuuoi/s6UJzPuVNpzcM4+XcDkXCHthgMr40rztK1o6xFcpHdhtQ8/beZEYnSAfSfLe7
-        +LA5Eqcd4+iLn8zgODqe69dR7yQ1SU6io9nCQ9aocfC3VGfLsb4ecAftoz4yprF0PvcGzMoZOEeO
-        U9Cpt+sQjvcZDtkJ+anOt1FfCK3ZeaqhU6j3e5ZHnTSTXCO5fVnW1dACzqS73jHS1JM6Hc7dRrdo
-        ohoOUb/Czk7ccs5iofVI1CQbdo++sdtz3JscztOIaThQ3+r7rUTLN+JDG9cHxpUgAp/ec5vNsDZn
-        nbUujPvn+gd1aNr02dh3UZeD1NFAJHmZkWeLsYgNtfdH4XA1nklXdgDl/szZHTYD/6bTREgBKJz1
-        LWeMd8OrdOl02elsJYmNNr2RuXVway8lYrRQtQ4p6brTnUwXjaFhmfq6pxhDpk7ssSWU7z+PIsWH
-        2GSxx5FtvbUnSZIgkz80x82JES0KfPWFw3u2HyMAZRcYSMZY7n5aLPmdTHzBj+R4ssB1wVVGgQP8
-        VpfBtueYeCOsE/V2pyE3Pc3blCMjZr63hz6LPK/zwSkRmkhK9xicBUk7oxMjhGMXCvp26Um37cq/
-        egtVd3ymuSFIa6TH/fl1srZ1cXl1BdNZ+fvbxHFdi5VN6RZtu+shc+r7H3t5Ov2o79xhk6oRXNSV
-        uc5yfGy7wlzeWDprO8qie95MNrVZNPBHXOODERYTJ7p6Xi+8hbP91dONRf3aJwTiY7aZLNcLTqAu
-        O6bhtXs7r7uM+uH2sDClUV+WTj1w+JieJjchCjrz3ZKdU85Ui+erm6T7h+YiUufS2dtNe8NT3XIc
-        0uNOctOZozlwrmZAz2KOhj26HxzVA9XYT2bj27yuGaC2GpkNrzdYnqNrp7YYNpaogYLzObbURqj7
-        K789QatIoTvnBuhwQ8KGRvdTnpkCaQd7trOLd/rUqKtz8qiKVMBSa00c9ZyhxzLbVX9C0F6DOLHj
-        XS9URNJ0a/ZiwIhHYREY05BrQC+eizQgjuJ2AGfN3WQgCnt3dpO6zCg0KbVXPymHqxcFq9k43Cy2
-        0nRAiJc2x52X7dtlMg/RXlFn7swzN1MLbIdoIbKb2UG5eTeOrItaD/jb+nZNuBqhoTkzsqDNKpwT
-        qkvg92bLntefro+LOrgcyU3srSThcBAbA9/1b6p/FrqTviAdVzNHEH1ASmR3L4rJ3X++gI/7mEVS
-        LYh91KIKVhm+c1u8Gvu6C+6/r32/QO9MGMSRBrIgCi5IxiaCyEePsvSlhw6g1lpidmVxhQh4lT2I
-        gteOKeneEQVIcfFYnmr7QG/Vmt+LiV5kr10gatHkd+aNDtELFU8YKkizWtQb+yF67gFx2hJGtgZa
-        NfZtQYXwpRPenaVEJmjR730esv+nBEYHqo1XKGtWYKfj50AhyS6MBSqd2POulbYS6ZVOJuOrT6RH
-        F9tHwIyU1MfrClKqhchXPNDSk5GKzin2YKBr+MZIsUez+CqWndpIMkh2WbIFtRMr01DFiAKvgvAW
-        TsCPQdK7zCo6eQBZgV4C0iNuT8RJqU927KUmvszprX2G/selJKk11lxrvFri+Uu8u6CgpsrRsvFL
-        xIfOXjdnw9yVvJh0YcV3SrbXxXLV6Y6XeKgnuGClS1+gWAc+quBjByVqti0/kAMjtUqY+LVyM5ch
-        W3NAWXoH+FdDL9l2PgJOI4Z7ut7kq0lCYet4UqTYbmIsgZskGaks/+aN2E0/8i73Jo+rF5xbIDwy
-        Arp8ssG55WPH+AXMR8E5G4Gv5p/pUrATvmTKqSZAqGBdBBH+rpbXVM1X/eKLSu6nWhwRwNcE/yi4
-        SMu03t3w1aKVCVIdd3Gpdz1bIAI5IffhthmH8klxY5C5pjLAazbK/Zgb4KTXJ2IHK+oBZvJ0oGEq
-        z4XZ0JqrQJj/ZHx8rxWULKCE5fK7FynLs2GwgtMSMhsurSufoUS3WDeygwNmPkM11eIdTErUnHrv
-        +UCexit4Xwzp2Dr8ethsI7n8CSso6V56ime71xIp22G1mLd6V1pyvFGu5lTpZeAhTvuvfBtfvcoA
-        F+642i6o+SlENjYVfEeTqymHAIfvJHlIo9CXIl5P6n2chZtABr6et/Pzif9VoRrIqgixGeMUoUZS
-        OE4VhIwbIw1bqAEBju5sMtErWtAg0PDFwWZd5yimzpBP7Lswo1/xP8/TsTfCk5INqpEzHzg+3KDB
-        kpScwslTBbJx4EjoBNkgqMaSav5Ekz+R5D9J6qdkpq875OO+aiBrQ4RLhDed1CisDAF7HfevVAlL
-        1Vi6/rtVUq9Rf0gldaJG/RmV5CpIXU92H5MgNBfag+6cr5bgnJKqYaQgbEjniogTSB/8A1bGeDuR
-        gn149Pd7p0xf2Tf2mexH7y5JPGj25eJbHhSOpAzmDLw8FMOWa58e8hy6E7IIWb2300AIbS9MUr00
-        qtz7ZSEy+45DCHAkcG2IntbYfV/jj9ae4INVGa9+MbYJAjmL4C7OkJKo2WLS/OHR5LEzNrNPgvxO
-        JaIHwFeL/pYCZRwssWEbMI1VT0DiC5NQA/SHE8ybvKdc5Cj2fazW7PypWlJpv6JJbf4V7xXlfQCS
-        AIcDHopxmpncpXQ9X+E5Oc7SwxLtjmSEZA9B5Ck+jvPp8t9QPkmAs5jYpuaV+nLMVx/Q3cHjSIoS
-        tux4LTLPHl5xHlpB6h6NbDvZ0+Yzxv+g3noqtH67wnoqrdLsL0+vhM6wO19susPhgq+WBDkpy64U
-        XKhE2Kw2+CLBOy0PL3mS8KesEYcW715/YPdSbvJP2i483gbo2CNySZT46z0ihx3/H/CI3JtH/JGJ
-        JrYRBoGbp53pIb9gicW4tpdE23vqd2/+N0fL/V5Hm16pbHWE0BTwlc2BXAJxiglt1c2v4SuYsQoP
-        l91Q7Mby7HCddykg/t2An403+ZsdHPedJivTEV8toExqWZ6HsxaqSacBvIxl8xU2mSTmsprsN509
-        2eALVOYkc1SfkGJraUYdgWMM4MPD+8EDAnqWSb9S+MzFlzTQ/pi3h91k2S+CJ2qWaoV4NxXNjjQX
-        PHfItfHVU8jrG0jWfil53sEnXqn8+Qrmv37zeHvs+PKV4+154/f6lbym/otdX/X+5vVnXovvr2n5
-        y83bK9sT/oee5KqPNzkD12k41qRSWL3HI+XqpYmPEunlgFSGeUXTQIgUNVkBBpI8P8WTv1my4SlJ
-        LYlVUkCZNHfbZWmurmKI54GwfqOk/cOxXgi/ORz2L8oPBloXoqchqu+7hXEYBhGCsmq7Sc4mK7qO
-        i2d4/9/CH0hTDUMZ4BrNfYD3xOAVz8mKmag9AgZIHrJAif4qSeqg3/4vzv8A6NIYbysdAAA=
+        H4sIAAAAAAAAA7VY21LkNhB9z1e4eEgeEmN7bjBE6xS3rWwBu1swhKq8uDS2ZsaFLU0kGZjvyZ/k
+        y9K62JY9ZkM2WR4Y6/RpXVqt7pbQLy9l4T0RLnJG3x1Eh+GBR2jKspyu3x3cL977xwe/xN8hyTEV
+        OJXASnK6YgknoipkjES1zFiJc5pUgvAkF8kSZzFlKBiWIPIiCae4SAQuSLLFaxLEqMB0XcFnUuRC
+        xoSioIugMqeVJCIpyEomMAcYnvAnEkfTwxAFr0lRySjZrQr2nKQbTCkpElgaiTNSwgRfESIOUkkS
+        kUs1NdsXzJ8dz8IoyTDIMM0SmZckHoXRzA+nfjhZREcn4fFJNPodBV/WabpUdonREqePBGRrzqqt
+        nhpY2NooI8tcGgkKukSUMmBRK4WJZmSFYUtgERWVfGcWUz2iYFCA1H6Mlnqn7CfMC4akGKZ4AbOg
+        AjZdbbh3D/NUi6qlSEhYUKkGz4hIeb6VjAcK3hUkXuUvJPMlXgrwAY0oJ0nMp/6f+Xi18u20tKMk
+        LrFpgg+CqQTz14QSnqeW2qUrI8LYxscyu7V1q90KY2vXjdUiKhFbQoaCASEosKIgO9ilimZqSPOb
+        MJ7BCNqicQRbs4/WTMEqnhJjdPD9BPxUho2GK+1pKNPGl/a0eAtQ886MB3h7+ppb60smsfLlcplT
+        ksXj+WHL78n6KnDUJuHhdI8uZI8KA26xTDdxtMduRF0NQbDcwiaSeDzdm1Ar7CnB6jaYr0k82ddp
+        ZCitOIeotWu/jEXXSzg2XahlrGCrGY+jMHQ4FmxZtCqX4DnHo5nDsmDL2hY4JSIeORwLORywYiJ2
+        5ZIVgQtzYtH4rz9d/RZv0RhpF1OH3RjZ7Py5ctJUeivOSk9uCAR0WhF18l1Wq1QSuWGZA2jTnH86
+        ++ToGHM5TXACvdtd6D9ORWUJLHH88X4B4zu8WtBS5W5L4tT07xA17LSbxeXCnsTeUWi9v6aYtZ5e
+        3F8voKMO2HL0xE8zCFkeRAeaYZ45ZLMsyhK20t4sVFhwm1YmczjCrrQGUP+AOGfC9gAB7XQxns0h
+        YmeqBYNKnBfKyVihwp2W2W+0qgr9YVXqpgr8EPMk9CxJljzl5LlOAn0YcciNugeIo+ZTTwVi2Isx
+        jwr6ZIshT+gEELhzCuyse2fYObZBu0UE3AR+MCQZY/fLBxS0LSMwERGKld3zhnBiCcbyaS7tCS8Y
+        zRj1VeZrQSPX1Gstt0KrXGAh7I/hYy4hfTmAFRonAKH3PS63P3vn4A6VmoojVhbWdY/pdkeEtq4D
+        KSuCFZJHyCxqpEAbq0ZUWrO8Wq1BOp21vH5/GaYpGe7UVkCW0AFbjl7HGYajJu1CL3oKZqVBO4Wg
+        NmK//OiWHXVL699TqLEy7woSPZSKLdXuCs/hcIBXKmdMtgQSncq2Ol4PipCusyCLQ9kIadK2dWeL
+        TfWTF0EKvSNbKF0genuqdAMXbCiGXckUTuVKEAmnSQ3VR1uaIFCCZXCUJ0ejo+mky66Fhr6Dv7LM
+        Ml0vhvMwsswGR18qL+d+GC2i+ck4PAnDH8PoRI30Sm0ZDNrAtCFscblnlanceDd493/aYzaaHI3D
+        N9tjGk7/lT2g3J5+jT3s+nWsMe6oss7t6fnV5S0KHNhStBlusIQ09uydQaVFyQ/C+wjL4aoQ497i
+        8m5RKxqbmW8IlLMP72uJCpvmqwBHZzF0h6WKGS5oGZDCNnEAyn5pxvWXelxf+LQZ11c1ZFDraxWr
+        bsvWIn9quq8rWdsyWTWo2zp5irzcqrJKZ6Jaz6RV811tBYHsYa5izhIv95cIXze/hi4eDPSxJiwx
+        2b2AK4aswOZTqC1G81kUjY/U7c+iCKL52nz64WEUwg5PZ1BmtTAK2s42WCSQVSEerIROah1ARVOV
+        kyDz12HUNlGJXxJeUQpbYfwmGqlrZR9V19AhXh9FlBCVCSEzquygfVLPZwi35MpcthxajRiCWgPj
+        pQrDZvp7KFIVpkme59GtN1l8REED1SkCUq5U7OSxjENbZvRxJDZMR9WVWY4eroehV+41nQvNm24y
+        nSuMvrgNRfwhAdK1pRnr7vTi+vL27uHy+voOBY7AknT3dxiuDxzO8AO4oqhpNpXZEuSrjz6ksrK+
+        GUB8d5uos01tiH0gGWSl6FsE4Pk8mrw9AEf7Cem1SKaO1Jaxwpa12jd6mDpoRV6q3F6XlnXzH+J6
+        9OY8pz3RzM4/DT+Dp1vASgSUsCJfFtZ7+6BhtdHQODaEPFt9/mZVWgipcc3GHB2OQ+/zDQpayEg3
+        m7KEGiiam+TnYqa/9qiqwj5ZqvWYuwfIe5DLUWMEHaSduq7IOfmjIqKJ9pQ1kHrZGKIgE+6dFZ5/
+        uD2/vlTT7gk6VFO4bWE1XprztCBdBWuNoSeI/tuDafeuTPtgh+dcn4ZgNPzWsPfIMPi6sPes8NbI
+        Ye/k3yYiBvXLU+cJNosX4GJ+qP4dza6O/avx8Vn3CUudBft8ldiHk+a9ahBv2L3HrSG4QePeoM7b
+        8N85QgmKXBYAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3017']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:38 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1891']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:12 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['108']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:39 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <transaction_info><describe_external_sale_page /><describe_trolley /><user_id>whitelabel-testuser</user_id><describe_customer
-      /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><transaction_id>Z000-0000-377R-M3BA</transaction_id></transaction_info>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['412']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61YzXLbNhC+9ylYX3poZZKSLckehBnHVWYycZyOLdczvnAgEpI4BgEVAG3refom
-        fbIufkiCFJ0maXywgG8/AIvlYncB9PalpMETEbLg7M1RfBwdBYRlPC/Y5s3R3fL9aH70NvkJKYGZ
-        xJkCVlqwNU8FkRVVCZLVKuclLlhaSSLSQqYrnCd7IlE4LELkRRHBME0lpiTd4Q0JE0Qx21TQTGkh
-        VUIYCrsIKgtWKSJTStYqBSVgfSKeSDKNjiMUviZFJWdkv6b8Oc22mDFCU9gbSZ63hSIUrwgdwTCl
-        9YNJhrlIkJIrkkoYEuqemRq2w+fTKE5zDDLM8lQVJUnGUTwdRSejcbSM4/P47Hxy9oDCL49pptRq
-        JGiFs0cCso3g1S5R8hmFXQhlnCnClO2CSjlZY/gYoG7FlNhbtatHFA4KYDkwPsOw8hL2HtxrWwRX
-        2hjBnTFES0BSgaqlXiwnMhPFTnERanhPSbKrBIHPbNraEVLTDF2719ebg6Z1hXz4C9TC1mLWJL73
-        aY0qmThCjsIBIQzglJI9GLNiudbO/qZc5LCCMUcSg10P0ZopeSUyYi0GHptqJaNmhC/tjdB2soa9
-        3UuwXfBABO8PNKR6oOIKa18rVwUjeTI+O24X6sn6Q+BkTKLj0wO6VD0qLLjDKtsm8QG7EXVHSILV
-        ThQZ+PT0QKFW2BsEu9tisSHJ5HBMI0NZJQREmX3bsqbcrHYo7EItYw3fmIskjiKP48CWxapyBS4z
-        H089lgNb1o7ijMhk7HEc5HHAiqnclytOQx8WxKHJP3/741u8RRNkfEsfUWtk++UvtXdmKlgLXgZq
-        SyAAs4ro8+qz2kElUVuee4AxzeXnd5+9MdZcXhecwHztLvQ/VdFBHSucXN8tYX2PVwtaqtrvSJLZ
-        +T2igb1+s7lCuiPYOwqt99cUu9fb5d3vi+slTNWBW5ZR/VZVOcSvQEAg86h2W4ynfG28Wep44Hed
-        TBUQen1pDaD+AfHOhJsBItnVw+TkDIU6phU5LKpwQbWTcarjnJG5NlpX1DTckLqLIG9CsFMwsyJ5
-        +lSQ54RBQBmAkYDcZWaAAGqbRhUIXi/WODoWkx0GW5gwHvo6hU7r3hn2jm3YfiICbgI/GFKFtfri
-        HoVtzwqMjRdQXOyft0SnihZFq2JT7dInTCtij7QPoKxQ7vxTznLORjqbtaCVm4mujNwJ7dQZxVK6
-        H8sHv8ZKK+BhTm7DdVdupwEDm+LFTmcqmi6kbQu2SR8h0bgVQmPFGtR5z1HrkQ3Sma/lDUz5WORy
-        eFq7ESfvYC3F7OU9Lgu690h2h2G7blgbrV9CdEuHumfG3zFI4XnwEUpFqPNaqvsKooCjAj6qXTPd
-        EUh7Ouma6D0oQqYqgmQONR8UO67vvk/1WxDP1Ta4qDYVpFZdZoE7NgTLrVQGJ3QtCWTFqV6oj7Y0
-        SaCIyuFYn8zi05PTqMOuhZa+h7+yzHNT20XzeO6YDY6+VArOR/F8qevA6DyKfo3ic73SK3VgOGgB
-        24fKRqgDm4xjMMYFRB36I00yjcfTyclXm+RkHH+TSaA6jr/HJM4EJvRYf9RJ6Obi8uPiBoUe7CjG
-        DJ+wgoP0HLyDwouRX2RwDdsRup4WP9eDrL1sG2Lm9MP7WqIjqG1R8HLeBhIfdAxXe9LiqZHX5ajr
-        2QwZ1n2TCGVR7nSJZLJKPc6mSNuudpJAJrC3IE/HxaGOr+mu8Y93Ph4OzL0hPLUZnGJV6KyZnJr6
-        oekiCMYb2xxFx7EWNQAK2/FbLFNIlnCw19Lkqg6gY6FONSRvgqDrohK/pKJiDMxqv3881pe7Pqov
-        g0O8PooYITrBQcJTcFUxvmX0GcIduYLcCDcJj1YjlqD3wEWJGeR5o/4BinThaHPiZXwTnCyvUdhA
-        dYCHTKo0O30sk8hVD30cyS034XFtt2Mv1V0MvXJP6VxQvnwz6VxJTPXnyquL368WN7f3i6urWxR6
-        Akey1RWGAl/AsboHR5I1zaUXVyR812mE1FLWdTuEF7+LOtZuI949ySEiznSW+PERcQaB/xsi4uwg
-        Ir52RPXZ2HFOXdlpPnIP0yeGFqXOtnXpV3f/K9DOvjbQGpey2o0uzi7AZR3gJBJKTFmsqHPDPmhZ
-        bYSzHgphzFWHf7ohLYT0uvbDzI4nUfDHJ7jKN5CVbrdlCVVJfDYxCdrH7HztmdOFd7rS+zGz6w30
-        IJ+j1wg7SKu6qZgF+asisongjDeQfnIYoiAbwr0dXn64ubxaaLV7gg7VllI72E2QFSKjpDvAWWPo
-        iaD/NmD7vSvNIdjhedebIRgNvwUcPAIM3v4Prv1fGzfcnfkHh7awfgvqvGXmyQP41ijS/yaz2c3o
-        0+TdRfdRSR8C96CUuheN5gVpEG/YveemIbhBk96i3iPrvxWLSz6lFQAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1809']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:39 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/CombinedOrderReservationTests.test_reservation_is_reservation.yaml
+++ b/tests/interface_objects/cassettes/CombinedOrderReservationTests.test_reservation_is_reservation.yaml
@@ -1,495 +1,446 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:39 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:12 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:40 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:13 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:40 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:13 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGNyeXB0b19ibG9jaz5FMC0tRXhJNTJKUkNxLWdMRHN2eDR3blVa
+      elpTV1NZRHFxZXZKRkd2bDRwb0NpdkNxVVVmdlVMQVhnOWJwOVhnNi1jY0s1THRRSlN2Um1MZXZl
+      eGUxMzBpNXo1UWdFV3puMVdtRTJ5WHdnVnhkTm85U21KZmNlWHlZN0tNTnQ4enV5Vkp3OWFSWE9T
+      ajV5Rk5wLTB3QWR2MktCSHZwaDZjRnFST2NyejktNGxEaHV4MlhIYUFtMUY0U2JuZEoybXF3a1Jn
+      WjwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bm9fb2ZfdGlja2V0cz4xPC9u
+      b19vZl90aWNrZXRzPjxiYW5kX3Rva2VuPi0xLS1RMW16UTBaV0tTZWNaazl6NFdQN1pCSi1GazFR
+      bGpSTGVIODl4djlzQ1llOGJFZXYxM2hoRkhheXlfNllkVWJIQUd5d0VSNlNSeW5ZLUJlWGhUd3Ey
+      YWQtYzVoQXc4WmhLcEpubTNONjJLZnpNM3B5QnNtUC1Dd0NVSVktY2dzV3F2S1kxcS1CUUFfQ1N3
+      SmE4SFJjdGZ2WlFpSktYN3JGZGNGTHlwQzZjQ29DWGdPaF9vc3ZXY295UU1MWjd1SWlpYk9Sa1ly
+      NFV2dEl3el8xbWhvVzNQVVdmRGVnUzJzWkpzV0RpcU56bXJkZ243Tlg4cjlfZmFaRGhPSDdjOUpi
+      WjwvYmFuZF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkZXNwYXRjaF90b2tlbj5jXy0t
+      RnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJYaWgtWnkyeFNwU09EZEhh
+      SHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5OC1zaExzUlpJRW45TEJX
+      M1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tlbj48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['449']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS0HvDihIg7XFxZDKMgoBCj+Tv9Jf1kHg4Je
+        O4fKzLeqlauS2GfHCeLEOWcHJvPHxbYqEfADw3V+/0R8xj9VgKO6muEcfv+0EgdY89Mf7b8xmhGo
+        buhAyfUgYgaSD4LQgm0mCBXNtWXDkcIA+JIRSIqstR2Xqb62MCACDpon+0CW0DqgzW6YajHKDBoI
+        1DaLXis+68AHOSFFGdWAcca1XEdzHSw0mWoBZvaUOkntuTGfbMlBkP+V8WUfBohSALkx5XeQsfJ3
+        2fb+Xemh7YbJq5TMDNpUusPMbQyQp0eICYDsq7pkgjhdqYriUiBJ9HLebdodeXBW8J79abKjgtdO
+        s+3cCA9gwUn30ZUtC8B8o/2nCdlOq8UrVG9BTBLCz8OeHkIZuJvT+SvHgECrjFFaoaQoqPmp+AY0
+        VJRTkQHOkgd8NckRAscR8aWJ0WQIJF92DkACjpaPU2eiHv6rQgSwsgQeBLYC/AqJE3WmWlAydghV
+        yd3vAwDbVD1Z6hktaAFQUSoFbYJukI0a/ci+GTN6jP6zbU1rJ4viLZzImXccnbTbrOOElMKyo0nQ
+        sEFKx/AWhhMi0fqNwn/D8X/ixG/JSq8n5H6fY5CNA4iS40NUalCvTOX4Z8ajTtINCv/meNTw2nfF
+        o4b+/Jl45PtPe02WjvxK7Amd3pgVmGoJzilpGKYyhDo4V7pu6DvgH0GFR9vxZdVEKSSyS/E2MYtZ
+        9mxo7fpwcLMYt/4mWSjR3TZyJ8OkZ5TBnOHJUG9X0WTMztbFlHRdLMCc+7oYBAGs3uanU/LpaIcw
+        DNqWEd3d59CNgNqvDOXqbQxjD7QDw/YsgAKGnMPbvNSSs0IvAJaF3jSAD1tkP24RPU05vIxXX/g4
+        ADc5KLnNWDI0YIhiXiM+18hWnSCoBlO9owzq5ofsEcM/Ezg64VqdRIQ7zFQLZ7ocSI6b9IN9kKrN
+        A5B0U9QRUce5t9F8yNjyRfJDx0FHkeUNQaI9fEAZG3XdF7xnlHEA0FBGeCjfkDqkOZm+zys8J4e+
+        nGhoiXZDMkKyB9e3kzacvf4HlPHcAGbi2SOECi3yTPUO3SQCSTZM2JJpt/HP+F0jyjgT6G7aVffZ
+        dtLlnjAmQHmJ6KlzcEH5gnIycVeCb5xMty8Q+I5sVURErHSTRHa0SjEjq5/0UvCq478yMCixwnyt
+        Zac/YYXlhp1Mlky1ZMhJqfulrFnARzW8QakY3Gi5lOVXkIeIFt1wAzQkIMSv6JWtFkF/e68kPmrH
+        /2s6SfZ7rmulaZ7fHZ6wpCYsw05kOM280vArLZj4ZklKkyZ7O6yDz1FS5kBuCaTICAzFyhPtGcxY
+        RePKchB1p/yiuM6nFBDzsUQfyzP5f3Zwjc8UXplPmWoBZVZdt210nSFamY6VsWy9e46ofuxBV1Is
+        VzXbUwrDvHkNEtSBlVXalIXudWeTuhutBMPhuVlgkuo4UubOUbCgNrqQvd4RP9dbR77FLk5S5F35
+        2DT7K8FuGrQ+6jkreFUipdk5cUNLBc3x3pZ74tjXvL1lDYQmO5KPVmO6dq3RwWxQxHKCNa5DsS/W
+        pS0fen2bVcXTGIZDSu1btBoC1rBFZ4L7RmdPc7EAIHccWoK4PMCVt2GbEmsv+krUeANrsyX68/gw
+        P+v6ecguW+bUtg+z/uy9f9VDq7GmG5sWL0Flya3mZ3eh0YOr1j8tsV204eaDbp/g5pG55jcTjDxv
+        V9Pu+0ggllA4jKlOIOG0wq5rltPz9my0cFW18cZe6xam6ZFKBRNtAPvyXMPm516NdJeu4hIgNiPB
+        Hg1mKuQ9TtqO3ll8Rtgrj+pq/JEfnrjxmxWc1V7EwcF+KncGrLAJ3wMruA58F9DcdQ4243ptSvOD
+        3di3CfXisFAzzoPl5djvw+OkT485stsYyjVX0YQ3BXawXXLXLJ0vo1iyg1RSKj59HCtOS+e1pfhG
+        SuuqTaHqfUQYNfR99HUVF09ZGh8UD63+ABWMvaxC189vw09gwXLC5KrbbpL1EisHC5ZnySoI2mSJ
+        k0MlDhISKYhtxbWqZRipWIa2//uf8vwCL9AiGMFDXNCNAH8IS3JFQLLt7qViAo0U7wm6+0Dfh0rg
+        WiFqO4EcoTrPpO0ZRB8ftmI4qLdRrcR+HxYvk0a5019NxNILZaG/D7NvQA19+VUSzdRkXyuRcz34
+        yu7uQ+giHWyrOIadTKzVXY/jCx5zw8b727pPDh1BdLX94rR78whpEZIUy5HN96CGMm0VXTWcvcwI
+        +mw1WHuwhz2ObACbr8VU1xodD1YwkMddthlxTTpyur6+UehtxxjESmfKc9vOarzAj9aJXkP7PD5z
+        /MzpT8QemG0Wi94+gkGzZfqboOGdotp+PhiMdmezNbXOHe1AKFdlI7sxPFIm5UbWdGlSfJeXVq7W
+        s2EX7weqUbP2FuYd9dF4PN4u+ucBuSsFIdt1KQrJZbMcpez2iVQAKSfK1VyasgFKDSd7lJ4O9IWh
+        RE4Uz/MN1LOp2iO7sJTp6Fqiy/4BtOkn9t1QYmeXZ+m1/wcjk9WfJEeyYcmJwiFF/4Ax+SVHPhQ5
+        nQrPE8ikTiUlkdsseRHrCSpzkvSsPiCFsvryGU1woHEI3TDIbwgEuo6/NKR06ELZemKWMeY56KVQ
+        PwW4FNYXwXwMYbWo/D/dA0jiSz2gxw0n/a/0gJ5uWFoF3dLBj9Y/hup/MrPtKdcbqoPpZLVRjAO2
+        ssfieL2bAKTbI3vcXGMY2Y+3w51CBCJ+4PZCPzk6QG8miq0vunWjX9eIix7hsqGe4vCs26ap2dtA
+        wSSIBHl42I07kWVKFKcvWuxA1nbS25BerhoT1msK727Ei+PT6r0xmVDXQcvvXqh+h++1LrPNynwb
+        rsH1elI9aYdhX61l4gdqOTuYb61lovldtUx9by0/+/+rlu9BeVnL1JdqOZv3C2r5i3q+FFd9lv+a
+        oi+TnxMc+FPq2UT17GPxebJddlnWqznX/ZD2uzzRiHrWfOny5mEyn7iR8z7ZHvsX8chpR65Xj+Z2
+        NI15DzojxdKN6I2bDa2Q3bwfV+pKEt6l3tCGbOOkHK52d79Vh6fNsYOu9cLaP8lig641u9dQsE7u
+        uaY3LouDyHbZCF3FLd7t4cPl2TwbyKUn7bueQY5YZbicjI6NWcemPPYwmR2c4/xiYS3K655W5D6O
+        pyuBvtRngIhtasg1AqMJTD7e94Y0JvC0EPaImo3PZuTX+wH5I/3gu7SdrP/afvDs/69+cA/K9/eD
+        bN7P7wfUF7V91pl/rRcAx3D9impA4wqcn9IS6qglDEyKmxgcTte6Y0ne4wK7D4TgeMbttdUYGWK0
+        ah6W0LlsKa+3vhr+vjmCO6G31UdGf2SbMqV350rY6h54rTkX45ALdV912bXWXEN/esa242406ZHH
+        eG1uZ4Sxj5quxQn8pkZOehoei9KFvC75GPi7S3PhHWcCCXbXGqmfSJ2iRKsf8EJwUtXjEA99bo6j
+        b3TaOknfIPfUj1zdv0vuyV8s98/+/yrve1D+RHl/We7vj0H2W2VRkrprJD8/3H+x/GAp5dvTvz3/
+        D1lRoYe8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:40 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:13 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcl9hbmRfcmVzZXJ2ZT48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkaXNjb3Vu
+      dF90b2tlbj5jMC0tcWstOUJWS3l4MHlISTdZR1ZEMkluUlRvZGZRcVpHcDFfUXUyM0VIMjhZczVh
+      bmtVdnpkMEV4TzE0d2w3RW1GZnRDSDI3ZW1ONXkzQmxKamdsc0ZhS0JFOHZIODR2bkJyaFdiNFhB
+      aUZ5YkFNTkhYQVVLUTBqbHE0VnRtd0t3SE5PbkRMVENlT1dRUUNmdnRzODlrcldzN3BxdjVmUEZG
+      Slp3azlNbHdBZGcxYnpiV2FveXRqM2szb3ZsTVNrM05CTl9Vb2RDbXRCMERzY2k1bGZsLXBqaEpL
+      S0tYUUR3RjJaPC9kaXNjb3VudF90b2tlbj48cHV6emxlZD55ZXM8L3B1enpsZWQ+PGRlc3BhdGNo
+      X3Rva2VuPmNfLS1GeUpWRGY4RHlFRGhNWVU2Zllsa29BMUcxempMbnZkVndoN0tMSmticlhpaC1a
+      eTJ4U3BTT0RkSGFIemR5YUdqLXBySGQ0N0s3dmZDUkZYdU1FSnVValJLQnNHbldScW1IdDk4LXNo
+      THNSWklFbjlMQlczV1ZLczNQLS13Sm5RSE9fenB5WnV5VWlBLVk8L2Rlc3BhdGNoX3Rva2VuPjxj
+      cnlwdG9fYmxvY2s+TTMtLXBQNXQxM2dFYWM0a2FSQnpabTJob3ZVUmluTkhPc2syY0t2YlBualJs
+      dGRKeDJDQ2owdzY5ak45RVFxX3Zwek55a2tEVVJtOGk0aEpDblV0emJ2YjhBcUhJbGNlOEtmbWFD
+      VEtyZHBmbGxGUjhFSmFqbDdNVm9sSmdrNzMxU0wtN3pJVERUNl9YTnVwRG1FY1RxS3R1STNjRGw0
+      Y3VlRWltVG5MMHJpQWY0SHlSZXRIaklsUlRTZ3RVcFdFOF9FbVFEYnY3R2VWazlUclB5Z1B3aGh3
+      SUVTOWtNbW1nT0RPWUR6aHVsN1Y0N1c5Tl90YlNIVVB3b1FkNEZ6ZERxUy1adldIUEZCRDFIUHZr
+      Vk5XTC0yd1hVTUJZSlIxU3RSZ0szQXNfMDRiRVY1bG5DcGZFdlFvY2M3R0V6NmwtZGh2YzNzTGRG
+      dERhUGQtUHdDNTJvU29ibzFleWt2Um1KRk9jdE5wSF9YSllFME8xbVVwM0JkTmpOSXFIS0dsc3dj
+      Q3ZIdEZmTWFBRkVSV3VZc2xzekZyb2U0SHpQZVdLNjVNNE5GWktybTFjeG5FdGRpd0ZTeGpERHRq
+      TEQ0S0gyQjdJYTVvYmRSR2J0QS1aPC9jcnlwdG9fYmxvY2s+PC9jcmVhdGVfb3JkZXJfYW5kX3Jl
+      c2VydmU+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1148']
+      Content-Length: ['1032']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
+        H4sIAAAAAAAAA+VZ2ZaqSBZ9769w3Yfuh26uoIhSTVFLEU1HnE19YQUQCsokBCr+Tv9Jf1kHk+CQ
+        Vbequ576rrsyYZ99IogTJ84Qyf1ytczSGXq+4dg/f6O+k99K0FYdzbD3P39bLjpE49sv/F841YMA
+        QdnxNOjJwNZkD/rQO8Pod2AinvMDRXMsYNhygAWy4csK0Hjb4crvJZwaeB6eKcyfZDwt5PeKy5Uf
+        oZyxAypyPJ4iyQInBXOWHVgK9PhGhSmwUjBnuSZQoc9XCpwUKnAcH8l+aCmOWS7CHkxR/t//Kurn
+        eI5iPS90kSMrpqMe+WONILRxWGe3tLC4ND/8hazDz9lE8+laH4aSC/cIufVFRZ2FDVAfCEisHOgz
+        7O1OTVsd0mLlpngt1L7Sh73cudFXceAKyDeNT2IlTjudzuwqyN3WqN2vDxXYDo7kktXWTCP0HUaa
+        oFl1E7JVEt7OY3ENVu3P3VWQOlPzNrVmc1ubeJuWXe9MgjXdX2yEZS1o6p1Ja+ZtLrXpnBnS5k6q
+        w+NpuPf6g5myv9Y+fXqgExc42p4ao8rsBGrudOc6LHPsax/M/mRe67LwsXRWSq1Bj0f91cLae0Gv
+        eVhJcHKYrpvT80Y31ovOtHnp9qXt9CKIRthmnXXFBacls2yNReW0Dokmy0x3crfuDR221Qz11kqf
+        AW2zaff04UwgKlpbn2q+KJofH58sZCejBvhcIXJ1Pq6Hqq/sFaGxXCvKWXHdERQAGQSUcEHbz2Xb
+        khrHcTOYr4Od3jwIzEHS6SkDtdlcndRFRdmvP6oW64GqzEo3b9O4iqeq1J94ttrYLpTrprpUu6rD
+        bKDPVsdmeFX2sLM517dKhxzY56vfmtSYVWu+WtHbXRcuzYVjdP1Gq9+WZ4w2V+3h6VC99teTmTqs
+        do9C0CaaUHMb1/E0/Fj5ffKsjtsT9zQiZ8R02GtvNclrgzpZI3s98hPsDPKiz1uL03URsm5/o4o9
+        5eAGw5Oy2FlMq0eD2q6/PynHFnOh91vyPKmPnd7YqbYX1qE7d87HPn1w9gxBEFvstUVf5ZAHbB8f
+        LxwcZEPjFyRJEmT0o84MGsSoKrBc+YnDWYYdIOjLJtwhGWNppOCp2ncyOrdfyfFkjmnCUEbOEdq8
+        SBPEx81k1AU8GytN0kjp1J8rfQAPl/2B7gXSzLc6EhsGR92Yejc48Rt+P5gdj+JtyHRkqXEwb864
+        L+2EjlWDrH5ZgjNLdz/pqsCs0ci0mxIxkkH9cK6ODdOaDtvHU6sWNn3kBxerWe/29qeuc2m7G4++
+        hAN62Qqd1cXfVqrL0UGiak5lPxMWMAyP1+252bkuO/uuVwHWxoBSeNq1xYt1qXd1ZXO9rsfkcQv0
+        WuDAi2jsum31oiyv+ufcvTTdumeQS0XsmtIaavUtfWl1Gma4g1tmAG71lS54R0Y5KpuLXUUAdWeu
+        eTsvx5v+zCVW48tJhFM76Dg7lw5GJHtjDsL61KRGiltZVI5SMArC/u1jLAm3fdfanYnOpS/OK32G
+        Ij+E4ZaoDCy9SjfXjWrDGjun2W2irySiFx5OC0Q1rtMwdKBRD9hjV5calYEcKtNlqzaVdkcaO+uC
+        kYgO1Hrbz71thoe1bFbtgekpjcZUGVb29n64vdWaR5fdziaMNXCkjig3xuFYXHXntNdU7QboiiEx
+        7aB+hQp2WwMtNcAIH/6U7rYGgqBQO2YlXTvMpNlwCdFTrEXbJWM/fXSWu+8kCUp1AhvxVM4qwhmX
+        55TA1kyY/X7WfYNmTN8JPBUmyQlekYzdGZF3jaL0SUODvsqLVwQ9G5ilBVYrtYCKV6CVXvRjbqaP
+        HARMPKSlGDbU+Cr7Pec/yZ5VfMTT5PfaC91HT1Q8oQuQqvPUC/suetTwcVHgeoYK+Wrt5YNy4ZMS
+        Xp0OvD3k6Vedu+z/qT6IXYznMiMnOy9ETqqi0s5zrBLSIS7S7ABy5UdWrmRBpDtaAYhNI0gtqaCT
+        mKvwip0g3u1H6L/8lKjiAwjw4+UCz1/gZYKcikIX8moyfoEYw4X3++IMPz2JT0ch9/6Mkqy12V4O
+        F3igBzDnxB/e1HAFW/IRLmuBpxXIybJsR3Z2sTf7UVgovqYyZOAjXJRmAPd8QApnIh0BZ8x5t8Zi
+        T4xyp6HhSREwzMjJHDPKp7EsfeZ2gRk/pCrZK4eLapxGER4ZQU0+G/ASl95vYM5zLskIXDl9jD8F
+        x7BrYp5yBLjAA/jQ4Ody8ZvK6Vc/neHCsS3nWwSxm+BfALcOid3FNVfO3xJBEhFxAxJedOjBlJBY
+        XjVQesJNx9YcmwiO2BR3MJHH1GEsT4Wpsgl8P/2V8IGHfEzJgVSYOAEWlv4KLPefJQG7QxB9SkEc
+        WTjuYZJhQ+jH1i1AkRWxFeQjzizRTOXYWBkS9UcpL1O7Iw+D5bzn8TRgq/D9oMlyMsIDmHPidbQA
+        PmooXWj7SSFZaTn/hHJmxGhDvdTs8SYUgbs41l/aBna20gA3kLjty6nprngGPhzYKyNnlF2IE12U
+        beN4/VbEaVHfiUvMPZRxmkzf48EWevCPEoVT6By6CEbRu1QhKXwsckrCDpCKT+XOh4ivMtFUz2hO
+        86GKXQkfZbpeqdfoR3YmTOgh/mdZmsZHk5IsSaXMO4532mkwJCXHcNQ0I8OCMZ0gWYKkFhT7U5X8
+        iST/TlI/RTO9V0jHfbZB8o7DloderFJDemkEwv+lPZgKXa+SP2yPGln7Xfao4f9/xB7p+uNYk7hj
+        lHVmTWEgzrhyAU4psRlGAOE0dim1cKVlw7/5pTFejhcVYl5pIc4XmWJis+QZB0qm18kkUdhMnkzs
+        6A6PhwMoihlFMGXgFKbzZaxMWMm8hBLPS/iEfZ+XiGrIcqYfq6TqeIUo8HnTON+HT6GMkGTVcvYe
+        J0/fsNyorIozUaaXpNXkOXB9iLOHafjoYYni6xLx0+iDLOLlN2PsoSMn2d0EyEABtnkN1xYVlqGo
+        ap0r31EOR/N98kiQ3ykS73CNwWVWDnPlfDAd+DLOqjge7Pw4qT0AUTSNchLO/FkYTV85C1xlL7Bt
+        vBWJ31CVqPt8RqN+9R3vGeVsCKNMiDNjlB1in4y/5x2ekgOcRHFbXKBlSEKI1uB4VhSGk89/Qbmo
+        wkySp0DNSvRizJXvUJYicMpFEVs+WjyZlhnPOOfrThxVd8ly4umeMO6LvuahofmhTuahhYmv/d5F
+        /HcCLq4tk7nmzfZQnM3X4nA458oFQUqKh58D3D54+AyvsSv6GS1NZWkJ8oePPk5lVtYZ4PhefOUe
+        tikPsbiJx1mJ+jMCMMtS9I8HYOo1IX0VyaIj5TqOmZa1sW88YdFBMw0ryu1ZaZm9/kZcp344z8We
+        mHwd0SQn2NNTIJX4uIT1DcVMvfcZTFh5NEwcG4e8tPpcpSo5xL2e+8czH/1MNq7+vUqWJiOunEOJ
+        VNctC9dIFJskxyKWzJcf5ajwl5VovUlvguVPUJETzVF+QPKlxRW7B08B9O/ZwHbuENSSSv2ZwiXp
+        oGABoTcThmL02U+CB2pS2Ll4NSXV8FQTPiqk1nh3RfF8N5G8P7VUr+ADr9BevYO593cRL5cQb28f
+        Xq4dfjSypD37nxMxy9nN1B+5f83uvNKLlZe7sAf8d12cle83ZzvcDuJMFUv9cpbNQGjF5Rbuoovp
+        rAhzQFVxtQ6U6AswEDUXMR79TOoTYMEr7gbu74koadIsiPcS2CXx6uLG1k9pqdHygYrDWSDqgJ0v
+        Rhw9SH9jIHywPDW+IvhirCfCrw6Hoxb4YqBVLnoYovxqPD9wXQd3h7JimFHRKQNNiyyT/uXtC2G8
+        X74MccdpPmi8w1My2Eeb6MEdjG6tYIH+LIlauV//a+F/AIswbEx2HAAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:41 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2892']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:14 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order_and_reserve><crypto_block>E7--NuwIhns8SF9pSFmOCtayGoPi5orsAykdVtQtCufnKnVXd5ijHtnqR7hewEY9Siu9mKWZXgSi50wUnsm6QPTTn5Ap3rEh2y8qt7LQOigLgEgeiLH4ylijiJOz3cCcGHfmz-mr55XI7fNrF6K5mYhYQ3qn1nCceIO3_pGh-y2ODATK_1unwgfaRcvmf9rRBGVuoIht5KuL4JvyIf1HGwjOVpnEZgHPJm7kxU7hRzZCGSznxEZHloNsR7I2pTbq40t7v2mLo1javANm8iUGKktt-5o16BpnLLteyP0yqrtW48EZlb91SwCaca-PJX0S8BvzKCatNcVD_hETlolGxPekOoYcRxyhOS0oqh4PNL4fG5MfxXXjHxpdCbQvBrDibivFS6vhbjmFeBcQYWikaldIWXGQFooHSH2dWMs_BXrsAz6-j8VMn40F2LZish9H3g6jBjVkrnayZ4NMPTq5FtXcdK_5L7WFk2ASLauJCqJowO_bV8X2sPX_At8097h3QpXw1Kh0OkgxfUXvzDHbFI_bN0XSMiJ0al9y_p-VXab83-6hG9eHDURd6DtENaA6ZdPR1b2kCR_toknr_BpFKcDNzxpBDj9-GWfRRbpiCUM9rPYDDkijx5sFQiucuV4RNL_xRMwwjtm79e8Q_Ffs_Rbj0MXC_rEfuYOIlmhROtFCXJpXG4CNo46bV1NKHU8emAOPjTy5eN5yHKnfgvMsrKq0Ix6-yFmDNxXSz4pazVchj_p8eOwdiIe_aY0Ybh9RJBrav76RZUsxDdWqMKRqoWJyL_--Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>k0--5q_Eg4_-x1Nz1FPUkY_jXomw7H7E1_PjxiUKNYUK3emm0ERjusgvnWUYFQqZHjDGEekx61hC9iIriru1LpexlQdiFWf9oohhZR3m54tmVkLEMIItGP0eGhqQULniBgRbrSIgFusujEyS0Rw91TvO3pqX8rgNeFy0FDAL-H3GFetfBUfLnD1Zi-94KcFBeU0CKwDSXAHtxFWU5WZiFJ-wMeIriNlK_uoAMR58EAI8VqC-Z</discount_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></create_order_and_reserve>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['1408']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+VZyZbqOBLd91fQb9OLbj88YGPquKgDxpAMZkgmw8bHgzDGY8oyYH6n/qS/rOUB
-        bMh81VXVteu3SKwbN0JSSIoI6Qm/XD23dgYwsgP/52/Ud/JbDfhGYNq+9fO39apP8N9+af9NMCDQ
-        EFADaAKoar6pQhABeAbpb+yithDFuhl4mu2rMRaodqTqmtlOQCTUvxYJRgwh7iopv1TcL2hbeijU
-        n6GScdAMFMA2RZIVTgGWLD/2dADbPM1VWAVYskJXM0DUpiucAqpwggipUeLpgVuvwhAUaPvfv1b1
-        S7xEsR5MQhSouhsYTtvhCMJdLKhGK5hMArimQklP+snQtFjSZKPkLC/WzXDxwYgEVLf9DUmM2QOp
-        jLUTEh1p42+1nuxyHUXi1Ssjf3RkhtU3lhXSA2mhU63B0O5/LLvStasYZuu46Pd8m72NpvOQdVtj
-        az69OGxyGh8IWiS3bIOjg9MyYa7hR4f13o7T0/naV00fHA+yTl9Ax1swm9Z5EyvbEyPGwXnTGN5E
-        ZTDex0udOHjONWhe112wmjenumKOBqZ2vnW00CDwTPYSzfUSR50vfTIYKPNYWrJ8sDJVgvCdzXIN
-        m/NWz2u4Jt09hQN3uGCm7G04pGXfGE2nZKen7pT90uIkZFFqZ210zugDgt34sN2qb4HL7UCHdy7T
-        Gdvvxv5qeerDxlwZrEmKgHEykwf8aaRPEo+WYmrDaFPdCfk50XcV4ry4ilu1k7jH3nKWECt9vPbH
-        6uy2XNm7I6vKTmNAdAb7mDWu5pUbE4YrvfnzcL+aGRRLg0hRW33FRHa/GzS4d/ayax6CYKvP1kM6
-        EocdcEp6ccj1YCNcn4L3/lLkiR7t8ttA9gaLa3fwQa1I3SIbkOZnnr2VJ7Zo7R2KchJZ316cptRl
-        SUUlRHG71Ock7xJ69Mb609NhM9pDNOHU4XUpidIBKorckoZqYlKBz7XQeLWXL6slt2usbxfrMrdF
-        kz5olzXLGYndYvmWyljJxHhXRudYuXITlwu6J36Hl+NDNrvnWNttFC2yyHXPZs9Miwqmk43YH8De
-        RDqJUmxu9zKt02KfHS0O7jR0N4xIJyb8GMjcm2V2+woz64sX+KbMziIc7GJ+c+GJPT4J1f0vIKj5
-        ET6yOOKottnekyRJkOkfptl8J6ZSnxLqLxzBs/0YgUh1wQGpGCvCT5sjv5NpLPiRHHcWuC5IVBQ4
-        wG9LLEHcHGs3STgH9ofe0JAV35HxFJrKxdxzaqs7Izhq2ZLVDVrI9HFom2i6a0xbH/0O3RqR+6Hh
-        W36fnzPI3/dXk40lb0EUaaq1jmmdbd1ECsryqUG8n4aiS3auH9xsz3kzqI2Hi80kkA8iZ4H94MC4
-        s4VzjI90z5V52Fo2JrPTCm2ZnT+5hHBsb+3kzdQGrbdms8eT0cJwuZmhwNuIs49TsNiCm9/oWm/O
-        +npuOmsUmDfST6ANxvNdc8fOt1zjMPCoqWbRMq8d+8meV2Yt52OxWEwNRZoutvRk9HbtDpVjd+fG
-        dPi+Uazb/tTsnMPQO8o3LeyKbqQ20E1abZpSfF2A90g5McehSI2WgJgfJOnEz29gRPjJ2vcX3Yb/
-        RiNyuSDm657TU1zjne5z6/iwPKqLBtySPb4vBRY8r/fWcB8fJ94URkwztr1FTweMrHOBur7aCXPs
-        qDrXWNC9kdwb+kY8hSei22vGcNShGyoXcWdKZNyWpRF7hxuy/cCNl4lueRbDIO88mC1p7/LB9kLF
-        G+rstGnNzmtXi50kltjpFPKxfXtnT86u3zJ5sePQjfVK00JG8ZcBOF76KJijc8I4XLBgySM2Rr+t
-        CG4eES151DQ4jWwlsWWpm/jtwsvT83x/bppJePMOsz3fXUN5T187/UnrI9xf/W6695834GM/5pnU
-        CGIftamSVYXv3Lagx77pgvvvq+4X6J0ZBTE0QJ5EwRWp+Igg8qFRlb5omCAy2ivMri2TCAGvtgcw
-        eFXMSHdFFCDNxbY83faB2aZb38uOXmSvKhFqM+R39hM9Qi9U3GGoIePYpj6xH6JnjQiXLSG0DdCm
-        uU8DKoUvSnh2Rw1aoM181nnI/p8KGBPoNh6hahwDO7NfAKUk3zBHUOvFnpfURA2atV4uE+pPpIeK
-        7SNgQS2L8aaGtHop8jUPtM3UUqmcYQ8GSsJPjAx7NMuvctjZGUmN5JslH5CYnjID1Q4w8GoIT+EM
-        /Bik2lVWqeQBdAzMCpAtsTjrzio6+bJXmngzZ7v2Gfofh5KW1thz7el6hfuv8O6Ckpo5x8jtV4gP
-        n71Ozo6KUPJypMtTfKfkc12u1j1pusKmnuCSlQ19iWIT+KiGlx1UqPm0/EANDtmpjNK4Vm0WMmQb
-        DqhK74DwetArZ7uwgMuIxaTB8kI9LShsE3eKNNtND0vgpkVGJiu+hUPsZh+Fyr0p4NsLri0QtoyA
-        qZ5tcGn7ODB+AQswuOQWhHrxmQ0FB+Fr7px6CoQa9kUA8Xe9OqZ6MeqXWFQJP/VyiQDeJvhHw5e0
-        3OvSVqiXrVyQ+VjCV73kcgQQFIQihttWHKpnzY1BHpqqgGDYqIhjbuCbgU/EDnbUA8zlmaFJJi+E
-        uWnD1aKo+Mn5eF9rKB1ABSvk9yhSledmsIOzK2RuLrtXPkOpb7FvVAcnzKKHeubFO5heUQvqXfOB
-        PNkreV+YdGwz+tpsPpFC/oSVlGwufc2z3aRCymdYL/ut352WLi8s3Jw5vQo8xJn+2rfx1quN8cUd
-        37ZLarEK0MZHBe/RdGuqIcDpOy0esiz0pUgw0/s+rsItoALfLNrF+sT/qlE8OtY6sRXjEoEmKZyn
-        SkLOjZGBT+ghAji7c2lHr2hJi4CBNw4+1o0mxTZY8ol9F+b0BP/zPBNHI9wpyVN8wXzgeHEDniMp
-        NYPTpwpk48SR0gmSJyh+RbV+YsifSPKfJPVT2tPXCoXdVw/k7QhpEH3yCU1hZ3Rw1HH/SpdwFM0x
-        jd/tkgZN/SGXNAia+jMuKVyQhZ58P6ZJ6L0jjqV3oV6BC0rmBllD+CBdal1cQPrgH1FtiqcDNRzD
-        4d/vSrm/8m8cM7lh/y5JI2j+5eJdHpSBpAoWDDw8FEdt1z4/5AV0J+QZsn5vZ4kwsr0wLfWyrHLX
-        y1Nk/h2HEcCZwLUj9DRG6fMYfzT2FB+vq3j9C9sWCNQ8g7u4QkqzZpvN6odHU8DB2Mo/CfI7lYoe
-        gFAv9Y9apOJkiQ/2Icpy1ROQxsI01QDzEQSLpuBpVxXGvo/dmq8/Rac37Vc0vZt/xXtFBR+ANMHh
-        hIdiXGameykbz1d4QY7z8rBCuyM5IZ1DAD3Nx3k+G/4nVEgL4DwnitR7rbGaCvUHdA/wOJOilK06
-        XpssqodXXIiOQRYeD/l08qfNZ0z4wX3r6aL12zesp6tVVv0V5VWnN5Hel1tpMlkK9YqgIOXVlYYv
-        KhAfqy3eSNGdVqSXokj4U6cRpxbvfv/A4aXaFJ68XUa8LTBxRGymWeKvj4hNHPj/QERsfoqIPzqi
-        6dkIg8Atys5skV+w9MS4tpdm23vpd2/+t0Db/L2BNttS+eiITquDt2wBFJIIl5iRrbvFNnwFc1YZ
-        4fIdisNYUR1uCpUSEj4f4OfDm/7NF675nSFrc1mol1AuPR49D1ctVIvJEngVy/srz2RamKt6Ot+s
-        93SCL1CVk/ZRf0LKqWUVNQQfMYgeEd4PHhAw80r6lSLkIb7iAXH4Lk6kdNgvgidqXmqFeDY1w4aG
-        C54VCm989RTy+gaSt1+uPJ/BJ17l+vMVLHz95vHpsePLV45Pzxu/N64Ud+q/OPTV729ef+a1+P6a
-        VrzcfHple8L/0JNc/fEmd8D3NJxrMmlUv+cjLfGywkeDZjUhVWFBMwwQIk1PR4CBtM7P8PRvXmx4
-        WnqXxC4poVxahO2qtHBXaeLZEPYvTNs/tPVC+E1zOL5oPzC0KUVPJuqfZxvFYRhAFKm67aY1m6qZ
-        Jr48R/f/LfyBNPNwpAJ8R3Mf4L0weMULsmalbofgANKHLFChv0rSe9Bv/xfnfwCVMHSjKx0AAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3019']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:41 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/CombinedOrderReservationTests.test_string_properties.yaml
+++ b/tests/interface_objects/cassettes/CombinedOrderReservationTests.test_string_properties.yaml
@@ -1,495 +1,446 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:42 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:14 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:42 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:14 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:42 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:15 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGNyeXB0b19ibG9jaz5FMC0tRXhJNTJKUkNxLWdMRHN2eDR3blVa
+      elpTV1NZRHFxZXZKRkd2bDRwb0NpdkNxVVVmdlVMQVhnOWJwOVhnNi1jY0s1THRRSlN2Um1MZXZl
+      eGUxMzBpNXo1UWdFV3puMVdtRTJ5WHdnVnhkTm85U21KZmNlWHlZN0tNTnQ4enV5Vkp3OWFSWE9T
+      ajV5Rk5wLTB3QWR2MktCSHZwaDZjRnFST2NyejktNGxEaHV4MlhIYUFtMUY0U2JuZEoybXF3a1Jn
+      WjwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bm9fb2ZfdGlja2V0cz4xPC9u
+      b19vZl90aWNrZXRzPjxiYW5kX3Rva2VuPi0xLS1RMW16UTBaV0tTZWNaazl6NFdQN1pCSi1GazFR
+      bGpSTGVIODl4djlzQ1llOGJFZXYxM2hoRkhheXlfNllkVWJIQUd5d0VSNlNSeW5ZLUJlWGhUd3Ey
+      YWQtYzVoQXc4WmhLcEpubTNONjJLZnpNM3B5QnNtUC1Dd0NVSVktY2dzV3F2S1kxcS1CUUFfQ1N3
+      SmE4SFJjdGZ2WlFpSktYN3JGZGNGTHlwQzZjQ29DWGdPaF9vc3ZXY295UU1MWjd1SWlpYk9Sa1ly
+      NFV2dEl3el8xbWhvVzNQVVdmRGVnUzJzWkpzV0RpcU56bXJkZ243Tlg4cjlfZmFaRGhPSDdjOUpi
+      WjwvYmFuZF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkZXNwYXRjaF90b2tlbj5jXy0t
+      RnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJYaWgtWnkyeFNwU09EZEhh
+      SHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5OC1zaExzUlpJRW45TEJX
+      M1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tlbj48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['449']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS0HvDihIg7XFxZDKMgoBCj+Tv9Jf1kHg4Je
+        O4fKzLeqlauS2GfHCeLEOWcHJvPHxbYqEfADw3V+/0R8xj9VgKO6muEcfv+0EgdY89Mf7b8xmhGo
+        buhAyfUgYgaSD4LQgm0mCBXNtWXDkcIA+JIRSIqstR2Xqb62MCACDpon+0CW0DqgzW6YajHKDBoI
+        1DaLXis+68AHOSFFGdWAcca1XEdzHSw0mWoBZvaUOkntuTGfbMlBkP+V8WUfBohSALkx5XeQsfJ3
+        2fb+Xemh7YbJq5TMDNpUusPMbQyQp0eICYDsq7pkgjhdqYriUiBJ9HLebdodeXBW8J79abKjgtdO
+        s+3cCA9gwUn30ZUtC8B8o/2nCdlOq8UrVG9BTBLCz8OeHkIZuJvT+SvHgECrjFFaoaQoqPmp+AY0
+        VJRTkQHOkgd8NckRAscR8aWJ0WQIJF92DkACjpaPU2eiHv6rQgSwsgQeBLYC/AqJE3WmWlAydghV
+        yd3vAwDbVD1Z6hktaAFQUSoFbYJukI0a/ci+GTN6jP6zbU1rJ4viLZzImXccnbTbrOOElMKyo0nQ
+        sEFKx/AWhhMi0fqNwn/D8X/ixG/JSq8n5H6fY5CNA4iS40NUalCvTOX4Z8ajTtINCv/meNTw2nfF
+        o4b+/Jl45PtPe02WjvxK7Amd3pgVmGoJzilpGKYyhDo4V7pu6DvgH0GFR9vxZdVEKSSyS/E2MYtZ
+        9mxo7fpwcLMYt/4mWSjR3TZyJ8OkZ5TBnOHJUG9X0WTMztbFlHRdLMCc+7oYBAGs3uanU/LpaIcw
+        DNqWEd3d59CNgNqvDOXqbQxjD7QDw/YsgAKGnMPbvNSSs0IvAJaF3jSAD1tkP24RPU05vIxXX/g4
+        ADc5KLnNWDI0YIhiXiM+18hWnSCoBlO9owzq5ofsEcM/Ezg64VqdRIQ7zFQLZ7ocSI6b9IN9kKrN
+        A5B0U9QRUce5t9F8yNjyRfJDx0FHkeUNQaI9fEAZG3XdF7xnlHEA0FBGeCjfkDqkOZm+zys8J4e+
+        nGhoiXZDMkKyB9e3kzacvf4HlPHcAGbi2SOECi3yTPUO3SQCSTZM2JJpt/HP+F0jyjgT6G7aVffZ
+        dtLlnjAmQHmJ6KlzcEH5gnIycVeCb5xMty8Q+I5sVURErHSTRHa0SjEjq5/0UvCq478yMCixwnyt
+        Zac/YYXlhp1Mlky1ZMhJqfulrFnARzW8QakY3Gi5lOVXkIeIFt1wAzQkIMSv6JWtFkF/e68kPmrH
+        /2s6SfZ7rmulaZ7fHZ6wpCYsw05kOM280vArLZj4ZklKkyZ7O6yDz1FS5kBuCaTICAzFyhPtGcxY
+        RePKchB1p/yiuM6nFBDzsUQfyzP5f3Zwjc8UXplPmWoBZVZdt210nSFamY6VsWy9e46ofuxBV1Is
+        VzXbUwrDvHkNEtSBlVXalIXudWeTuhutBMPhuVlgkuo4UubOUbCgNrqQvd4RP9dbR77FLk5S5F35
+        2DT7K8FuGrQ+6jkreFUipdk5cUNLBc3x3pZ74tjXvL1lDYQmO5KPVmO6dq3RwWxQxHKCNa5DsS/W
+        pS0fen2bVcXTGIZDSu1btBoC1rBFZ4L7RmdPc7EAIHccWoK4PMCVt2GbEmsv+krUeANrsyX68/gw
+        P+v6ecguW+bUtg+z/uy9f9VDq7GmG5sWL0Flya3mZ3eh0YOr1j8tsV204eaDbp/g5pG55jcTjDxv
+        V9Pu+0ggllA4jKlOIOG0wq5rltPz9my0cFW18cZe6xam6ZFKBRNtAPvyXMPm516NdJeu4hIgNiPB
+        Hg1mKuQ9TtqO3ll8Rtgrj+pq/JEfnrjxmxWc1V7EwcF+KncGrLAJ3wMruA58F9DcdQ4243ptSvOD
+        3di3CfXisFAzzoPl5djvw+OkT485stsYyjVX0YQ3BXawXXLXLJ0vo1iyg1RSKj59HCtOS+e1pfhG
+        SuuqTaHqfUQYNfR99HUVF09ZGh8UD63+ABWMvaxC189vw09gwXLC5KrbbpL1EisHC5ZnySoI2mSJ
+        k0MlDhISKYhtxbWqZRipWIa2//uf8vwCL9AiGMFDXNCNAH8IS3JFQLLt7qViAo0U7wm6+0Dfh0rg
+        WiFqO4EcoTrPpO0ZRB8ftmI4qLdRrcR+HxYvk0a5019NxNILZaG/D7NvQA19+VUSzdRkXyuRcz34
+        yu7uQ+giHWyrOIadTKzVXY/jCx5zw8b727pPDh1BdLX94rR78whpEZIUy5HN96CGMm0VXTWcvcwI
+        +mw1WHuwhz2ObACbr8VU1xodD1YwkMddthlxTTpyur6+UehtxxjESmfKc9vOarzAj9aJXkP7PD5z
+        /MzpT8QemG0Wi94+gkGzZfqboOGdotp+PhiMdmezNbXOHe1AKFdlI7sxPFIm5UbWdGlSfJeXVq7W
+        s2EX7weqUbP2FuYd9dF4PN4u+ucBuSsFIdt1KQrJZbMcpez2iVQAKSfK1VyasgFKDSd7lJ4O9IWh
+        RE4Uz/MN1LOp2iO7sJTp6Fqiy/4BtOkn9t1QYmeXZ+m1/wcjk9WfJEeyYcmJwiFF/4Ax+SVHPhQ5
+        nQrPE8ikTiUlkdsseRHrCSpzkvSsPiCFsvryGU1woHEI3TDIbwgEuo6/NKR06ELZemKWMeY56KVQ
+        PwW4FNYXwXwMYbWo/D/dA0jiSz2gxw0n/a/0gJ5uWFoF3dLBj9Y/hup/MrPtKdcbqoPpZLVRjAO2
+        ssfieL2bAKTbI3vcXGMY2Y+3w51CBCJ+4PZCPzk6QG8miq0vunWjX9eIix7hsqGe4vCs26ap2dtA
+        wSSIBHl42I07kWVKFKcvWuxA1nbS25BerhoT1msK727Ei+PT6r0xmVDXQcvvXqh+h++1LrPNynwb
+        rsH1elI9aYdhX61l4gdqOTuYb61lovldtUx9by0/+/+rlu9BeVnL1JdqOZv3C2r5i3q+FFd9lv+a
+        oi+TnxMc+FPq2UT17GPxebJddlnWqznX/ZD2uzzRiHrWfOny5mEyn7iR8z7ZHvsX8chpR65Xj+Z2
+        NI15DzojxdKN6I2bDa2Q3bwfV+pKEt6l3tCGbOOkHK52d79Vh6fNsYOu9cLaP8lig641u9dQsE7u
+        uaY3LouDyHbZCF3FLd7t4cPl2TwbyKUn7bueQY5YZbicjI6NWcemPPYwmR2c4/xiYS3K655W5D6O
+        pyuBvtRngIhtasg1AqMJTD7e94Y0JvC0EPaImo3PZuTX+wH5I/3gu7SdrP/afvDs/69+cA/K9/eD
+        bN7P7wfUF7V91pl/rRcAx3D9impA4wqcn9IS6qglDEyKmxgcTte6Y0ne4wK7D4TgeMbttdUYGWK0
+        ah6W0LlsKa+3vhr+vjmCO6G31UdGf2SbMqV350rY6h54rTkX45ALdV912bXWXEN/esa242406ZHH
+        eG1uZ4Sxj5quxQn8pkZOehoei9KFvC75GPi7S3PhHWcCCXbXGqmfSJ2iRKsf8EJwUtXjEA99bo6j
+        b3TaOknfIPfUj1zdv0vuyV8s98/+/yrve1D+RHl/We7vj0H2W2VRkrprJD8/3H+x/GAp5dvTvz3/
+        D1lRoYe8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:42 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:16 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcl9hbmRfcmVzZXJ2ZT48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkaXNjb3Vu
+      dF90b2tlbj5jMC0tcWstOUJWS3l4MHlISTdZR1ZEMkluUlRvZGZRcVpHcDFfUXUyM0VIMjhZczVh
+      bmtVdnpkMEV4TzE0d2w3RW1GZnRDSDI3ZW1ONXkzQmxKamdsc0ZhS0JFOHZIODR2bkJyaFdiNFhB
+      aUZ5YkFNTkhYQVVLUTBqbHE0VnRtd0t3SE5PbkRMVENlT1dRUUNmdnRzODlrcldzN3BxdjVmUEZG
+      Slp3azlNbHdBZGcxYnpiV2FveXRqM2szb3ZsTVNrM05CTl9Vb2RDbXRCMERzY2k1bGZsLXBqaEpL
+      S0tYUUR3RjJaPC9kaXNjb3VudF90b2tlbj48cHV6emxlZD55ZXM8L3B1enpsZWQ+PGRlc3BhdGNo
+      X3Rva2VuPmNfLS1GeUpWRGY4RHlFRGhNWVU2Zllsa29BMUcxempMbnZkVndoN0tMSmticlhpaC1a
+      eTJ4U3BTT0RkSGFIemR5YUdqLXBySGQ0N0s3dmZDUkZYdU1FSnVValJLQnNHbldScW1IdDk4LXNo
+      THNSWklFbjlMQlczV1ZLczNQLS13Sm5RSE9fenB5WnV5VWlBLVk8L2Rlc3BhdGNoX3Rva2VuPjxj
+      cnlwdG9fYmxvY2s+TTMtLXBQNXQxM2dFYWM0a2FSQnpabTJob3ZVUmluTkhPc2syY0t2YlBualJs
+      dGRKeDJDQ2owdzY5ak45RVFxX3Zwek55a2tEVVJtOGk0aEpDblV0emJ2YjhBcUhJbGNlOEtmbWFD
+      VEtyZHBmbGxGUjhFSmFqbDdNVm9sSmdrNzMxU0wtN3pJVERUNl9YTnVwRG1FY1RxS3R1STNjRGw0
+      Y3VlRWltVG5MMHJpQWY0SHlSZXRIaklsUlRTZ3RVcFdFOF9FbVFEYnY3R2VWazlUclB5Z1B3aGh3
+      SUVTOWtNbW1nT0RPWUR6aHVsN1Y0N1c5Tl90YlNIVVB3b1FkNEZ6ZERxUy1adldIUEZCRDFIUHZr
+      Vk5XTC0yd1hVTUJZSlIxU3RSZ0szQXNfMDRiRVY1bG5DcGZFdlFvY2M3R0V6NmwtZGh2YzNzTGRG
+      dERhUGQtUHdDNTJvU29ibzFleWt2Um1KRk9jdE5wSF9YSllFME8xbVVwM0JkTmpOSXFIS0dsc3dj
+      Q3ZIdEZmTWFBRkVSV3VZc2xzekZyb2U0SHpQZVdLNjVNNE5GWktybTFjeG5FdGRpd0ZTeGpERHRq
+      TEQ0S0gyQjdJYTVvYmRSR2J0QS1aPC9jcnlwdG9fYmxvY2s+PC9jcmVhdGVfb3JkZXJfYW5kX3Jl
+      c2VydmU+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1148']
+      Content-Length: ['1032']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
+        H4sIAAAAAAAAA+VZ2ZaqSBZ9769w3Yfuh26uICBaTVHLAZV0ShXHF1YIgaJMEoFD/k7/SX9ZB5Og
+        aVbdqu566rvuyoR99okgTpw4Q6T4y9WxS2cYIMtzf/7GfKe/laCre4bl7n7+Nlc7VO3bL9JfRD2A
+        AEPNCwwYaMA1tAAiGJxh9Du0sSSicGt4DrBcLSQCzULaFhiS64nl1xJRD4OAzHTLnzQyLZR2W18s
+        P0I5wwQ69gKJoekCJwVzlhs6WxhItUq1wErBnOXbQIdIqhQ4KVTgeAhr6OZsPbtchAOYotK//1XU
+        z/EcJXrBzceetrU9/SgdeYo6w+N80MG4W6dXxtuHJ7em+5BrMxNF6W+m5hunO9fO3D9oNZ5arK5j
+        fWO6gsoAesbCsOIY69YZu8ZiqsoLznkP1OaMmnT7cr2NWw7zthoMj5sPsFN90zeQbK0Ut601GpZi
+        zrnu2JjJJ/toeh/mADHVi9xVNsPGTWO7YXM40I0Kt2ktqbDT41gesnLDmh+5ynkz7tzqnYGHhqy8
+        U5Cz6bX9s947GDXLOXaWC0Ufrwb8TG8ebL1d90+rlWXowdGd9w7CftZV1kq1srPOGzyTF3P2th9e
+        3NG4P5Qp842+8p69a7lX2VyrvLNEhnEyjfNK3075qjrZodubIgeH+fW0NNFCPe1Ctbttd+Sqyh8a
+        54/D+7DhhFqvHlz9zWVh3ertkaGOastRsO9tA0G1ekFvZjiN61Zrchi3Vlbl5FmYf8PjTnUMB3RN
+        /XhTOGJuZTWf+rC6fe+iC7Vnh83m+r3Tn+wmjaYyr6xryB+NhDdFA4MOmO430zXb5UfnYDzTrq2t
+        zFNsOJ6c93tj1eyb2nAuK4JNMXNWUYeYoZdvoEKPQqROh+999byaXEfG1Jkem5M3mkUj2LSP1d7a
+        lVu7ef04vtSvgfbeP7eopsGeeoMaD85c/cT1hMObZcz967yH5h70mXEVGt7B2lErc14Nbvp0/G6b
+        5nQiUJi9WKy6X6gzfQovuOsfu82z0K69d9iZsDkxne62enQbNZ+Sg62jtn2aojbEa4u+KuIAuIgc
+        LxIcNMuQVJqmKTr6IVT7NWrUaLBi+YkjOpYbYog0G5pYI1gaKSSG/05H5/YrOZnMs21407B3hK5U
+        5Siq5rVO/eHO7whT77YfndbXw5rzB2dB4eVWZaPSG7a51C1b5t+3p4WhTwdb+MFNzgJmDiFETY45
+        0aDht9uUAPaNiTDlRnNqgCnKaFlQUdsKT9W7x7ajTLurmi/QHnYPk11juLyqKqe4A9NnZF0JuqA6
+        mUxY9cAoq4HZl1sb7iKMtgdjdzscOq0JqrWXwwXNsnVwblyhDUwllButpUDz60pHX3mTrvceLpZj
+        tQKatZNQnfgdWbbk7mTgrWc2OV/ry07RR8Zs4i1go1s1oDVXwit/WcrVS7u/YK4j/TLsXKwDxdlO
+        XZkL+HiiTi2M6lx3B4b2cq6O+EbFYvq9fsPpWs0pcCHH3baWMLqaF07AACxkBrEr1EZysxeujvo5
+        PHQMXq3d1o1JpRL0Za7Nuj2OseqdoG6Zbboe1sIuh1p4Xtur+0anGeoLttOTR7PrvDq7UvWRNQ0+
+        PpZ2n2nJXg+PBoePnWvK3kLtrvfUkvGCJTcen1SyI2ewCtjKAWPaN7qbXbXXbzcX25EvnDvrVXNx
+        EvQ1ngCFnY1X3LJ76zWWBuvpA5oKfes6aA34yDcfHeTuL0lS0r3QxRKTs4pwxpXEbegaNsx+P+u+
+        QDMm8sJAh0lCglesERfG9F2jKH3SMCDSJfmKYeACu6QStVIT6GQFRumTfszN9LGHgU2GdLaWCw2J
+        rX/P+U+yZxWEJY7+zn+iI/xEJRP6AOt7ifnEvoseNRApBPzA0qHE8p8+KBc+KZHV7UGwgxL3Wecu
+        +3+qCWIXk8TMyMnOtyIn1XHJDDynhPeQFGZuCMXyIytXciDee0YBiE3TGjfHBZ3EXIVX4gTxbj9C
+        /+WnRFUewEAazVUyf4GXCXIqvvlQ0pPxC8QYLrzfF2eh9CQ+HYXc+zNKstZGez5QyUAPYM6JP7xh
+        kKq1hDApZUFgFMjJslxP88zYm1EUFoqvqQxb5AgXpRkgPh+QwplIRyBZstOI/TXKl5ZBJsXAsiMn
+        8+wohya+nDyLZmjHD6lK9iqSQpqkTkxGxtDQzha8xOX2C1gMvEsyglhOH+NPITHsmpinHAE+CAA5
+        NOS5XPymcvrVT2e4cGzL+RZB4ibkFyDtQmJ3eSmW87dEkERE0nTcLnsYwJSQWF63cHrCbc81PJcK
+        j8QUdzCRx9RBLE+FqbINEEp/JXwQYEQoOZAKEycgwtJfgeP/s9Qi7hBGn1IQRxaO+5Zk2BtEsXUL
+        UGRFYgXtSDJLNFM5NlaGRD1RysvU7sjDYDnveTwDuDp8PWiynIzwAOaceB1NQI4aThfaflJIVlrO
+        P6GcGTHa0CA1e7wJReAujvXnrkWcrdQnTSNp9XJquiuBRQ4H8crIGTUfkkQXZdvYx1+KRCPqNUlZ
+        uYMaSZPpezyYug//UWJICp1BH8MoepcqNENiek5J2CHWyak0EcQSW42mekZzGoI6cSVylDmhIvDc
+        IzsTJvQb+ec4hiFFk9J1mkmZd5zstFer0owWw1GjjC0HxnSKrlM0ozL1n1j6J5r+O838FIeAlwrp
+        uM82SN5J2ArwJ6vweF8agtv/0h7VCiew9A/bg6f532UPnvz/I/ZI1x/HmsQdo6wzbbT68lQsF+CU
+        EpthCDBJY5dSk1RaLvwbKo3IcoKoEAtKqjxTM8XEZskzCZRVpZNJorCZPNnE0T2JDAdwFDOKYMog
+        KWwvlYky5STzUtt4XgpR7n1eKqohy5l+rJKqkxXiEEm2db4Pn0IZIcmq5ew9Tp7IcvyorIozUaaX
+        pNXkOfQRJNnDthB+WKL8eYnkadiji3j5xRg76GlJdrcBtnBIbM6T2qJSrzIMK4jlOyqSaL5LHin6
+        O0OTHearpMzKYbGcD7YHSCNZlcQDE8VJ7QGIommUk0jmz8Jo+io64KoFoeuSrUj8hqlEHeczGvWo
+        r3jPqOhCGGVCkhmj7BD7ZPw9r/CUHJIkSlrhAi1DEkK0Bi9wojCcfP4nVIwqzCR5tphpiVNHYvkO
+        ZSmCpFwcsbWjI9FpmfGMi2jvxVHVTJYTT/eEiV/0NQ8NzQ91Mg8tTHzV9yrivxKIcW2ZzDVrtAfy
+        dLaUB4OZWC4IUlI8/AyQ9iEgZ3hJXBFltDSVpSXIHz76JJU5WWdA4nvxVXzYpjzELqFBshLzZwTg
+        ep3hfjwAM58T0leRLDpSvufZaVkb+8YTFh0023Ki3J6Vltnrb8R15ofzXOyJyddRDfqdeHoKpBJE
+        Slhkbe3Ue5/BhJVHw8SxSchLq89FqpJD4udz/3jmo5/JxgnfWbr0PhTLOZRI93vHITUSU0+SYxFL
+        5suPclT4a9tovUlvQuRPUJETzVF+QPKlxRV7AE8hRPds4Hp3CBpJpf5MEZN0ULBAS5m2BnL02U+C
+        B2pS2PlkNSXdCnQbPiqk1nh1RfF8N5G8P7VUn8EHXqG9egWLr+8iPl1CvLx9+HTt8KORJe3Z/5yI
+        Wc5upv7InWt255VerHy6C3vAf9fFWfl+c2aSdpBkqliKylk2AzcnLrdIF11MZ0VYBLpOqnWwjb6A
+        AFFzEePRz6Q+AQ68km7g/p6IkibNgWQvgVuSrz5pbFFKS42WD1QczgFRB+x9MeLwQfobA5GDFejx
+        FcEXYz0RfnU4ErXAFwMtctHDEOXPxkOh73ukO9S2lh0VnRowjMgy6V/bvhDG+4U0SDpO+0HjFZ6S
+        wS7axACaMLq1ggX6syRq5X79L4T/Adjrm3pqHAAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:43 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2880']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:17 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order_and_reserve><crypto_block>E7--NuwIhns8SF9pSFmOCtayGoPi5orsAykdVtQtCufnKnVXd5ijHtnqR7hewEY9Siu9mKWZXgSi50wUnsm6QPTTn5Ap3rEh2y8qt7LQOigLgEgeiLH4ylijiJOz3cCcGHfmz-mr55XI7fNrF6K5mYhYQ3qn1nCceIO3_pGh-y2ODATK_1unwgfaRcvmf9rRBGVuoIht5KuL4JvyIf1HGwjOVpnEZgHPJm7kxU7hRzZCGSznxEZHloNsR7I2pTbq40t7v2mLo1javANm8iUGKktt-5o16BpnLLteyP0yqrtW48EZlb91SwCaca-PJX0S8BvzKCatNcVD_hETlolGxPekOoYcRxyhOS0oqh4PNL4fG5MfxXXjHxpdCbQvBrDibivFS6vhbjmFeBcQYWikaldIWXGQFooHSH2dWMs_BXrsAz6-j8VMn40F2LZish9H3g6jBjVkrnayZ4NMPTq5FtXcdK_5L7WFk2ASLauJCqJowO_bV8X2sPX_At8097h3QpXw1Kh0OkgxfUXvzDHbFI_bN0XSMiJ0al9y_p-VXab83-6hG9eHDURd6DtENaA6ZdPR1b2kCR_toknr_BpFKcDNzxpBDj9-GWfRRbpiCUM9rPYDDkijx5sFQiucuV4RNL_xRMwwjtm79e8Q_Ffs_Rbj0MXC_rEfuYOIlmhROtFCXJpXG4CNo46bV1NKHU8emAOPjTy5eN5yHKnfgvMsrKq0Ix6-yFmDNxXSz4pazVchj_p8eOwdiIe_aY0Ybh9RJBrav76RZUsxDdWqMKRqoWJyL_--Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>k0--5q_Eg4_-x1Nz1FPUkY_jXomw7H7E1_PjxiUKNYUK3emm0ERjusgvnWUYFQqZHjDGEekx61hC9iIriru1LpexlQdiFWf9oohhZR3m54tmVkLEMIItGP0eGhqQULniBgRbrSIgFusujEyS0Rw91TvO3pqX8rgNeFy0FDAL-H3GFetfBUfLnD1Zi-94KcFBeU0CKwDSXAHtxFWU5WZiFJ-wMeIriNlK_uoAMR58EAI8VqC-Z</discount_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></create_order_and_reserve>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['1408']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+VZybaqSBad11dYb1KDKp6ACpqLNBc22CuKzdUJiyYUpDUIUPyd/JP6sgoaBb33
-        ZWVm5aze4Erss080J+I0EY/75ebYlQjAwPTcn79R38lvFeBqnm66p5+/bdYC0fz2S/tvnAaBgoDs
-        QR1AWXF1GYIAwAgkv6GN2lwQqrrnKKYrh1ggm4GsKno7BgFX/VrEaSGEeKi4+JLxuKB9Un2u+goV
-        jKOiIQ+2KZIscXKwYLmhowLYbtJMiZWDBcu3FQ0EbbrEyaESxwuQHMSO6tnVMgxBjrb//WtZv8AL
-        FOvB2EeerNqeZrUthiB2k06gg3B4nkc3QWD2826dPNWANI7WK8qRFie6hmJ/TFpguDHt8FyXBlTj
-        3mmJ80vYW62MiYOWt2C3hWHcnDtrwrv11P3eVBvdjnGlaqG1MoxInhJCHKpLa+4jB9JzcwYvzcFo
-        pcNgwUO25637M346isJRR2EaZ/rc+1gcZvOlK5yaK2kodbYQOIvzEmz5yyDeSTumN6UXXoPxxYa9
-        Yxx6ZpEicd8u4bV3oa4hPaiPp/uPLuOM12yrgcShpAvskh7VuzvXsjQRDWWeia+D+2RTs8yuRQ0O
-        tZ448X37OlgKV79vGH1N5KOVeGkeYd/lD1S/c2QiUwcxIlVB6JuSeI8+ehO/rgYaf/KQdtnYZ3HY
-        iAbC+Xa0pkrUmjI0kG6yrYwBL+BFdHab2uVg6bHyEUbumIqM4XnXUqLrTVYFTR9Gges58XJZc07j
-        ic0G2ketu+72ejEE7GIZRfWp3hXvjZvnjOzp/C4uJT+EjWsXkSRS5vwt7ssktURrrQW6zFmuX0XH
-        Vvnjak9bJ6t5ui28cYeYj3XecgiaZM6KrO/nm6vD0B9zdj9kR/Eo3owP7EhwW7f+Ug/Ga3g3pj5h
-        ulSfh3cXMN3+dUzej8zxStIbUzbr+kL+kInRbLDbb0nmdPJmV95oTnliJS6Z6eR2rhkjZzgYmAf+
-        vNTHvZXOsozksrMz2wTrnXeTwV2Y0o7K9NXDObRt24KdQ7zq3qcOAeOtJNjxfjFfq+SJbJAnZWd1
-        /JG95RFb9+ebdX1oC3WLJTt1g9x2FkHNQOebZMiK+nHjCbLHN8LD6b7ss3etQxywJ5TPP4eg4gbY
-        ZXHEkU29fSBJkiCTPzWWXRELoSlw1TcO55huiEAg2+CIZIzl4afNkN/JJBb8SI4H82wbxDLyLOC2
-        +w2CaCqt26TD9ycgaM20xW0caV3pBvvDS+1CO+g8a1kkHNiD7Ww2RbPDvHbu9kZIpyR9NNyL/e5Y
-        HNWDoU26/Ni/6mPF2TagFffdukLPqdMk6LVGxs5sTXm07tR36Ay82bHTXDtjyfImg1WPahHT4Vgi
-        peDcnNyEY01Yonr9EI47ZHCi6F5PvJ3uiDgq9am0D9SW0TRU1YcmpKNWMHRvlxboe9FiGt82DaU5
-        tFydiCl6d6V857rcK8ESRcg9dPbzcfCxUXi3A5nLaqtOpltVbRoHRwioHnsySeeymTWBtwXHyVzp
-        HvqHjjy4XPqUt0ensDEU4Vr0RQ82os7gOKG8cKvWw8PaX6oOjjii1pkN3GBzGUtGS2ncCJ1m4HAi
-        NqVapBmUPYwu1uw84C3xtGXX/M2UyTntTMVJ7d4XLgZL8gLhD6PeWXZ0e7y6TyeN2NCaZMeWxgOR
-        dWGLVOnLrt51Ro41o9gL1bEHpIKD24zv7hxkiN36ZfZB3FzJuJO1I6WtYhZ1lYXlTFtLdb11d0dm
-        BDfduLEgxfHM8qfuaDVWvHtjPdjJ9fNxbQuSH289gXR4QYxmBiEJpjEfnvWN0NGnM+tc35onxb0N
-        5kKrM2HE1aI2V/cSdW8gux8O+JG+nH8oYnNszu7sDsdx6aNV3+uQ77iAHJLYnunZfz2Az/OYZVLN
-        C13UpgpWGX5w25wauroNHr/vul+gD2bghVADWRIFNyRjF0HkU6MsfdPQQaC115hdkeIAAadyANB7
-        V0xJD0XkIcXGfTmq6QK9Tbe+FwO9yd5VAtSukd8bn+gBeqPiAX0FaUab+sR+il41Aly2YN/RQJtm
-        Pk2oEL4p4dUZCjyBdu2zzlP2/1TA6EA18QxlzfDMtP8cKCTZgTFApRc6TlzpKlCv9DIZV30hPVVM
-        F4ETVNIYrytIqRYiV3FAW096KpRT7MnA5dEnRoo9m8VXMe3UR5JOssOSTaibeJmGKkfoORWElxAB
-        NwSJdplVKDkAGZ5eAtIt7i46i5JOtu2lJj7M6al9hf7HqSSlNbZcG+dkPH6J9xAU1NQ4WtZ/ifi0
-        2fvizCAPJW8uXXjxg5KtVVpvev35Gnf1AhesdOoSCnXgogredlCiZstyPdk7pl4ZJHGt3MxlyNQs
-        UJY+AO7d0Uu+nfeAy4hep9ZkuWpSUJg6HhQppp04i2cnRUYqy7+5Iy6K5ELl0eTw7QXXFgj3jIAu
-        Rya4tl0cGL+AOehdsx64av6ZTgUH4VtmnGoC+Aq2hQfxd7U8p2o+67dYVAo/1WKLAD4m+EfBl7TM
-        6v0dVy1amSC1cR9f9eKrASDICXkMN0+hL0eKHYIsNJUBTjNRHsdsz9U9lwgtbKgnmMnTjqapPBdm
-        XWu2EgT5T8bH51pByQRKWC5/RJGyPOsGGzi9QmbdpffKVyixLbaNbOGEmY9QTa34AJMrak59aD6R
-        l/4K3hddWqYefN1ttpBc/oIVlHQtguKYdlwiZSusFuNWH0ZLthfmZk6NXgae4lR/45r46FUm+OKO
-        b9sFNd8FaGJXwWc0OZqyD3D6ToqHNAt9KeL05L6Pq/ATkIGr5+18f8J/VagmMip8eApxiUCTFM5T
-        BSHjhkjDHnoMAM7uTDLQO1rQAqDhg4Pdus5SjXqDfGE/hBk9xv8cR8fRCA9KNqlmznzieHO9JkNS
-        cgonTxXIxIkjoRNkk6Caa6r1U438iST/SVI/JSN9rZD3+26BrB0gBaJPNqEpbAweRx37rzQJQ9FM
-        rf67TVKnqT9kkjpBU3/GJLkJ0tCTncckCa347qS/4qolOKekZpgpCDvStdLBBaQL/hFU5ng5UMEx
-        HP79oZTZK/vGMZMZCQ9JEkGzLxufcq8IJGUwZ+DpoTBo22b0lOfQg5BlyOqjnSbCwHT8pNRLs8pD
-        L0uR2XfoBwBnAtsM0Msc+5/n+KO5J/hkU8arX/R9Ap6cZXAbV0hJ1mw30vrh2eRwMD5lnwT5nUpE
-        T4CrFvqGEsg4WWLHPgZprnoBkliYpBqgP4Ng3uQc5SbD0HWxWbP9p+jkpv2OJnfzr3jvKOcCkCQ4
-        nPBQiMvM5Cyl8/kKz8lhVh6WaA8kIyRr8KCjuDjPp9P/hHJJAZzlxC61qtTXc676hB4BHmdSlLBl
-        y2mTefXwjnOB4aXh8ZgtJ3vafMW4H9y3Xi5av33DerlapdVfXl7xvWl/Je3606nEVUuCnJRVVwq+
-        qEDsVjt8kIIHLU8veZHwp7wRpxbncf/A4aXc5F6sXUS8HdBxRGSTLPHXR0QWB/4/EBHZTxHxRy6a
-        +IbveXZedqab/IYlHmObTpJtH6Xfo/nfAi37ewNteqSy2RF8i8dHNgdySYBLzMBU7fwYvoMZq4hw
-        2QnFYSyvDre5SgFxnx341XmTv9nGsd9rZEWccdUCyqSG4Ti4aqFatTSBl7FsvMInk8JcVpP1pqMn
-        C3yDypxkjOoLUiwtraghuIQgeEZ413tCQM8q6XcKl4X4kgW6o1V32k+m/SZ4oWallo9XU9FMqNng
-        VSG3xldPIe9vIFn77crzGXzhla4/X8Hc128enx47vnzl+PS88XvjSn6n/otDX/Xx5vVnXosfr2n5
-        y82nV7YX/A89yVWfb3JHfE/DuSaVBtVHPlJiJy18FKiXE1IZ5hRNAz5S1GQGGEjq/BRP/mbFhqMk
-        d0lskgLKpHnYLktzcxVdvHaE7QuT9g/7eiP8Znc4vig/6GhbiF66qH5ebRD6vgdRIKumndRssqLr
-        +PIcPP638AfS1MKBDPAdzX6Cj8LgHc/JyikxOwRHkDxkgRL9XZLcg377vzj/A8fP5lYrHQAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3018']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:43 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/ConcessionTests.test_float_properties.yaml
+++ b/tests/interface_objects/cassettes/ConcessionTests.test_float_properties.yaml
@@ -1,411 +1,347 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbuBW+71NoctG92MoE/8kslzuxY2/T2N6sJdfd3nBAALQYkyBDgLbU1+mb
+        9Mn2ECRFStbWUrLupMlmmLH44ePBwcEH8BBA8MMyzyb3rBJpwb9/oR+hFxPGSUFTfvv9i+v52dR7
+        8UP4p4DdMy4jwXBFFlHFRJ3JMBB1TIscpzyqBauiVEQxpiEvAm13SUCqVSmLKM4KcheSaDp1prF4
+        f/PT++zqtmJT8Tr+25X/0zFJvMVbZ/lhdpn8KC9n747fxY6eodWrNC7P5rfyOP4Q/0Ic76S2z4/f
+        4cX17N2VH52If/z9n0vxLzGrXztzo7QMHt/dvDmf3qMz9nC9/NFandwtFgZOEz8zqZ2s4sWF/bN9
+        cZmh8tia/hJoG/4FNBUSc8JEhCsW3eMsbRu3C28DFAaA4AjCx8LTm0Ab7toCygQJTyHaq4cFq1hH
+        UGhAUrlquVnBacGn9R04tAbbckU9V+VdYfdwhoXo/rR8XEkBlAHoChX/FRRO/ozz8rvJCfRk3bgy
+        Kg6gv1TntWZXDCxtQkGnhDu2UjVp0OUD0gij4/WPrZENYwNv2x5tArzbaNucnrABDhzVjmOcZUx2
+        DX299UDbUm1wQeuDWAgZVZjfgr0cL8FyHqec0dA2jlCgbUCKAE7KskoJCy23ZwxYS6mhGbgCk/aa
+        sYaCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlmDLXwIhIwqjPWBOvLbOKHGnPZjIqilDCfQWeq0Rn1
+        eKgH2hayzTCeZJhPMqwnGfaTDOcxQ3vcPNWHEamrCiZtoPS/2uFwG5eg6g1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4bGnEazYlVHheZNoZhCm3R8D//Hj8/4IG23UztN7T8R/9/Jf0/
+        7nRS1FxWXfvUS3MMrIvVfH/NU8no5C1oB/KTgdq9RatUpgTSm/uUPUQlq0jzTm8jtLMooFiy1o+I
+        cdrdK2PzRf2XiS7kZMZKyZp4TQykQxQHSsuuJYmKJBFMhqbTVLWNDjTBCLz6RahbruHa1ia7L2zp
+        K/iX5xTmWqgU+UjvmGsc3syF5yA9UjDmNJJpzhR9ivwp0ue6/9JELxH6Fukvm5p2P9DZ3Y5Bew95
+        UiUfRcWWi8kFXv2e8XAMyzXR3vGwkX1QPGy4PiYeXfvb5FnJ8fJ6fnL16uTt6VWgjeCOosJwgaVc
+        sIfJcVFXnH0jJpfQnAqTO5DQ/HQ27x9sY9b+hgzUeXPWl6zz0SgDoRchmMOyyfHGYMfIGU0xSB+r
+        KQVG5gKGVkj1h6X1YNp1nNN0eUSyoqZJVXB5xJkMNMUJUg4xhtyxeYuXkGhB3KssXEhZipea9l9N
+        aALe2IxqIx9giBUlDCzNN+EiyIoTRA2LJSZFNvMSllgxdl3k0wRZpsWwbpKj9+UtdMROPwKOoTsy
+        6BgBjYPGq/ugxHIR/q7VK4vB5xGKnYEQdVkWkFRHjT/d59kY2SR0KfoWFmgbcvlcteMyuJDlEce2
+        E9enOmZIt3Sf+IZlIM/RaaLbTuyZyR7ayXH1oWb7K+fgyp9ROQf78gUo5xPiFSmmZvhwuRazPdd3
+        MQw6X3dtI3ZNik0fYeYkXoIdZnmO8bR8mi8XmGmbTIjvq6GP9eP5lPSxHu2hp8dq+cwE9Ukj0GZw
+        IWQlhh3bGMdOYpkGoS5zPNOPYfK2DOphO9HdeA8tQepf7T8THVz3M85EB/vylc5EbCkjyYRE2rdi
+        JeCTIRqQpiFZyqo9hNIxn5TK/tU9gzb2r/yrn0YSHy6MIeODPNByXWIik7peTGwduYQg+A6kiWc5
+        mHhPq0NWaQNFSXq//2RysAfPOJkc7MsXMJl8hvKBL9M/5PN/Ip9Pz/0Qg8uwbWolvhNTZMQYu3FC
+        DQP+Exz7iHiJQxg1rf01VPC9Z6CPdePZk+KDPfoS3mafHjYCADaoZXs+9nzLQ7ZuwRcFZIaEEQ/7
+        nuHYhuEh5Jv760k+FAfq6WA3nl1PB3v0P9ZTG1jnzdk0b9cop7Fao5yKKV+vUU6bNE7rn29j1p0e
+        kFjWIsxU8rEB9YQ6plhirb+XxR3j44XNFuhLVyXku2nT9EimULVc05qSjlWXgmVZlKVCbiyWnj5e
+        LIVfF39FY1zbYeOWFc2SLwQlg+97WVMW2vqRbfiOrptuoK3RICv4bftzio505CDddgwgrOFAG4wt
+        sIh40ewsJEK9UzaAZh+9WU9gdL2B3t2qvdeq5rxZalAr0LrRbb9uoGr3dAdvGw04YzSirMRVcy5A
+        rW4rf3bhHbmucDPBjGg90hKaNhRV3mzAt+4/QoNmd6g9NnGiX02s+SUMtx7qDwf05y6iuzxEze7v
+        DjwQi0LtzyRtc1ptb2KBANUS1q68rz88gDaCe057YmMpWcVxNpkDcXLcyJzTyfBEuxKvTrrs2jva
+        VRCAsOqurtmr1+enV7Ob0/PzWaCNCjqSMj/DNGPVN2JyA1IUPa07xNAdPukH1cYpnV8BIKqZa+Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:00 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:05:57 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYmtXSUwtdjBGZXdVeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wVscI+PT7EmHZYQltDkxiVsAQYvYNkseZ15k3my
+        kWUbG0IqnVRSJwnu6qrgv/6SLOnD308kSP57a5nUGrrIcOy/vnEX7DcK2pqjG/b0r2+Dfp0ufvtb
+        +ZesAw+qnmFB1Vl62IpUFyLf9BQZ+WPdsYBhqz6CrmogdQx0xXZk5nSJrLm7peeoY9PRFgrN0rRI
+        j9F8eDM3u9POBtz05wPNXOWm/Rx/OaAbo1V39GvSmpi13mJW8R6kmma1Id3k9dzttLraeYXO6p5d
+        iPWmQ5dKD457o062nMtz+t2VXcm3nd1s1tvyTXV+rd9InK/2WOiuNOt2uC6O76DfuB4PhZ+XCzq/
+        KZfHgrNuINO4LG79eWXHldy7nIB6w87VUoAwJ9AjmTm4f9mGUFd1uASu57tQDeaJDP6ULs8AUpfQ
+        nag2sCBSdhDJzJEm+whPfaiYBsITDNfQTn4AFwIVrw9UakOZSa7CAh0iTanh5dxtZtCFkYGosmZ4
+        u9BrOrbu2LS/wIPZi2E5sTZJeVQYVTYBQtGP0I8Hhu8+JUSFxF/ChdQfwFr+h6rgKPGDW0kVyzgW
+        SGCEzZJ5OJRkBIGrzdQF3JGeGBxOiRIEXeSLq+2Vg8YS33F7OrA1eLrRcDix4UBMPGQcZWCa0IsG
+        Wj2qEI6USW6BiSfRQZ7qAnuK27PAFrdsjQ0b6orAX7AycyARA75Jb+kaGlTyhdiRaKHFx8MALm5S
+        2Dv2kmwF8xo3yXPEkZaIIWmRK8aOdC9kOuMmc3tH0ovtqEHsmjCYrK85xJUPbC94V0RPQUVeA9PQ
+        1VhXOJk5Uo4d/LOO3LOO/LMO4VmH+NjBPB4eWUNV810XZwVsiV+Fb4fpeImj+kBKHBOgeY6rcCyb
+        8kRi4rJ9awxdpciLKVckJq6lCTT8cORTnkhKeYKYQztr7JhMWsZP31BV/vffdP1El5njYTJPxHK2
+        /mey/ulF1xzf9txofCRppoV9MXneD2zDgzrVwLGD2SexRlnUNTxDw+i0NuAmyPFakNPDGTpZFHJX
+        eHfQ1qNr0lh/5n+nOORRPbj0YDBfFM9yeBYTS+j2PU11JhMEPSUnBl0dq4kNQQ2nfqRw+QJfEPKH
+        7rgwtO/wP8vS8bMWd8pKLBc59zrOzE5RZDmCPiqwdYKPxE6zEs1yfU76kWN/sOy/We5H0NPpClG7
+        x3MQXiMPJ/NHsyJ4M6oFdm85HyKfL+TY354PgRVeNB8C/v+a+YjGT9gwDMf2oF/pliqNWldmUnJk
+        IdPQAp43gxuq7PiuDf9EVBsPxwXaAodQv9brxxXDOQtfG7oi/qzHJfgq0k0c6I6CmwNewHhpMXIs
+        gTdTGFyZtsJ+6THpl0a0ve+X9iDymLg+qRJVxyP0fKSYxnrffCTFBrzLAB5g4mtvt4QKMqylGWxY
+        cONeXI+URC5/iaBppgk7HGLt8RDxq9YVm9aZE21MoRMsFFBkE+BHqI/nXOAuBF4SOS5XkJm9KmP6
+        noYvafaCY/EKCyJ+sCWyzCSNBbsDnIuC7QAi+4oDIaDfgF8w38TYG10SYnJ92w42EyRuOD6CpgOV
+        MM8J37H6sn1OKPouCLJIyhYroSEYg+NaATaHt/9IlYNnerjZqXBdKt9vy8xeipFex/MfuNWFpbAB
+        s53QZTRzNuGmigyHdHekyQjHJbaTxuEWxwuOyaC5lBx7wn3W1oOuDUyqj41UOQhkW6eSGuH7h+x9
+        Tz3xTxXIOLD8qK9eqdqsdXvDWrPZw7k6KYhMpPke0E3o4vfwEIciim3R1iPaMp4dtMQDPwglDWgz
+        HF7xxgIFbT3Ssr3Z5x3i2YX5ubJ5tjc77/VPL/qnIP+nEJp89Os4ZpR8ko+DEy0gPNOwgk0l4ajU
+        5ZttKAgChXdHl9hrjFiREJUgdW0gY2xG2HQshq4Ew0OicjAMKQuapnOS3RohozIvbeDVrdHQd7We
+        x8KyiPorNHU31blndBYArEW7yDbQvFDOD5r9SX76C9anbNsaRT2GLUatY5KPPgS/i4v3kvwYZw9R
+        lvwag4RF4SLHUp2WzCRSWDqbWRbCqy+FK5/Wwv4SQs0YI2OMLMd8tRyTMcZ5r/9pxqi7xndKfA/G
+        EAQp/wLGED8IY4ivY4zGGzPGePDr1qiWirXl8qojDac1rVup0Pz19XS4Ag+NPlttGoOiXZPu1Hyv
+        PenmO+as0s0Y4/Ml4IwxshzzVXJMxhjnvf6nGaPn29+p4nswRiHH8y9gjOIHYYzi6xij9caM4a93
+        m9tWuT0CTfdyNi1Wc013d40Kavmqddepjkfididpi51K+/X77bVEl+7nq4wxPmECzhgjyzFfJcdk
+        jHHe63+aMVoOZgzpPRijyBV//6/GBFb6IIwhvY4x2m/MGOzlcE2Pe9zEmNub2bZvjkr93Dbn3gqj
+        YqVSum+treaqfbMetBcNq/LADwvqzLvNGOPzJeCMMbIc81VyTMYY573+T/w9hg+/Uxz7HpAhYXL4
+        fcjg2I8BGRz7Osi4eR1kBF8nVH7amukH3+WkxkBbUMgDU0gtAYprEdMzUGL+XEzKv+bdu+7qkl5W
+        TbprrBbqg5hbLcxR3bm+qhd0dE/fbyYLUBr7W9+13UEGJZ8wY2dQkiWlr5KUMig57/U/DSVDqGMo
+        4d4FSiTuBX/BwT3+vtw/AyW//TW8QyjpvPEnH2JvVJfuRY6GrFRsbafOegB3rXbv/n7Z7aCqWbdM
+        vtYQXeNyYcxUwHrNIs9+HshgnjrVITvOITvO4YOiUkaDGQ18FRrIaPC81z87ziE7ziE7ziE7ziE7
+        ziE7zuGzH+cQRusXR5enBhk+LU8dRPl/HlYf8spSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:01 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:05:57 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0piVzVJR2stNHdCQmI1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a6Zaiypb+30/hOj/63l7dlIwi53q9S1BxABxAUf+wkEFQJhlEfJ1+k36yDgbT
+        ITMrM+tWndN9a51VRXzxRRCxY+9v7zjS+sfZdWonI4xs3/v7b8g3+Lea4Wm+bnu7v/+2kPpQ87d/
+        tP+tpZ5U21G3tmPHmeIHMWBHSmhEiRO3W1Gy1X1XtT0liYxQsSNlq+ptz2/V3+5pHRPVi+9mardO
+        qmPryhVvI636E/LMQD9kYB8y8A8ZxIeMxmtG/fX2tDALYl/ZOr52aPdgCOqdhwQ6mjNHKJWYSbZl
+        0k1oYONot2wmHfwM0xlrMY1+mJkX5rhYmKcF11lFiz6yTnD10j2j+IlHZRg9c+qGIPwMWwk6BK+P
+        jHRM99EREqdJExq6qeN3L/B4L2zIMbpkDtN0gOtcug3JDd5V7YaspPumORiuh5DVkOfkkOEaqC4G
+        TXkUHen+2CX7ohDTK8XReYJVPX2Eusf0MN9tWvWHPbWMk+EBV1BDQ1WA+xjtntyq31plh25EWrsH
+        vC1LLSM0KkKBtrTcYAXX8T3d96DkAN7xApb9BZUr+qvOarCjRlH1T8lXwzgClBtQdRb8Duis/bvq
+        Bn+rMcCDk3wpd90t4KeF05bTZgaY6RFqRYYaapZyMLLiTXXg6jckD4iKdx32gjxMduM9z6ernma8
+        PWm5nSvhAbxxin3QquMYcbXR7tOAcqf12xLqVyP6iReHldmLQ7gHXrqL8QvPjg29NgZqAeL8Rq1O
+        JbRjWwMycbKNVAmMUMt9BIHh3Hne6mrpamwooertDMXw9KpdTCZZyX/VkCiuiUYQG+7WCGsojIDo
+        u1FKdhJrim+akRG3sUb+qmf0RosMDbhS1EZwEiUJ/JF97SzpGfjjurrezl8KUzBSMV9wcNJ+swEj
+        SgGDSFFi2zUKOgRTEIxICPU7Bv8Ow/8JI7/nb3p7QDXvsw3KdhQD53hlFSK2arya/Ux7NFCcxOBP
+        24OAiS/ZgwD//Yg9qv0XWlO6o7CQmHmHGffmrfodXFEKM/BqHFtGWqP9JPSMv0Q1AWwnVLUDcCGp
+        J0rXgaXNymdbbzeG/WsPaFW4Axzdb4Pp1DjXjHuwYgRqbLXrYDDklu+FtsV7oQjyXt4LxUYU16/j
+        iyHVcLDDOInajn16mb6CrgSQUdVYrV/bcRYY7ch2A8cABgOTx9dxRU/FSoLIcByw0ih+2GLv9RbB
+        Ez+A7/H6G3PsDD8/KLXdclSQ6hJgcwL5RqBUA0EwslV/QVtAzXflIwR/Q2BwwkQDJO8b3KrfJrPU
+        SPH8XA/MqCggHoBcTYEiAsV5kdGq2XLVsxImngeOovQbBAV7eIW2XKC6b/Ce0ZZnGDrwiAD4G8gO
+        hU8W63kLr8hJqObZ/o52RUpCvgc/dHMZLpf/Cm0FfhSXyZNB5jVcElr1F+iaInRg/5ytHNw2/A1+
+        yRH3eCuy/EJVzXI7xeuesFYE/BLQi8mNM/AX4JP5dHfwlVPm7XNshJ7q1CRArNG5I3t67TaijJ+i
+        zntL8d/qaAHHSqp3iZ0u15uLco/jRFBT3ToqUjG9qOqOEYIYloErRldalcqqEuTBojc1lA0dJBDk
+        V2glRSH457USeZ073hOd3PsD33cKN69qhycsjwnHdvM0XHjeXfMDCUY+nZIKpylXB3XgKXDKCqh6
+        IuVkR/bWqRztGSxZN+EqfRCoU1UoLqshN6j1OkQfwzP/uzw48hsG16Z8q36Dyl7Lcl1QziBUmcfu
+        sfJ9Lz6iJWEI7jzZ7alcxW4bgELlAboxTFWL/bAqZp7AG8tL8kql3UQbd6wKvLECR9WMKL/SPEN3
+        HKADSpS5W9+p38NAhEq0/T//fT/+ht/Q9sM1LrdTni+qRBGENgjirZqXHOo28p0E+ECknoDRS515
+        BlvbwkN8IANtCIGgGeJeZvBGHouGtjlQF1yekht6BPUPyMzZzzlj0KTOJypi1kZz2zNOCGZZ/YGa
+        ZUpjrS+2gw6bpb15Q5xn3hqijZUlpUdU1SGNsDppc2ONg5HnYkIDHZsXHgsyOnKnEJMyi+Ea0naR
+        fDyN18gRomcdhRHTkdoczLXYPG1m9mi8IsO+rvW5LGAaGuMzq93EUvzoJGt+NuO5DZkMbXs7mR/W
+        Ib44xcP0oiCu5cvYdCGbXWMnotFmFMld+yhc3FDfeaSwaoYUOPBN15oMSI0abcGV6M4ioE52t7YH
+        whCjcuu9NPOABWoCHKAK17LR8nyvfFSeRr7RcUfOVaA4ujZGPLJvPfd0INWWGu6MNv7Efum4Y1cO
+        8vb8D52t0qmVysFA1AOPf4W1KuFXdzfXKoLxCbxzxjLuOoD1BN1z8rCvPyA3tQnVFAwA9/Fd4idR
+        pZoIKFHe7CjosR+rzhPzHms9G/3O1E8GvjPrG8Z8NGH9PgT/qXCMYAjaSysW7zNnmEQ9HB5tLDMb
+        NFh/2EuTYMEYqdUhkf12E2EziuARfbVuIlOHWicTLyEvkMj2T9DhaE9nntjAJJSXiRnrHv1hoGmD
+        Q4NAtDVBdWmKMLmZxB69CdqgjI0cCRl6QTk56kngBnHSG9xWpAx9gyG8wJN7KjJdcn6czFCeY6no
+        0lCdRTigEbMZTO0zO+U2WjKH+fke8oRJ2mDlSyeksaXqd+UEWSHCgIFSVUSt4EQwsG3anKXyfhS6
+        5NCY6M1sxAAZejcM8ccwNM5qUTRf06jeFvoY1QQhqb+0GtcW8LAYOHFxO3byzFcwq+eWmTjFQzXB
+        tZlHeghqJXCSIB0reeVzjflnuBWC2qyYAXhb+Vg4GSjKzuWVpp4DoOxUQYIBz/X7Nb25vsbb62v8
+        CeurP9n6oamoIFWFhuoU736n6yuiiX9JNOFfLJrwnyea9E8WTeqzmkl9XzLhH5RM+FdKJg8k0/B3
+        Gr7kFuFsHAYXXpHXErUE13VKHdABT/EyJ8HIANFtcaktmqkjwfHiqKTuQIIDRDw0RtpOYEQi2PS1
+        ybkXkkci5QeMJG4QwdjsUWYHbd2xvDYFTO/uJ5xOdrAtypqMmpojvjsCJtnj9urA2riSJAHeXa5T
+        Y4JTu/TQ2S8mGsR3lpDEmjy0hoZpPEoOpGA6zbPSmWv4/pCRA2ONnqypywT0uzKI/nA1gn6pGkF/
+        cTXyPP8fGVjMz65G0E9XI+h3Qwv9wWoE/agaubspVCYYzhmu9zLm7up2j5T/jzgAJq1pdqg5xuOA
+        623thpTe2lAgSDA7MKq7zc5uNuuxTTY8L3U3Vkm8e/IFp7GbD/dzY3WZsgfNMRcnJ9a2DWJ8bPoH
+        dgWtWDNcOEbqnvEGlSKrtaUez4igbDvSAL1oQmOyWz8upQqT+sOV6Ofdjw5AXcRI46LmbqIyPr7N
+        lAHquyN34aTuio8E47JJRmqmL9UJO9pzLpkcM55obhcXMCvV93V9MiVMU6C8vnPRpnNDZBnqsJXn
+        QjKlZTnkRUlHpxNFlf1ZqvlrN57z0nxGDmlnnZmQc8EU2xjKtBoLTZ9r2PvQlvowuOfQK248DyeC
+        Ka3M03KVwWGg9nW1N46O+uW4P+OUT2+X9ow9JwchjQ4Lv9uPmvoJsvtTiJfJATSRsZRW5MRMIGMq
+        0hdh1nlffT4uwmYoAd+KMNBC3i3CCuarIqec4J8pcmY/qQgr1v7W+pA/YX1/aBGGfqkIQ5Ev5Qrs
+        y7kC+Re6uf60XIG8myuw7+YK5FeWYflv48SK0pfSebrFaJYSk47WdBe7lbTQrNBXNX5D6pmYjghk
+        NSVDJpnFIuG7c+oSN63hCd2NZnS2GFodfsz5YwieTJXt0dosRhNDhHvZJd0tBM5npXG0uwTomUAg
+        e71vYqg+78uCzHG04fi8FzXT7DxLYyrpSSNWxM/zWPdsn0o6hsm7rD6Rjg14YcRNghyM4WMYMqfG
+        ZNrzlselsn5X/JAfLr2Qr4QT0vy14fQ8/wfhhP1fvtNgn40m7LvBVJrk68FUjvtK4SVKneIHkk8U
+        XiJYav4jyWdKLgiUXFbmEjI0U1wby/DNVNsc+dmGnVBUFo9juo/34NnAQsYzUze1pT30DvykN/bo
+        5KjTKLLWQnyFSuZxgoonfUVkSHrSMNwF8fzHllr5RW4lEkNtkGnuzONB+HY0u6+YHUG4iPvDhUft
+        RERFaOZchjNhND5jJwEn2WEisZtGt9kfrlh8toxtAd7FW7UZ+sJe9ObqXsBGaxmerUSJiqT1MJ3p
+        qz2XHCadbo8YrDpR0sjiIY6Nzr5zypJBQDaWl1Rankh+7fpucNowso/sPPayndOLS+BEJDGCxJHP
+        8nMYFlmC9ThzMJW4ScBDITeCQzcRfOXdUopAf1RNypGfVROc/JKaPF/7PlST5/n/PyfnvLD7nJxc
+        me/oSWmUN/WE+J6elOO+oid0h2MmwvpTgkKrDthZ9vlL3JyHqJOKHfBdBIngIHrnJsihqhNIi4ia
+        M01cssQNj/XwJjzwhZkwZnxuEE50odmN/d54lU6RoBGqnrvrXI492rXiXYdasTTkn/U0HFifUZb6
+        429emuopjqGegFMAl3CM6lfV13ALbCxQY826fcX3grhGbPn6HVDeiSf0pFV/xO4pUdxGvhEPjPxT
+        ipdmYUnGdxxDi2tm6Lu12DJqxU/cd4Oqn6uvzcojiw9hJvQd79pxo5bm0cC59LPRsms2u1mva/Hr
+        RcNcOwe/g7DIZc95J32ZWuSYGx224cq2oE2GnsVAnHT1gTq46JnK7qEgHOg4OSZPJjPvrxK+N0oW
+        +/mYjlhPnh/dQUw1ocjiovlm2PMojpYxeTmOsCkEpSNvNpgolyDbJNnC7uTZ4WmFdyvOT1ArLXJP
+        Kw/2/eN4+3ymk/xjn++eD/bh+UwBVvvrYlx9VTcMDQcEVs33nOw/PnVKYBWfOKUInBKLGynZOR8w
+        nCO5LF1IO3m6ljjneNYleL7NqIEI4QPOGZH0mk8hU1PkHrlK+90uwo44WsiiUJ8N4RCZaB2KOJBK
+        POw1mSNnkptIl/FguVTpmesrsq/tpzY+wXz8DKX983i0c/uTTtBgnZHjZNQFPbHJeWPQA80jt6Mw
+        pIV+TxbOH55c/pv1q2MDsuzacX6pLT8WtI3bN4dPHx/axnc/Pqxs//zVYf15sp/5SeNt8vqbG3nt
+        lDfkRUfq3/ua+n8BkYGS3ZItAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:02 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3839']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:05:58 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGNyeXB0b19ibG9jaz5FMC0tRXhJNTJKUkNxLXdUQ095YkN3WnJl
+      M0tzZ1Y4dUE0eDBCeUdoQzZGcnlmekNxVVVmdlVMQVhzVUYxWXU0YXpEeDI0dk0yVzAyeExhWjU1
+      b3kzWE5kLTBZcUNUcXdqc3EtU1B1OC1JbXdsb0R6MEtqTlo3SzJWQ2tQd0g0ZEx3YnI3WjREYWk2
+      V193ajhmSElZSS1oNldSN0lDTDYyZFNwOFdKc3FCRkttN0ZTTnRCWF9sZE01R2FuZEoybXF3a1Jn
+      WjwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bm9fb2ZfdGlja2V0cz4xPC9u
+      b19vZl90aWNrZXRzPjxiYW5kX3Rva2VuPi0xLS1RMW16UTBaV0tTZWNaazl6NFdQN1pCSi1GazFR
+      bGpSTGVIODl4djlzQ1llOGJFZXYxM2hoRkhheXlfNllkVWJIQUd5d0VSNlNSeW5ZLUJlWGhUd3Ey
+      YWQtYzVoQXc4WmhLcEpubTNONjJLZnpNM3B5QnNtUC1Dd0NVSVktY2dzV3F2S1kxcS1CUUFfQ1N3
+      SmE4SFJjdGZ2WlFpSktYN3JGZGNGTHlwQzZjQ29DWGdPaF9vc3ZXY295UU1MWjd1SWlpYk9Sa1ly
+      NFV2dEl3el8xbWhvVzNQVVdmRGVnUzJzWkpzV0RpcU56bXJkZ243Tlg4cjlfZmFaRGhPSDdjOUpi
+      WjwvYmFuZF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkZXNwYXRjaF90b2tlbj5jXy0t
+      RnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJYaWgtWnkyeFNwU09EZEhh
+      SHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5OC1zaExzUlpJRW45TEJX
+      M1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tlbj48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['449']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS1RvOIsjtcXFkMoKJNEgOLv9J/0l3UwKOi1
+        c6jMfKtauSqJfXacIE6cc3Zgcn9cbKsUAh+arvP7J+oz+akEHM3VTWf/+6flokvUP/3R/Bunm1Bz
+        AwfJrocwE8o+gIGFmhwMVN21FdORAwh82YSyquhNx+XKry0cCIGD5yk+UGS8DmgKa66cj1KDDqDW
+        FPBrRWcD+CAjJCinmShKuZbr6K5DBEeunIOpPaEOE3tmzCZbCoTZXylf8RHElBzIjAm/hY2lvyu2
+        9+9SG283iF+lYObwppIdpm4jgD09QhwEiq8Z8hFEyUplHJcciaOX8W7T7siDs5z37E9XHA28dppu
+        50Z4AHNOsg9esSyAso12niakOy3nr1C+BTFOCD8Le3IIReBuTuYvHRMBvTTAaYWTIqdmp+KbyNRw
+        ToUmOMse8LU4RyiSxMSXJk5XEJB9xdkDGTh6Nk6cLYzgXyUKotIceAjYKvBLNElVuXJOSdkB0mR3
+        t4MANZlqvNQzmtMg0HAqwSbF1uhahX1k34wpPcL/2bauN+NFyQZJZcw7jk/arVdJSk5gxdFlZNog
+        oRNkgyCpBdX4jSF/I8l/ktRv8UqvJ2R+n2OQjiHCyfEhKhVklEZK9DPjUaXZGkN+czwqZOW74lHB
+        f/5MPLL9J70mTcfxctGWWu2BIHHlApxRkjCMFIQMcC7xbuA74B+wNMbb8RXtiFNoIcwXt4lpzNJn
+        U29Wxe7NYt76m2zhRHeb2J2C4p5RBDOGpyCjWcaTCTtdl1CTdQlIOPd1CQQgKt/mJ1Oy6XiHKIBN
+        ywzv7jPoRsDtV0FK+TZGkQea0LQ9C+CAYefoNi+xZKzAg8Cy8JtC9LBF4eMW8dOoRxbx8gsfe+DG
+        B6U0OUtBJgpwzCvU5wrdqFIUU+PKd5TD3XyfPhLkZ4rEJ1yp0phwh7ly7sxQoOy4cT/YwURtHoC4
+        m+KOiDvOvY1mQ85WLrIfOA4+ijRvKBrv4QPK2bjrvuA9o5wDgI4zwsP5htUhycnkfV7hGTnwlVhD
+        C7QbkhLiPbi+Hbfh9PU/oJznQpSKZ5uSSuxizJXv0E0isGSjmC0f7Sb5mbxrRBHnoOEmXXWXbidZ
+        7gnjIM5LTE+cgwvOF5yTsbsCfOOkun1BwHcUq7TAxBIfJ7Kjl/IZaf0kl4JXHf+VgcOJFWRrzVud
+        oSDN18JwOOfKBUNGStzPFd0CPq7hNU5FeKNlUpZdQR4imnfDNdCxgFC/olc2GhT77b2S+qgd/6/p
+        xNnvua6VpHl2d3jC4pqwTDuW4STzCsOvtGDqmyUpSZr07YgWOcVJmQGZBcqhCU3VyhLtGUxZeeNK
+        cxB3p+yiuMqm5BD3sUQfyzP+f3pwtc8MWZqOuHIOpVbDsG18naEaqY4VsXS9e45ofuQhV1YtVzs2
+        RwxBeNMKopi9oGjsUZH469amDTdcSqYz7k3gkVbrZhBcLyHcAuNy3M3m++Hqum1dGHYlePWlBnWr
+        td5Y7zwv9i/h1pVkUD+8X+zFets6dSVTtv1g464kWSAEdqP4xrIzA/pltarN672ZwLJdudul+uvz
+        9XodbwPy0h5fFkqj3j3s0HlVMcSdcd2tuhXjPIkkgHoH0ZIWbIROkLAN9OaxvhsdKiM2HOtVfjeY
+        ztF6JvLGxjz1Q6O+nx+p7Ul668hVjX3fvptYPaNa5VALe07/ZLRHZF8S2x3fMyW64ezQyjouYfV6
+        BdH1LNZb/HjybjXESqNz6Jx0ngUkGDQkXay07PdxuIksQTBEqvaODvKwTsvd7RgOug1rSg/7A6N/
+        JBeGeEboshxOxeXJvBBdqAZ9v8OI/YqiyHR33p/stXN7vAumVQtqvfb5oo/3A7Z9OcEhtLtvdrj2
+        DzTuRhMLHJczcRrKQ1ZtWafutbZjhm8r8yrIZzWqheq8Q2zju2bhfDnVUhysknL+6eNYUVI6ry35
+        N1JSV00GV+8jwmmB7+Ovqyh/StN4r3p49QcoZ+wUDbl+dht+AnOWE8RX3WadrhZYGZizPEvRAGzS
+        BU4GFThYSGQY2aprlYswVrEUbf73P8X5OZ6jeTDgQ1zwjYB8CEt8RcCy7e7kfAKLFe8JuvvA34cq
+        dK0Atx2ohLjOU2l7BvHHh62aDu5tTCO234f5yyRRbnWWw0XhhdLQ34fpN6COv/xKsWbqiq8XyJke
+        fGV39yFysQ42NZIgTkeiwa8G0YWMemLt/W3VoUVHWrj6bnbavnmUPAtoRujR9XdYwZm2DK86KVwm
+        FHu2aoLd3aF2j64Be1yJGN7qH/YW7CoDXqiHvTobOrxvrFV20zK7kdoajXub1nIwIw/WiV0h+zw4
+        98YTpzNctMFkPZu1dyGC9cbRX8Oadworu2m329+ej42RdW7pe0q9qmvFjdCBOTJuaI3mR2bMj+Wl
+        q7dtxJMdqJkVa2cR3sHoDwaDzaxz7tLbQhDSXReiEF82i1FKb59YBbBy4lzNpCkd4NRw0kf56UBf
+        GArkWPE838Q9m6k8snNLkY6vJYbi70GTfWLfDQV2enmWX/t/MHJp/clKqJiWEiscVvQPGJddcpR9
+        ntOJ8DyBXOJUVmO5TZMXs56gIidOz/IDkiurr5zxBAeZ+8ANYHZDoPB1/KUhoSMXKdYTs4hxz0Ev
+        hPopwIWwvgjmYwjLeeX/6R5AU1/qAe2eOOx8pQe0DdPSS/iWDn60/glc/8OJbY96bVHrjobLtWru
+        iaU9WAxW2yFgtaBvD+orgqA70UbcqhRckPveTurERwfY9VC1jRlfNTtVnboYIamY2ikKzoZ9POr2
+        BqqEjLp8R9xvB63QOspMz5g1hK6ib+U3kZ0va0N88ZDe3XC8GJyW77XhkLl2Gz5/YTqtcbtxmayX
+        xzdxBa7Xk+bJW4L4ai1TP1DL6cF8ay1T9e+qZeZ7a/nZ/1+1fA/Ky1pmvlTL6bxfUMtf1PP5YtkR
+        xl9T9Hn8c4KDfko9H3E9+0R0Hm7mvCB4Fee6E1mfH1O1sG1N5+74uB9Oh27ovA83h85lcejph167
+        Gk7tcBSNPeT0Vcsww7feRLQCYf1+WGpLWXqX26KNhNpJ3V9tfrfRxNP60OpYrLTyT8qixlbq/DWQ
+        rJN7rhi1y2y/EHghnHZ5a+y2SXF+Pp5N7NKTd7xn0n1BFefD/qE2admMJ+yHk71zmF4sosF4/GlJ
+        76JotJTYS3UCqMhmxF4NmnVwHEe7tsgS0piVgjZVscnJhP56P6B/pB98l7bT1V/bD579/9UP7kH5
+        /n6Qzvv5/YD5orZPWtOv9QLgmK5f0kxkXoHzU1pCFbeE7pHpDc0eyVb4gazsSEnYQQkezqS9smp9
+        cxEu8ec1ci4bxmuvrqa/q/fRVmpvjL7Z6dtHhTH4qRo0+P1Yr08XUdALDF9zhZVeXyF/dCY2Az4c
+        tulDtDpuJpS5C+uu1ZPG6wo9bOtktJAv9HU+joC/vdRn3mEi0WB7rdDGiTYYZmF14FiCJ007iGTg
+        96YkyaqsdZK/Qe6ZH7m6f5fc079Y7p/9/1Xe96D8ifL+stzfH2H6W2VekoZrxj8/3H+x/GAp5NvT
+        vz3/Dxp+z4a8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:02 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2691']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:05:58 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['1148']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:03 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/ConcessionTests.test_string_properties.yaml
+++ b/tests/interface_objects/cassettes/ConcessionTests.test_string_properties.yaml
@@ -1,411 +1,347 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbuBW+71NoctG92MoE/8kslzuxY2/T2N6sJdfd3nBAALQYkyBDgLbU1+mb
+        9Mn2ECRFStbWUrLupMlmmLH44ePBwcEH8BBA8MMyzyb3rBJpwb9/oR+hFxPGSUFTfvv9i+v52dR7
+        8UP4p4DdMy4jwXBFFlHFRJ3JMBB1TIscpzyqBauiVEQxpiEvAm13SUCqVSmLKM4KcheSaDp1prF4
+        f/PT++zqtmJT8Tr+25X/0zFJvMVbZ/lhdpn8KC9n747fxY6eodWrNC7P5rfyOP4Q/0Ic76S2z4/f
+        4cX17N2VH52If/z9n0vxLzGrXztzo7QMHt/dvDmf3qMz9nC9/NFandwtFgZOEz8zqZ2s4sWF/bN9
+        cZmh8tia/hJoG/4FNBUSc8JEhCsW3eMsbRu3C28DFAaA4AjCx8LTm0Ab7toCygQJTyHaq4cFq1hH
+        UGhAUrlquVnBacGn9R04tAbbckU9V+VdYfdwhoXo/rR8XEkBlAHoChX/FRRO/ozz8rvJCfRk3bgy
+        Kg6gv1TntWZXDCxtQkGnhDu2UjVp0OUD0gij4/WPrZENYwNv2x5tArzbaNucnrABDhzVjmOcZUx2
+        DX299UDbUm1wQeuDWAgZVZjfgr0cL8FyHqec0dA2jlCgbUCKAE7KskoJCy23ZwxYS6mhGbgCk/aa
+        sYaCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlmDLXwIhIwqjPWBOvLbOKHGnPZjIqilDCfQWeq0Rn1
+        eKgH2hayzTCeZJhPMqwnGfaTDOcxQ3vcPNWHEamrCiZtoPS/2uFwG5eg6g1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4bGnEazYlVHheZNoZhCm3R8D//Hj8/4IG23UztN7T8R/9/Jf0/
+        7nRS1FxWXfvUS3MMrIvVfH/NU8no5C1oB/KTgdq9RatUpgTSm/uUPUQlq0jzTm8jtLMooFiy1o+I
+        cdrdK2PzRf2XiS7kZMZKyZp4TQykQxQHSsuuJYmKJBFMhqbTVLWNDjTBCLz6RahbruHa1ia7L2zp
+        K/iX5xTmWqgU+UjvmGsc3syF5yA9UjDmNJJpzhR9ivwp0ue6/9JELxH6Fukvm5p2P9DZ3Y5Bew95
+        UiUfRcWWi8kFXv2e8XAMyzXR3vGwkX1QPGy4PiYeXfvb5FnJ8fJ6fnL16uTt6VWgjeCOosJwgaVc
+        sIfJcVFXnH0jJpfQnAqTO5DQ/HQ27x9sY9b+hgzUeXPWl6zz0SgDoRchmMOyyfHGYMfIGU0xSB+r
+        KQVG5gKGVkj1h6X1YNp1nNN0eUSyoqZJVXB5xJkMNMUJUg4xhtyxeYuXkGhB3KssXEhZipea9l9N
+        aALe2IxqIx9giBUlDCzNN+EiyIoTRA2LJSZFNvMSllgxdl3k0wRZpsWwbpKj9+UtdMROPwKOoTsy
+        6BgBjYPGq/ugxHIR/q7VK4vB5xGKnYEQdVkWkFRHjT/d59kY2SR0KfoWFmgbcvlcteMyuJDlEce2
+        E9enOmZIt3Sf+IZlIM/RaaLbTuyZyR7ayXH1oWb7K+fgyp9ROQf78gUo5xPiFSmmZvhwuRazPdd3
+        MQw6X3dtI3ZNik0fYeYkXoIdZnmO8bR8mi8XmGmbTIjvq6GP9eP5lPSxHu2hp8dq+cwE9Ukj0GZw
+        IWQlhh3bGMdOYpkGoS5zPNOPYfK2DOphO9HdeA8tQepf7T8THVz3M85EB/vylc5EbCkjyYRE2rdi
+        JeCTIRqQpiFZyqo9hNIxn5TK/tU9gzb2r/yrn0YSHy6MIeODPNByXWIik7peTGwduYQg+A6kiWc5
+        mHhPq0NWaQNFSXq//2RysAfPOJkc7MsXMJl8hvKBL9M/5PN/Ip9Pz/0Qg8uwbWolvhNTZMQYu3FC
+        DQP+Exz7iHiJQxg1rf01VPC9Z6CPdePZk+KDPfoS3mafHjYCADaoZXs+9nzLQ7ZuwRcFZIaEEQ/7
+        nuHYhuEh5Jv760k+FAfq6WA3nl1PB3v0P9ZTG1jnzdk0b9cop7Fao5yKKV+vUU6bNE7rn29j1p0e
+        kFjWIsxU8rEB9YQ6plhirb+XxR3j44XNFuhLVyXku2nT9EimULVc05qSjlWXgmVZlKVCbiyWnj5e
+        LIVfF39FY1zbYeOWFc2SLwQlg+97WVMW2vqRbfiOrptuoK3RICv4bftzio505CDddgwgrOFAG4wt
+        sIh40ewsJEK9UzaAZh+9WU9gdL2B3t2qvdeq5rxZalAr0LrRbb9uoGr3dAdvGw04YzSirMRVcy5A
+        rW4rf3bhHbmucDPBjGg90hKaNhRV3mzAt+4/QoNmd6g9NnGiX02s+SUMtx7qDwf05y6iuzxEze7v
+        DjwQi0LtzyRtc1ptb2KBANUS1q68rz88gDaCe057YmMpWcVxNpkDcXLcyJzTyfBEuxKvTrrs2jva
+        VRCAsOqurtmr1+enV7Ob0/PzWaCNCjqSMj/DNGPVN2JyA1IUPa07xNAdPukH1cYpnV8BIKqZa+Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:03 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:05:58 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYmtXSUwtdjBGZXdVeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wVscI+PT7EmHZYQltDkxiVsAQYvYNkseZ15k3my
+        kWUbG0IqnVRSJwnu6qrgv/6SLOnD308kSP57a5nUGrrIcOy/vnEX7DcK2pqjG/b0r2+Dfp0ufvtb
+        +ZesAw+qnmFB1Vl62IpUFyLf9BQZ+WPdsYBhqz6CrmogdQx0xXZk5nSJrLm7peeoY9PRFgrN0rRI
+        j9F8eDM3u9POBtz05wPNXOWm/Rx/OaAbo1V39GvSmpi13mJW8R6kmma1Id3k9dzttLraeYXO6p5d
+        iPWmQ5dKD457o062nMtz+t2VXcm3nd1s1tvyTXV+rd9InK/2WOiuNOt2uC6O76DfuB4PhZ+XCzq/
+        KZfHgrNuINO4LG79eWXHldy7nIB6w87VUoAwJ9AjmTm4f9mGUFd1uASu57tQDeaJDP6ULs8AUpfQ
+        nag2sCBSdhDJzJEm+whPfaiYBsITDNfQTn4AFwIVrw9UakOZSa7CAh0iTanh5dxtZtCFkYGosmZ4
+        u9BrOrbu2LS/wIPZi2E5sTZJeVQYVTYBQtGP0I8Hhu8+JUSFxF/ChdQfwFr+h6rgKPGDW0kVyzgW
+        SGCEzZJ5OJRkBIGrzdQF3JGeGBxOiRIEXeSLq+2Vg8YS33F7OrA1eLrRcDix4UBMPGQcZWCa0IsG
+        Wj2qEI6USW6BiSfRQZ7qAnuK27PAFrdsjQ0b6orAX7AycyARA75Jb+kaGlTyhdiRaKHFx8MALm5S
+        2Dv2kmwF8xo3yXPEkZaIIWmRK8aOdC9kOuMmc3tH0ovtqEHsmjCYrK85xJUPbC94V0RPQUVeA9PQ
+        1VhXOJk5Uo4d/LOO3LOO/LMO4VmH+NjBPB4eWUNV810XZwVsiV+Fb4fpeImj+kBKHBOgeY6rcCyb
+        8kRi4rJ9awxdpciLKVckJq6lCTT8cORTnkhKeYKYQztr7JhMWsZP31BV/vffdP1El5njYTJPxHK2
+        /mey/ulF1xzf9txofCRppoV9MXneD2zDgzrVwLGD2SexRlnUNTxDw+i0NuAmyPFakNPDGTpZFHJX
+        eHfQ1qNr0lh/5n+nOORRPbj0YDBfFM9yeBYTS+j2PU11JhMEPSUnBl0dq4kNQQ2nfqRw+QJfEPKH
+        7rgwtO/wP8vS8bMWd8pKLBc59zrOzE5RZDmCPiqwdYKPxE6zEs1yfU76kWN/sOy/We5H0NPpClG7
+        x3MQXiMPJ/NHsyJ4M6oFdm85HyKfL+TY354PgRVeNB8C/v+a+YjGT9gwDMf2oF/pliqNWldmUnJk
+        IdPQAp43gxuq7PiuDf9EVBsPxwXaAodQv9brxxXDOQtfG7oi/qzHJfgq0k0c6I6CmwNewHhpMXIs
+        gTdTGFyZtsJ+6THpl0a0ve+X9iDymLg+qRJVxyP0fKSYxnrffCTFBrzLAB5g4mtvt4QKMqylGWxY
+        cONeXI+URC5/iaBppgk7HGLt8RDxq9YVm9aZE21MoRMsFFBkE+BHqI/nXOAuBF4SOS5XkJm9KmP6
+        noYvafaCY/EKCyJ+sCWyzCSNBbsDnIuC7QAi+4oDIaDfgF8w38TYG10SYnJ92w42EyRuOD6CpgOV
+        MM8J37H6sn1OKPouCLJIyhYroSEYg+NaATaHt/9IlYNnerjZqXBdKt9vy8xeipFex/MfuNWFpbAB
+        s53QZTRzNuGmigyHdHekyQjHJbaTxuEWxwuOyaC5lBx7wn3W1oOuDUyqj41UOQhkW6eSGuH7h+x9
+        Tz3xTxXIOLD8qK9eqdqsdXvDWrPZw7k6KYhMpPke0E3o4vfwEIciim3R1iPaMp4dtMQDPwglDWgz
+        HF7xxgIFbT3Ssr3Z5x3i2YX5ubJ5tjc77/VPL/qnIP+nEJp89Os4ZpR8ko+DEy0gPNOwgk0l4ajU
+        5ZttKAgChXdHl9hrjFiREJUgdW0gY2xG2HQshq4Ew0OicjAMKQuapnOS3RohozIvbeDVrdHQd7We
+        x8KyiPorNHU31blndBYArEW7yDbQvFDOD5r9SX76C9anbNsaRT2GLUatY5KPPgS/i4v3kvwYZw9R
+        lvwag4RF4SLHUp2WzCRSWDqbWRbCqy+FK5/Wwv4SQs0YI2OMLMd8tRyTMcZ5r/9pxqi7xndKfA/G
+        EAQp/wLGED8IY4ivY4zGGzPGePDr1qiWirXl8qojDac1rVup0Pz19XS4Ag+NPlttGoOiXZPu1Hyv
+        PenmO+as0s0Y4/Ml4IwxshzzVXJMxhjnvf6nGaPn29+p4nswRiHH8y9gjOIHYYzi6xij9caM4a93
+        m9tWuT0CTfdyNi1Wc013d40Kavmqddepjkfididpi51K+/X77bVEl+7nq4wxPmECzhgjyzFfJcdk
+        jHHe63+aMVoOZgzpPRijyBV//6/GBFb6IIwhvY4x2m/MGOzlcE2Pe9zEmNub2bZvjkr93Dbn3gqj
+        YqVSum+treaqfbMetBcNq/LADwvqzLvNGOPzJeCMMbIc81VyTMYY573+T/w9hg+/Uxz7HpAhYXL4
+        fcjg2I8BGRz7Osi4eR1kBF8nVH7amukH3+WkxkBbUMgDU0gtAYprEdMzUGL+XEzKv+bdu+7qkl5W
+        TbprrBbqg5hbLcxR3bm+qhd0dE/fbyYLUBr7W9+13UEGJZ8wY2dQkiWlr5KUMig57/U/DSVDqGMo
+        4d4FSiTuBX/BwT3+vtw/AyW//TW8QyjpvPEnH2JvVJfuRY6GrFRsbafOegB3rXbv/n7Z7aCqWbdM
+        vtYQXeNyYcxUwHrNIs9+HshgnjrVITvOITvO4YOiUkaDGQ18FRrIaPC81z87ziE7ziE7ziE7ziE7
+        ziE7zuGzH+cQRusXR5enBhk+LU8dRPl/HlYf8spSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:03 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:05:59 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0piVzVJR2stNHdCQmI1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a6Zaiypb+30/hOj/63l7dlIwi53q9S1BxABxAUf+wkEFQJhlEfJ1+k36yDgbT
+        ITMrM+tWndN9a51VRXzxRRCxY+9v7zjS+sfZdWonI4xs3/v7b8g3+Lea4Wm+bnu7v/+2kPpQ87d/
+        tP+tpZ5U21G3tmPHmeIHMWBHSmhEiRO3W1Gy1X1XtT0liYxQsSNlq+ptz2/V3+5pHRPVi+9mardO
+        qmPryhVvI636E/LMQD9kYB8y8A8ZxIeMxmtG/fX2tDALYl/ZOr52aPdgCOqdhwQ6mjNHKJWYSbZl
+        0k1oYONot2wmHfwM0xlrMY1+mJkX5rhYmKcF11lFiz6yTnD10j2j+IlHZRg9c+qGIPwMWwk6BK+P
+        jHRM99EREqdJExq6qeN3L/B4L2zIMbpkDtN0gOtcug3JDd5V7YaspPumORiuh5DVkOfkkOEaqC4G
+        TXkUHen+2CX7ohDTK8XReYJVPX2Eusf0MN9tWvWHPbWMk+EBV1BDQ1WA+xjtntyq31plh25EWrsH
+        vC1LLSM0KkKBtrTcYAXX8T3d96DkAN7xApb9BZUr+qvOarCjRlH1T8lXwzgClBtQdRb8Duis/bvq
+        Bn+rMcCDk3wpd90t4KeF05bTZgaY6RFqRYYaapZyMLLiTXXg6jckD4iKdx32gjxMduM9z6ernma8
+        PWm5nSvhAbxxin3QquMYcbXR7tOAcqf12xLqVyP6iReHldmLQ7gHXrqL8QvPjg29NgZqAeL8Rq1O
+        JbRjWwMycbKNVAmMUMt9BIHh3Hne6mrpamwooertDMXw9KpdTCZZyX/VkCiuiUYQG+7WCGsojIDo
+        u1FKdhJrim+akRG3sUb+qmf0RosMDbhS1EZwEiUJ/JF97SzpGfjjurrezl8KUzBSMV9wcNJ+swEj
+        SgGDSFFi2zUKOgRTEIxICPU7Bv8Ow/8JI7/nb3p7QDXvsw3KdhQD53hlFSK2arya/Ux7NFCcxOBP
+        24OAiS/ZgwD//Yg9qv0XWlO6o7CQmHmHGffmrfodXFEKM/BqHFtGWqP9JPSMv0Q1AWwnVLUDcCGp
+        J0rXgaXNymdbbzeG/WsPaFW4Axzdb4Pp1DjXjHuwYgRqbLXrYDDklu+FtsV7oQjyXt4LxUYU16/j
+        iyHVcLDDOInajn16mb6CrgSQUdVYrV/bcRYY7ch2A8cABgOTx9dxRU/FSoLIcByw0ih+2GLv9RbB
+        Ez+A7/H6G3PsDD8/KLXdclSQ6hJgcwL5RqBUA0EwslV/QVtAzXflIwR/Q2BwwkQDJO8b3KrfJrPU
+        SPH8XA/MqCggHoBcTYEiAsV5kdGq2XLVsxImngeOovQbBAV7eIW2XKC6b/Ce0ZZnGDrwiAD4G8gO
+        hU8W63kLr8hJqObZ/o52RUpCvgc/dHMZLpf/Cm0FfhSXyZNB5jVcElr1F+iaInRg/5ytHNw2/A1+
+        yRH3eCuy/EJVzXI7xeuesFYE/BLQi8mNM/AX4JP5dHfwlVPm7XNshJ7q1CRArNG5I3t67TaijJ+i
+        zntL8d/qaAHHSqp3iZ0u15uLco/jRFBT3ToqUjG9qOqOEYIYloErRldalcqqEuTBojc1lA0dJBDk
+        V2glRSH457USeZ073hOd3PsD33cKN69qhycsjwnHdvM0XHjeXfMDCUY+nZIKpylXB3XgKXDKCqh6
+        IuVkR/bWqRztGSxZN+EqfRCoU1UoLqshN6j1OkQfwzP/uzw48hsG16Z8q36Dyl7Lcl1QziBUmcfu
+        sfJ9Lz6iJWEI7jzZ7alcxW4bgELlAboxTFWL/bAqZp7AG8tL8kql3UQbd6wKvLECR9WMKL/SPEN3
+        HKADSpS5W9+p38NAhEq0/T//fT/+ht/Q9sM1LrdTni+qRBGENgjirZqXHOo28p0E+ECknoDRS515
+        BlvbwkN8IANtCIGgGeJeZvBGHouGtjlQF1yekht6BPUPyMzZzzlj0KTOJypi1kZz2zNOCGZZ/YGa
+        ZUpjrS+2gw6bpb15Q5xn3hqijZUlpUdU1SGNsDppc2ONg5HnYkIDHZsXHgsyOnKnEJMyi+Ea0naR
+        fDyN18gRomcdhRHTkdoczLXYPG1m9mi8IsO+rvW5LGAaGuMzq93EUvzoJGt+NuO5DZkMbXs7mR/W
+        Ib44xcP0oiCu5cvYdCGbXWMnotFmFMld+yhc3FDfeaSwaoYUOPBN15oMSI0abcGV6M4ioE52t7YH
+        whCjcuu9NPOABWoCHKAK17LR8nyvfFSeRr7RcUfOVaA4ujZGPLJvPfd0INWWGu6MNv7Efum4Y1cO
+        8vb8D52t0qmVysFA1AOPf4W1KuFXdzfXKoLxCbxzxjLuOoD1BN1z8rCvPyA3tQnVFAwA9/Fd4idR
+        pZoIKFHe7CjosR+rzhPzHms9G/3O1E8GvjPrG8Z8NGH9PgT/qXCMYAjaSysW7zNnmEQ9HB5tLDMb
+        NFh/2EuTYMEYqdUhkf12E2EziuARfbVuIlOHWicTLyEvkMj2T9DhaE9nntjAJJSXiRnrHv1hoGmD
+        Q4NAtDVBdWmKMLmZxB69CdqgjI0cCRl6QTk56kngBnHSG9xWpAx9gyG8wJN7KjJdcn6czFCeY6no
+        0lCdRTigEbMZTO0zO+U2WjKH+fke8oRJ2mDlSyeksaXqd+UEWSHCgIFSVUSt4EQwsG3anKXyfhS6
+        5NCY6M1sxAAZejcM8ccwNM5qUTRf06jeFvoY1QQhqb+0GtcW8LAYOHFxO3byzFcwq+eWmTjFQzXB
+        tZlHeghqJXCSIB0reeVzjflnuBWC2qyYAXhb+Vg4GSjKzuWVpp4DoOxUQYIBz/X7Nb25vsbb62v8
+        CeurP9n6oamoIFWFhuoU736n6yuiiX9JNOFfLJrwnyea9E8WTeqzmkl9XzLhH5RM+FdKJg8k0/B3
+        Gr7kFuFsHAYXXpHXErUE13VKHdABT/EyJ8HIANFtcaktmqkjwfHiqKTuQIIDRDw0RtpOYEQi2PS1
+        ybkXkkci5QeMJG4QwdjsUWYHbd2xvDYFTO/uJ5xOdrAtypqMmpojvjsCJtnj9urA2riSJAHeXa5T
+        Y4JTu/TQ2S8mGsR3lpDEmjy0hoZpPEoOpGA6zbPSmWv4/pCRA2ONnqypywT0uzKI/nA1gn6pGkF/
+        cTXyPP8fGVjMz65G0E9XI+h3Qwv9wWoE/agaubspVCYYzhmu9zLm7up2j5T/jzgAJq1pdqg5xuOA
+        623thpTe2lAgSDA7MKq7zc5uNuuxTTY8L3U3Vkm8e/IFp7GbD/dzY3WZsgfNMRcnJ9a2DWJ8bPoH
+        dgWtWDNcOEbqnvEGlSKrtaUez4igbDvSAL1oQmOyWz8upQqT+sOV6Ofdjw5AXcRI46LmbqIyPr7N
+        lAHquyN34aTuio8E47JJRmqmL9UJO9pzLpkcM55obhcXMCvV93V9MiVMU6C8vnPRpnNDZBnqsJXn
+        QjKlZTnkRUlHpxNFlf1ZqvlrN57z0nxGDmlnnZmQc8EU2xjKtBoLTZ9r2PvQlvowuOfQK248DyeC
+        Ka3M03KVwWGg9nW1N46O+uW4P+OUT2+X9ow9JwchjQ4Lv9uPmvoJsvtTiJfJATSRsZRW5MRMIGMq
+        0hdh1nlffT4uwmYoAd+KMNBC3i3CCuarIqec4J8pcmY/qQgr1v7W+pA/YX1/aBGGfqkIQ5Ev5Qrs
+        y7kC+Re6uf60XIG8myuw7+YK5FeWYflv48SK0pfSebrFaJYSk47WdBe7lbTQrNBXNX5D6pmYjghk
+        NSVDJpnFIuG7c+oSN63hCd2NZnS2GFodfsz5YwieTJXt0dosRhNDhHvZJd0tBM5npXG0uwTomUAg
+        e71vYqg+78uCzHG04fi8FzXT7DxLYyrpSSNWxM/zWPdsn0o6hsm7rD6Rjg14YcRNghyM4WMYMqfG
+        ZNrzlselsn5X/JAfLr2Qr4QT0vy14fQ8/wfhhP1fvtNgn40m7LvBVJrk68FUjvtK4SVKneIHkk8U
+        XiJYav4jyWdKLgiUXFbmEjI0U1wby/DNVNsc+dmGnVBUFo9juo/34NnAQsYzUze1pT30DvykN/bo
+        5KjTKLLWQnyFSuZxgoonfUVkSHrSMNwF8fzHllr5RW4lEkNtkGnuzONB+HY0u6+YHUG4iPvDhUft
+        RERFaOZchjNhND5jJwEn2WEisZtGt9kfrlh8toxtAd7FW7UZ+sJe9ObqXsBGaxmerUSJiqT1MJ3p
+        qz2XHCadbo8YrDpR0sjiIY6Nzr5zypJBQDaWl1Rankh+7fpucNowso/sPPayndOLS+BEJDGCxJHP
+        8nMYFlmC9ThzMJW4ScBDITeCQzcRfOXdUopAf1RNypGfVROc/JKaPF/7PlST5/n/PyfnvLD7nJxc
+        me/oSWmUN/WE+J6elOO+oid0h2MmwvpTgkKrDthZ9vlL3JyHqJOKHfBdBIngIHrnJsihqhNIi4ia
+        M01cssQNj/XwJjzwhZkwZnxuEE50odmN/d54lU6RoBGqnrvrXI492rXiXYdasTTkn/U0HFifUZb6
+        429emuopjqGegFMAl3CM6lfV13ALbCxQY826fcX3grhGbPn6HVDeiSf0pFV/xO4pUdxGvhEPjPxT
+        ipdmYUnGdxxDi2tm6Lu12DJqxU/cd4Oqn6uvzcojiw9hJvQd79pxo5bm0cC59LPRsms2u1mva/Hr
+        RcNcOwe/g7DIZc95J32ZWuSYGx224cq2oE2GnsVAnHT1gTq46JnK7qEgHOg4OSZPJjPvrxK+N0oW
+        +/mYjlhPnh/dQUw1ocjiovlm2PMojpYxeTmOsCkEpSNvNpgolyDbJNnC7uTZ4WmFdyvOT1ArLXJP
+        Kw/2/eN4+3ymk/xjn++eD/bh+UwBVvvrYlx9VTcMDQcEVs33nOw/PnVKYBWfOKUInBKLGynZOR8w
+        nCO5LF1IO3m6ljjneNYleL7NqIEI4QPOGZH0mk8hU1PkHrlK+90uwo44WsiiUJ8N4RCZaB2KOJBK
+        POw1mSNnkptIl/FguVTpmesrsq/tpzY+wXz8DKX983i0c/uTTtBgnZHjZNQFPbHJeWPQA80jt6Mw
+        pIV+TxbOH55c/pv1q2MDsuzacX6pLT8WtI3bN4dPHx/axnc/Pqxs//zVYf15sp/5SeNt8vqbG3nt
+        lDfkRUfq3/ua+n8BkYGS3ZItAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:04 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3839']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:05:59 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGNyeXB0b19ibG9jaz5FMC0tRXhJNTJKUkNxLXdUQ095YkN3WnJl
+      M0tzZ1Y4dUE0eDBCeUdoQzZGcnlmekNxVVVmdlVMQVhzVUYxWXU0YXpEeDI0dk0yVzAyeExhWjU1
+      b3kzWE5kLTBZcUNUcXdqc3EtU1B1OC1JbXdsb0R6MEtqTlo3SzJWQ2tQd0g0ZEx3YnI3WjREYWk2
+      V193ajhmSElZSS1oNldSN0lDTDYyZFNwOFdKc3FCRkttN0ZTTnRCWF9sZE01R2FuZEoybXF3a1Jn
+      WjwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bm9fb2ZfdGlja2V0cz4xPC9u
+      b19vZl90aWNrZXRzPjxiYW5kX3Rva2VuPi0xLS1RMW16UTBaV0tTZWNaazl6NFdQN1pCSi1GazFR
+      bGpSTGVIODl4djlzQ1llOGJFZXYxM2hoRkhheXlfNllkVWJIQUd5d0VSNlNSeW5ZLUJlWGhUd3Ey
+      YWQtYzVoQXc4WmhLcEpubTNONjJLZnpNM3B5QnNtUC1Dd0NVSVktY2dzV3F2S1kxcS1CUUFfQ1N3
+      SmE4SFJjdGZ2WlFpSktYN3JGZGNGTHlwQzZjQ29DWGdPaF9vc3ZXY295UU1MWjd1SWlpYk9Sa1ly
+      NFV2dEl3el8xbWhvVzNQVVdmRGVnUzJzWkpzV0RpcU56bXJkZ243Tlg4cjlfZmFaRGhPSDdjOUpi
+      WjwvYmFuZF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkZXNwYXRjaF90b2tlbj5jXy0t
+      RnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJYaWgtWnkyeFNwU09EZEhh
+      SHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5OC1zaExzUlpJRW45TEJX
+      M1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tlbj48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['449']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS1RvOIsjtcXFkMoKJNEgOLv9J/0l3UwKOi1
+        c6jMfKtauSqJfXacIE6cc3Zgcn9cbKsUAh+arvP7J+oz+akEHM3VTWf/+6flokvUP/3R/Bunm1Bz
+        AwfJrocwE8o+gIGFmhwMVN21FdORAwh82YSyquhNx+XKry0cCIGD5yk+UGS8DmgKa66cj1KDDqDW
+        FPBrRWcD+CAjJCinmShKuZbr6K5DBEeunIOpPaEOE3tmzCZbCoTZXylf8RHElBzIjAm/hY2lvyu2
+        9+9SG283iF+lYObwppIdpm4jgD09QhwEiq8Z8hFEyUplHJcciaOX8W7T7siDs5z37E9XHA28dppu
+        50Z4AHNOsg9esSyAso12niakOy3nr1C+BTFOCD8Le3IIReBuTuYvHRMBvTTAaYWTIqdmp+KbyNRw
+        ToUmOMse8LU4RyiSxMSXJk5XEJB9xdkDGTh6Nk6cLYzgXyUKotIceAjYKvBLNElVuXJOSdkB0mR3
+        t4MANZlqvNQzmtMg0HAqwSbF1uhahX1k34wpPcL/2bauN+NFyQZJZcw7jk/arVdJSk5gxdFlZNog
+        oRNkgyCpBdX4jSF/I8l/ktRv8UqvJ2R+n2OQjiHCyfEhKhVklEZK9DPjUaXZGkN+czwqZOW74lHB
+        f/5MPLL9J70mTcfxctGWWu2BIHHlApxRkjCMFIQMcC7xbuA74B+wNMbb8RXtiFNoIcwXt4lpzNJn
+        U29Wxe7NYt76m2zhRHeb2J2C4p5RBDOGpyCjWcaTCTtdl1CTdQlIOPd1CQQgKt/mJ1Oy6XiHKIBN
+        ywzv7jPoRsDtV0FK+TZGkQea0LQ9C+CAYefoNi+xZKzAg8Cy8JtC9LBF4eMW8dOoRxbx8gsfe+DG
+        B6U0OUtBJgpwzCvU5wrdqFIUU+PKd5TD3XyfPhLkZ4rEJ1yp0phwh7ly7sxQoOy4cT/YwURtHoC4
+        m+KOiDvOvY1mQ85WLrIfOA4+ijRvKBrv4QPK2bjrvuA9o5wDgI4zwsP5htUhycnkfV7hGTnwlVhD
+        C7QbkhLiPbi+Hbfh9PU/oJznQpSKZ5uSSuxizJXv0E0isGSjmC0f7Sb5mbxrRBHnoOEmXXWXbidZ
+        7gnjIM5LTE+cgwvOF5yTsbsCfOOkun1BwHcUq7TAxBIfJ7Kjl/IZaf0kl4JXHf+VgcOJFWRrzVud
+        oSDN18JwOOfKBUNGStzPFd0CPq7hNU5FeKNlUpZdQR4imnfDNdCxgFC/olc2GhT77b2S+qgd/6/p
+        xNnvua6VpHl2d3jC4pqwTDuW4STzCsOvtGDqmyUpSZr07YgWOcVJmQGZBcqhCU3VyhLtGUxZeeNK
+        cxB3p+yiuMqm5BD3sUQfyzP+f3pwtc8MWZqOuHIOpVbDsG18naEaqY4VsXS9e45ofuQhV1YtVzs2
+        RwxBeNMKopi9oGjsUZH469amDTdcSqYz7k3gkVbrZhBcLyHcAuNy3M3m++Hqum1dGHYlePWlBnWr
+        td5Y7zwv9i/h1pVkUD+8X+zFets6dSVTtv1g464kWSAEdqP4xrIzA/pltarN672ZwLJdudul+uvz
+        9XodbwPy0h5fFkqj3j3s0HlVMcSdcd2tuhXjPIkkgHoH0ZIWbIROkLAN9OaxvhsdKiM2HOtVfjeY
+        ztF6JvLGxjz1Q6O+nx+p7Ul668hVjX3fvptYPaNa5VALe07/ZLRHZF8S2x3fMyW64ezQyjouYfV6
+        BdH1LNZb/HjybjXESqNz6Jx0ngUkGDQkXay07PdxuIksQTBEqvaODvKwTsvd7RgOug1rSg/7A6N/
+        JBeGeEboshxOxeXJvBBdqAZ9v8OI/YqiyHR33p/stXN7vAumVQtqvfb5oo/3A7Z9OcEhtLtvdrj2
+        DzTuRhMLHJczcRrKQ1ZtWafutbZjhm8r8yrIZzWqheq8Q2zju2bhfDnVUhysknL+6eNYUVI6ry35
+        N1JSV00GV+8jwmmB7+Ovqyh/StN4r3p49QcoZ+wUDbl+dht+AnOWE8RX3WadrhZYGZizPEvRAGzS
+        BU4GFThYSGQY2aprlYswVrEUbf73P8X5OZ6jeTDgQ1zwjYB8CEt8RcCy7e7kfAKLFe8JuvvA34cq
+        dK0Atx2ohLjOU2l7BvHHh62aDu5tTCO234f5yyRRbnWWw0XhhdLQ34fpN6COv/xKsWbqiq8XyJke
+        fGV39yFysQ42NZIgTkeiwa8G0YWMemLt/W3VoUVHWrj6bnbavnmUPAtoRujR9XdYwZm2DK86KVwm
+        FHu2aoLd3aF2j64Be1yJGN7qH/YW7CoDXqiHvTobOrxvrFV20zK7kdoajXub1nIwIw/WiV0h+zw4
+        98YTpzNctMFkPZu1dyGC9cbRX8Oadworu2m329+ej42RdW7pe0q9qmvFjdCBOTJuaI3mR2bMj+Wl
+        q7dtxJMdqJkVa2cR3sHoDwaDzaxz7tLbQhDSXReiEF82i1FKb59YBbBy4lzNpCkd4NRw0kf56UBf
+        GArkWPE838Q9m6k8snNLkY6vJYbi70GTfWLfDQV2enmWX/t/MHJp/clKqJiWEiscVvQPGJddcpR9
+        ntOJ8DyBXOJUVmO5TZMXs56gIidOz/IDkiurr5zxBAeZ+8ANYHZDoPB1/KUhoSMXKdYTs4hxz0Ev
+        hPopwIWwvgjmYwjLeeX/6R5AU1/qAe2eOOx8pQe0DdPSS/iWDn60/glc/8OJbY96bVHrjobLtWru
+        iaU9WAxW2yFgtaBvD+orgqA70UbcqhRckPveTurERwfY9VC1jRlfNTtVnboYIamY2ikKzoZ9POr2
+        BqqEjLp8R9xvB63QOspMz5g1hK6ib+U3kZ0va0N88ZDe3XC8GJyW77XhkLl2Gz5/YTqtcbtxmayX
+        xzdxBa7Xk+bJW4L4ai1TP1DL6cF8ay1T9e+qZeZ7a/nZ/1+1fA/Ky1pmvlTL6bxfUMtf1PP5YtkR
+        xl9T9Hn8c4KDfko9H3E9+0R0Hm7mvCB4Fee6E1mfH1O1sG1N5+74uB9Oh27ovA83h85lcejph167
+        Gk7tcBSNPeT0Vcsww7feRLQCYf1+WGpLWXqX26KNhNpJ3V9tfrfRxNP60OpYrLTyT8qixlbq/DWQ
+        rJN7rhi1y2y/EHghnHZ5a+y2SXF+Pp5N7NKTd7xn0n1BFefD/qE2admMJ+yHk71zmF4sosF4/GlJ
+        76JotJTYS3UCqMhmxF4NmnVwHEe7tsgS0piVgjZVscnJhP56P6B/pB98l7bT1V/bD579/9UP7kH5
+        /n6Qzvv5/YD5orZPWtOv9QLgmK5f0kxkXoHzU1pCFbeE7pHpDc0eyVb4gazsSEnYQQkezqS9smp9
+        cxEu8ec1ci4bxmuvrqa/q/fRVmpvjL7Z6dtHhTH4qRo0+P1Yr08XUdALDF9zhZVeXyF/dCY2Az4c
+        tulDtDpuJpS5C+uu1ZPG6wo9bOtktJAv9HU+joC/vdRn3mEi0WB7rdDGiTYYZmF14FiCJ007iGTg
+        96YkyaqsdZK/Qe6ZH7m6f5fc079Y7p/9/1Xe96D8ifL+stzfH2H6W2VekoZrxj8/3H+x/GAp5NvT
+        vz3/Dxp+z4a8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:04 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2691']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:05:59 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['1148']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:04 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/ConcessionTests.test_unicode_properties.yaml
+++ b/tests/interface_objects/cassettes/ConcessionTests.test_unicode_properties.yaml
@@ -1,411 +1,347 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbuBW+71NoctG92MoE/8kslzuxY2/T2N6sJdfd3nBAALQYkyBDgLbU1+mb
+        9Mn2ECRFStbWUrLupMlmmLH44ePBwcEH8BBA8MMyzyb3rBJpwb9/oR+hFxPGSUFTfvv9i+v52dR7
+        8UP4p4DdMy4jwXBFFlHFRJ3JMBB1TIscpzyqBauiVEQxpiEvAm13SUCqVSmLKM4KcheSaDp1prF4
+        f/PT++zqtmJT8Tr+25X/0zFJvMVbZ/lhdpn8KC9n747fxY6eodWrNC7P5rfyOP4Q/0Ic76S2z4/f
+        4cX17N2VH52If/z9n0vxLzGrXztzo7QMHt/dvDmf3qMz9nC9/NFandwtFgZOEz8zqZ2s4sWF/bN9
+        cZmh8tia/hJoG/4FNBUSc8JEhCsW3eMsbRu3C28DFAaA4AjCx8LTm0Ab7toCygQJTyHaq4cFq1hH
+        UGhAUrlquVnBacGn9R04tAbbckU9V+VdYfdwhoXo/rR8XEkBlAHoChX/FRRO/ozz8rvJCfRk3bgy
+        Kg6gv1TntWZXDCxtQkGnhDu2UjVp0OUD0gij4/WPrZENYwNv2x5tArzbaNucnrABDhzVjmOcZUx2
+        DX299UDbUm1wQeuDWAgZVZjfgr0cL8FyHqec0dA2jlCgbUCKAE7KskoJCy23ZwxYS6mhGbgCk/aa
+        sYaCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlmDLXwIhIwqjPWBOvLbOKHGnPZjIqilDCfQWeq0Rn1
+        eKgH2hayzTCeZJhPMqwnGfaTDOcxQ3vcPNWHEamrCiZtoPS/2uFwG5eg6g1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4bGnEazYlVHheZNoZhCm3R8D//Hj8/4IG23UztN7T8R/9/Jf0/
+        7nRS1FxWXfvUS3MMrIvVfH/NU8no5C1oB/KTgdq9RatUpgTSm/uUPUQlq0jzTm8jtLMooFiy1o+I
+        cdrdK2PzRf2XiS7kZMZKyZp4TQykQxQHSsuuJYmKJBFMhqbTVLWNDjTBCLz6RahbruHa1ia7L2zp
+        K/iX5xTmWqgU+UjvmGsc3syF5yA9UjDmNJJpzhR9ivwp0ue6/9JELxH6Fukvm5p2P9DZ3Y5Bew95
+        UiUfRcWWi8kFXv2e8XAMyzXR3vGwkX1QPGy4PiYeXfvb5FnJ8fJ6fnL16uTt6VWgjeCOosJwgaVc
+        sIfJcVFXnH0jJpfQnAqTO5DQ/HQ27x9sY9b+hgzUeXPWl6zz0SgDoRchmMOyyfHGYMfIGU0xSB+r
+        KQVG5gKGVkj1h6X1YNp1nNN0eUSyoqZJVXB5xJkMNMUJUg4xhtyxeYuXkGhB3KssXEhZipea9l9N
+        aALe2IxqIx9giBUlDCzNN+EiyIoTRA2LJSZFNvMSllgxdl3k0wRZpsWwbpKj9+UtdMROPwKOoTsy
+        6BgBjYPGq/ugxHIR/q7VK4vB5xGKnYEQdVkWkFRHjT/d59kY2SR0KfoWFmgbcvlcteMyuJDlEce2
+        E9enOmZIt3Sf+IZlIM/RaaLbTuyZyR7ayXH1oWb7K+fgyp9ROQf78gUo5xPiFSmmZvhwuRazPdd3
+        MQw6X3dtI3ZNik0fYeYkXoIdZnmO8bR8mi8XmGmbTIjvq6GP9eP5lPSxHu2hp8dq+cwE9Ukj0GZw
+        IWQlhh3bGMdOYpkGoS5zPNOPYfK2DOphO9HdeA8tQepf7T8THVz3M85EB/vylc5EbCkjyYRE2rdi
+        JeCTIRqQpiFZyqo9hNIxn5TK/tU9gzb2r/yrn0YSHy6MIeODPNByXWIik7peTGwduYQg+A6kiWc5
+        mHhPq0NWaQNFSXq//2RysAfPOJkc7MsXMJl8hvKBL9M/5PN/Ip9Pz/0Qg8uwbWolvhNTZMQYu3FC
+        DQP+Exz7iHiJQxg1rf01VPC9Z6CPdePZk+KDPfoS3mafHjYCADaoZXs+9nzLQ7ZuwRcFZIaEEQ/7
+        nuHYhuEh5Jv760k+FAfq6WA3nl1PB3v0P9ZTG1jnzdk0b9cop7Fao5yKKV+vUU6bNE7rn29j1p0e
+        kFjWIsxU8rEB9YQ6plhirb+XxR3j44XNFuhLVyXku2nT9EimULVc05qSjlWXgmVZlKVCbiyWnj5e
+        LIVfF39FY1zbYeOWFc2SLwQlg+97WVMW2vqRbfiOrptuoK3RICv4bftzio505CDddgwgrOFAG4wt
+        sIh40ewsJEK9UzaAZh+9WU9gdL2B3t2qvdeq5rxZalAr0LrRbb9uoGr3dAdvGw04YzSirMRVcy5A
+        rW4rf3bhHbmucDPBjGg90hKaNhRV3mzAt+4/QoNmd6g9NnGiX02s+SUMtx7qDwf05y6iuzxEze7v
+        DjwQi0LtzyRtc1ptb2KBANUS1q68rz88gDaCe057YmMpWcVxNpkDcXLcyJzTyfBEuxKvTrrs2jva
+        VRCAsOqurtmr1+enV7Ob0/PzWaCNCjqSMj/DNGPVN2JyA1IUPa07xNAdPukH1cYpnV8BIKqZa+Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:05 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:00 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYmtXSUwtdjBGZXdVeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wVscI+PT7EmHZYQltDkxiVsAQYvYNkseZ15k3my
+        kWUbG0IqnVRSJwnu6qrgv/6SLOnD308kSP57a5nUGrrIcOy/vnEX7DcK2pqjG/b0r2+Dfp0ufvtb
+        +ZesAw+qnmFB1Vl62IpUFyLf9BQZ+WPdsYBhqz6CrmogdQx0xXZk5nSJrLm7peeoY9PRFgrN0rRI
+        j9F8eDM3u9POBtz05wPNXOWm/Rx/OaAbo1V39GvSmpi13mJW8R6kmma1Id3k9dzttLraeYXO6p5d
+        iPWmQ5dKD457o062nMtz+t2VXcm3nd1s1tvyTXV+rd9InK/2WOiuNOt2uC6O76DfuB4PhZ+XCzq/
+        KZfHgrNuINO4LG79eWXHldy7nIB6w87VUoAwJ9AjmTm4f9mGUFd1uASu57tQDeaJDP6ULs8AUpfQ
+        nag2sCBSdhDJzJEm+whPfaiYBsITDNfQTn4AFwIVrw9UakOZSa7CAh0iTanh5dxtZtCFkYGosmZ4
+        u9BrOrbu2LS/wIPZi2E5sTZJeVQYVTYBQtGP0I8Hhu8+JUSFxF/ChdQfwFr+h6rgKPGDW0kVyzgW
+        SGCEzZJ5OJRkBIGrzdQF3JGeGBxOiRIEXeSLq+2Vg8YS33F7OrA1eLrRcDix4UBMPGQcZWCa0IsG
+        Wj2qEI6USW6BiSfRQZ7qAnuK27PAFrdsjQ0b6orAX7AycyARA75Jb+kaGlTyhdiRaKHFx8MALm5S
+        2Dv2kmwF8xo3yXPEkZaIIWmRK8aOdC9kOuMmc3tH0ovtqEHsmjCYrK85xJUPbC94V0RPQUVeA9PQ
+        1VhXOJk5Uo4d/LOO3LOO/LMO4VmH+NjBPB4eWUNV810XZwVsiV+Fb4fpeImj+kBKHBOgeY6rcCyb
+        8kRi4rJ9awxdpciLKVckJq6lCTT8cORTnkhKeYKYQztr7JhMWsZP31BV/vffdP1El5njYTJPxHK2
+        /mey/ulF1xzf9txofCRppoV9MXneD2zDgzrVwLGD2SexRlnUNTxDw+i0NuAmyPFakNPDGTpZFHJX
+        eHfQ1qNr0lh/5n+nOORRPbj0YDBfFM9yeBYTS+j2PU11JhMEPSUnBl0dq4kNQQ2nfqRw+QJfEPKH
+        7rgwtO/wP8vS8bMWd8pKLBc59zrOzE5RZDmCPiqwdYKPxE6zEs1yfU76kWN/sOy/We5H0NPpClG7
+        x3MQXiMPJ/NHsyJ4M6oFdm85HyKfL+TY354PgRVeNB8C/v+a+YjGT9gwDMf2oF/pliqNWldmUnJk
+        IdPQAp43gxuq7PiuDf9EVBsPxwXaAodQv9brxxXDOQtfG7oi/qzHJfgq0k0c6I6CmwNewHhpMXIs
+        gTdTGFyZtsJ+6THpl0a0ve+X9iDymLg+qRJVxyP0fKSYxnrffCTFBrzLAB5g4mtvt4QKMqylGWxY
+        cONeXI+URC5/iaBppgk7HGLt8RDxq9YVm9aZE21MoRMsFFBkE+BHqI/nXOAuBF4SOS5XkJm9KmP6
+        noYvafaCY/EKCyJ+sCWyzCSNBbsDnIuC7QAi+4oDIaDfgF8w38TYG10SYnJ92w42EyRuOD6CpgOV
+        MM8J37H6sn1OKPouCLJIyhYroSEYg+NaATaHt/9IlYNnerjZqXBdKt9vy8xeipFex/MfuNWFpbAB
+        s53QZTRzNuGmigyHdHekyQjHJbaTxuEWxwuOyaC5lBx7wn3W1oOuDUyqj41UOQhkW6eSGuH7h+x9
+        Tz3xTxXIOLD8qK9eqdqsdXvDWrPZw7k6KYhMpPke0E3o4vfwEIciim3R1iPaMp4dtMQDPwglDWgz
+        HF7xxgIFbT3Ssr3Z5x3i2YX5ubJ5tjc77/VPL/qnIP+nEJp89Os4ZpR8ko+DEy0gPNOwgk0l4ajU
+        5ZttKAgChXdHl9hrjFiREJUgdW0gY2xG2HQshq4Ew0OicjAMKQuapnOS3RohozIvbeDVrdHQd7We
+        x8KyiPorNHU31blndBYArEW7yDbQvFDOD5r9SX76C9anbNsaRT2GLUatY5KPPgS/i4v3kvwYZw9R
+        lvwag4RF4SLHUp2WzCRSWDqbWRbCqy+FK5/Wwv4SQs0YI2OMLMd8tRyTMcZ5r/9pxqi7xndKfA/G
+        EAQp/wLGED8IY4ivY4zGGzPGePDr1qiWirXl8qojDac1rVup0Pz19XS4Ag+NPlttGoOiXZPu1Hyv
+        PenmO+as0s0Y4/Ml4IwxshzzVXJMxhjnvf6nGaPn29+p4nswRiHH8y9gjOIHYYzi6xij9caM4a93
+        m9tWuT0CTfdyNi1Wc013d40Kavmqddepjkfididpi51K+/X77bVEl+7nq4wxPmECzhgjyzFfJcdk
+        jHHe63+aMVoOZgzpPRijyBV//6/GBFb6IIwhvY4x2m/MGOzlcE2Pe9zEmNub2bZvjkr93Dbn3gqj
+        YqVSum+treaqfbMetBcNq/LADwvqzLvNGOPzJeCMMbIc81VyTMYY573+T/w9hg+/Uxz7HpAhYXL4
+        fcjg2I8BGRz7Osi4eR1kBF8nVH7amukH3+WkxkBbUMgDU0gtAYprEdMzUGL+XEzKv+bdu+7qkl5W
+        TbprrBbqg5hbLcxR3bm+qhd0dE/fbyYLUBr7W9+13UEGJZ8wY2dQkiWlr5KUMig57/U/DSVDqGMo
+        4d4FSiTuBX/BwT3+vtw/AyW//TW8QyjpvPEnH2JvVJfuRY6GrFRsbafOegB3rXbv/n7Z7aCqWbdM
+        vtYQXeNyYcxUwHrNIs9+HshgnjrVITvOITvO4YOiUkaDGQ18FRrIaPC81z87ziE7ziE7ziE7ziE7
+        ziE7zuGzH+cQRusXR5enBhk+LU8dRPl/HlYf8spSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:05 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:00 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0piVzVJR2stNHdCQmI1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a6Zaiypb+30/hOj/63l7dlIwi53q9S1BxABxAUf+wkEFQJhlEfJ1+k36yDgbT
+        ITMrM+tWndN9a51VRXzxRRCxY+9v7zjS+sfZdWonI4xs3/v7b8g3+Lea4Wm+bnu7v/+2kPpQ87d/
+        tP+tpZ5U21G3tmPHmeIHMWBHSmhEiRO3W1Gy1X1XtT0liYxQsSNlq+ptz2/V3+5pHRPVi+9mardO
+        qmPryhVvI636E/LMQD9kYB8y8A8ZxIeMxmtG/fX2tDALYl/ZOr52aPdgCOqdhwQ6mjNHKJWYSbZl
+        0k1oYONot2wmHfwM0xlrMY1+mJkX5rhYmKcF11lFiz6yTnD10j2j+IlHZRg9c+qGIPwMWwk6BK+P
+        jHRM99EREqdJExq6qeN3L/B4L2zIMbpkDtN0gOtcug3JDd5V7YaspPumORiuh5DVkOfkkOEaqC4G
+        TXkUHen+2CX7ohDTK8XReYJVPX2Eusf0MN9tWvWHPbWMk+EBV1BDQ1WA+xjtntyq31plh25EWrsH
+        vC1LLSM0KkKBtrTcYAXX8T3d96DkAN7xApb9BZUr+qvOarCjRlH1T8lXwzgClBtQdRb8Duis/bvq
+        Bn+rMcCDk3wpd90t4KeF05bTZgaY6RFqRYYaapZyMLLiTXXg6jckD4iKdx32gjxMduM9z6ernma8
+        PWm5nSvhAbxxin3QquMYcbXR7tOAcqf12xLqVyP6iReHldmLQ7gHXrqL8QvPjg29NgZqAeL8Rq1O
+        JbRjWwMycbKNVAmMUMt9BIHh3Hne6mrpamwooertDMXw9KpdTCZZyX/VkCiuiUYQG+7WCGsojIDo
+        u1FKdhJrim+akRG3sUb+qmf0RosMDbhS1EZwEiUJ/JF97SzpGfjjurrezl8KUzBSMV9wcNJ+swEj
+        SgGDSFFi2zUKOgRTEIxICPU7Bv8Ow/8JI7/nb3p7QDXvsw3KdhQD53hlFSK2arya/Ux7NFCcxOBP
+        24OAiS/ZgwD//Yg9qv0XWlO6o7CQmHmHGffmrfodXFEKM/BqHFtGWqP9JPSMv0Q1AWwnVLUDcCGp
+        J0rXgaXNymdbbzeG/WsPaFW4Axzdb4Pp1DjXjHuwYgRqbLXrYDDklu+FtsV7oQjyXt4LxUYU16/j
+        iyHVcLDDOInajn16mb6CrgSQUdVYrV/bcRYY7ch2A8cABgOTx9dxRU/FSoLIcByw0ih+2GLv9RbB
+        Ez+A7/H6G3PsDD8/KLXdclSQ6hJgcwL5RqBUA0EwslV/QVtAzXflIwR/Q2BwwkQDJO8b3KrfJrPU
+        SPH8XA/MqCggHoBcTYEiAsV5kdGq2XLVsxImngeOovQbBAV7eIW2XKC6b/Ce0ZZnGDrwiAD4G8gO
+        hU8W63kLr8hJqObZ/o52RUpCvgc/dHMZLpf/Cm0FfhSXyZNB5jVcElr1F+iaInRg/5ytHNw2/A1+
+        yRH3eCuy/EJVzXI7xeuesFYE/BLQi8mNM/AX4JP5dHfwlVPm7XNshJ7q1CRArNG5I3t67TaijJ+i
+        zntL8d/qaAHHSqp3iZ0u15uLco/jRFBT3ToqUjG9qOqOEYIYloErRldalcqqEuTBojc1lA0dJBDk
+        V2glRSH457USeZ073hOd3PsD33cKN69qhycsjwnHdvM0XHjeXfMDCUY+nZIKpylXB3XgKXDKCqh6
+        IuVkR/bWqRztGSxZN+EqfRCoU1UoLqshN6j1OkQfwzP/uzw48hsG16Z8q36Dyl7Lcl1QziBUmcfu
+        sfJ9Lz6iJWEI7jzZ7alcxW4bgELlAboxTFWL/bAqZp7AG8tL8kql3UQbd6wKvLECR9WMKL/SPEN3
+        HKADSpS5W9+p38NAhEq0/T//fT/+ht/Q9sM1LrdTni+qRBGENgjirZqXHOo28p0E+ECknoDRS515
+        BlvbwkN8IANtCIGgGeJeZvBGHouGtjlQF1yekht6BPUPyMzZzzlj0KTOJypi1kZz2zNOCGZZ/YGa
+        ZUpjrS+2gw6bpb15Q5xn3hqijZUlpUdU1SGNsDppc2ONg5HnYkIDHZsXHgsyOnKnEJMyi+Ea0naR
+        fDyN18gRomcdhRHTkdoczLXYPG1m9mi8IsO+rvW5LGAaGuMzq93EUvzoJGt+NuO5DZkMbXs7mR/W
+        Ib44xcP0oiCu5cvYdCGbXWMnotFmFMld+yhc3FDfeaSwaoYUOPBN15oMSI0abcGV6M4ioE52t7YH
+        whCjcuu9NPOABWoCHKAK17LR8nyvfFSeRr7RcUfOVaA4ujZGPLJvPfd0INWWGu6MNv7Efum4Y1cO
+        8vb8D52t0qmVysFA1AOPf4W1KuFXdzfXKoLxCbxzxjLuOoD1BN1z8rCvPyA3tQnVFAwA9/Fd4idR
+        pZoIKFHe7CjosR+rzhPzHms9G/3O1E8GvjPrG8Z8NGH9PgT/qXCMYAjaSysW7zNnmEQ9HB5tLDMb
+        NFh/2EuTYMEYqdUhkf12E2EziuARfbVuIlOHWicTLyEvkMj2T9DhaE9nntjAJJSXiRnrHv1hoGmD
+        Q4NAtDVBdWmKMLmZxB69CdqgjI0cCRl6QTk56kngBnHSG9xWpAx9gyG8wJN7KjJdcn6czFCeY6no
+        0lCdRTigEbMZTO0zO+U2WjKH+fke8oRJ2mDlSyeksaXqd+UEWSHCgIFSVUSt4EQwsG3anKXyfhS6
+        5NCY6M1sxAAZejcM8ccwNM5qUTRf06jeFvoY1QQhqb+0GtcW8LAYOHFxO3byzFcwq+eWmTjFQzXB
+        tZlHeghqJXCSIB0reeVzjflnuBWC2qyYAXhb+Vg4GSjKzuWVpp4DoOxUQYIBz/X7Nb25vsbb62v8
+        CeurP9n6oamoIFWFhuoU736n6yuiiX9JNOFfLJrwnyea9E8WTeqzmkl9XzLhH5RM+FdKJg8k0/B3
+        Gr7kFuFsHAYXXpHXErUE13VKHdABT/EyJ8HIANFtcaktmqkjwfHiqKTuQIIDRDw0RtpOYEQi2PS1
+        ybkXkkci5QeMJG4QwdjsUWYHbd2xvDYFTO/uJ5xOdrAtypqMmpojvjsCJtnj9urA2riSJAHeXa5T
+        Y4JTu/TQ2S8mGsR3lpDEmjy0hoZpPEoOpGA6zbPSmWv4/pCRA2ONnqypywT0uzKI/nA1gn6pGkF/
+        cTXyPP8fGVjMz65G0E9XI+h3Qwv9wWoE/agaubspVCYYzhmu9zLm7up2j5T/jzgAJq1pdqg5xuOA
+        623thpTe2lAgSDA7MKq7zc5uNuuxTTY8L3U3Vkm8e/IFp7GbD/dzY3WZsgfNMRcnJ9a2DWJ8bPoH
+        dgWtWDNcOEbqnvEGlSKrtaUez4igbDvSAL1oQmOyWz8upQqT+sOV6Ofdjw5AXcRI46LmbqIyPr7N
+        lAHquyN34aTuio8E47JJRmqmL9UJO9pzLpkcM55obhcXMCvV93V9MiVMU6C8vnPRpnNDZBnqsJXn
+        QjKlZTnkRUlHpxNFlf1ZqvlrN57z0nxGDmlnnZmQc8EU2xjKtBoLTZ9r2PvQlvowuOfQK248DyeC
+        Ka3M03KVwWGg9nW1N46O+uW4P+OUT2+X9ow9JwchjQ4Lv9uPmvoJsvtTiJfJATSRsZRW5MRMIGMq
+        0hdh1nlffT4uwmYoAd+KMNBC3i3CCuarIqec4J8pcmY/qQgr1v7W+pA/YX1/aBGGfqkIQ5Ev5Qrs
+        y7kC+Re6uf60XIG8myuw7+YK5FeWYflv48SK0pfSebrFaJYSk47WdBe7lbTQrNBXNX5D6pmYjghk
+        NSVDJpnFIuG7c+oSN63hCd2NZnS2GFodfsz5YwieTJXt0dosRhNDhHvZJd0tBM5npXG0uwTomUAg
+        e71vYqg+78uCzHG04fi8FzXT7DxLYyrpSSNWxM/zWPdsn0o6hsm7rD6Rjg14YcRNghyM4WMYMqfG
+        ZNrzlselsn5X/JAfLr2Qr4QT0vy14fQ8/wfhhP1fvtNgn40m7LvBVJrk68FUjvtK4SVKneIHkk8U
+        XiJYav4jyWdKLgiUXFbmEjI0U1wby/DNVNsc+dmGnVBUFo9juo/34NnAQsYzUze1pT30DvykN/bo
+        5KjTKLLWQnyFSuZxgoonfUVkSHrSMNwF8fzHllr5RW4lEkNtkGnuzONB+HY0u6+YHUG4iPvDhUft
+        RERFaOZchjNhND5jJwEn2WEisZtGt9kfrlh8toxtAd7FW7UZ+sJe9ObqXsBGaxmerUSJiqT1MJ3p
+        qz2XHCadbo8YrDpR0sjiIY6Nzr5zypJBQDaWl1Rankh+7fpucNowso/sPPayndOLS+BEJDGCxJHP
+        8nMYFlmC9ThzMJW4ScBDITeCQzcRfOXdUopAf1RNypGfVROc/JKaPF/7PlST5/n/PyfnvLD7nJxc
+        me/oSWmUN/WE+J6elOO+oid0h2MmwvpTgkKrDthZ9vlL3JyHqJOKHfBdBIngIHrnJsihqhNIi4ia
+        M01cssQNj/XwJjzwhZkwZnxuEE50odmN/d54lU6RoBGqnrvrXI492rXiXYdasTTkn/U0HFifUZb6
+        429emuopjqGegFMAl3CM6lfV13ALbCxQY826fcX3grhGbPn6HVDeiSf0pFV/xO4pUdxGvhEPjPxT
+        ipdmYUnGdxxDi2tm6Lu12DJqxU/cd4Oqn6uvzcojiw9hJvQd79pxo5bm0cC59LPRsms2u1mva/Hr
+        RcNcOwe/g7DIZc95J32ZWuSYGx224cq2oE2GnsVAnHT1gTq46JnK7qEgHOg4OSZPJjPvrxK+N0oW
+        +/mYjlhPnh/dQUw1ocjiovlm2PMojpYxeTmOsCkEpSNvNpgolyDbJNnC7uTZ4WmFdyvOT1ArLXJP
+        Kw/2/eN4+3ymk/xjn++eD/bh+UwBVvvrYlx9VTcMDQcEVs33nOw/PnVKYBWfOKUInBKLGynZOR8w
+        nCO5LF1IO3m6ljjneNYleL7NqIEI4QPOGZH0mk8hU1PkHrlK+90uwo44WsiiUJ8N4RCZaB2KOJBK
+        POw1mSNnkptIl/FguVTpmesrsq/tpzY+wXz8DKX983i0c/uTTtBgnZHjZNQFPbHJeWPQA80jt6Mw
+        pIV+TxbOH55c/pv1q2MDsuzacX6pLT8WtI3bN4dPHx/axnc/Pqxs//zVYf15sp/5SeNt8vqbG3nt
+        lDfkRUfq3/ua+n8BkYGS3ZItAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:05 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3839']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:01 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGNyeXB0b19ibG9jaz5FMC0tRXhJNTJKUkNxLXdUQ095YkN3WnJl
+      M0tzZ1Y4dUE0eDBCeUdoQzZGcnlmekNxVVVmdlVMQVhzVUYxWXU0YXpEeDI0dk0yVzAyeExhWjU1
+      b3kzWE5kLTBZcUNUcXdqc3EtU1B1OC1JbXdsb0R6MEtqTlo3SzJWQ2tQd0g0ZEx3YnI3WjREYWk2
+      V193ajhmSElZSS1oNldSN0lDTDYyZFNwOFdKc3FCRkttN0ZTTnRCWF9sZE01R2FuZEoybXF3a1Jn
+      WjwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bm9fb2ZfdGlja2V0cz4xPC9u
+      b19vZl90aWNrZXRzPjxiYW5kX3Rva2VuPi0xLS1RMW16UTBaV0tTZWNaazl6NFdQN1pCSi1GazFR
+      bGpSTGVIODl4djlzQ1llOGJFZXYxM2hoRkhheXlfNllkVWJIQUd5d0VSNlNSeW5ZLUJlWGhUd3Ey
+      YWQtYzVoQXc4WmhLcEpubTNONjJLZnpNM3B5QnNtUC1Dd0NVSVktY2dzV3F2S1kxcS1CUUFfQ1N3
+      SmE4SFJjdGZ2WlFpSktYN3JGZGNGTHlwQzZjQ29DWGdPaF9vc3ZXY295UU1MWjd1SWlpYk9Sa1ly
+      NFV2dEl3el8xbWhvVzNQVVdmRGVnUzJzWkpzV0RpcU56bXJkZ243Tlg4cjlfZmFaRGhPSDdjOUpi
+      WjwvYmFuZF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkZXNwYXRjaF90b2tlbj5jXy0t
+      RnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJYaWgtWnkyeFNwU09EZEhh
+      SHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5OC1zaExzUlpJRW45TEJX
+      M1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tlbj48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['449']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS1RvOIsjtcXFkMoKJNEgOLv9J/0l3UwKOi1
+        c6jMfKtauSqJfXacIE6cc3Zgcn9cbKsUAh+arvP7J+oz+akEHM3VTWf/+6flokvUP/3R/Bunm1Bz
+        AwfJrocwE8o+gIGFmhwMVN21FdORAwh82YSyquhNx+XKry0cCIGD5yk+UGS8DmgKa66cj1KDDqDW
+        FPBrRWcD+CAjJCinmShKuZbr6K5DBEeunIOpPaEOE3tmzCZbCoTZXylf8RHElBzIjAm/hY2lvyu2
+        9+9SG283iF+lYObwppIdpm4jgD09QhwEiq8Z8hFEyUplHJcciaOX8W7T7siDs5z37E9XHA28dppu
+        50Z4AHNOsg9esSyAso12niakOy3nr1C+BTFOCD8Le3IIReBuTuYvHRMBvTTAaYWTIqdmp+KbyNRw
+        ToUmOMse8LU4RyiSxMSXJk5XEJB9xdkDGTh6Nk6cLYzgXyUKotIceAjYKvBLNElVuXJOSdkB0mR3
+        t4MANZlqvNQzmtMg0HAqwSbF1uhahX1k34wpPcL/2bauN+NFyQZJZcw7jk/arVdJSk5gxdFlZNog
+        oRNkgyCpBdX4jSF/I8l/ktRv8UqvJ2R+n2OQjiHCyfEhKhVklEZK9DPjUaXZGkN+czwqZOW74lHB
+        f/5MPLL9J70mTcfxctGWWu2BIHHlApxRkjCMFIQMcC7xbuA74B+wNMbb8RXtiFNoIcwXt4lpzNJn
+        U29Wxe7NYt76m2zhRHeb2J2C4p5RBDOGpyCjWcaTCTtdl1CTdQlIOPd1CQQgKt/mJ1Oy6XiHKIBN
+        ywzv7jPoRsDtV0FK+TZGkQea0LQ9C+CAYefoNi+xZKzAg8Cy8JtC9LBF4eMW8dOoRxbx8gsfe+DG
+        B6U0OUtBJgpwzCvU5wrdqFIUU+PKd5TD3XyfPhLkZ4rEJ1yp0phwh7ly7sxQoOy4cT/YwURtHoC4
+        m+KOiDvOvY1mQ85WLrIfOA4+ijRvKBrv4QPK2bjrvuA9o5wDgI4zwsP5htUhycnkfV7hGTnwlVhD
+        C7QbkhLiPbi+Hbfh9PU/oJznQpSKZ5uSSuxizJXv0E0isGSjmC0f7Sb5mbxrRBHnoOEmXXWXbidZ
+        7gnjIM5LTE+cgwvOF5yTsbsCfOOkun1BwHcUq7TAxBIfJ7Kjl/IZaf0kl4JXHf+VgcOJFWRrzVud
+        oSDN18JwOOfKBUNGStzPFd0CPq7hNU5FeKNlUpZdQR4imnfDNdCxgFC/olc2GhT77b2S+qgd/6/p
+        xNnvua6VpHl2d3jC4pqwTDuW4STzCsOvtGDqmyUpSZr07YgWOcVJmQGZBcqhCU3VyhLtGUxZeeNK
+        cxB3p+yiuMqm5BD3sUQfyzP+f3pwtc8MWZqOuHIOpVbDsG18naEaqY4VsXS9e45ofuQhV1YtVzs2
+        RwxBeNMKopi9oGjsUZH469amDTdcSqYz7k3gkVbrZhBcLyHcAuNy3M3m++Hqum1dGHYlePWlBnWr
+        td5Y7zwv9i/h1pVkUD+8X+zFets6dSVTtv1g464kWSAEdqP4xrIzA/pltarN672ZwLJdudul+uvz
+        9XodbwPy0h5fFkqj3j3s0HlVMcSdcd2tuhXjPIkkgHoH0ZIWbIROkLAN9OaxvhsdKiM2HOtVfjeY
+        ztF6JvLGxjz1Q6O+nx+p7Ul668hVjX3fvptYPaNa5VALe07/ZLRHZF8S2x3fMyW64ezQyjouYfV6
+        BdH1LNZb/HjybjXESqNz6Jx0ngUkGDQkXay07PdxuIksQTBEqvaODvKwTsvd7RgOug1rSg/7A6N/
+        JBeGeEboshxOxeXJvBBdqAZ9v8OI/YqiyHR33p/stXN7vAumVQtqvfb5oo/3A7Z9OcEhtLtvdrj2
+        DzTuRhMLHJczcRrKQ1ZtWafutbZjhm8r8yrIZzWqheq8Q2zju2bhfDnVUhysknL+6eNYUVI6ry35
+        N1JSV00GV+8jwmmB7+Ovqyh/StN4r3p49QcoZ+wUDbl+dht+AnOWE8RX3WadrhZYGZizPEvRAGzS
+        BU4GFThYSGQY2aprlYswVrEUbf73P8X5OZ6jeTDgQ1zwjYB8CEt8RcCy7e7kfAKLFe8JuvvA34cq
+        dK0Atx2ohLjOU2l7BvHHh62aDu5tTCO234f5yyRRbnWWw0XhhdLQ34fpN6COv/xKsWbqiq8XyJke
+        fGV39yFysQ42NZIgTkeiwa8G0YWMemLt/W3VoUVHWrj6bnbavnmUPAtoRujR9XdYwZm2DK86KVwm
+        FHu2aoLd3aF2j64Be1yJGN7qH/YW7CoDXqiHvTobOrxvrFV20zK7kdoajXub1nIwIw/WiV0h+zw4
+        98YTpzNctMFkPZu1dyGC9cbRX8Oadworu2m329+ej42RdW7pe0q9qmvFjdCBOTJuaI3mR2bMj+Wl
+        q7dtxJMdqJkVa2cR3sHoDwaDzaxz7tLbQhDSXReiEF82i1FKb59YBbBy4lzNpCkd4NRw0kf56UBf
+        GArkWPE838Q9m6k8snNLkY6vJYbi70GTfWLfDQV2enmWX/t/MHJp/clKqJiWEiscVvQPGJddcpR9
+        ntOJ8DyBXOJUVmO5TZMXs56gIidOz/IDkiurr5zxBAeZ+8ANYHZDoPB1/KUhoSMXKdYTs4hxz0Ev
+        hPopwIWwvgjmYwjLeeX/6R5AU1/qAe2eOOx8pQe0DdPSS/iWDn60/glc/8OJbY96bVHrjobLtWru
+        iaU9WAxW2yFgtaBvD+orgqA70UbcqhRckPveTurERwfY9VC1jRlfNTtVnboYIamY2ikKzoZ9POr2
+        BqqEjLp8R9xvB63QOspMz5g1hK6ib+U3kZ0va0N88ZDe3XC8GJyW77XhkLl2Gz5/YTqtcbtxmayX
+        xzdxBa7Xk+bJW4L4ai1TP1DL6cF8ay1T9e+qZeZ7a/nZ/1+1fA/Ky1pmvlTL6bxfUMtf1PP5YtkR
+        xl9T9Hn8c4KDfko9H3E9+0R0Hm7mvCB4Fee6E1mfH1O1sG1N5+74uB9Oh27ovA83h85lcejph167
+        Gk7tcBSNPeT0Vcsww7feRLQCYf1+WGpLWXqX26KNhNpJ3V9tfrfRxNP60OpYrLTyT8qixlbq/DWQ
+        rJN7rhi1y2y/EHghnHZ5a+y2SXF+Pp5N7NKTd7xn0n1BFefD/qE2admMJ+yHk71zmF4sosF4/GlJ
+        76JotJTYS3UCqMhmxF4NmnVwHEe7tsgS0piVgjZVscnJhP56P6B/pB98l7bT1V/bD579/9UP7kH5
+        /n6Qzvv5/YD5orZPWtOv9QLgmK5f0kxkXoHzU1pCFbeE7pHpDc0eyVb4gazsSEnYQQkezqS9smp9
+        cxEu8ec1ci4bxmuvrqa/q/fRVmpvjL7Z6dtHhTH4qRo0+P1Yr08XUdALDF9zhZVeXyF/dCY2Az4c
+        tulDtDpuJpS5C+uu1ZPG6wo9bOtktJAv9HU+joC/vdRn3mEi0WB7rdDGiTYYZmF14FiCJ007iGTg
+        96YkyaqsdZK/Qe6ZH7m6f5fc079Y7p/9/1Xe96D8ifL+stzfH2H6W2VekoZrxj8/3H+x/GAp5NvT
+        vz3/Dxp+z4a8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:05 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2691']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:01 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['1148']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:06 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/CoreTests.test_search_events_auto_date_range.yaml
+++ b/tests/interface_objects/cassettes/CoreTests.test_search_events_auto_date_range.yaml
@@ -1,442 +1,657 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxyZXF1ZXN0
+      X2N1c3RvbV9maWVsZHMgLz48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJl
+      cXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0
+      X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVl
+      c3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9t
+      ZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48c19rZXlzPnRlc3Q8L3Nfa2V5cz48c19hdXRv
+      X3JhbmdlPnRvZGF5X29ubHk8L3NfYXV0b19yYW5nZT48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHJl
+      cXVlc3RfY29zdF9yYW5nZSAvPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PC9ldmVudF9zZWFyY2g+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['627']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1d23KjOBq+36eg+mJqt6YJ4mi7l/FUHDvpTOe0sZNM5oaSQY7pcHAjSOK93FfZ
+        2619iHmUfZKVBARjGx/akO5OmHLVhF8fEvol9P3/B6j1X59ch3tAAbZ975d34h54xyHP9C3bu/vl
+        3dXgkG+++7X9Fx09IC80MIKBOTYChCMnbOs4Glq+C23PiDAKDBsbQ2i1PV8XlpfoZjCdhL4xdHzz
+        vm0aPK/xQ/z55vyzc3kXIB53h79dts475qg5/qQ9femfjY7Cs/5F52KoiQ6Y7tvDyeHgLuwMvwxv
+        Ta15EKknnQs4vupfXLaMA/z79R9P+J+4H3W1gTRRJG94f3N8wj+AQ/R49XSkTA/ux2MJ2qOWI1vq
+        aDocn6r/UE/PHDDpKPytLuSuT7dsHELPRNiAATIeoGPHnVtmjx3U1okFGsR9qN270YXsKC6wEDbb
+        PeLt6eMYBSgBMKtu2uE0xjq24yB+FJDrebbFxQx5QouTsuRUB2Kc/C+GwzAMoBmSMcUEmdkTDDtt
+        fxETV0dGiw1dXO0UkeK8SU/mwT2azrYkkHHPCujsSODp2c+WXJ0ZrqDacIxcNIHBPV7eQNy1HCpX
+        kgFZ/wYUyP0E3cnfuRsYooC7mDsrdoOQXZiQetjHoRFA745U6sInUr07tD1ktRV1D+hCzsQA5HLD
+        SWCbqK2AFJHZYkhEOgQDUuVzHZlJd6nT51qZNTHAQis5WwyZayVn0j3fwOSGdxD12Ovs4pcIeiG9
+        ZfwJm1Vtnd24Rmpvi7owZ5lHSGsR8lqEshahrkVoiwhhsXtsDA0zCgKynhNI+ld8T6CILi85U4YY
+        kTvPD9oiADOYxJihvMgdoqDdajRnUIkxQ00cSFZK6rt50wyGzjk8dYe+I8yayeoaW9v/+9d/ZivI
+        CnRhvp9CwWSuJ8BbmQCzo276kRcGSQcZpc4anovZin8YUFbPIDENWIQi4toM5FnJMSs69b33nIhD
+        7jfoRTCYchIQiSsyQIyNQtPwRyOMwjZISmdMGQYj0/cs3BZVUWmqothqzaDTwhg+Jf+5rmW1aYtA
+        BGKCfLYTyvWbGhANZoaeZYS2ixicByL5DST5g9oivz8oES/DJlXO9zw+JgFQEM76YjCO3nNqOOZO
+        IfODVoIfFE1SgKYAsJEfNKACdXM/aDxQyW8AwAf228wPSb/jaJhNoe7+7eD4d12YMSXFrOsi3yUO
+        GdjmPQpTUOyT+G8SOmqf+mnJcyBpOGQF82eioBQR2xOQiywbkkkM2S1P7pwxmfltS3x8Uh5lNRq6
+        lv20Zzp+ZI0C3wv3PHoNDKPbHvFkRG4jQrMTB1HvBk57HIaTD4KwsgYBE0ZFljBzCQJ6Co0Q4RAI
+        vRtBksCTKKp7nyd3xKdL29E9SDzrEB9jcvHklmPH+gSG4/Z29bNT9KK+4HI7s7QrOJpM/CDEBm0w
+        jmzzpjwCL4HQCDM3ot/z8DYAeJIBWD+8Lgy+RGjLwc3VXvXg5hqrB5d4pHd1ed497p/1bgVRITNf
+        2WCcMQk9gi2Huaidqke8qN168H/GUxwi18gstCOOjYINZkCC3GIOrGuu0omwrvG3OhvMwJ9MUGAw
+        pDBqkR+EI2VoAkVpNEwZyFajOTRVETRMEzRUxRo1FQ2azfVTJAxsajJ8b/1KseNlVDB1dryiF55P
+        sWNJWMmLvAWnfMiiTyHFxv5JBN0QhhFuO/YDSosTUwqIhiT8hUJ6HPr3yJsNWWNDWjqdkNXApt00
+        wlzMy0r0O+TT6JpcqQNJshqRYFkFew0Stj8f647v3cV/ylTGyQ51ITt9DLFB8nwyJiPMNNmcgQqO
+        VBxCsV6bHekeQhaJvyckiqcjQiP72K/LChJ0FEB6X7Kq8pYYQNv0A5fmjhlm1pjqmqlubNy7bSZi
+        LbHreOw/srPj7IOJ6XmTjv0oMFGSxqdLGIHNmFNMLDg/hSjwoMMNCJDrQDIunsVlZ8T5CBmmKDk7
+        Y0ldmDEnEAbv2thDUxrB//lfqp/aOIUm4mmih9ey+FuWxUWwVjQWQQmqcdrOCtk4bacKafwVdLNW
+        R9+KOlrL4298AtTyeC2Pv5g8Lnf3bz+eX1z0LgslcplJ5B9ZhlUokQ9qibyWyL9j6aSWyN/K4NYS
+        +Vsd/FoiryXyWiJ/VRL5gJeZRD5mF1+uRD6oJfJaIn9ZiXxCWymWyJOL2FAi30QhT/Tivn03DjFC
+        JPMqRTOvRjIXZvtWrJjnUKsU89yTgk1U8uq0lkGEYq0l0RdK0VkkVRJbJP7bUGdRt9RZ1Exn2VRf
+        WKuz3CDrPaeUrrPIEgBb6CzKtjqLsvtriNfdQoGl70fkwA64GdCcwHJ0vf9aBBaxYoFlsf4KA/HF
+        xt5q4J3zSGUCy2LtVQ9uLbDMe6QqVWWx8qrHttZPch6Z1xTEKvWT9c1VOvrrGv8m+S5heR4nwQBv
+        PVhl5rszEcRivuva2DRs4o+1ua7S3Gs2leXJrrQny1LjJfLdLI+tKN2lT3RZnNZQWbD+fPwSibC4
+        dSIsFifCp+dXJ8dnl+dXR73CTLhD6rMi7tSPSOjIXfrRHdowFe70Tgpy4Q5yRhCH+UT4db/wNYKu
+        7UxXpa7PiFVp6+E8aLOMNbpfmbFeeeT+trhPJDewfHfzzLUPw/ecTFPXLjIRfTmitLytKUuisvHz
+        cVGSt8hfNV6UeJnkr1vlbSXnr7IGNk9hybJabQqbuuJnIH6gLX1VHivKklaYyLI1qUePOZ4bEAqh
+        C9PSfFY+KE5owzFZ+QO0NJuNeZKezdOVkmdWnrIVL5bJlrPXt6s8LDJ+WEqYoAR5OF2jXogvM6l5
+        OWF2BiIndXolUWYcQK3gTDI5AoSxT5/KMPJcwZ3HCbaYLPdvj4RBMU3GlMYNyNmYOwmtFyLJ5xui
+        gCAH+fKvIMekhTKJMa3SCqALV3FiClhFid05zGtmREmrlhHF1gf5B2FEbWNXfB0jpq7YjREV0NiG
+        EQH3V/S3Ylo82IkWDxZpEfCoZGY8qJmxZsaaGXdlxnvbWvllUFL+46SKjAokz9rsIefGVECfc2qN
+        5oZUQJ9zSts+55QGorI1FdTUuJ4aZXkbapSLafFoJ1o8WqRFuWRSPKpJsSbF74IUyYitEFNJYfJS
+        0EHk0KHdRVMllZUqptL6fDJ0KxPGFLCKGM/nMN+eF2VAiODMfyg5YQSq3No8YRRlsFXCKPIyGEji
+        jyKhtqSK3wJKXbEjK4pgG1ZUVieM3Z2YsbvIjErpCWO35saaG2tu3J0brfit0xViagJYxY0d6Dgo
+        TDranTvhmxIl+yJZ0gg3lK+sSiSD3EJZlbQtlVVJ+4GU1Uar4meNYqOc9FHagihbxRx5uBNHHi5w
+        ZKtkgjysCbImyFIIcoftm8gK4Hs8W9qX7t/EyuuvU77Z1ykFmxupYN3eRur6rY3Auq2NVLBuZyN1
+        /cZGoKSNjbbeLeZuOClpt5gmDQyq3i3mz3/vvllMlSEae/h9ThxUZoTWaLTUprzh10yaCLZ89g3Y
+        22D110ylfM102jvt9C77H48v+oUB2jVb3Pe5UxbI47E9wYW7xxTGZz/ax0317jGv+huJeveY1z64
+        lW4Z86L7xNQfN9Wbw9Sbw9Sbw7zezWEO+Qce8m4WX5a7P0xpopwq7iktrSVKqrxcm+PBntiQSNzf
+        UF7X13P9mwYnXZ68lEBXyU4yg4+96/2z7n6hVHdtU6nAhhyJ5rl9h0zGkDuNMIrc5ZpdOglz/1br
+        /wFTP9cu6HUAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:06 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2803']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:01 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><s_keys>test</s_keys><s_auto_range>today_only</s_auto_range><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxyZXF1ZXN0
+      X2N1c3RvbV9maWVsZHMgLz48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJl
+      cXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0
+      X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVl
+      c3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9t
+      ZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48c19rZXlzPnRlc3Q8L3Nfa2V5cz48c19hdXRv
+      X3JhbmdlPnRoaXNfd2Vla2VuZDwvc19hdXRvX3JhbmdlPjxwdXp6bGVkPnllczwvcHV6emxlZD48
+      cmVxdWVzdF9jb3N0X3JhbmdlIC8+PHVzZXJfaWQ+ZGVtbzwvdXNlcl9pZD48L2V2ZW50X3NlYXJj
+      aD4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['798']
+      Content-Length: ['629']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1aa3PaOBT9vr/C00/tbI2fGNNx3ckuoZtts0lb0k72i0fYAhT8iiST8O9XD9vY
-        DWQhJWm7SyaTxOcey9K5F+keiPfmNomVBcQEZenrZ0ZHf6bANMwilE5fP7sYDVX32Rv/Fw8uYEoD
-        AgEOZwGGpIip75FiHGUJQGlQEIgDRIIxiPwlJJ62PuSFeJnTLBjHWTj3LwJVXczzSX/+ez+/6J6N
-        1SnOJpFB396Ef51fXlkwJFfW4NJwrj7Mz/TLL+lgkYzezciRlQe3F9e9j++Hy0HYVT9GxsR5dz0p
-        Lk+up0dDcvYxvVleA31kOGc2DgaJ9f7k+MPyGh9fXbv9GJvnJ2nfGsxvpvGlp7Xm5EWIUJCGkAQA
-        w2ABYhT5aeZp63Cpiu8xBARMM+h3e562upKBCJLQP6EgXpYxAXghoktJS9iPFKiIsrnUoIwL6qmI
-        l8Hy5hgQUv6SfJoVmOneQMqouGHUjMohWEpEfuRQImltyCuzPYdLObrG0rqCePZLYnVfjbRGW/Hu
-        DEhyGCIQrx9XrmJFacEr1mp9iqp8kmzlJKWQVSlt3CZXra1mo1UiZkVKcSm7SEITqMPNNLYwLwIU
-        BhikUxjANCqvRegLjF4qBqHKKV+eYuoGq49VWDILGgbZZEIg9fUy2oBWHALDLI2Ib9iua5mOrTfZ
-        VVDSl+wrSaLI50/ULd0omTXOUpa5jm4EAgZpFFCUQEFXdUvVjZGuvxLff/NEruOWQ369bnnNXiuY
-        NpUYzQqmhE1nylGOUcylcPYhhaN3+6a+pRSObhv29lI4qm6rhr2jFOXS5YYpSsjpGe650fW0BlbG
-        xdqHEGOAkTIs4lgZgKVyfJtDjNg2DJUbxCQbsUpWBxgtYDWG1Ez+zTYi6+zsbRWq96UgZnt45tMZ
-        BBTXd0qwZCQwQoCVOMgp2/4135tlhPohCGeQ7cUgn6GQxGjcWSBAM9wJs8TTBMVDKZO5YDshw/IY
-        culx7M8ozV9p2n0DaA1YzTGM2ao0OiuSMXF69q1tOxrXS/t0Il7T2kSKo06YOGoEliqsxVG5OCrl
-        4kRcHBWlarmXmn3XMHudq3zKcrZ2ql4KWOZilkPCls/kEddeDujMf/o5isd6P42kawUlRZ5nmJKA
-        T7nqAppQm0HEsfoVVFVpWZiHKhVVSa4LgA8l+tOU6G47enXT/66sKUYcCrL0UNs/cG2zhoYWxI8b
-        7UcJVQTm9QAFWnVNszlMWz2JRKrwMmdbGuJzZ+1TOIe0pvGIN4UZ76/Y82NAES1Yt2TbHcd2HNbG
-        1pAXZ+lU/mnonb7pmHafhWvQ01bjzAAJ0ixgKk/kslsAty/Mf1Aojd7qykshjFirlbOGjuvNmzxB
-        WYeX5AID8WJe0SpEEvgjM5xwJylzdAetXFJlOIN54usdvfZITdwjs+xG3C0bUZHSNuQRVnQhlF2n
-        LFrGaWAVQbSUn9sE2Way3BQl2ey6hutpDaSMtoxqAypTu8Yq981NXvkc4mKDVY5RAlTera01yu9Z
-        9GCTn8ImixRstskyg9u65FEBXzJDyI7FAQxhMoZ4b/bQNY0d7KFhmvou9tAwVVPft1MeYsSccvcR
-        nLLTc7d904A75e6uTrn7zU6Z7eJ699wwN1rlP0A8EQ3VZ0QQVWimMHvL311BmeipUJoppwWBRbLR
-        KY+s/45TFnrVjcWMiSMaigUXR6WZylakJlwc0VMwcdREiMP7CrGVmm6/17Ue0SfvdYaP3abtdbIH
-        j/yE9fkwh3wozu/ijtvb9fPTo9Hxi3rX/rHc8JMV8Dd44UMV/+A+eNVxfKsPZh1nR7ct/rXeCqu9
-        Xkc33ZJwMMOPaob75mYrLK3oVkbY7Jvbf2h819BWTesmS9uOP8TUyhH2amvLIRNEwvtcbRm/z9Ke
-        MopSi/BdP+0Vn3Fa3Mf+WaTw342b5bSd6X3mrWdaPWdr8+ZYO/lY3VEt5mNdad5+NfjPPZpZsysk
-        iZdcEntfkuiOaXFvv5Uktt4zd/Cztqr3VLP7EEnumlrDtI6HGx0tP+aUYbzBrpq/2UcPsasPPKua
-        j9vprNr6UKn2hupUScBtgIs0ZZOXYtr8LZg7qJewrWQN72v05zulZINyzzFV4DFIAxBxtdnUSUDl
-        G3abTq0LzleOar5otDcfYq6z8Qy7M9LzYZxh/jnFi/VHW1Vprf8S+wdjVj8NYiYAAA==
+        H4sIAAAAAAAAA+1d23LjOJJ9369g9MP2bEzRAnhnrUYTsi1fquTLWLI91S8KiIQstilSzYvL3sf9
+        lXnd2I/oT9kvWYCkLOpCibRIS5bRoY6ywBQBJkBmnsNEZv3vzyObe8Keb7nO336BB+AXDjuGa1rO
+        w99+ue2e8Novf2/8Wx0/YSfo+Rh5xrDnYT+0g0bdD/umO0KW0wt97PUsv9dHZsNx67XlR+qG9zIO
+        3F7fdo3HhtHjeYXv+7/fX/1u3zx4mPeP+99u9KtDY6ANvyvPf3QuB6fBZef68LqvQBu8NK3++KT7
+        EBz2/+j/MBTtKJTbh9doeNu5vtF7R/4/73579v/L74THSlcYS4LTf7w/b/NP4AT/vH0+lV6OHodD
+        AVkD3RZNefDSH17I/5AvLm0wPpT4H/XazPjqpuUHyDGw30Me7j0h24ovbll7rKBGnbSgHlEfbrTu
+        67Xpt/iAiX2j0SLafvk5xB5OBKLWumEFL7Gsbdk25gceGc9rW3w4kmzTw8mx5Kc28v3kn1gcBYGH
+        jIDMqU8kp+2JTPSz5qJMfDoyW9HUxad9weTwbFM9WQeP+CXdU43M+/QAXR2J+OTXry0z55zKZZw2
+        GOIRHiPv0V/eQXxpM1IzR6aC0fV1qSD372g0/k/uHgXY467nfhWroTYdWG2iYdcPeh5yHshJR+iZ
+        nH7UtxxsNiT5ANRrM02RABluMPYsAzckMJGYtsUiIbkg5JFTvp5j2lQfUaXP9ZJuigQWeplpi0Xm
+        eplpqjtuzyc3vI2pxvbzEv8IkRPQW8YdR6uqUY9u3N6kvQHrtbmWeQlhrYS4VkJaKyGvlVAWJWqL
+        lxfNYc8IPY88z4nI5K/4nsAhfbzMNE0lBuTOc70GBCAlkzROpZxw1MdeQ1e1lFTSOJUa24g8Kanu
+        5ptSMnTN+S+jvmvX0s3k6Rq3Nv7vv/8nfYLpgXpt/jprGYuZLYDPsgDSs264oRN4yQVGJjXd8Ho4
+        euKfeNSqT0ViM2ASExGfrYcdM/keHbpwnS8c9APuG3JC5L1wAoBEFVOBWDYMjJ47GPg4aIDkaKpp
+        KuNjw3VMvwFlKGkyhLqekp4cjMVfyH+jkWk2aI8AAphIvrYTk+tqCoC9qBk5Zi+wRjgS5wEkn64g
+        fpV18vmNGuJlsskp5688/k4cIC9I66I7DL9wcjDkLlCkB6UEPUiKIAFFAiCXHhQgAzm/HhQeyOTT
+        BeBr9Mmnh+S6Y284WkLHzR/d83/Wa6mm5HB06ZA/JgrpWsYjDiZCsU7iv4nrqHzvTI68OpI9mzzB
+        3JQXNJGI2xOhETYtRBYxim55cucMycpvmPDns/RTlMP+yLSeDwzbDc2B5zrBgUPHEMnULYdoMiS3
+        ETGzYxtT7Xp2YxgE46+12soz1HxiUbFZSw2hhp+DXoD9ANRa9zVBAM8Qyge/jx+ITpf2U3cQ0axN
+        dOyTwZNbLvpeH6Ng2Ch2/ugn9axr8cu9mKWX4ofjsesFfo92GHu2s02zEv4SEephzszoLk+vCsCz
+        CMD66R0h748QF5zcmbNXPbkznbHJJRpp3d5cHZ93Lls/alAiK1/KMc8+cT28gtOc1U/VM57VL5v8
+        v/ovfoBHvWkLvRDbwl6OFZBIFlgD67qrdCGs6/yzrgbDc8dj7PUiydpAJx+EBlLfAJKkqoYIRFPV
+        +oYMgWoYQJUlc6BJCjK09Usk8Cza1HOd9U+KDYdRwdLZcETvvJ5ixRK3koe8iV74IPI+axPZWD8J
+        oRugIPQbtvWEJ4eTpolA2CfuL6pNvgfuI3bSLmvcMDn6MiZPA4teZi+Y8XmjI/UH7FLvmozURgSs
+        hsRZlsGBStz21+9123Ue4j9FSuNMv9Zr058Pkd8jOJ/MycCPONmZBko4UnIIx3zt9Fvdwdgk/veY
+        ePF0RqhnH+t12YFEOvQQvS+jU822xAK0T9cbUew4lUk3TnjNCW/cexw1IhJrSXvdH7o/o1/H6CMi
+        02eb6r4begZOYPzkEUbEUs0TmZhwfg6w5yCb6xJB7hCReXFMbvqLGI+QaQqTX0+tZL2Wak5EIvFj
+        y3fwC/Xg//xfyp9a/kQ0IU8TPpzR4p+ZFodgLWkMQQms8aSfFbTxpJ8qqPE9uEzGjn4WdpTR4598
+        ATB6nNHj70aPi8fNH2dX19etm0yKXIwo8rMIYWVS5F1GkTOKfIepE0aRf5bJZRT5Z518RpEzipxR
+        5HtFkXd5MaLIh9Hgy6XIu4wiZxT5O1PkBPy5Dh8+ZnHk0fE1JDnBU0/YzuTHuzOH30CNx+cvkxVP
+        zjh0A2yvJMNfJVYR4WfzQit47xRZEik9mz25dSxye3HfCTg13VF+FqUb4i+cQBZjM3wIydpcSx6I
+        CsjJH6gAirKSmz/QgFCIP9B4IHShEPMHfwXwK+3p/cmU/PpQBEkiwpXyKW/QxyKpcnN1dZFJpzSD
+        IXYQDkcZXMq5mBluGN0ejEZhNMpuTC+jUfZ4civlTt6VMGEsCWNJGEvCWJJ9ZUmIw8ijiVNZJkWS
+        8kQXKZLIF+15rjtaz4/AAxkQ711ZzpHw4IBgHVEXymZKaKiOFzoOcZRjtx0KSQDPTGsUfbNEbr51
+        KfMyZVRWEi8pgiabeZkKzVAvNLogQhH38BunHn4jC3/S8uFomWb3rHXZbN1eZLIyKXjEyBhGxjAy
+        hpExFZIxR64X+tzZi4mjaNpMSiYzvIVRMoyS2aHpZZTMHk8uo2T2dG4ZJcMoGUbJ7BUl0+UN6lry
+        Q+Ja8nR7V7nEzIrYlYLEDPGf9BXEjKqKNDyfETMriRmBE9unH5mXObq6ue2cXWeyMglOoksrjZYY
+        Q8MYGsbQMIamQobmzLID1+G+Y4fuigym24gWOJpbxtEwjmY3nXvG0XyWyWUczZ7OLeNoGEfDOJq9
+        4mhu+WHkXPKPr85luSzNbXnhM0R1WiZLI0BRUFTG0qwLn4GcdNv+yDTN97PzdvfqMpOmScBSzIvM
+        YKZqmJoVCbzy5O9Ksll1rIdh4GNMxlpKRq9qEnrV/PQws0mZWbGVGb3ILL+BmPHzEDMd8oDCPucO
+        uOYIe5aBKqRoeAEWIWlUQa6YpJG/kg8APFC2RNIU0YgiSLIoVJwlRo1pmgIaWaRpzi+uWzfnzXYm
+        VXM+Is9CizzOzrBtGe6Y5qijazyDsTm+1rMYmyD1q90mbGDFhM3i+Sv0/Bc7+6ye/oxGKiNsFs9e
+        9eQywmZeI1URNosnr3puGWEzo5F5EgNWSdis767S2V/X+VYANrHvvJW4BPzw1SXgqXEvE2en/IhN
+        M3mI8oGuwAycDaFwAEVFfo+EHjlxcZ58HutgMXEEBbEkUByvkByoGBZGxXAFKj49yobEp8SdNbkj
+        5LwQRNy0PLp4qw9cIDP/hB+Qz0dobWnsAvK5OyrymVJiG6hP9BWsgs9TkVXQ+SiWSgiEY8txCNbo
+        kIW3H3haFvLjaQEI+dHjm/C0IHwVY/Sobg1P59eIIshAzB8G8iY8LYAJns6tkUU83W6etC4uWplw
+        uo24Ezwa4Qz4rLSz4fOQmBYPMwTNEPRuTC9D0Hs8uQxB7+ncMgS9ZQRNTDxvI35AvYBSc1+2y0PM
+        ygEEopQJmeUDqAqbbyCYwIyN303rZb+aLgOCX95pOgT6hwbhF6cXpzfNy+P2XSYUJyJcDMdT4Ldq
+        JF7GFgIy/SvANzmY4NCj0KbrZBMMTk5WKvim5zPjuiDZmHsisApxHyLbngLuuR+sQNoZJZlkYV1F
+        JkndvCCTANfWY9LWlmMS31h16oNfIis4NFNd6KE/LqngkEYTIc03ll1w6M9/sYJTbP43qze10RYw
+        w7OIC9nz8JOFI0/EoDY91tDSQ6sYVEoW0kpVHTwmTjrRV6n7xgRVlvIThnqRclUKD3RargrqMYX6
+        QfaNqWLV+8aK62ORQL287R7dNI++r6hddYGCYIh/cofEa3Xwrz53SS7Ho96sx3VbnW4Wt3p+sjPc
+        6iYB2TVdJB8DSP0BMAUJD0QTyFgb4IHUR6oKdHMAJFHCCIpGmdzrm7uvLja9+FhyQP4oCHiH+Z+N
+        FKZi8gGSZiiyPFB1EyIMoAR1QxckAWgKNAdQVvqaOMixdvISu2/uvMKVU3gse7ByNt8FIujko0pY
+        1lRdReSm06EqC31VNJGoA4SVgTZACpY0RchBJ5KHLqVriCfkFNwfU3gcle+PKTyifaCiN7oDZUw+
+        AEgDQe7LCPWVgSQKhqliRRP1Pnl4S4KpIXkA1X5pryHe3HeFT6LCY/mkTyK2bXNft21udPtUsmNz
+        EL18yfkw2aHNmpVs09z1h8kOLp9oqwtbPh9i+Wzu+wFMPoIsm9JAV/omEPoIqf2BKQjkfwP1dWBo
+        A8XApihVuWm88DAqd4oLj2gfrNnmajNIAxJMSdZ0pOmSBmQoEURBPEMDGxrSNUGRBUEDQBfzr6fg
+        p1twPRUeRuXrqfCIthPhcX7Cj2KOku9HHCXv884rR8lTN67UyI8psVko8iP+Oxz72LZ7tuUHM2Rp
+        a5EsJX9dnIF0e23JOTKyHQi6AqGoZmelBAqAsrJ5wZDSwkrKT3lQRlxJ6wjecFL38r0DSzbPeRD6
+        5EZe9u5o2YF0GEqnedxu3XTuW+12JzMQpYNMG3u/+tw9WYqfLwYl2X9USghK+ly7GYGymBB08gYn
+        KyPo7PE3RPEkPZSaEzQ55aNlrkwJmhxfpccTNLLsl42id0R5XWiLCNeGtkhrQ1vEdaEtAqgseueD
+        XyKL3vgk0Rsseudzz3810TvbjMVRpGpjcSab9z5ILI6sVbyZEcolxOJ07puX7eb37N2MC5E4nZ/I
+        4droEXMUMmQG4izBlh9wk2OUUTWNTWoThVWe7TlHr1Wnks0xhM/K5uXQk29XmzE6V6/bWSJzg2CL
+        JFNTleadztHldtYH27DJgh32ONihortGUsgzVVL4Am8Yc72lLt71dp4ac4NgK2WtpmC576KL97zd
+        hQLZQsmpqSIvmYdeOZ7qXN/bXSrbeZn8kZYKxf0U9k80liP6u0hcwttHsJ2FkzGYLUUjtBajEXwy
+        QN4mI6wgGKFVQTDCkp1btP37kvJgnyxIYSdzX3zcGIVdjzooLwclK6H5thKaO5dZkhXT3OBFzB4U
+        05xm4GkaxLVwTRSXaln67uVcvMl69/KBKmqy9JJ7DTRYesl9n1yWXnJP55all9xyekli4PnRw4h/
+        oB4Bj1IeQbllEG+yUX6BMojvlGlyz4sglptqMm8RxP3NNNm3HsJx7wnZIW6oZHGmv6fAOJlXy+cH
+        XgYQv6aHWSGI9y8EsaDlgeuameo9IQe/cMee5TxydHFd0lKPtjXYYLcF7a/E3RbR6cxICyu3W0wk
+        Vql2o6oa0VLP5j5OvHj/Rl6moxM6XzjRM7lvoZ0D16v5q0WosiLnr5+hArEQrld5INJkZwmuF7bE
+        cxTQh0BUUnXAaXF9LPIcx+eXl62bztnVfTbb4Ya25XA3bviAub+klvN/ZFWkPPxtL6JNGeex59CJ
+        cR77PbmM89jTuWWcx7aLUh7+xo8iv4D3qF/Ax64wT1FsqUUpp67EpiU2JO1A0zJ4D+FAFAV1d0IM
+        djMPgioDqH3s6hpXt+3zy5ur29NWJulxSM5nhlza660qyGAFOZGHm0jQeofCZx9jsk5KYSuqIStq
+        fnqY2Zh6VmwVsO6SSd6HaAJegEXiCTQh/8bOt8UTaJOqjMrW6lTm1wjd2inmZx7ehLSj8pTFNLIk
+        zfrVTfcsE2RfErs7nNTXPXut8sx1ox0Dy2H29WEmzE79imFshrEZxmYYm2FshrEZxv5IGPv6kHeo
+        W8AbkVvAD1/dAp4a+FJx9tSX2LiUpXygKzAzvkA4gKIilx1fsGVkTLxBQfzQyPj76dFlJiSOYwAS
+        57RpeXQBVx54X+q7/v2D0+lry0bTM1KrwPRMyMN2X1JHAJqmRkqworYSK+aDibIgC1An1j0XTNQI
+        TCyQEUmLYCLsCuJXmb6T/a0czHyPzS+clBcz54bLFCwXgMtSUbgsdUGSGSqfHpa8k747zsTJHTck
+        XyyPSwnN4eLTu2YWLk7fDgwdM3S8C9PL0PEeTy5Dx3s6twwdbxkdEyvP+4kzwJtPZploOOVBLKLh
+        keUbPYvoYxfeOL8vDH6Vqf798HZC4nfr9XC5me/Z7vO37T6vKP8v23PO9pwX2XPeCbiWN7KcX/3M
+        feZ3e7DPHFSMeBfPX3W+IoZ45zVSbR7ed823yxDvvEYqzaD7rrlyGeJlWXFZVtwZDc3WBqykkGvx
+        Ipw7VM31rSPaUt6CO94PeEy9St4vN1fBXTZ/UiBXgQwPJF2HqpadHVCUJFln2QpWhyd07uEZB/5x
+        /87cTLm5Abutm4vzy1Z2YsBvrm2/cGmclIuWOWy1M3iZQ2wPEK2pkjNmfw8SCgwmRe0yuZbBfNm7
+        TWvjVc+1dFDwhRNpRMExNnLWWsrJLWiiAKXc8fhQEAsVWoICL04LLW0lrKAIzSJqWv6tCW+KLHhD
+        zalFmgWKtPZYBs0SPY5a9DvHc11imChfvJRvEY+y4wxWbXOPjS/9dZQJmI9aeWoDeVimEU6Pb9OY
+        PhiZhqXvMeIj5e6b23I032EXcsJh673i+cji8LDvu9T1jezmCrN5nshm28nmj9NaN/vtRWzSom0l
+        PtcOzHcykh+6WKzpoRFamQcmEViZBmZOZp8topD77cPbLCLU41J7H8AiKkWSwLzBIk5UsZlFlIBa
+        xCIC7i84K/kLMTtHG5nFo0WzCHhcsmU8YpaRWUZmGTe1jO9cRr16wxiZAvpaPlfseW5TQMPPFVXL
+        aQpo+HmBd/Jx+LnQhVJhU8BM43rTKIpFTKOYbRZPNzKLp4tmUSzZKJ4yo8iM4k4YRTJjK8hUcjDZ
+        q3UU2nRqN+FUyclKJVPp+VwydSsB40RglWG8mpPZvl0UATEEl+5TyYARyKKeHzBCERQCjJAXQVeA
+        H4VC1YWKN2dNVLGhVYSgiFWUVgPG440s4/GiZZRKB4zHzDYy28hs4+a20Yw3A68gUxOBVbbxENn2
+        NFv53A+2aigvXIcASIXYhvKZVYEgyALMqqAUZFYF5QMxq6pe8btGqJYDH4UChlLPtpFL6nEWsJEn
+        CzZSL9lAnjADyQxkKQZyy/ukWNKQ6pKG+EH8pIxD7Ax31LccchPK0fqeaYoE6D069ixyw0wlpm2x
+        CFmZQ+SRU04lXpuiAL35XtJNkcBCLzNtschcLzNN9T9C5AR0SblRfC650idkW2Zv0t6AZOXPttRr
+        iz+KbYgReh52DCIy+StW/UN/TBQ50zSVGJBZcD3y6AQpmaRxKuWE1B9paNQxmG+cSo1tZGC/IaRk
+        kqaUDJ1J/2XUd+1aupk8KOPWxp//Sv9+2l6vzV9mLb0s3s1Fi15+XxEFlemhqaoua2LOJDMKBAXf
+        fYMoGowlmSklycxF6+KQFj45v+5kOmh30cO9yV1Ejrw/tMZZm++U75n+2UfLOcN24O3l1g22A++z
+        TC7bgbenc8t24LEdeGwH3h7twCNeI//EI3409S/LZOVSTummpFy0E0/RoSCL2XvxVIH4/bR66z4l
+        Nercq5xw037v5L6l7p3rnrXumpfHzUyq7s6iVIGFonKsTZssxoC7CH0cjpZzdpNFGF+wh/3QDhr/
+        D8kyPMxkTQEA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1645']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:06 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['5709']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:02 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><s_keys>test</s_keys><s_auto_range>this_weekend</s_auto_range><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxyZXF1ZXN0
+      X2N1c3RvbV9maWVsZHMgLz48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJl
+      cXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0
+      X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVl
+      c3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9t
+      ZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48c19rZXlzPnRlc3Q8L3Nfa2V5cz48c19hdXRv
+      X3JhbmdlPm5leHRfd2Vlazwvc19hdXRvX3JhbmdlPjxwdXp6bGVkPnllczwvcHV6emxlZD48cmVx
+      dWVzdF9jb3N0X3JhbmdlIC8+PHVzZXJfaWQ+ZGVtbzwvdXNlcl9pZD48L2V2ZW50X3NlYXJjaD4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['800']
+      Content-Length: ['626']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1c23LbOBJ936/Q5mVma4YiQIK3FEdTntie9eY6tjypzAsLJEGLMS8yAdrW9+yf
-        7JctAFISqZspWU6cjFyqxDpogkB3A+jDbtr99T5NerekoHGe/fIC9sGLHsmCPIyzq19eXA5PFfvF
-        r4N/uOSWZMyjBBfByCsILRM2cGnph3mK48wrKSm8mHo+DgcTQl11dZMbFJMxyz0/yYPrwaWnKLfX
-        48i5fuWML433vnJV5FEI2e93wbsPnz7rJKCf9eNP0Pz8x/V78OljdnybDl+P6JE+9u4vb6zzN6eT
-        48BQzkMYma9vovLT2c3V0Sl9f57dTW4wGELzPSq841R/c3byx+SmOPl8YztJoX04yxz9+PruKvnk
-        qq0xuWFMGc4CQj1cEO8WJ3E4yHJXXYVXWhm4HMEe1xkZGJarzr9VDSGhweCM4WRSt0nADWI2qcRS
-        /k+GlZjxsczAql2KvpXtdWN9cYIprf+r5FleFlzvDaRulRcMm61VF9wk0j5VV9JobcitrX1NJlXv
-        KjfrHBLWrwWn182QVm9zuaUO6ZgEMU5W91vNYi7SgudS8/n1lN5FJd07yxjhXsoal1WzVuejUadK
-        zMuMFbXapRGawKy5acYW5oaYEa/A2RXxSBbW32XTRxL+3IOU9d6K6fU0ALl/zJsryZIFXh5FlLAB
-        qFsb0FyGkiDPQjqAyLZ1zUSgKT1trMQn/CdNw3Ag7gh0AGvJGc5NltsmgJ6EcRZ6LE6JFFeArgA4
-        BOCl/PwlDLlKtu5ycd7Vd75WCtbUxHBUck0gNuodjYs4Eaow96EKExiOBjqqwgQIou6qMBWAFIi2
-        VEU99WrDlC5kWtD+AA1XbWB1u5z7KSkKXMS90zJJesd40ju5H5Mi5tsw6d3FXGVD7snKcRHfkmkf
-        lc6q3/lGpL9///u0abYveQnfw/MBGxHMitmVFVhLpCSMMXdxPGZ8+1cH7iinbBDgYET4XozHozig
-        Sez3b2PM8qIf5KmrShE3zriaS74TcmycEKH6IhmMGBu/VNVNHagNWBkXJOGzUtmoTH1qWugeIVMV
-        +lIvzuSaVqNKOUrElaOEeKKQmXIUoRyFCeWEQjlKnCn1Xqo5NtSs/ufxFbfZyqG6GeaWS7gNKZ8+
-        V4/87o4xGw2+/Bjlbd1vRqUrFUrL8TgvGPXEkKdRQBNqS1B5rC5AUy+tHfPgpdIr6U2Ji4OLfjMu
-        ut2OPr3ob+fWrIgF5OXZwbefsW/zgIaVdJA0wo8amgpwrocZVqffWX5NslZMUiHT5smYb2mxGDsP
-        n4JrwmZiosW9IrmIr/j9E8xiVvJoCaG+iUyTh7EzyE3y7Kr6FYK+o5kacnjzDHTVeT8jTL0s97iW
-        o2raLUDQF84/GKmI3vybmxES8lBrzAM6oW8R5EmRVXgtXBZYLua52BSpBMQt8yIVTLKy0RI6ZUlT
-        wuldpwPQBzOO1MRdOsrv5NVVICpN2oZcyp0uIFXUWTktl2lgUwEZUv7ZFqjCTG6bshbWDBvartpA
-        6tYWUW1AtWlXUGVHW8eVP5CiXEOVkzjFiojWVhLlN7z1QJO/BE2WJlhPkysLdmXJw5L8zAkhPxaP
-        SUBSnxR7o4e2Bregh1DTwDb0EGqKBvbNlE+LmDNl4wmYsmnZXR8aCKZsbMuUjUczZb6LA+MD1NZS
-        5X/jJJIB1Z8xjVmP5T1Ob8XTlTiXMVWc5b23JSVlupYpD/XvhylLfc0CixFXjgwoboVyFJYrfEZK
-        KpQjYwquHCWVyhFxhdxKNduxDP0JefJeR/jUYdpeB3vgyF/QP3djyAfn/CrsuL1d//j2aHjyr9mu
-        /bzY8Bdz4Edw4YMXP3MePI84HsuDecTZB0gXP6upsGJZfaDZtcCBDD8pGXa09VS4oqKdiPDJxzU8
-        +OSWFJO7EREHW4MN+/FVORYZ6FI8+uC6aAJNrsxj+zxTyut1bFm2P8SXpzHxOsbcbt+FM1c97JU1
-        111exyHdRJrr9k2M+RSnscj4duHHlFXEhpuI712VQQQjIwW3qk/zpOR7FMW3nFcMoC68eBF1xTNB
-        sZ/5ccbXnKEJoTZWiYhFydkhXyHImsnMwVqIu+0IF3xAxlxmhrlyZPOOdUcILYC10Lxn3ZhLNe5X
-        A7POUUNqfke+EAPu/PhqNmGNk8xllLv0kgJTfL841hYkBarrDzrfSefLCpTIwjDaWCXSHkIbclOx
-        6qdzg5VEE6oFuL3XmA11sBq0H7ZaQ2a91UAHq0HUxWpNqQ1WA12tpq2x2oL2xPfFQbSxSqQ9gDbk
-        8nCA8u4TQr3DtnbY1r5pnR+2tcO2Vt/+psQZE9FuLp8x8KBN1nF6U3wAecjeRhYltAcl9Acl0IMS
-        xoMS5rKEujy96jk7J8kFyQIuMv2tCnWv/DGPXlvQXCLCASc/FcFYBOdSWSnSNQNbMxtSNTiXGic4
-        IFTobhFqyAhj00nq54nahDmlrNDB//7bvH6Ou+riNFk+9qRTHLbMnbbMJf2pawKCw4I6LKjDgtpl
-        QTVXUSuRLh/XrM+sX2YxI2HvNe83FI/A2zn2oIhZHHgFuY2JfO4lRlK73MqmTVl5WbFtizx0eVVS
-        9nAiWjdb2eUNuWgLGsjoXrUta062yEXbCrSH0Hmpi1z0TwC+FHfaWxW7Jgr6O+bmu6vEhJqpb5Ge
-        17ao6ZfpeQ3uopLlHP27y+Gr86NXr0/O12bp32LGRuSu91teFhn5gfbe8ekUOLgmxT/X5OXNs9P9
-        peUl2q+eqdO7mAWjbvki+lJVV1+rUr7mSdhMC/AVlY/5OlIdnX8CgPwIhBoikR4Cg9gRiZCPLQs4
-        YQSQjgiGerBzon2ft9+c4vlCOuiQulnKyyxlbpaTO1tlx7+sm1iEfwCyA9MwIssJISYAIugEjoY0
-        YJswjKBh+rYedXCTFBc3JenuJFvf/CmcZOtB/P2cxCD8AwCKNMM3MPbNCOlaEFrEtHXH5wsJaaGN
-        jQha/m5FEfu891P4yNaDeA4+EsK7e3SnG6WfhvF9P0jyMoyKPGP9TCR1O5QpbOxhlb7IPfNEhhyo
-        P9EJZST15oiYSBKTooOH1JIP+kj32z3sFE841/0UBHxTO0bk8A/G/KDlxy+yrEAHemjZfmBAYAUB
-        sAwURjYycWB3r0KJZI1Dx31j6xE8xb6x9SCew77xPXgKD/EPnvI9njC1vjwpqToG//hO4CPs2BG2
-        fAMiHyETAcfCwLYi37d8C8IgwI8odtv/MJ7gOHrkiJ7FGfXV/Ukz+AeYRugEZoi1wDQtqDv8u2Vh
-        FCKkm44ZQMMJ9S38iY2K7pxo14E8uUdtPaJn4VHfwVnG7vLDUbbHo2zHgtnGo8Ct6mWr38sxJUni
-        JTFlrceLJ8uPF9c9dhT468smrq7oe0V5rgH7xpq6XNAX71M9siJ3Wvk4LckVJQlFmWWitkE+uoVa
-        XajQQmVmfIXcIvqVSnxFoqoqhH0Fz3to+I4vlin0mPrfyk83FADPWOSGGmDxlkLvQrLO3l+kyNdX
-        A18cHb85Ob/4ePLmzcXasuALHCak+IH2PnJHoh0LhDVH6/5Xpb6vCt40psGmCt66fVMF71su0psp
-        4av+OSiZPtLFi67/KTPSLXvUNX1kabpldk4fmfpWL7oCU9HBENjV250/QbC3jJp821UzpEqSiVAJ
-        2pdKgKnp4uXfTipBwNK2eOEVKcBSNGMXlSxn1KCmn5yuTaaJHap3mqzJm2m/oaNdEmc7ns3N2211
-        OO/vjEMdzzj0nM64pzzGysLHmYdDoW0+dCrPtA1H2qWQ7x3N5OWbeOvPNdtce5ot9fTjaZKLkhHy
-        r9VH29TTWn9G8v9hDjdcg1IAAA==
+        H4sIAAAAAAAAA+1d23LjOJJ9369g9MP2bEzRAnhnrUYTsi1fquTLWLI91S8KiIQstilSzYvL3sf9
+        lXnd2I/oT9kvWYCkLOpCibRIS5bRoY6ywBQBJkBmnsNEZv3vzyObe8Keb7nO336BB+AXDjuGa1rO
+        w99+ue2e8Novf2/8Wx0/YSfo+Rh5xrDnYT+0g0bdD/umO0KW0wt97PUsv9dHZsNx67XlR+qG9zIO
+        3F7fdo3HhtHjeYXv+7/fX/1u3zx4mPeP+99u9KtDY6ANvyvPf3QuB6fBZef68LqvQBu8NK3++KT7
+        EBz2/+j/MBTtKJTbh9doeNu5vtF7R/4/73579v/L74THSlcYS4LTf7w/b/NP4AT/vH0+lV6OHodD
+        AVkD3RZNefDSH17I/5AvLm0wPpT4H/XazPjqpuUHyDGw30Me7j0h24ovbll7rKBGnbSgHlEfbrTu
+        67Xpt/iAiX2j0SLafvk5xB5OBKLWumEFL7Gsbdk25gceGc9rW3w4kmzTw8mx5Kc28v3kn1gcBYGH
+        jIDMqU8kp+2JTPSz5qJMfDoyW9HUxad9weTwbFM9WQeP+CXdU43M+/QAXR2J+OTXry0z55zKZZw2
+        GOIRHiPv0V/eQXxpM1IzR6aC0fV1qSD372g0/k/uHgXY467nfhWroTYdWG2iYdcPeh5yHshJR+iZ
+        nH7UtxxsNiT5ANRrM02RABluMPYsAzckMJGYtsUiIbkg5JFTvp5j2lQfUaXP9ZJuigQWeplpi0Xm
+        eplpqjtuzyc3vI2pxvbzEv8IkRPQW8YdR6uqUY9u3N6kvQHrtbmWeQlhrYS4VkJaKyGvlVAWJWqL
+        lxfNYc8IPY88z4nI5K/4nsAhfbzMNE0lBuTOc70GBCAlkzROpZxw1MdeQ1e1lFTSOJUa24g8Kanu
+        5ptSMnTN+S+jvmvX0s3k6Rq3Nv7vv/8nfYLpgXpt/jprGYuZLYDPsgDSs264oRN4yQVGJjXd8Ho4
+        euKfeNSqT0ViM2ASExGfrYcdM/keHbpwnS8c9APuG3JC5L1wAoBEFVOBWDYMjJ47GPg4aIDkaKpp
+        KuNjw3VMvwFlKGkyhLqekp4cjMVfyH+jkWk2aI8AAphIvrYTk+tqCoC9qBk5Zi+wRjgS5wEkn64g
+        fpV18vmNGuJlsskp5688/k4cIC9I66I7DL9wcjDkLlCkB6UEPUiKIAFFAiCXHhQgAzm/HhQeyOTT
+        BeBr9Mmnh+S6Y284WkLHzR/d83/Wa6mm5HB06ZA/JgrpWsYjDiZCsU7iv4nrqHzvTI68OpI9mzzB
+        3JQXNJGI2xOhETYtRBYxim55cucMycpvmPDns/RTlMP+yLSeDwzbDc2B5zrBgUPHEMnULYdoMiS3
+        ETGzYxtT7Xp2YxgE46+12soz1HxiUbFZSw2hhp+DXoD9ANRa9zVBAM8Qyge/jx+ITpf2U3cQ0axN
+        dOyTwZNbLvpeH6Ng2Ch2/ugn9axr8cu9mKWX4ofjsesFfo92GHu2s02zEv4SEephzszoLk+vCsCz
+        CMD66R0h748QF5zcmbNXPbkznbHJJRpp3d5cHZ93Lls/alAiK1/KMc8+cT28gtOc1U/VM57VL5v8
+        v/ovfoBHvWkLvRDbwl6OFZBIFlgD67qrdCGs6/yzrgbDc8dj7PUiydpAJx+EBlLfAJKkqoYIRFPV
+        +oYMgWoYQJUlc6BJCjK09Usk8Cza1HOd9U+KDYdRwdLZcETvvJ5ixRK3koe8iV74IPI+axPZWD8J
+        oRugIPQbtvWEJ4eTpolA2CfuL6pNvgfuI3bSLmvcMDn6MiZPA4teZi+Y8XmjI/UH7FLvmozURgSs
+        hsRZlsGBStz21+9123Ue4j9FSuNMv9Zr058Pkd8jOJ/MycCPONmZBko4UnIIx3zt9Fvdwdgk/veY
+        ePF0RqhnH+t12YFEOvQQvS+jU822xAK0T9cbUew4lUk3TnjNCW/cexw1IhJrSXvdH7o/o1/H6CMi
+        02eb6r4begZOYPzkEUbEUs0TmZhwfg6w5yCb6xJB7hCReXFMbvqLGI+QaQqTX0+tZL2Wak5EIvFj
+        y3fwC/Xg//xfyp9a/kQ0IU8TPpzR4p+ZFodgLWkMQQms8aSfFbTxpJ8qqPE9uEzGjn4WdpTR4598
+        ATB6nNHj70aPi8fNH2dX19etm0yKXIwo8rMIYWVS5F1GkTOKfIepE0aRf5bJZRT5Z518RpEzipxR
+        5HtFkXd5MaLIh9Hgy6XIu4wiZxT5O1PkBPy5Dh8+ZnHk0fE1JDnBU0/YzuTHuzOH30CNx+cvkxVP
+        zjh0A2yvJMNfJVYR4WfzQit47xRZEik9mz25dSxye3HfCTg13VF+FqUb4i+cQBZjM3wIydpcSx6I
+        CsjJH6gAirKSmz/QgFCIP9B4IHShEPMHfwXwK+3p/cmU/PpQBEkiwpXyKW/QxyKpcnN1dZFJpzSD
+        IXYQDkcZXMq5mBluGN0ejEZhNMpuTC+jUfZ4civlTt6VMGEsCWNJGEvCWJJ9ZUmIw8ijiVNZJkWS
+        8kQXKZLIF+15rjtaz4/AAxkQ711ZzpHw4IBgHVEXymZKaKiOFzoOcZRjtx0KSQDPTGsUfbNEbr51
+        KfMyZVRWEi8pgiabeZkKzVAvNLogQhH38BunHn4jC3/S8uFomWb3rHXZbN1eZLIyKXjEyBhGxjAy
+        hpExFZIxR64X+tzZi4mjaNpMSiYzvIVRMoyS2aHpZZTMHk8uo2T2dG4ZJcMoGUbJ7BUl0+UN6lry
+        Q+Ja8nR7V7nEzIrYlYLEDPGf9BXEjKqKNDyfETMriRmBE9unH5mXObq6ue2cXWeyMglOoksrjZYY
+        Q8MYGsbQMIamQobmzLID1+G+Y4fuigym24gWOJpbxtEwjmY3nXvG0XyWyWUczZ7OLeNoGEfDOJq9
+        4mhu+WHkXPKPr85luSzNbXnhM0R1WiZLI0BRUFTG0qwLn4GcdNv+yDTN97PzdvfqMpOmScBSzIvM
+        YKZqmJoVCbzy5O9Ksll1rIdh4GNMxlpKRq9qEnrV/PQws0mZWbGVGb3ILL+BmPHzEDMd8oDCPucO
+        uOYIe5aBKqRoeAEWIWlUQa6YpJG/kg8APFC2RNIU0YgiSLIoVJwlRo1pmgIaWaRpzi+uWzfnzXYm
+        VXM+Is9CizzOzrBtGe6Y5qijazyDsTm+1rMYmyD1q90mbGDFhM3i+Sv0/Bc7+6ye/oxGKiNsFs9e
+        9eQywmZeI1URNosnr3puGWEzo5F5EgNWSdis767S2V/X+VYANrHvvJW4BPzw1SXgqXEvE2en/IhN
+        M3mI8oGuwAycDaFwAEVFfo+EHjlxcZ58HutgMXEEBbEkUByvkByoGBZGxXAFKj49yobEp8SdNbkj
+        5LwQRNy0PLp4qw9cIDP/hB+Qz0dobWnsAvK5OyrymVJiG6hP9BWsgs9TkVXQ+SiWSgiEY8txCNbo
+        kIW3H3haFvLjaQEI+dHjm/C0IHwVY/Sobg1P59eIIshAzB8G8iY8LYAJns6tkUU83W6etC4uWplw
+        uo24Ezwa4Qz4rLSz4fOQmBYPMwTNEPRuTC9D0Hs8uQxB7+ncMgS9ZQRNTDxvI35AvYBSc1+2y0PM
+        ygEEopQJmeUDqAqbbyCYwIyN303rZb+aLgOCX95pOgT6hwbhF6cXpzfNy+P2XSYUJyJcDMdT4Ldq
+        JF7GFgIy/SvANzmY4NCj0KbrZBMMTk5WKvim5zPjuiDZmHsisApxHyLbngLuuR+sQNoZJZlkYV1F
+        JkndvCCTANfWY9LWlmMS31h16oNfIis4NFNd6KE/LqngkEYTIc03ll1w6M9/sYJTbP43qze10RYw
+        w7OIC9nz8JOFI0/EoDY91tDSQ6sYVEoW0kpVHTwmTjrRV6n7xgRVlvIThnqRclUKD3RargrqMYX6
+        QfaNqWLV+8aK62ORQL287R7dNI++r6hddYGCYIh/cofEa3Xwrz53SS7Ho96sx3VbnW4Wt3p+sjPc
+        6iYB2TVdJB8DSP0BMAUJD0QTyFgb4IHUR6oKdHMAJFHCCIpGmdzrm7uvLja9+FhyQP4oCHiH+Z+N
+        FKZi8gGSZiiyPFB1EyIMoAR1QxckAWgKNAdQVvqaOMixdvISu2/uvMKVU3gse7ByNt8FIujko0pY
+        1lRdReSm06EqC31VNJGoA4SVgTZACpY0RchBJ5KHLqVriCfkFNwfU3gcle+PKTyifaCiN7oDZUw+
+        AEgDQe7LCPWVgSQKhqliRRP1Pnl4S4KpIXkA1X5pryHe3HeFT6LCY/mkTyK2bXNft21udPtUsmNz
+        EL18yfkw2aHNmpVs09z1h8kOLp9oqwtbPh9i+Wzu+wFMPoIsm9JAV/omEPoIqf2BKQjkfwP1dWBo
+        A8XApihVuWm88DAqd4oLj2gfrNnmajNIAxJMSdZ0pOmSBmQoEURBPEMDGxrSNUGRBUEDQBfzr6fg
+        p1twPRUeRuXrqfCIthPhcX7Cj2KOku9HHCXv884rR8lTN67UyI8psVko8iP+Oxz72LZ7tuUHM2Rp
+        a5EsJX9dnIF0e23JOTKyHQi6AqGoZmelBAqAsrJ5wZDSwkrKT3lQRlxJ6wjecFL38r0DSzbPeRD6
+        5EZe9u5o2YF0GEqnedxu3XTuW+12JzMQpYNMG3u/+tw9WYqfLwYl2X9USghK+ly7GYGymBB08gYn
+        KyPo7PE3RPEkPZSaEzQ55aNlrkwJmhxfpccTNLLsl42id0R5XWiLCNeGtkhrQ1vEdaEtAqgseueD
+        XyKL3vgk0Rsseudzz3810TvbjMVRpGpjcSab9z5ILI6sVbyZEcolxOJ07puX7eb37N2MC5E4nZ/I
+        4droEXMUMmQG4izBlh9wk2OUUTWNTWoThVWe7TlHr1Wnks0xhM/K5uXQk29XmzE6V6/bWSJzg2CL
+        JFNTleadztHldtYH27DJgh32ONihortGUsgzVVL4Am8Yc72lLt71dp4ac4NgK2WtpmC576KL97zd
+        hQLZQsmpqSIvmYdeOZ7qXN/bXSrbeZn8kZYKxf0U9k80liP6u0hcwttHsJ2FkzGYLUUjtBajEXwy
+        QN4mI6wgGKFVQTDCkp1btP37kvJgnyxIYSdzX3zcGIVdjzooLwclK6H5thKaO5dZkhXT3OBFzB4U
+        05xm4GkaxLVwTRSXaln67uVcvMl69/KBKmqy9JJ7DTRYesl9n1yWXnJP55all9xyekli4PnRw4h/
+        oB4Bj1IeQbllEG+yUX6BMojvlGlyz4sglptqMm8RxP3NNNm3HsJx7wnZIW6oZHGmv6fAOJlXy+cH
+        XgYQv6aHWSGI9y8EsaDlgeuameo9IQe/cMee5TxydHFd0lKPtjXYYLcF7a/E3RbR6cxICyu3W0wk
+        Vql2o6oa0VLP5j5OvHj/Rl6moxM6XzjRM7lvoZ0D16v5q0WosiLnr5+hArEQrld5INJkZwmuF7bE
+        cxTQh0BUUnXAaXF9LPIcx+eXl62bztnVfTbb4Ya25XA3bviAub+klvN/ZFWkPPxtL6JNGeex59CJ
+        cR77PbmM89jTuWWcx7aLUh7+xo8iv4D3qF/Ax64wT1FsqUUpp67EpiU2JO1A0zJ4D+FAFAV1d0IM
+        djMPgioDqH3s6hpXt+3zy5ur29NWJulxSM5nhlza660qyGAFOZGHm0jQeofCZx9jsk5KYSuqIStq
+        fnqY2Zh6VmwVsO6SSd6HaAJegEXiCTQh/8bOt8UTaJOqjMrW6lTm1wjd2inmZx7ehLSj8pTFNLIk
+        zfrVTfcsE2RfErs7nNTXPXut8sx1ox0Dy2H29WEmzE79imFshrEZxmYYm2FshrEZxv5IGPv6kHeo
+        W8AbkVvAD1/dAp4a+FJx9tSX2LiUpXygKzAzvkA4gKIilx1fsGVkTLxBQfzQyPj76dFlJiSOYwAS
+        57RpeXQBVx54X+q7/v2D0+lry0bTM1KrwPRMyMN2X1JHAJqmRkqworYSK+aDibIgC1An1j0XTNQI
+        TCyQEUmLYCLsCuJXmb6T/a0czHyPzS+clBcz54bLFCwXgMtSUbgsdUGSGSqfHpa8k747zsTJHTck
+        XyyPSwnN4eLTu2YWLk7fDgwdM3S8C9PL0PEeTy5Dx3s6twwdbxkdEyvP+4kzwJtPZploOOVBLKLh
+        keUbPYvoYxfeOL8vDH6Vqf798HZC4nfr9XC5me/Z7vO37T6vKP8v23PO9pwX2XPeCbiWN7KcX/3M
+        feZ3e7DPHFSMeBfPX3W+IoZ45zVSbR7ed823yxDvvEYqzaD7rrlyGeJlWXFZVtwZDc3WBqykkGvx
+        Ipw7VM31rSPaUt6CO94PeEy9St4vN1fBXTZ/UiBXgQwPJF2HqpadHVCUJFln2QpWhyd07uEZB/5x
+        /87cTLm5Abutm4vzy1Z2YsBvrm2/cGmclIuWOWy1M3iZQ2wPEK2pkjNmfw8SCgwmRe0yuZbBfNm7
+        TWvjVc+1dFDwhRNpRMExNnLWWsrJLWiiAKXc8fhQEAsVWoICL04LLW0lrKAIzSJqWv6tCW+KLHhD
+        zalFmgWKtPZYBs0SPY5a9DvHc11imChfvJRvEY+y4wxWbXOPjS/9dZQJmI9aeWoDeVimEU6Pb9OY
+        PhiZhqXvMeIj5e6b23I032EXcsJh673i+cji8LDvu9T1jezmCrN5nshm28nmj9NaN/vtRWzSom0l
+        PtcOzHcykh+6WKzpoRFamQcmEViZBmZOZp8topD77cPbLCLU41J7H8AiKkWSwLzBIk5UsZlFlIBa
+        xCIC7i84K/kLMTtHG5nFo0WzCHhcsmU8YpaRWUZmGTe1jO9cRr16wxiZAvpaPlfseW5TQMPPFVXL
+        aQpo+HmBd/Jx+LnQhVJhU8BM43rTKIpFTKOYbRZPNzKLp4tmUSzZKJ4yo8iM4k4YRTJjK8hUcjDZ
+        q3UU2nRqN+FUyclKJVPp+VwydSsB40RglWG8mpPZvl0UATEEl+5TyYARyKKeHzBCERQCjJAXQVeA
+        H4VC1YWKN2dNVLGhVYSgiFWUVgPG440s4/GiZZRKB4zHzDYy28hs4+a20Yw3A68gUxOBVbbxENn2
+        NFv53A+2aigvXIcASIXYhvKZVYEgyALMqqAUZFYF5QMxq6pe8btGqJYDH4UChlLPtpFL6nEWsJEn
+        CzZSL9lAnjADyQxkKQZyy/ukWNKQ6pKG+EH8pIxD7Ax31LccchPK0fqeaYoE6D069ixyw0wlpm2x
+        CFmZQ+SRU04lXpuiAL35XtJNkcBCLzNtschcLzNN9T9C5AR0SblRfC650idkW2Zv0t6AZOXPttRr
+        iz+KbYgReh52DCIy+StW/UN/TBQ50zSVGJBZcD3y6AQpmaRxKuWE1B9paNQxmG+cSo1tZGC/IaRk
+        kqaUDJ1J/2XUd+1aupk8KOPWxp//Sv9+2l6vzV9mLb0s3s1Fi15+XxEFlemhqaoua2LOJDMKBAXf
+        fYMoGowlmSklycxF6+KQFj45v+5kOmh30cO9yV1Ejrw/tMZZm++U75n+2UfLOcN24O3l1g22A++z
+        TC7bgbenc8t24LEdeGwH3h7twCNeI//EI3409S/LZOVSTummpFy0E0/RoSCL2XvxVIH4/bR66z4l
+        Nercq5xw037v5L6l7p3rnrXumpfHzUyq7s6iVIGFonKsTZssxoC7CH0cjpZzdpNFGF+wh/3QDhr/
+        D8kyPMxkTQEA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2869']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:07 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['5709']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:03 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><s_keys>test</s_keys><s_auto_range>next_week</s_auto_range><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxyZXF1ZXN0
+      X2N1c3RvbV9maWVsZHMgLz48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJl
+      cXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0
+      X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVl
+      c3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9t
+      ZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48c19rZXlzPnRlc3Q8L3Nfa2V5cz48c19hdXRv
+      X3JhbmdlPnRoaXNfbW9udGg8L3NfYXV0b19yYW5nZT48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHJl
+      cXVlc3RfY29zdF9yYW5nZSAvPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PC9ldmVudF9zZWFyY2g+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['797']
+      Content-Length: ['627']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1c63LbthL+f55CJ3/STksJIMGbh1XHje3WJ9facjPpHw5IghJjipQJ0rae57zJ
-        ebKzACmJuppSZMdJldG05uIjCOwudvERIJxf74dx65ZlPEqTX17gNnrRYomfBlHS/+XFVe9MsV78
-        2v2Xw25Zkruc0cwfuBnjRZx3HV54QTqkUeIWnGVuxF2PBt0x405ndZHjZ+NRnrpenPrX3StXUW6v
-        R6F9/coeXenvPaWfpWGA89/v/HcfPn3WmM8/ayefsPH5z+v36NPH5OR22Hs94MfayL2/ujEv3pyN
-        T3xduQhwaLy+CYtP5zf94zP+/iK5G99Q1MPGe5K5J0Ptzfnpn+Ob7PTzjWXHmfrhPLG1k+u7fvzJ
-        6cy1yQkintPEZ9ylGXNvaRwF3SR1OqvkpVa6DkioCzpjXYyQ5XRm12VRwLjfvRzznA1bLwXkZYWR
-        BY4fU86r/5W35QNG84xB22ayqlze0psvL6sBHUuFl9VJK8yLnMp812w8eUIHLDUTCoNW0MmdU8lc
-        fTPciiqHEfdXV1t2pCqfk80gsi9vAdKaKmG+bHbdrfoPqkmLJM/GZV3FNcjrgmmxvP8qiXIWtF6D
-        g4OHzqBl5QHNmZvRpM9clgTVdWk/mv/cwiQftN7ScUtF2ACnmJaWwCL33TQMOcu7moFQBahJZzDO
-        /DQJeBcTQ1OxQebQk8ISPoZ/w2EQdMVDkY5JhZzKwVqpZSDsSjFNAjePhkzCFaQrmPQwOkLi9xPC
-        R+JJq2+o6l3sfnkN7p/lcwopElAIz/euDxXZmtpcHwhvqQ+Ed9FH1f8yEE4H+xGBbtdkVbnUwW9R
-        v3XBOMS/W3C4HuP5BFqqqPwb4oh2/hZPiqZhxY3BQ9NZKKgLJ+E4p3nBu3F0Oy2vRBMARGGa087k
-        Ok+vWTL3uFIyKR6PWJdHw1HMQAH+NZs2WJY4A8rdJHVHLAu5DIpzAhEzYNTD4JoGi+rSGdJ7NyuS
-        BBpfatYAnS8JnSGElmXYotBJGAtAhSOwRwGxWNhItmaVvAIXGc0hwdVgE0kJED1Is6EI8GXjl6ST
-        SDfJA+71sIvaaBro6nKHD9I7eXfZ4jIjzsscnhYZwKXXZCwwsHsDSYMmNKAArhVOkNJpLgSy9edx
-        65VEtnLwqhaXqWV6V+ldYLeC1RxVJZ3SYSF81Moq3NRh/xKXRy3x5+WI+mwCrmJvlfGWEp9urkl7
-        5zmNx/PpLsqrwDyE/yRUicDNZsKyvEwDsrwqXJsrodN8faasl+6SJ8X9e82SskI+Yn5E401pcgbZ
-        lCll/1oK2EqiW+dJzjIZabbMmtII67NmZcamyfIjCya5AbonsoO5MTs0TA2WpamNU6WJtG1Sg6kg
-        TaQGVKWGv/eTJXuDopo2HI+yKH44UTbNkki3IUk2zZJky1kDEbOG7VSxnCANE1sfsL42QZ6xLKNZ
-        1Dor4rh1ArOI03sIkBHwD9a6i0BlImcqJ1ktvy1mzvfvf98lcw5ZEFFwcToSSQDy4yDleden/oAB
-        CaGjQeTzOPLatxHN06zti4mihDhRAmoW6QVkkCeF6rO4O8jz0VGns6mCTk2sjDImsnYnHxRDjxsm
-        uSfE6Ah9dS7P5ZjuhKVylBCUowR0rLCpchShHEWEfiUQylGiRKliqWpbWDXbn0d9sNnKpjoJBcvF
-        YEMO3Qf1yGtnRPNB9+nbKB/rfDMqXalQXoxGaZZzVzR5Qn/ronlEOXVaEE28tHLMg5dKr+Q3Bc0O
-        LvrNuOh2EX1y0z/OrfMsEiI3TQ6+/Yx9e1d6XZuTbEWv+ywV8yt4fgzcNC9gtkRI2yCGAdPYqciJ
-        06Rf/olR21YNldhQPBU6nVk9jQm7KKvx9W+OYUuTbiDYpdNu4NV/zQOWKLSqW9haS5wnRLURVbbV
-        dVz5A8uKNVQ5joZUEbO1lUT5DZQeaPJT0GRpgvU0ubRgU5bcK9jPQAghLZ4wnw09lu2NHloq3oIe
-        YlVF29BDrCoq2jdTPssiYMr6IzBlw7Sav18ngrBux5T1L2bKEMWR/gGra6nyHzQO5YTqr4hHeStP
-        xfKIeLsSpXJOFSVp623BWTFcy5R72vfDlKW+phOLAShHTihuhXKUPFWgR8pQKEfOKUA5ylAqR8wr
-        ZChVLdvUtUfkyXtt4WNP0/ba2ANHfkL/3I0hH5zzq7Dj+XD9w9vj3umP06j9vNjwkznwF3Dhgxc/
-        cx48m3F8KQ+GGWcbEU38W02FFdNsI9WqAAcy/Khk2FbXU+GSijYiwqcf1/Dg01uWje8GTCS2Ghv2
-        on4xEluvCrmk7XTqgjpXhrl9mihyH9BKtizLH+LL3/IWrOso4JtIc1W+iTGf0WEkVnyb8GOel8QG
-        TASxqzSIYGQsA6t6PI0LiFGc3gKv6GJNePGi1BHvBEU886IExpyuCtC8rISIQQnsEEYIMaeYmbAC
-        gdsOaAYN0meYqcyRLZtVrNkCtCCsQLOaNX2Gqj2vEkwrJzXU7IkwEH1wftqfdlgFkrksBZdeUqDY
-        JrPQ1jmRBJT3H3S+k86XFSglC82Yl5WQ+SbMi+RupmnfcImoiyoA2HuN2UgDq2HrYavVMOuthhpY
-        DZMmVqujNlgNNbWausZqC9oT14uNmJeVkPkGzIscmA5wqD5m3D2EtUNY+6Z1fghrh7BWPf6moEku
-        ZrupfMcAkzb5AYM7kXcxTNnnJYsI9UGE9iCCPIjQH0QYy4jOcvfK9+xAkjOW+ACZ/FVOdfveCGav
-        c6IZIqQ+kJ+SYCwKZ6ikEMs1XUs1aqhKOEONYuozLnS3KKphhLH5eOilcacuBkpZSrv/+2/9/pnc
-        6Sx2M09HrnSKQ8jcKWQu6a+zZkJwGFCHAXUYULsMqPoo2t9nW34W5ZHvZuw2YvK9l2hJ5XIrizat
-        yssd25ZYhy76Bc/3+W2TiXWiN9+1LfecbLEWbSnY6mH7SNv3t15SJ6rY0N9wbX6Lz72wamhbLM+r
-        233uRRQV76KS5TX6d1e9VxfHr16fXqxdpX9L83zA7lq/pUWWsJe89Q66k1H/mmX/XrMub5yf7W9Z
-        Xkrb5Tt1fhfl/qDZehE/6nRW39vhMOZZUF8WgBGVjmAcdWwNfj4iXogClbBQC5DOrJCFxKOmiewg
-        REQjjGLN33mhfZ+P37zE80Q6aLB0s7Qus7Rys7y4s9Xq+NO6icngh4jlG7oemnaAKUOYYNu3VaIi
-        y8BBiHXDs7SwgZsMaXZTsOZOsvXDH8NJtm7EP89JdAY/hEio6p5OqWeERFP9wGSGpdkeDCSiBhbV
-        Q2x6u22K2OezH8NHtm7Ec/CRAN/dkztNL7xhEN23/TgtgjBLk7ydiEXdBtsUNtawSl/sPnfFCjnq
-        /FR+9urOJKIjccSyBh5SIR/0keaPe9gpHrGv+9kQ8E1FjNCGH6WQaCH9EtP0NaQFpuX5Okam7yNT
-        J0FoEYP6VvNdKKHc49AwbmzdgseIG1s34jnEje/BU2CKf/CU7zHDVPpyJbJj6/DzbN8j1LZCano6
-        Jh4hBkG2SZFlhp5neibGvk+/YLPb/pvxCOnoC1v0LHLUV/cnVYcfMvTA9o2Aqr5hmFiz4do0KQkI
-        0Qzb8LFuB9oW/pQPsuacaNeGPLpHbd2iZ+FR30Euy+/SQyrbYyrbccNs7VXgVvtly7+LEWdx7MYR
-        z+deL54uv15c99pRyF9f1eWdFXWv2J6r47a+Zl8uaovvqb5wR+6D50lhtdmBUiXumZwoJRaqyo2w
-        r/BFi/TewWCZiB71uKkpi9ywB1h8pdCqziz8m2Xp+t3Al8cnb04vLj+evnlzuXZb8CUNYpa95K2P
-        4Ei84QZh1Vabnyr1fe3g/dqHKO73OCi5fKSJD13/UySs2epR0+UjU9VMo/HykaFt9aErMhQN9ZBV
-        nRYojw3c49euqi5VEsvzE8m+VIIMVbObHqBIkKlu8cErUZCpqPouKllxgKKqnZ6tXUyTR9udxWvW
-        zdTfyPETnplYf9xXOjORNMxx5DnluMdMY0Xm0cSlgdA2NJ3LnLYhpV0JfOt4iq+O5FyX1yxjbTZb
-        qumHszgVW0bYj6tT28TT5s5P/j/84JdnfFkAAA==
+        H4sIAAAAAAAAA+1d23LjOJJ9369g9MP2bEzRAnhnrUYTsi1fquTLWLI91S8KiIQstilSzYvL3sf9
+        lXnd2I/oT9kvWYCkLOpCibRIS5bRoY6ywBQBJkBmnsNEZv3vzyObe8Keb7nO336BB+AXDjuGa1rO
+        w99+ue2e8Novf2/8Wx0/YSfo+Rh5xrDnYT+0g0bdD/umO0KW0wt97PUsv9dHZsNx67XlR+qG9zIO
+        3F7fdo3HhtHjeYXv+7/fX/1u3zx4mPeP+99u9KtDY6ANvyvPf3QuB6fBZef68LqvQBu8NK3++KT7
+        EBz2/+j/MBTtKJTbh9doeNu5vtF7R/4/73579v/L74THSlcYS4LTf7w/b/NP4AT/vH0+lV6OHodD
+        AVkD3RZNefDSH17I/5AvLm0wPpT4H/XazPjqpuUHyDGw30Me7j0h24ovbll7rKBGnbSgHlEfbrTu
+        67Xpt/iAiX2j0SLafvk5xB5OBKLWumEFL7Gsbdk25gceGc9rW3w4kmzTw8mx5Kc28v3kn1gcBYGH
+        jIDMqU8kp+2JTPSz5qJMfDoyW9HUxad9weTwbFM9WQeP+CXdU43M+/QAXR2J+OTXry0z55zKZZw2
+        GOIRHiPv0V/eQXxpM1IzR6aC0fV1qSD372g0/k/uHgXY467nfhWroTYdWG2iYdcPeh5yHshJR+iZ
+        nH7UtxxsNiT5ANRrM02RABluMPYsAzckMJGYtsUiIbkg5JFTvp5j2lQfUaXP9ZJuigQWeplpi0Xm
+        eplpqjtuzyc3vI2pxvbzEv8IkRPQW8YdR6uqUY9u3N6kvQHrtbmWeQlhrYS4VkJaKyGvlVAWJWqL
+        lxfNYc8IPY88z4nI5K/4nsAhfbzMNE0lBuTOc70GBCAlkzROpZxw1MdeQ1e1lFTSOJUa24g8Kanu
+        5ptSMnTN+S+jvmvX0s3k6Rq3Nv7vv/8nfYLpgXpt/jprGYuZLYDPsgDSs264oRN4yQVGJjXd8Ho4
+        euKfeNSqT0ViM2ASExGfrYcdM/keHbpwnS8c9APuG3JC5L1wAoBEFVOBWDYMjJ47GPg4aIDkaKpp
+        KuNjw3VMvwFlKGkyhLqekp4cjMVfyH+jkWk2aI8AAphIvrYTk+tqCoC9qBk5Zi+wRjgS5wEkn64g
+        fpV18vmNGuJlsskp5688/k4cIC9I66I7DL9wcjDkLlCkB6UEPUiKIAFFAiCXHhQgAzm/HhQeyOTT
+        BeBr9Mmnh+S6Y284WkLHzR/d83/Wa6mm5HB06ZA/JgrpWsYjDiZCsU7iv4nrqHzvTI68OpI9mzzB
+        3JQXNJGI2xOhETYtRBYxim55cucMycpvmPDns/RTlMP+yLSeDwzbDc2B5zrBgUPHEMnULYdoMiS3
+        ETGzYxtT7Xp2YxgE46+12soz1HxiUbFZSw2hhp+DXoD9ANRa9zVBAM8Qyge/jx+ITpf2U3cQ0axN
+        dOyTwZNbLvpeH6Ng2Ch2/ugn9axr8cu9mKWX4ofjsesFfo92GHu2s02zEv4SEephzszoLk+vCsCz
+        CMD66R0h748QF5zcmbNXPbkznbHJJRpp3d5cHZ93Lls/alAiK1/KMc8+cT28gtOc1U/VM57VL5v8
+        v/ovfoBHvWkLvRDbwl6OFZBIFlgD67qrdCGs6/yzrgbDc8dj7PUiydpAJx+EBlLfAJKkqoYIRFPV
+        +oYMgWoYQJUlc6BJCjK09Usk8Cza1HOd9U+KDYdRwdLZcETvvJ5ixRK3koe8iV74IPI+axPZWD8J
+        oRugIPQbtvWEJ4eTpolA2CfuL6pNvgfuI3bSLmvcMDn6MiZPA4teZi+Y8XmjI/UH7FLvmozURgSs
+        hsRZlsGBStz21+9123Ue4j9FSuNMv9Zr058Pkd8jOJ/MycCPONmZBko4UnIIx3zt9Fvdwdgk/veY
+        ePF0RqhnH+t12YFEOvQQvS+jU822xAK0T9cbUew4lUk3TnjNCW/cexw1IhJrSXvdH7o/o1/H6CMi
+        02eb6r4begZOYPzkEUbEUs0TmZhwfg6w5yCb6xJB7hCReXFMbvqLGI+QaQqTX0+tZL2Wak5EIvFj
+        y3fwC/Xg//xfyp9a/kQ0IU8TPpzR4p+ZFodgLWkMQQms8aSfFbTxpJ8qqPE9uEzGjn4WdpTR4598
+        ATB6nNHj70aPi8fNH2dX19etm0yKXIwo8rMIYWVS5F1GkTOKfIepE0aRf5bJZRT5Z518RpEzipxR
+        5HtFkXd5MaLIh9Hgy6XIu4wiZxT5O1PkBPy5Dh8+ZnHk0fE1JDnBU0/YzuTHuzOH30CNx+cvkxVP
+        zjh0A2yvJMNfJVYR4WfzQit47xRZEik9mz25dSxye3HfCTg13VF+FqUb4i+cQBZjM3wIydpcSx6I
+        CsjJH6gAirKSmz/QgFCIP9B4IHShEPMHfwXwK+3p/cmU/PpQBEkiwpXyKW/QxyKpcnN1dZFJpzSD
+        IXYQDkcZXMq5mBluGN0ejEZhNMpuTC+jUfZ4civlTt6VMGEsCWNJGEvCWJJ9ZUmIw8ijiVNZJkWS
+        8kQXKZLIF+15rjtaz4/AAxkQ711ZzpHw4IBgHVEXymZKaKiOFzoOcZRjtx0KSQDPTGsUfbNEbr51
+        KfMyZVRWEi8pgiabeZkKzVAvNLogQhH38BunHn4jC3/S8uFomWb3rHXZbN1eZLIyKXjEyBhGxjAy
+        hpExFZIxR64X+tzZi4mjaNpMSiYzvIVRMoyS2aHpZZTMHk8uo2T2dG4ZJcMoGUbJ7BUl0+UN6lry
+        Q+Ja8nR7V7nEzIrYlYLEDPGf9BXEjKqKNDyfETMriRmBE9unH5mXObq6ue2cXWeyMglOoksrjZYY
+        Q8MYGsbQMIamQobmzLID1+G+Y4fuigym24gWOJpbxtEwjmY3nXvG0XyWyWUczZ7OLeNoGEfDOJq9
+        4mhu+WHkXPKPr85luSzNbXnhM0R1WiZLI0BRUFTG0qwLn4GcdNv+yDTN97PzdvfqMpOmScBSzIvM
+        YKZqmJoVCbzy5O9Ksll1rIdh4GNMxlpKRq9qEnrV/PQws0mZWbGVGb3ILL+BmPHzEDMd8oDCPucO
+        uOYIe5aBKqRoeAEWIWlUQa6YpJG/kg8APFC2RNIU0YgiSLIoVJwlRo1pmgIaWaRpzi+uWzfnzXYm
+        VXM+Is9CizzOzrBtGe6Y5qijazyDsTm+1rMYmyD1q90mbGDFhM3i+Sv0/Bc7+6ye/oxGKiNsFs9e
+        9eQywmZeI1URNosnr3puGWEzo5F5EgNWSdis767S2V/X+VYANrHvvJW4BPzw1SXgqXEvE2en/IhN
+        M3mI8oGuwAycDaFwAEVFfo+EHjlxcZ58HutgMXEEBbEkUByvkByoGBZGxXAFKj49yobEp8SdNbkj
+        5LwQRNy0PLp4qw9cIDP/hB+Qz0dobWnsAvK5OyrymVJiG6hP9BWsgs9TkVXQ+SiWSgiEY8txCNbo
+        kIW3H3haFvLjaQEI+dHjm/C0IHwVY/Sobg1P59eIIshAzB8G8iY8LYAJns6tkUU83W6etC4uWplw
+        uo24Ezwa4Qz4rLSz4fOQmBYPMwTNEPRuTC9D0Hs8uQxB7+ncMgS9ZQRNTDxvI35AvYBSc1+2y0PM
+        ygEEopQJmeUDqAqbbyCYwIyN303rZb+aLgOCX95pOgT6hwbhF6cXpzfNy+P2XSYUJyJcDMdT4Ldq
+        JF7GFgIy/SvANzmY4NCj0KbrZBMMTk5WKvim5zPjuiDZmHsisApxHyLbngLuuR+sQNoZJZlkYV1F
+        JkndvCCTANfWY9LWlmMS31h16oNfIis4NFNd6KE/LqngkEYTIc03ll1w6M9/sYJTbP43qze10RYw
+        w7OIC9nz8JOFI0/EoDY91tDSQ6sYVEoW0kpVHTwmTjrRV6n7xgRVlvIThnqRclUKD3RargrqMYX6
+        QfaNqWLV+8aK62ORQL287R7dNI++r6hddYGCYIh/cofEa3Xwrz53SS7Ho96sx3VbnW4Wt3p+sjPc
+        6iYB2TVdJB8DSP0BMAUJD0QTyFgb4IHUR6oKdHMAJFHCCIpGmdzrm7uvLja9+FhyQP4oCHiH+Z+N
+        FKZi8gGSZiiyPFB1EyIMoAR1QxckAWgKNAdQVvqaOMixdvISu2/uvMKVU3gse7ByNt8FIujko0pY
+        1lRdReSm06EqC31VNJGoA4SVgTZACpY0RchBJ5KHLqVriCfkFNwfU3gcle+PKTyifaCiN7oDZUw+
+        AEgDQe7LCPWVgSQKhqliRRP1Pnl4S4KpIXkA1X5pryHe3HeFT6LCY/mkTyK2bXNft21udPtUsmNz
+        EL18yfkw2aHNmpVs09z1h8kOLp9oqwtbPh9i+Wzu+wFMPoIsm9JAV/omEPoIqf2BKQjkfwP1dWBo
+        A8XApihVuWm88DAqd4oLj2gfrNnmajNIAxJMSdZ0pOmSBmQoEURBPEMDGxrSNUGRBUEDQBfzr6fg
+        p1twPRUeRuXrqfCIthPhcX7Cj2KOku9HHCXv884rR8lTN67UyI8psVko8iP+Oxz72LZ7tuUHM2Rp
+        a5EsJX9dnIF0e23JOTKyHQi6AqGoZmelBAqAsrJ5wZDSwkrKT3lQRlxJ6wjecFL38r0DSzbPeRD6
+        5EZe9u5o2YF0GEqnedxu3XTuW+12JzMQpYNMG3u/+tw9WYqfLwYl2X9USghK+ly7GYGymBB08gYn
+        KyPo7PE3RPEkPZSaEzQ55aNlrkwJmhxfpccTNLLsl42id0R5XWiLCNeGtkhrQ1vEdaEtAqgseueD
+        XyKL3vgk0Rsseudzz3810TvbjMVRpGpjcSab9z5ILI6sVbyZEcolxOJ07puX7eb37N2MC5E4nZ/I
+        4droEXMUMmQG4izBlh9wk2OUUTWNTWoThVWe7TlHr1Wnks0xhM/K5uXQk29XmzE6V6/bWSJzg2CL
+        JFNTleadztHldtYH27DJgh32ONihortGUsgzVVL4Am8Yc72lLt71dp4ac4NgK2WtpmC576KL97zd
+        hQLZQsmpqSIvmYdeOZ7qXN/bXSrbeZn8kZYKxf0U9k80liP6u0hcwttHsJ2FkzGYLUUjtBajEXwy
+        QN4mI6wgGKFVQTDCkp1btP37kvJgnyxIYSdzX3zcGIVdjzooLwclK6H5thKaO5dZkhXT3OBFzB4U
+        05xm4GkaxLVwTRSXaln67uVcvMl69/KBKmqy9JJ7DTRYesl9n1yWXnJP55all9xyekli4PnRw4h/
+        oB4Bj1IeQbllEG+yUX6BMojvlGlyz4sglptqMm8RxP3NNNm3HsJx7wnZIW6oZHGmv6fAOJlXy+cH
+        XgYQv6aHWSGI9y8EsaDlgeuameo9IQe/cMee5TxydHFd0lKPtjXYYLcF7a/E3RbR6cxICyu3W0wk
+        Vql2o6oa0VLP5j5OvHj/Rl6moxM6XzjRM7lvoZ0D16v5q0WosiLnr5+hArEQrld5INJkZwmuF7bE
+        cxTQh0BUUnXAaXF9LPIcx+eXl62bztnVfTbb4Ya25XA3bviAub+klvN/ZFWkPPxtL6JNGeex59CJ
+        cR77PbmM89jTuWWcx7aLUh7+xo8iv4D3qF/Ax64wT1FsqUUpp67EpiU2JO1A0zJ4D+FAFAV1d0IM
+        djMPgioDqH3s6hpXt+3zy5ur29NWJulxSM5nhlza660qyGAFOZGHm0jQeofCZx9jsk5KYSuqIStq
+        fnqY2Zh6VmwVsO6SSd6HaAJegEXiCTQh/8bOt8UTaJOqjMrW6lTm1wjd2inmZx7ehLSj8pTFNLIk
+        zfrVTfcsE2RfErs7nNTXPXut8sx1ox0Dy2H29WEmzE79imFshrEZxmYYm2FshrEZxv5IGPv6kHeo
+        W8AbkVvAD1/dAp4a+FJx9tSX2LiUpXygKzAzvkA4gKIilx1fsGVkTLxBQfzQyPj76dFlJiSOYwAS
+        57RpeXQBVx54X+q7/v2D0+lry0bTM1KrwPRMyMN2X1JHAJqmRkqworYSK+aDibIgC1An1j0XTNQI
+        TCyQEUmLYCLsCuJXmb6T/a0czHyPzS+clBcz54bLFCwXgMtSUbgsdUGSGSqfHpa8k747zsTJHTck
+        XyyPSwnN4eLTu2YWLk7fDgwdM3S8C9PL0PEeTy5Dx3s6twwdbxkdEyvP+4kzwJtPZploOOVBLKLh
+        keUbPYvoYxfeOL8vDH6Vqf798HZC4nfr9XC5me/Z7vO37T6vKP8v23PO9pwX2XPeCbiWN7KcX/3M
+        feZ3e7DPHFSMeBfPX3W+IoZ45zVSbR7ed823yxDvvEYqzaD7rrlyGeJlWXFZVtwZDc3WBqykkGvx
+        Ipw7VM31rSPaUt6CO94PeEy9St4vN1fBXTZ/UiBXgQwPJF2HqpadHVCUJFln2QpWhyd07uEZB/5x
+        /87cTLm5Abutm4vzy1Z2YsBvrm2/cGmclIuWOWy1M3iZQ2wPEK2pkjNmfw8SCgwmRe0yuZbBfNm7
+        TWvjVc+1dFDwhRNpRMExNnLWWsrJLWiiAKXc8fhQEAsVWoICL04LLW0lrKAIzSJqWv6tCW+KLHhD
+        zalFmgWKtPZYBs0SPY5a9DvHc11imChfvJRvEY+y4wxWbXOPjS/9dZQJmI9aeWoDeVimEU6Pb9OY
+        PhiZhqXvMeIj5e6b23I032EXcsJh673i+cji8LDvu9T1jezmCrN5nshm28nmj9NaN/vtRWzSom0l
+        PtcOzHcykh+6WKzpoRFamQcmEViZBmZOZp8topD77cPbLCLU41J7H8AiKkWSwLzBIk5UsZlFlIBa
+        xCIC7i84K/kLMTtHG5nFo0WzCHhcsmU8YpaRWUZmGTe1jO9cRr16wxiZAvpaPlfseW5TQMPPFVXL
+        aQpo+HmBd/Jx+LnQhVJhU8BM43rTKIpFTKOYbRZPNzKLp4tmUSzZKJ4yo8iM4k4YRTJjK8hUcjDZ
+        q3UU2nRqN+FUyclKJVPp+VwydSsB40RglWG8mpPZvl0UATEEl+5TyYARyKKeHzBCERQCjJAXQVeA
+        H4VC1YWKN2dNVLGhVYSgiFWUVgPG440s4/GiZZRKB4zHzDYy28hs4+a20Yw3A68gUxOBVbbxENn2
+        NFv53A+2aigvXIcASIXYhvKZVYEgyALMqqAUZFYF5QMxq6pe8btGqJYDH4UChlLPtpFL6nEWsJEn
+        CzZSL9lAnjADyQxkKQZyy/ukWNKQ6pKG+EH8pIxD7Ax31LccchPK0fqeaYoE6D069ixyw0wlpm2x
+        CFmZQ+SRU04lXpuiAL35XtJNkcBCLzNtschcLzNN9T9C5AR0SblRfC650idkW2Zv0t6AZOXPttRr
+        iz+KbYgReh52DCIy+StW/UN/TBQ50zSVGJBZcD3y6AQpmaRxKuWE1B9paNQxmG+cSo1tZGC/IaRk
+        kqaUDJ1J/2XUd+1aupk8KOPWxp//Sv9+2l6vzV9mLb0s3s1Fi15+XxEFlemhqaoua2LOJDMKBAXf
+        fYMoGowlmSklycxF6+KQFj45v+5kOmh30cO9yV1Ejrw/tMZZm++U75n+2UfLOcN24O3l1g22A++z
+        TC7bgbenc8t24LEdeGwH3h7twCNeI//EI3409S/LZOVSTummpFy0E0/RoSCL2XvxVIH4/bR66z4l
+        Nercq5xw037v5L6l7p3rnrXumpfHzUyq7s6iVIGFonKsTZssxoC7CH0cjpZzdpNFGF+wh/3QDhr/
+        D8kyPMxkTQEA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3049']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:07 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['5709']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:03 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><s_keys>test</s_keys><s_auto_range>this_month</s_auto_range><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxyZXF1ZXN0
+      X2N1c3RvbV9maWVsZHMgLz48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJl
+      cXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0
+      X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVl
+      c3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9t
+      ZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48c19rZXlzPnRlc3Q8L3Nfa2V5cz48c19hdXRv
+      X3JhbmdlPm5leHRfbW9udGg8L3NfYXV0b19yYW5nZT48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHJl
+      cXVlc3RfY29zdF9yYW5nZSAvPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PC9ldmVudF9zZWFyY2g+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['798']
+      Content-Length: ['627']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1c23LbOBJ936/Q5mVma4YiQIK3FEdTntie9eY6tjypzAsLJEGLMS8yAdrW9+yf
-        7JctAFISqZspWU6cjFyqxDpogkB3A+jDbtr99T5NerekoHGe/fIC9sGLHsmCPIyzq19eXA5PFfvF
-        r4N/uOSWZMyjBBfByCsILRM2cGnph3mK48wrKSm8mHo+DgcTQl11dZMbFJMxyz0/yYPrwaWnKLfX
-        48i5fuWML433vnJV5FEI2e93wbsPnz7rJKCf9eNP0Pz8x/V78OljdnybDl+P6JE+9u4vb6zzN6eT
-        48BQzkMYma9vovLT2c3V0Sl9f57dTW4wGELzPSq841R/c3byx+SmOPl8YztJoX04yxz9+PruKvnk
-        qq0xuWFMGc4CQj1cEO8WJ3E4yHJXXYVXWhm4HMEe1xkZGJarzr9VDSGhweCM4WRSt0nADWI2qcRS
-        /k+GlZjxsczAql2KvpXtdWN9cYIprf+r5FleFlzvDaRulRcMm61VF9wk0j5VV9JobcitrX1NJlXv
-        KjfrHBLWrwWn182QVm9zuaUO6ZgEMU5W91vNYi7SgudS8/n1lN5FJd07yxjhXsoal1WzVuejUadK
-        zMuMFbXapRGawKy5acYW5oaYEa/A2RXxSBbW32XTRxL+3IOU9d6K6fU0ALl/zJsryZIFXh5FlLAB
-        qFsb0FyGkiDPQjqAyLZ1zUSgKT1trMQn/CdNw3Ag7gh0AGvJGc5NltsmgJ6EcRZ6LE6JFFeArgA4
-        BOCl/PwlDLlKtu5ycd7Vd75WCtbUxHBUck0gNuodjYs4Eaow96EKExiOBjqqwgQIou6qMBWAFIi2
-        VEU99WrDlC5kWtD+AA1XbWB1u5z7KSkKXMS90zJJesd40ju5H5Mi5tsw6d3FXGVD7snKcRHfkmkf
-        lc6q3/lGpL9///u0abYveQnfw/MBGxHMitmVFVhLpCSMMXdxPGZ8+1cH7iinbBDgYET4XozHozig
-        Sez3b2PM8qIf5KmrShE3zriaS74TcmycEKH6IhmMGBu/VNVNHagNWBkXJOGzUtmoTH1qWugeIVMV
-        +lIvzuSaVqNKOUrElaOEeKKQmXIUoRyFCeWEQjlKnCn1Xqo5NtSs/ufxFbfZyqG6GeaWS7gNKZ8+
-        V4/87o4xGw2+/Bjlbd1vRqUrFUrL8TgvGPXEkKdRQBNqS1B5rC5AUy+tHfPgpdIr6U2Ji4OLfjMu
-        ut2OPr3ob+fWrIgF5OXZwbefsW/zgIaVdJA0wo8amgpwrocZVqffWX5NslZMUiHT5smYb2mxGDsP
-        n4JrwmZiosW9IrmIr/j9E8xiVvJoCaG+iUyTh7EzyE3y7Kr6FYK+o5kacnjzDHTVeT8jTL0s97iW
-        o2raLUDQF84/GKmI3vybmxES8lBrzAM6oW8R5EmRVXgtXBZYLua52BSpBMQt8yIVTLKy0RI6ZUlT
-        wuldpwPQBzOO1MRdOsrv5NVVICpN2oZcyp0uIFXUWTktl2lgUwEZUv7ZFqjCTG6bshbWDBvartpA
-        6tYWUW1AtWlXUGVHW8eVP5CiXEOVkzjFiojWVhLlN7z1QJO/BE2WJlhPkysLdmXJw5L8zAkhPxaP
-        SUBSnxR7o4e2Bregh1DTwDb0EGqKBvbNlE+LmDNl4wmYsmnZXR8aCKZsbMuUjUczZb6LA+MD1NZS
-        5X/jJJIB1Z8xjVmP5T1Ob8XTlTiXMVWc5b23JSVlupYpD/XvhylLfc0CixFXjgwoboVyFJYrfEZK
-        KpQjYwquHCWVyhFxhdxKNduxDP0JefJeR/jUYdpeB3vgyF/QP3djyAfn/CrsuL1d//j2aHjyr9mu
-        /bzY8Bdz4Edw4YMXP3MePI84HsuDecTZB0gXP6upsGJZfaDZtcCBDD8pGXa09VS4oqKdiPDJxzU8
-        +OSWFJO7EREHW4MN+/FVORYZ6FI8+uC6aAJNrsxj+zxTyut1bFm2P8SXpzHxOsbcbt+FM1c97JU1
-        111exyHdRJrr9k2M+RSnscj4duHHlFXEhpuI712VQQQjIwW3qk/zpOR7FMW3nFcMoC68eBF1xTNB
-        sZ/5ccbXnKEJoTZWiYhFydkhXyHImsnMwVqIu+0IF3xAxlxmhrlyZPOOdUcILYC10Lxn3ZhLNe5X
-        A7POUUNqfke+EAPu/PhqNmGNk8xllLv0kgJTfL841hYkBarrDzrfSefLCpTIwjDaWCXSHkIbclOx
-        6qdzg5VEE6oFuL3XmA11sBq0H7ZaQ2a91UAHq0HUxWpNqQ1WA12tpq2x2oL2xPfFQbSxSqQ9gDbk
-        8nCA8u4TQr3DtnbY1r5pnR+2tcO2Vt/+psQZE9FuLp8x8KBN1nF6U3wAecjeRhYltAcl9Acl0IMS
-        xoMS5rKEujy96jk7J8kFyQIuMv2tCnWv/DGPXlvQXCLCASc/FcFYBOdSWSnSNQNbMxtSNTiXGic4
-        IFTobhFqyAhj00nq54nahDmlrNDB//7bvH6Ou+riNFk+9qRTHLbMnbbMJf2pawKCw4I6LKjDgtpl
-        QTVXUSuRLh/XrM+sX2YxI2HvNe83FI/A2zn2oIhZHHgFuY2JfO4lRlK73MqmTVl5WbFtizx0eVVS
-        9nAiWjdb2eUNuWgLGsjoXrUta062yEXbCrSH0Hmpi1z0TwC+FHfaWxW7Jgr6O+bmu6vEhJqpb5Ge
-        17ao6ZfpeQ3uopLlHP27y+Gr86NXr0/O12bp32LGRuSu91teFhn5gfbe8ekUOLgmxT/X5OXNs9P9
-        peUl2q+eqdO7mAWjbvki+lJVV1+rUr7mSdhMC/AVlY/5OlIdnX8CgPwIhBoikR4Cg9gRiZCPLQs4
-        YQSQjgiGerBzon2ft9+c4vlCOuiQulnKyyxlbpaTO1tlx7+sm1iEfwCyA9MwIssJISYAIugEjoY0
-        YJswjKBh+rYedXCTFBc3JenuJFvf/CmcZOtB/P2cxCD8AwCKNMM3MPbNCOlaEFrEtHXH5wsJaaGN
-        jQha/m5FEfu891P4yNaDeA4+EsK7e3SnG6WfhvF9P0jyMoyKPGP9TCR1O5QpbOxhlb7IPfNEhhyo
-        P9EJZST15oiYSBKTooOH1JIP+kj32z3sFE841/0UBHxTO0bk8A/G/KDlxy+yrEAHemjZfmBAYAUB
-        sAwURjYycWB3r0KJZI1Dx31j6xE8xb6x9SCew77xPXgKD/EPnvI9njC1vjwpqToG//hO4CPs2BG2
-        fAMiHyETAcfCwLYi37d8C8IgwI8odtv/MJ7gOHrkiJ7FGfXV/Ukz+AeYRugEZoi1wDQtqDv8u2Vh
-        FCKkm44ZQMMJ9S38iY2K7pxo14E8uUdtPaJn4VHfwVnG7vLDUbbHo2zHgtnGo8Ct6mWr38sxJUni
-        JTFlrceLJ8uPF9c9dhT468smrq7oe0V5rgH7xpq6XNAX71M9siJ3Wvk4LckVJQlFmWWitkE+uoVa
-        XajQQmVmfIXcIvqVSnxFoqoqhH0Fz3to+I4vlin0mPrfyk83FADPWOSGGmDxlkLvQrLO3l+kyNdX
-        A18cHb85Ob/4ePLmzcXasuALHCak+IH2PnJHoh0LhDVH6/5Xpb6vCt40psGmCt66fVMF71su0psp
-        4av+OSiZPtLFi67/KTPSLXvUNX1kabpldk4fmfpWL7oCU9HBENjV250/QbC3jJp821UzpEqSiVAJ
-        2pdKgKnp4uXfTipBwNK2eOEVKcBSNGMXlSxn1KCmn5yuTaaJHap3mqzJm2m/oaNdEmc7ns3N2211
-        OO/vjEMdzzj0nM64pzzGysLHmYdDoW0+dCrPtA1H2qWQ7x3N5OWbeOvPNdtce5ot9fTjaZKLkhHy
-        r9VH29TTWn9G8v9hDjdcg1IAAA==
+        H4sIAAAAAAAAA+1d23LjOJJ9369g9MP2bEzRAnhnrUYTsi1fquTLWLI91S8KiIQstilSzYvL3sf9
+        lXnd2I/oT9kvWYCkLOpCibRIS5bRoY6ywBQBJkBmnsNEZv3vzyObe8Keb7nO336BB+AXDjuGa1rO
+        w99+ue2e8Novf2/8Wx0/YSfo+Rh5xrDnYT+0g0bdD/umO0KW0wt97PUsv9dHZsNx67XlR+qG9zIO
+        3F7fdo3HhtHjeYXv+7/fX/1u3zx4mPeP+99u9KtDY6ANvyvPf3QuB6fBZef68LqvQBu8NK3++KT7
+        EBz2/+j/MBTtKJTbh9doeNu5vtF7R/4/73579v/L74THSlcYS4LTf7w/b/NP4AT/vH0+lV6OHodD
+        AVkD3RZNefDSH17I/5AvLm0wPpT4H/XazPjqpuUHyDGw30Me7j0h24ovbll7rKBGnbSgHlEfbrTu
+        67Xpt/iAiX2j0SLafvk5xB5OBKLWumEFL7Gsbdk25gceGc9rW3w4kmzTw8mx5Kc28v3kn1gcBYGH
+        jIDMqU8kp+2JTPSz5qJMfDoyW9HUxad9weTwbFM9WQeP+CXdU43M+/QAXR2J+OTXry0z55zKZZw2
+        GOIRHiPv0V/eQXxpM1IzR6aC0fV1qSD372g0/k/uHgXY467nfhWroTYdWG2iYdcPeh5yHshJR+iZ
+        nH7UtxxsNiT5ANRrM02RABluMPYsAzckMJGYtsUiIbkg5JFTvp5j2lQfUaXP9ZJuigQWeplpi0Xm
+        eplpqjtuzyc3vI2pxvbzEv8IkRPQW8YdR6uqUY9u3N6kvQHrtbmWeQlhrYS4VkJaKyGvlVAWJWqL
+        lxfNYc8IPY88z4nI5K/4nsAhfbzMNE0lBuTOc70GBCAlkzROpZxw1MdeQ1e1lFTSOJUa24g8Kanu
+        5ptSMnTN+S+jvmvX0s3k6Rq3Nv7vv/8nfYLpgXpt/jprGYuZLYDPsgDSs264oRN4yQVGJjXd8Ho4
+        euKfeNSqT0ViM2ASExGfrYcdM/keHbpwnS8c9APuG3JC5L1wAoBEFVOBWDYMjJ47GPg4aIDkaKpp
+        KuNjw3VMvwFlKGkyhLqekp4cjMVfyH+jkWk2aI8AAphIvrYTk+tqCoC9qBk5Zi+wRjgS5wEkn64g
+        fpV18vmNGuJlsskp5688/k4cIC9I66I7DL9wcjDkLlCkB6UEPUiKIAFFAiCXHhQgAzm/HhQeyOTT
+        BeBr9Mmnh+S6Y284WkLHzR/d83/Wa6mm5HB06ZA/JgrpWsYjDiZCsU7iv4nrqHzvTI68OpI9mzzB
+        3JQXNJGI2xOhETYtRBYxim55cucMycpvmPDns/RTlMP+yLSeDwzbDc2B5zrBgUPHEMnULYdoMiS3
+        ETGzYxtT7Xp2YxgE46+12soz1HxiUbFZSw2hhp+DXoD9ANRa9zVBAM8Qyge/jx+ITpf2U3cQ0axN
+        dOyTwZNbLvpeH6Ng2Ch2/ugn9axr8cu9mKWX4ofjsesFfo92GHu2s02zEv4SEephzszoLk+vCsCz
+        CMD66R0h748QF5zcmbNXPbkznbHJJRpp3d5cHZ93Lls/alAiK1/KMc8+cT28gtOc1U/VM57VL5v8
+        v/ovfoBHvWkLvRDbwl6OFZBIFlgD67qrdCGs6/yzrgbDc8dj7PUiydpAJx+EBlLfAJKkqoYIRFPV
+        +oYMgWoYQJUlc6BJCjK09Usk8Cza1HOd9U+KDYdRwdLZcETvvJ5ixRK3koe8iV74IPI+axPZWD8J
+        oRugIPQbtvWEJ4eTpolA2CfuL6pNvgfuI3bSLmvcMDn6MiZPA4teZi+Y8XmjI/UH7FLvmozURgSs
+        hsRZlsGBStz21+9123Ue4j9FSuNMv9Zr058Pkd8jOJ/MycCPONmZBko4UnIIx3zt9Fvdwdgk/veY
+        ePF0RqhnH+t12YFEOvQQvS+jU822xAK0T9cbUew4lUk3TnjNCW/cexw1IhJrSXvdH7o/o1/H6CMi
+        02eb6r4begZOYPzkEUbEUs0TmZhwfg6w5yCb6xJB7hCReXFMbvqLGI+QaQqTX0+tZL2Wak5EIvFj
+        y3fwC/Xg//xfyp9a/kQ0IU8TPpzR4p+ZFodgLWkMQQms8aSfFbTxpJ8qqPE9uEzGjn4WdpTR4598
+        ATB6nNHj70aPi8fNH2dX19etm0yKXIwo8rMIYWVS5F1GkTOKfIepE0aRf5bJZRT5Z518RpEzipxR
+        5HtFkXd5MaLIh9Hgy6XIu4wiZxT5O1PkBPy5Dh8+ZnHk0fE1JDnBU0/YzuTHuzOH30CNx+cvkxVP
+        zjh0A2yvJMNfJVYR4WfzQit47xRZEik9mz25dSxye3HfCTg13VF+FqUb4i+cQBZjM3wIydpcSx6I
+        CsjJH6gAirKSmz/QgFCIP9B4IHShEPMHfwXwK+3p/cmU/PpQBEkiwpXyKW/QxyKpcnN1dZFJpzSD
+        IXYQDkcZXMq5mBluGN0ejEZhNMpuTC+jUfZ4civlTt6VMGEsCWNJGEvCWJJ9ZUmIw8ijiVNZJkWS
+        8kQXKZLIF+15rjtaz4/AAxkQ711ZzpHw4IBgHVEXymZKaKiOFzoOcZRjtx0KSQDPTGsUfbNEbr51
+        KfMyZVRWEi8pgiabeZkKzVAvNLogQhH38BunHn4jC3/S8uFomWb3rHXZbN1eZLIyKXjEyBhGxjAy
+        hpExFZIxR64X+tzZi4mjaNpMSiYzvIVRMoyS2aHpZZTMHk8uo2T2dG4ZJcMoGUbJ7BUl0+UN6lry
+        Q+Ja8nR7V7nEzIrYlYLEDPGf9BXEjKqKNDyfETMriRmBE9unH5mXObq6ue2cXWeyMglOoksrjZYY
+        Q8MYGsbQMIamQobmzLID1+G+Y4fuigym24gWOJpbxtEwjmY3nXvG0XyWyWUczZ7OLeNoGEfDOJq9
+        4mhu+WHkXPKPr85luSzNbXnhM0R1WiZLI0BRUFTG0qwLn4GcdNv+yDTN97PzdvfqMpOmScBSzIvM
+        YKZqmJoVCbzy5O9Ksll1rIdh4GNMxlpKRq9qEnrV/PQws0mZWbGVGb3ILL+BmPHzEDMd8oDCPucO
+        uOYIe5aBKqRoeAEWIWlUQa6YpJG/kg8APFC2RNIU0YgiSLIoVJwlRo1pmgIaWaRpzi+uWzfnzXYm
+        VXM+Is9CizzOzrBtGe6Y5qijazyDsTm+1rMYmyD1q90mbGDFhM3i+Sv0/Bc7+6ye/oxGKiNsFs9e
+        9eQywmZeI1URNosnr3puGWEzo5F5EgNWSdis767S2V/X+VYANrHvvJW4BPzw1SXgqXEvE2en/IhN
+        M3mI8oGuwAycDaFwAEVFfo+EHjlxcZ58HutgMXEEBbEkUByvkByoGBZGxXAFKj49yobEp8SdNbkj
+        5LwQRNy0PLp4qw9cIDP/hB+Qz0dobWnsAvK5OyrymVJiG6hP9BWsgs9TkVXQ+SiWSgiEY8txCNbo
+        kIW3H3haFvLjaQEI+dHjm/C0IHwVY/Sobg1P59eIIshAzB8G8iY8LYAJns6tkUU83W6etC4uWplw
+        uo24Ezwa4Qz4rLSz4fOQmBYPMwTNEPRuTC9D0Hs8uQxB7+ncMgS9ZQRNTDxvI35AvYBSc1+2y0PM
+        ygEEopQJmeUDqAqbbyCYwIyN303rZb+aLgOCX95pOgT6hwbhF6cXpzfNy+P2XSYUJyJcDMdT4Ldq
+        JF7GFgIy/SvANzmY4NCj0KbrZBMMTk5WKvim5zPjuiDZmHsisApxHyLbngLuuR+sQNoZJZlkYV1F
+        JkndvCCTANfWY9LWlmMS31h16oNfIis4NFNd6KE/LqngkEYTIc03ll1w6M9/sYJTbP43qze10RYw
+        w7OIC9nz8JOFI0/EoDY91tDSQ6sYVEoW0kpVHTwmTjrRV6n7xgRVlvIThnqRclUKD3RargrqMYX6
+        QfaNqWLV+8aK62ORQL287R7dNI++r6hddYGCYIh/cofEa3Xwrz53SS7Ho96sx3VbnW4Wt3p+sjPc
+        6iYB2TVdJB8DSP0BMAUJD0QTyFgb4IHUR6oKdHMAJFHCCIpGmdzrm7uvLja9+FhyQP4oCHiH+Z+N
+        FKZi8gGSZiiyPFB1EyIMoAR1QxckAWgKNAdQVvqaOMixdvISu2/uvMKVU3gse7ByNt8FIujko0pY
+        1lRdReSm06EqC31VNJGoA4SVgTZACpY0RchBJ5KHLqVriCfkFNwfU3gcle+PKTyifaCiN7oDZUw+
+        AEgDQe7LCPWVgSQKhqliRRP1Pnl4S4KpIXkA1X5pryHe3HeFT6LCY/mkTyK2bXNft21udPtUsmNz
+        EL18yfkw2aHNmpVs09z1h8kOLp9oqwtbPh9i+Wzu+wFMPoIsm9JAV/omEPoIqf2BKQjkfwP1dWBo
+        A8XApihVuWm88DAqd4oLj2gfrNnmajNIAxJMSdZ0pOmSBmQoEURBPEMDGxrSNUGRBUEDQBfzr6fg
+        p1twPRUeRuXrqfCIthPhcX7Cj2KOku9HHCXv884rR8lTN67UyI8psVko8iP+Oxz72LZ7tuUHM2Rp
+        a5EsJX9dnIF0e23JOTKyHQi6AqGoZmelBAqAsrJ5wZDSwkrKT3lQRlxJ6wjecFL38r0DSzbPeRD6
+        5EZe9u5o2YF0GEqnedxu3XTuW+12JzMQpYNMG3u/+tw9WYqfLwYl2X9USghK+ly7GYGymBB08gYn
+        KyPo7PE3RPEkPZSaEzQ55aNlrkwJmhxfpccTNLLsl42id0R5XWiLCNeGtkhrQ1vEdaEtAqgseueD
+        XyKL3vgk0Rsseudzz3810TvbjMVRpGpjcSab9z5ILI6sVbyZEcolxOJ07puX7eb37N2MC5E4nZ/I
+        4droEXMUMmQG4izBlh9wk2OUUTWNTWoThVWe7TlHr1Wnks0xhM/K5uXQk29XmzE6V6/bWSJzg2CL
+        JFNTleadztHldtYH27DJgh32ONihortGUsgzVVL4Am8Yc72lLt71dp4ac4NgK2WtpmC576KL97zd
+        hQLZQsmpqSIvmYdeOZ7qXN/bXSrbeZn8kZYKxf0U9k80liP6u0hcwttHsJ2FkzGYLUUjtBajEXwy
+        QN4mI6wgGKFVQTDCkp1btP37kvJgnyxIYSdzX3zcGIVdjzooLwclK6H5thKaO5dZkhXT3OBFzB4U
+        05xm4GkaxLVwTRSXaln67uVcvMl69/KBKmqy9JJ7DTRYesl9n1yWXnJP55all9xyekli4PnRw4h/
+        oB4Bj1IeQbllEG+yUX6BMojvlGlyz4sglptqMm8RxP3NNNm3HsJx7wnZIW6oZHGmv6fAOJlXy+cH
+        XgYQv6aHWSGI9y8EsaDlgeuameo9IQe/cMee5TxydHFd0lKPtjXYYLcF7a/E3RbR6cxICyu3W0wk
+        Vql2o6oa0VLP5j5OvHj/Rl6moxM6XzjRM7lvoZ0D16v5q0WosiLnr5+hArEQrld5INJkZwmuF7bE
+        cxTQh0BUUnXAaXF9LPIcx+eXl62bztnVfTbb4Ya25XA3bviAub+klvN/ZFWkPPxtL6JNGeex59CJ
+        cR77PbmM89jTuWWcx7aLUh7+xo8iv4D3qF/Ax64wT1FsqUUpp67EpiU2JO1A0zJ4D+FAFAV1d0IM
+        djMPgioDqH3s6hpXt+3zy5ur29NWJulxSM5nhlza660qyGAFOZGHm0jQeofCZx9jsk5KYSuqIStq
+        fnqY2Zh6VmwVsO6SSd6HaAJegEXiCTQh/8bOt8UTaJOqjMrW6lTm1wjd2inmZx7ehLSj8pTFNLIk
+        zfrVTfcsE2RfErs7nNTXPXut8sx1ox0Dy2H29WEmzE79imFshrEZxmYYm2FshrEZxv5IGPv6kHeo
+        W8AbkVvAD1/dAp4a+FJx9tSX2LiUpXygKzAzvkA4gKIilx1fsGVkTLxBQfzQyPj76dFlJiSOYwAS
+        57RpeXQBVx54X+q7/v2D0+lry0bTM1KrwPRMyMN2X1JHAJqmRkqworYSK+aDibIgC1An1j0XTNQI
+        TCyQEUmLYCLsCuJXmb6T/a0czHyPzS+clBcz54bLFCwXgMtSUbgsdUGSGSqfHpa8k747zsTJHTck
+        XyyPSwnN4eLTu2YWLk7fDgwdM3S8C9PL0PEeTy5Dx3s6twwdbxkdEyvP+4kzwJtPZploOOVBLKLh
+        keUbPYvoYxfeOL8vDH6Vqf798HZC4nfr9XC5me/Z7vO37T6vKP8v23PO9pwX2XPeCbiWN7KcX/3M
+        feZ3e7DPHFSMeBfPX3W+IoZ45zVSbR7ed823yxDvvEYqzaD7rrlyGeJlWXFZVtwZDc3WBqykkGvx
+        Ipw7VM31rSPaUt6CO94PeEy9St4vN1fBXTZ/UiBXgQwPJF2HqpadHVCUJFln2QpWhyd07uEZB/5x
+        /87cTLm5Abutm4vzy1Z2YsBvrm2/cGmclIuWOWy1M3iZQ2wPEK2pkjNmfw8SCgwmRe0yuZbBfNm7
+        TWvjVc+1dFDwhRNpRMExNnLWWsrJLWiiAKXc8fhQEAsVWoICL04LLW0lrKAIzSJqWv6tCW+KLHhD
+        zalFmgWKtPZYBs0SPY5a9DvHc11imChfvJRvEY+y4wxWbXOPjS/9dZQJmI9aeWoDeVimEU6Pb9OY
+        PhiZhqXvMeIj5e6b23I032EXcsJh673i+cji8LDvu9T1jezmCrN5nshm28nmj9NaN/vtRWzSom0l
+        PtcOzHcykh+6WKzpoRFamQcmEViZBmZOZp8topD77cPbLCLU41J7H8AiKkWSwLzBIk5UsZlFlIBa
+        xCIC7i84K/kLMTtHG5nFo0WzCHhcsmU8YpaRWUZmGTe1jO9cRr16wxiZAvpaPlfseW5TQMPPFVXL
+        aQpo+HmBd/Jx+LnQhVJhU8BM43rTKIpFTKOYbRZPNzKLp4tmUSzZKJ4yo8iM4k4YRTJjK8hUcjDZ
+        q3UU2nRqN+FUyclKJVPp+VwydSsB40RglWG8mpPZvl0UATEEl+5TyYARyKKeHzBCERQCjJAXQVeA
+        H4VC1YWKN2dNVLGhVYSgiFWUVgPG440s4/GiZZRKB4zHzDYy28hs4+a20Yw3A68gUxOBVbbxENn2
+        NFv53A+2aigvXIcASIXYhvKZVYEgyALMqqAUZFYF5QMxq6pe8btGqJYDH4UChlLPtpFL6nEWsJEn
+        CzZSL9lAnjADyQxkKQZyy/ukWNKQ6pKG+EH8pIxD7Ax31LccchPK0fqeaYoE6D069ixyw0wlpm2x
+        CFmZQ+SRU04lXpuiAL35XtJNkcBCLzNtschcLzNN9T9C5AR0SblRfC650idkW2Zv0t6AZOXPttRr
+        iz+KbYgReh52DCIy+StW/UN/TBQ50zSVGJBZcD3y6AQpmaRxKuWE1B9paNQxmG+cSo1tZGC/IaRk
+        kqaUDJ1J/2XUd+1aupk8KOPWxp//Sv9+2l6vzV9mLb0s3s1Fi15+XxEFlemhqaoua2LOJDMKBAXf
+        fYMoGowlmSklycxF6+KQFj45v+5kOmh30cO9yV1Ejrw/tMZZm++U75n+2UfLOcN24O3l1g22A++z
+        TC7bgbenc8t24LEdeGwH3h7twCNeI//EI3409S/LZOVSTummpFy0E0/RoSCL2XvxVIH4/bR66z4l
+        Nercq5xw037v5L6l7p3rnrXumpfHzUyq7s6iVIGFonKsTZssxoC7CH0cjpZzdpNFGF+wh/3QDhr/
+        D8kyPMxkTQEA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2869']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:07 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['5709']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:04 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><s_keys>test</s_keys><s_auto_range>next_month</s_auto_range><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['798']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1c63abSBL+v0/B5k/mskhcmlsOozme2J71xIkTW04284fTQCMRI5BpsK3n2TfZ
-        J9vqBknoggyK7NiJcnRmTHXRdFdV19cf3bT9+90oEm5ISsMk/u2F3JFeCCT2Ej+MB7+9uOwfi+aL
-        33v/sMkNiTOHEpx6QyclNI+ynk1z109GOIydnJLUCanjYr83IdTuri+yvXQyzhLHjRLvqnfpiOLN
-        1Tiwrl5b40vtzBUHaRL4cvbnrffu/ecvKvHoF/Xws6x/+XB1Jn3+FB/ejPpvhvRAHTt3l9fG+enx
-        5NDTxHNfDvQ310H++eR6cHBMz87j28k1lvqyfoZS53Cknp4cfZhcp0dfrk0rSpX3J7GlHl7dDqLP
-        dnehTbYf0gzHHqEOTolzg6PQ78WJ3V0nL6zSs0GCHbAZ6cmSZNrd+XVR5BPq9S4mNCMj4SVTeVnq
-        8ALbizCl5f+K27IhwVlKoG1zWVnOb+kvlhfVgI25wYvquBcWRXbpvisymT6hC56aC5lDS9XpnTPJ
-        Qn1zvTVVjkLqra+26EhZviCbq/C+vAUVYWaExbL5da/sP5gmyeMsnRR15Vcgrwpmxfz+yzjMiC+8
-        gQCHCJ2rFpX7OCNOiuMBcUjsl9eF/3D2L0FG2VB4iyeCIsk6BMWstFDMM89JgoCSrKfqklQqVKRz
-        NUq8JPZpT0a6qsg6WtCeFhbqE/g3Gvl+jz1U0mRUas7k4K3E1CXZ4WIc+04WjghXFyVNlFFfll5J
-        7PerJL9iT1p/Q1nvcveLawj/NFswSB6DQWi2c3sokqUqze0hyS3tIcnb2KPsf5EIZ4P9FYJuV2Rl
-        ObfBH+FAOCcU8t8NBFyf0GyqWpio+BvyiHryVp4WzdKKE0GEJvNUUBVO03GGs5z2ovBmVl6KpgqQ
-        hXGGu9PrLLki8cLjCsm0eDImPRqOxhEBA3hXZNZgXmIPMXXixBmTNKA8KS4IWM6AUQ+Da5Ysykt7
-        hO+cNI9jaHxhWR1sviK0R5BaVtWWhXZMiA8mHIM/csjFzEe8NevkpXKe4gwArqI2lRQKrAdJOmIJ
-        vmj8inSa6aY44FyNelJHmiW6qtymw+SW3120uEDERZlNkzwFdR41KfF12bkG0MAx9jEoVwqnmjxo
-        zpmm8OFAeM01hQyiSqAcWmZ3FdEFfstJJVAV1C0CFtJHpazUmwXsR3b5SmB/XoyxR6bKZe4tEW8F
-        +PpHFzW4x+JeOE08bu497j073OvnBNK89AC4p1hSmzwvS21xDyaA1u5x70czyCrwKaap1KPeyfnh
-        Z2Ec5VSgY+KFOBIGOeQAWgd+p68/PCb4VR73OOD3/cEVuAEoIE2cJCYbsOqX05OPR78IJ6W2cFbR
-        XsGo/n+Mbr8WmTiI8Gvhr+OGkKQZNYh0kuFosohEYVbmzBH8J8ZiCM6fC4vyIkPz8rKwFsagj7Qe
-        xKql20AYu3+nAMYrLAfrJgSbq2wCMd4/QYTpQzH6T+KMpHzy2xLQuBPqAa10Y1Mc+0T8KV2B7rG8
-        bWzM2w2TtmmqSmP2ZkhqG7ZiiJLK2IpUspW/dwRgw7xksgfjNIzuh7Cm+CVpFsBXU/xCLYksYkS2
-        nSlWoUs3ZPO9rNWi1zFJU5yGwnEeRcIh4PvRHSTBkECqFG5DMBnLROJhWkGdZTw7O/tzGzwbET/E
-        EOJ4zBI9oNYwoVnPw96QiIMUj4ehR6PQ7dyEOEvSjsfmcFzFDmMwM4MQkAF6MdOnUW+YZeNX3e6m
-        CroVsThOCcPSbjbMRy7VDXSHkN5l9upenPAx3Q0K44gBGEf08UQkM+OIzDgiYyOiz4wjhrFY5lLF
-        MmXF6HwZD8Bna5tqxxg8F4EPKXQfzMOv7THOhr3HbyN/rP1sTLrWoDQfj5M0ow5r8vSNbFW0qFFM
-        aJZE0ygtA3MfpTwq6XWO032IPpsQbZfRpzf9cGGdpSETFTP6fWw/1djelvRW5iStSO+AJGx+Bc+P
-        gH9mOcyWEOroSNdhGjsT2VESD4o/ZaljKbqCLCieCe3uvJ7GNJqVPWcWzV26gUQXQbuBPn9cVFhh
-        zIpmymYtY54S1UZU2VLquPJ7kuY1VDkKR1hks7W1RPkUSvc0+TFoMndBPU0uPNjqba/CXm4eEo+M
-        XJLujB6aityCHsqK0ur1pqyIirRrpnychsCUtQdgyrphNl/yRYywtmPK2lczZcjikvZern/R+28c
-        BXxC9TGkYSZkCVu5YG9XwoTPqcI4Ed7mlOSjWqbcV78fpsztNZtYDME4fEJxw4wjZokIPRJHzDh8
-        TgHGEUfcOGxewVOpYlqGpj4gT95pCx96mrbTxu458iPG53YMeR+c34QdL6brn94e9I9+nmXtp8WG
-        Hy2Av4IL76P4ifPg+Yzja3kwzDg7ElLZv/VUWDSMjqSYpcKeDD8oGbaUeipcUNFGRPjoUw0PProh
-        6eR2SBiwVdiwGw7yMdsNnPNdVna3KqhyZZjbJ7HIt+isZcu8/D6+/Jx3R12FPt1EmsvyTYz5GI9C
-        tuLbhB/TrCA24CLIXYVDGCMjKXjVpUmUQ46i+AZ4RU9WWRQvS232TpDlMzeMYcxpClNalBUqbFAC
-        O4QRgoyZzlxYKkHYDnEKDdLmOjOZzVs2r1i1mNKSsFSa16xqc63K80rBrHJU0Zo/EQaiB8GPB7MO
-        K0AyV6UQ0isGZDs3l9q6IOIKxf17m29l81UDcslSMxZlhcpiExZFfIPtrG9yoVEVlQrg7xq3oQZe
-        k837vVbRqfea1MBrMmritarWBq9JTb2m1HhtyXrserkRi7JCZbEBiyIbpgMUqo8IdfZpbZ/WnrXN
-        92ltn9bKx1/nOM7YbDfh7xhg0sa/qXOm8p4MU/ZFybKGcq+Geq8GuldDu1dDX9XornaveM8OJDkl
-        sQcq07+Kqe7AHcPsdUE01wiwB+SnIBjLwrlWnLPlmp6p6BWtUjjXGkfYI5TZbllU0WHOppORm0Td
-        qhgoZSHt/e+/1fvncru73M0sGTs8KPYpc6uUuWK/bs2EYD+g9gNqP6C2GVDVUbS7L6q8NMxCz0nJ
-        TUj4ey/WkjLk1hZtWpXnO7ZNtg6dD3Ka7fKrI0PWkNZ81zbfc9JiLdoUZZN9daTu/DMsZhOFbehv
-        uDbf4kMsWdHVFsvzSrsvkJGoyNuYZHWN/t1l//X5wes3R+e1q/RvcZYNya3wR5KnMXlJhXfQnRR7
-        VyT9Z826vH5yvLtleS7tFO/U6W2YecNm60X0Vbe7/t4uhTFP/OqyAIyoZAzjqGup8PMk5AaSryAS
-        qL6kETMgAXKxYUiWH0hIRQTLqrf1QvsuH795ieeRbNBg6WZlXWZl5WZ1cafV6vjjholB4Cch09M1
-        LTAsX8ZEkpFseZaCFMnUZT+QNd011aBBmIxwep2T5kHS+uEPESStG/HjBYlG4CdJKFA0V8PY1QOk
-        Kp5vEN1ULRcGElJ8E2uBbLjbbYrY5bMfIkZaN+IpxIgv396hW1XL3ZEf3nW8KMn9IE3irBOzRd0G
-        2xQ21rDOXuQuc9gKudT9tTiJwZlLWEeikKQNIqTUvDdGmj/u/qB4wL7uZkPAs8oYgQU/jAFoAX6R
-        YXiqpPqG6XqaLBmeJxka8gMT6dgzm+9CCfgeh4Z5o3ULHiJvtG7EU8gb30OkwBR/HynfI8KU9nK4
-        ZtfS4OdanouwZQbYcDUZuQjpSLIMLJlG4LqGa8iy5+Gv2Oy2+2Y8ABx9ZYueBEZ983hSNPhJuuZb
-        nu5jxdN1Q1YtuDYMjHyEVN3SPVmzfLVFPGXDtDkn2rYhDx5RrVv0JCLqO8Cy7DbZQ9kOoWzLDbOV
-        V4Gt9ssWf+djSqLIiUKaLbxePFp9vVj32pHJ31xW5d01da/ZnqvJHa1mX67UYd9TfeWO3HuPOJSV
-        ZmccFnpP5JBDtlBVbIR9LZ8LqP8OBstU9KBHSs1Y5IY9wPwQqPIY3b9JmtTvBr44ODw9Or/4dHR6
-        elG7LfgC+xFJX1LhEwQSbbhBWLGU5qdKfV87eL/1+Ya7PQ6KLx+p7EPXv/KYNFs9arp8ZCiqoTde
-        PtLVduf46aIq9SWzPMePn2S7w69dFY2bJOInG6JdmUTSFdVqerQhkgylxQevSJQMUdG2McmaM30V
-        9ei4djGNn7Z6HNWsmyl/oINHPMmw+rhvdIwvaohx6Clh3EPCWJ66OHawz6wNTacc0zZA2iXTFw5m
-        +uUp0XW4Zuq1aLZS00/HUcK2jJCf10PbNNIWjvT/P7pEflYPYAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3174']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:07 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/CoreTests.test_search_events_categories.yaml
+++ b/tests/interface_objects/cassettes/CoreTests.test_search_events_categories.yaml
@@ -1,139 +1,167 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxyZXF1ZXN0
+      X2N1c3RvbV9maWVsZHMgLz48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJl
+      cXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0
+      X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVl
+      c3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9t
+      ZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48c19rZXlzPnRlc3Q8L3Nfa2V5cz48cHV6emxl
+      ZD55ZXM8L3B1enpsZWQ+PHJlcXVlc3RfY29zdF9yYW5nZSAvPjx1c2VyX2lkPmRlbW88L3VzZXJf
+      aWQ+PC9ldmVudF9zZWFyY2g+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['588']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1dS3PjSHK++1cg5rCP2AaJwhttLjcoiXp0U5RWpKTRXBggURQxAgEOHurWHmcO
+        doRP/gF72ptjwxE+esPhw/4Ut8O/w1UAKIIPgAAJiCRUHZwYsZBEAVUFZOaXX2bV/vB1bFDP0HZ0
+        y/z9d6DCfEdBc2Bpuvn4++9uu6e0/N0f6v9Qg8/QdHsOVO3BqGdDxzPces3x+po1VnWz5znQ7ulO
+        r69qddOqVVcfqQ3sl4lr9fqGNXiqD3o0LdJ958f7qx+Nm0cb0s5J/9ONcnU0GMqjz+LXnzrt4Znb
+        7lwfXfdFYDAvDb0/Oe0+ukf9n/oPA1E+9oTW0bU6uu1c3yi9Y+f7ux++On9yOt6J2GUnPGv2n+4v
+        WvQzcwq/3H4941+On0YjVtWHisFpwvClP7oU/ihctg1mcsTTD7Xq3PXVNN1xVXMAnZ5qw96zaujB
+        za1qDwaoXkMtag8NH6w372vV2bfggAadQb2JRvvlywjaMBTwW2sD3X0JZA3dMCA9tNH1vLYFh33J
+        Fj4cHgt/aqiOE/4vEFdd11YHLppTB0nO2kMZ/2eNZZngdGi2/KkLTvsC0eH5plq4Dp7gS7SnKpr3
+        2QG8OkLx6a9fW+bOOZOLOa07gmM4Ue0nZ3UHwa3NSc0dmQn699fFgtSv1PHkH6l71YU2db3wq2AY
+        qrMLq05H2HLcnq2aj+ikY/UrOv24r5tQq/NChalV55p8AXS57sTWB7DOM1OJWVsg4qEbUm10ytdz
+        zJpqYzzoC71Em3yBpV7m2gKRhV7mmmqm1XPQA29APGLlvMWfPNV08SNjTfxVVa/5D25v2l4HtepC
+        y6IEu1aCWyvBr5UQ1kqIyxLV5dvz57A38Gwbvc+RyPSv4JmAHn69zDXNJIboybPsOmCYiEzYOJMy
+        vXEf2nVFkiNSYeNMamKo6E2Jx26xKSKD15zzMu5bRjXajN6uQWv9f37+a/QEswO16uJ9VmMWM1kA
+        72UBRGd9YHmma4c36KvUaMPrYf+Nf2pjrT4TCdSAhlREcLYeNLXwu3/o0jI/UMBxqU+q6an2C8Uy
+        AA3FTCCQ9dxBzxoOHejWmfBopGkm48CBZWpOHQiAlwUAFCUiPT0YiL+gf+OxptVxjwxgQCj52o5U
+        riWLDOj5zaqp9Vx9DH1xmgHo02W5j4KCPj9gRbxKNjzl4p0H35EBZLvRseiOvA+U4I6oS9UfBzGH
+        ceBFlmdEnmFSjYPICIyQfhxEmhHQp8swH/1PunEI7zuwhv0ldNJ46F58X6tGmsLD/q0D+gQNSFcf
+        PEF3KhSMSfA3Mh3Fz53pkVdDsmegN5gVsYKmEkF7KDSGmq6iRaz6jzx6ckZo5dc18OUr/4UTvP5Y
+        079WBoblaUPbMt2Kia/Bl6npJhpJDz1GSM1ODIhH1zbqI9edfKxWE89QdZBGhVo1cglV+NXtudBx
+        mWrzvsqyzFcAhMqPk0c0piv7qZkqGlkDjbGDLh49cv732kR1R/Vs5/d/Uou7Fyffm1l5K443mVi2
+        6/Rwh4FlO980L+GsEMEW5tyM7vP0SgzzlWOY9dM7Vu2fPJhxcufOXvTkznVGJheNSPP25urkotNu
+        PlQBj1Y+n2KeHWR62BmnOa6fomc8rl8y+b9zXhwXjnuzFnwjhg7tFCsglMywBtZ1V+hCWNf5e10N
+        A9uaTKDd8yWrQwV9VHXI9wcMz0vSgGM4TZL7AwEw0mDASAKvDWVeVAfy+iXi2jpu6lnm+jfFlpdR
+        wNLZ8oreeD0FA4vMShrQmvpCu771WZ3KBuMTArqu6npO3dCf4fRw2DQV8PrI/FWr0++u9QTNqMka
+        NEyPvkzQ20DHt9lz52xe/0jtEVrYukZXaqjIWfWQsSwwFQmZ7a/fa4ZlPgZ/chjGmX2tVWc/H6lO
+        D/n5aE6Gjo/JzjVgwBGDQzDAa2ffaiaEGrK/J8iKxzOCLftgXFcdCKU9W8XPpX+q+ZZAAPdp2WPs
+        O85koo1TXHOKG/eexnUfxFrRXnNG1hf/14H34YPp8001x/LsAQzd+OkrDIlFmqcyAeD81YW2qRpU
+        FwlSRyqaF1OjZr8I/BE0TV7465mWrFUjzaGIL36iOyZ8wRb83/8d46e6MxUNwdMQD88RFh96ptpX
+        nZFO/ziJgcZPpyIEHt8NPB7BVvxJigdbPqkT1SRYC8FaMmAt4KTxcN3odK6vbrrxiMu3X/7p2y//
+        9e2Xf/32839+++XP/t//TP3myoQUxmKu0VLFKvS3MXBM40wuCxwDCoZjls9foNm+3Nl7NdPnRqQw
+        OGb57EVPLoFjFkekKAxm+eRFzy1BW+ZGZBGBAEWiLeu7K3T213W+E+8YaXkaYH8P/cRyLdoyoe8r
+        T0LrIE9vOWJRbOstc0JF5LDBt8pfBpxSkWXh0Hzm2bne2mkGmZ1mEO80d68+P6zzmv/vz//xv3/7
+        KzZQf/7Lt5//9u2Xf/Gt03/79vN/T83UrvX0YlGBe03dQCewVAt2rQnjbH9d6hg6FmDW8rEAkwMh
+        a9pPAiNr2k8RrLMS3CYhHr0X4hFhnr3zBUCYZwQNfTM0lDtpPJxfXV83b2KxUM5nn537wctY9lm3
+        LHAnYZ+VGjUh7LOyTy5hn73XySfsM8I+I+yzUrHPujTnI+oj/+LzZZ91CfuMsM/eln2GVoJmmbT3
+        FIeR+8fXgOTIn3qGRiw+3p07vAE0Hpw/T1Q8POPIcqGRCIa/SiQB4eeLQumoZP6gx6Mnt6aOHi/q
+        M3JONWucHkXpevADxaLF2PAePbQ214IHnMikxA8kBnCCmBo/kBk2E34g0wzbBWyAH/yOAR9xT28P
+        pqQfD5HleSRcKJ6ywXgsgyo3V1eXsXBKwx1BU4XeOAZLueBiM/n8x4PAKARG2Y/pJTBKiSe3UOzk
+        TQETgpIQlISgJAQlKStKggxGWp0alXlCJBFLdBki8W3Rnm1Z4/X4CKgIDLLeYxiHNFNBvg6nsHkj
+        JZiqY3umiQzlwGwHbEjgmWv12Tcr5BZbVyIvM0QlEXiJADSZOYyYXeB7EffgEyUdfUILf9pycLBM
+        o3vebDeat5exqEzEPSJgDAFjCBhDwJgCwZhjy/Yc6vxFgz6bNhaSiaW3EEiGQDJ7NL0Ekinx5BJI
+        pqRzSyAZAskQSKZUkEyXHmDTkh4h05LG6V35AjMJ3JWMwAyyn5QEYEaSOEzPJ8BMIjDDUlzr7JBx
+        meOrm9vO+XUsKhP6SXhpRb2lghGaCeZf2Wie40Ga66nIB6qNns0R9WDZT85It1Ommr5NmmkBKaZV
+        F00lWkaJuaWvIomJpYEUNXfHKfCc/LGw8DWRExQWPVsSEvanse4MkoZxKpA0iFcuWseVSmWrdFyR
+        XZemKshrs1T5dVmqYS8JSaphL0k5qvyGqbgHfoskC3Mu5fKxP8kpC1PG0aGiszD//heShUvmf7sk
+        3IIiF/dQ+0BxOBv3Cg0QuvncsnF5wCAfKW02LhLOlI0LGJoj2bh5ZeOeNi4vWg+x0YpTdawbazeC
+        uCWpuCRgscdIFwlYvJfJJQGLks4tCVjsWcDiy5cvlaGBzAOkz7EirAysCrZUUyyD1T+toltGFja6
+        4er0YA8fRZc2NoSqPlYf0aGJaquGoX6d1TqjkTXEVw3r0apMzE3jEjn1nbwsCr/1fBZGsBFu+ozZ
+        W3roW4mFbNhwGx92yJgyy1dYRpAVmZVjYw8yIzPoH/cWCbQpowVbVKJ8jQ08XAGJEm+/P+RwwWnr
+        on121WrExgtOI09VUWECUj1yBxsyeE4a+KPj4tcnZQ2pxhja+kAlVckIDpIBBxHWVyU7Rcor3IrB
+        fgqrkyUjI8r392VBRsieDKV2sMieDGWfXLInQ0nnluzJsOM9GZCWp4fINgg3YkBueVA7qgB/OGJQ
+        ZPKH97Xy0zrP9bihsDL2x9/Ucc11f4WgJFSr0T5JURYq3DmB0k3qWDV0NCKmrpK0RJKWSNISSVpi
+        oWmJ57rhWib1GZqYhOTO3NKlxMTYYD9JTCRx/j2aXhLnL/Hkkjh/SeeWxPn3LM5PEhNJYuJ2iYm3
+        9Mg3LumnV+My39TEBI5A1ppRaOji6QEs4FhRIqmJ62pGAYq/bR0y2eDz+UWre9WOBWxCZynAReZ8
+        pjfnHaShHYRB+I7+OHIdCHVMFcqBiFAMD6HqRC8zHpSZF1uXbbiHtIPMEA3NgiwgjcQKBYM0wkf0
+        YRiaEXcE0mQZEZHlBY4tmIQgBTBNhhFZhmkuLq+bNxeNVixUczFG70Idvc7OoaEPrAmm1uA1HoPY
+        nFwrcYiNG/nVfgM2hH5QSkuf0A/ey+QS+kFJ55bQD3ZMP0D6ndZDk4AevZoENFbuefrZETtiWy4+
+        J1QUEcT42QCwFcCJQslI+MgQZPMiMgQr5K2ZDJ/PjuNd4jMb0xeOVfMFecQN3caLtwzVegi1P29q
+        f0yZFqCsK9MCxLVlWrh1ZVrCXhLKtIS9JJVp4TasRHPgt0gqkbyTSiSkEs37nn9SiYZUonn7DKzO
+        Rfus1YxHPU1Nf9Y1DxusydVo7sqSc0VYaqXGTghLreyTS1hqJZ1bwlLbM5YaqUZDqtEE1WjuaP3V
+        UiykIs1dXij4vlWkecvEPlKSJm8s3EAT/wwfVYf2mUsr8/hUh7rDIu8J+h6ofTReiUXrZyJJoPdx
+        IBXC3ie6aUKb6qBFVw5umcCm55axDJueSbURt4xlP3IBk0raGbcs/YiIrMBw6VMiN4JXWGbKLUs9
+        IssYS6tx2ry8jAdZWip1CsdjGIettOKpZCOkWWx4GMAKYZOV2j8jbLKyTy5hk5V0bgmbbMdsMqTi
+        aUOlh9gKyNVvbuXHHhMrgOH4WPqYUAESu/0OclM3Y+s8LSXvNK08HPD2nawARjloQtrl2eXZTaN9
+        0rqLdcGRCBVQ0yLOb9GeeB7ldND0Jzjf6GDohx57Bl4n2/jg6GS5Ot/4fBpeKUk+91QgyeM+Ug1j
+        5nAv/CA7w0xYuxEYL62lXwnr6FcsWEu/Wr8R2KYMswO/RcIweicMI8Iwe9/zXwzDbGDryITs2fBZ
+        h74lMsA6PRihlYeSEFQMFmJKWgdOkJEektJyq6HGSgKfHjBUslQGF2lGwZXBgRJAqAdSQ03iiq6h
+        ln08lgHU9m33+KZx/DmhTPil6roj+IU6QlarCX/tUG10Oza2Zm2q2+x047DVi9O9wVa3KU5SVTj0
+        GTB8f8hoLA+HnMYIUB7CId9XJYlRtCHDczxUATfIE3vduPvi6rRkv5YULv9SPHzP8J+tBkyC6MPw
+        8kAUhKGkaECFDOCBMlBYnmVkEWhDIIh9mRumWDtpgd2NOy9w5WS+lhKsnO0rIrEK+kg8FGRJkVT0
+        0ClAEti+xGkqpzAqFIfyUBUhL4tsCjgRvXQxXIMsITNjrajM11F4rajMV1QGKHqrJ1CA6MMw/JAV
+        +oKq9sUhz7EDTYKizCl99PLmWU1WhSGQ+rmFITbuu8A3UeZreadvIkIO3Vty6C5fI4VULxz6wZeU
+        L5M9KlxYSMnCfX+Z7OHy8cs+keVzEMtne9uPgejDCoLGDxWxrzFsX1Wl/lBjWfTfQO0rzEAeigOo
+        cXyRBVQzX0bhRnHmKyqDNtt+2AaoQWU1XpAVVVZ4mREAjzwKZBkO4EBWFZkVBZaVGUbh0q8n94uV
+        cT1lvozC11PmK9oNw+PilB4HGCXd9zFK2qHNV4ySxmZcrsyPGbCZifkR/O1NHGgYPUN33DmwtLkM
+        lqK/Ls+ZaHt1xTliKv+yiggAJ8UmYgBGZIAgsvtDK8m//G8evJLmMbih+G77rYkl22d2eA56kFfF
+        jlYdiNJQOo2TVvOmc99stTqxRJSOqhnQ/rVD3aOl+P44KGH6US4UlOi59pOBsrw51jSCE7c71vzx
+        DVg8YQ+57o8VnvJJ1xLLRoXHk8bx1N8gfiv2Dieso7ZwYC21hV9LbeHWUVtYpjD2zoHfImFvvBP2
+        BmHvvO/5f+v6UMVzcTLURtqIizNN3jsQLo4gF5zMCIQcuDid+0a71fgcn824xMTpfFFNqqU+QQq7
+        DLFEnBW+5QEmOfp1W6K+SXU6YIXXlErRa9EFa1JcwntF81KMk2MUW5cqVa+7WSILF0EWSexIFVrd
+        KkWXu1kfJGGTkB1KTHYo6KnhRfRO5UU6Q4QxVZQ6e9e7eWssXARZKWtHCuQbi87e824XCiALJeVI
+        ZQkyj+x8LNWFvne7VHYTTD6kpYL9fuz2T0csBfs7Cy9h8yvYzcKJuZgdsRGay2wEB10gbaArLICM
+        0CyAjLAic8uvRH777kkKe1n74nA5CvvOOsivBqVrq8/QiA+Yzx3eJF7unyDXcHlwRn/H8cR4+atE
+        UsT8fFHoUCtLZgjEMIAT0gceNtuzmD2oQAzOES82EJN9PJYDMTdXV5fxQZjXCjyNATItLE2NbsCx
+        EHu54G7iYi/+U3MYkRdSXrLUjgYpL1n2ySXlJUs6t6S85I7LSyIFT48fx/QjtghoNWIR5OnlR8yI
+        ZS/fNyR6toUZSFEXf3eVJhf2ZtijjIDIlhD7Umoy7VYP5a002dcfvUnvWTU8WJfQ4ox+j26OrNq6
+        Qw/tuI2R8WGyEcTbbwSxNMpDy9Jih/cUHfxAndi6+UThxdXWH0euoQ+3yLbA/eWYbeGfTvNHITHd
+        YiqRNLRb7arhL/V47OPUDvI30iIdHc/8QHG2Rn3yjBR+vZR+twhJEIX0+2dIePefDH69RDMcLnYW
+        +vXsjnCODOPBoiEpmnCafTyWcY6Ti3a7edM5v7qPRzssz9BN6sbyHiH1m8hy/m0M4nFy9EMp2KYE
+        8yi560Qwj3JPLsE8Sjq3BPPYMeaBVDw99u0C2sZ2AR2YwjT2YvNEPSKmxLZbbPByRZZjcA+2wnGs
+        tD8Ug/2sgyAJDJAPe3eNq9vWRfvm6vasGQt6HKHzaR4VtXqLIhkkgBNpsInQW+9g99mBUMcb1OaA
+        VhQDVlSd6GXG+9TzYkmOdRdNchnYBDQLsvAJZDZ9YudmfAJ5uiujuLN9KtOPCE7t5NIjDxt52v72
+        lNlGZEWZ9aub7nmsk91GendEHavmi2VS59DQB9bExdXV/YyB1W729VGsmx35FfGxiY9NfGziYxMf
+        m/jYxMc+JB/7+og2sVlAD3yzgB69mgU0VvC5+tkzW2LrrSyFiiKCWH4BWwGcKOTNL9ixZ4ysQZY7
+        aM/489lxO9YlDjgAoXHa0G28gAsn3uca6y+fOx29t3hvek4qyZmeozzsNkjtO9C4NFLoK8qJvmI6
+        N1FgBRYoSLunchNl5CZmqIgk+24i6LLcRwHHZH/Ix2e+h9oHik/rM6d2l7GznMFd5rO6y3yXCStD
+        pRuHFTHpu5NYP7ljeeiLblMRoQW/+OyuEecXRx8H4h0T73gfppd4xyWeXOIdl3RuiXe8Y+8YaXna
+        CY0BWnvW8vSGIxbEsjc81p1BT0fjsQ8R57d1g19lio8P74YSv1/h4Xwr35Ps882yzwuq/0tyzknO
+        eZac845LNe2xbv7aic0zvytBnjlTsMe7fP6i6xURj3dxRIqtw/um9XaJx7s4IoVW0H3TWrnE4yVV
+        cUlV3LkRmt8bsJCNXLNvwrlHu7luekU7qltwRzsuDbFVSTv51iq4i8dPMtQqEECFVxQgyfHVATme
+        FxRSrSCZntC5B+cU88f7N8Zm8q0N2G3eXF60m/GFAT9ZhvFCRf2kVLDMUbMVg8scQWOo4j1VUnL2
+        S1BQYDjd1C4Waxkubnu37d54xWMtHdX9QHGYUXACByn3WkqJLcgcC/jUfHzAcpk2WgIszc02WtoJ
+        rSALzMLJcvrUhI2YBRvsObUMswAO7z0WA7P4r6Mm/k7RVBcpJowXr8RbuON4nkFSmnugfPGv/UrA
+        tN9KYx1IgzyVcPT6tuX0AV81rIxjBEfyzZvbMZvvqAso9qj5Vnw+tDhs6DgWNn19vZmgNi9C2Xg9
+        2Xg4q3bjoxeBSvPTShyq5WpvpCQPerNYZJZDLVEpvkok1thZFNqpUvTVAMcgPdC2nnNWiozApQfc
+        AeCYTEoR0BxTiFJ8L6OxSiUqShaVyFC/0eKqvyC9E5+XlkYvHi3rRYbONb4fvUSiGolqJKpxU9Wo
+        2epYTSyRFgokVkhbkCmzs8imDsxv5iwCJdiF9gCcRTFLfbQNnMXpUGznLPKMlFEzwgTNeLyVZjxe
+        pRlhzprxmGhGohmJZtxWMz7pWiJnLTx+OCiqrwowYy1VWlZqVYAzs0RJTqkKcGZWBrpakJnFdgGf
+        WRUQ1bheNXJcFtXIxavFs63U4tmyWuRyVopnRCkSpbgXShHNWEKcER0M05iPPQNP7TbhRnSyXOOM
+        +HwWmrpEh3EqkKQYrxZkdq8Xi4MOlfQO42bQITiU6KLCFpy3PB2KLbUiYLJoRT7ZYTzZSjOeLGtG
+        PneH8YToRqIbiW7cXjc+qoYB7cRA40wkST+e+VI6nN7vpedAb7w3uU8BxIo1ZhRilfIo84F3ogBp
+        q0EiySwaU/IhVqQx2Vw1ZsGAM5PWtd4ccN4u9MgDkEVfCsn6srmVvmwu60shd3252W7dRF8SfUn0
+        5dz5tKCuVELwMRRI0pVHWFe+bny18IOdqslLy/xAseKCmsxHMbCSzGSIRLJiRsXAigcUiZSUgmmr
+        QMoHbmUzKEolXkeebqUjT5d0pJKzgjwlCpIoyFwUZJ47MpQguwM932O8DJ8SI5NzUokbMGDBUHPe
+        q7ha/fXCr1Lqz6K3ZPA1KfawPqmmp9r5VZVEmlQAAHMnU8UuQcaqkmBWVVJQctKj2apspC+xwYhZ
+        lOgmmzBsyXFlTxoP51fX182beC36xaI0NCx4GY/8hM4YJap8/0BKTJISk9EZ3efpJSUmSzy5pMRk
+        SeeWlJjccYlJpOVp94tFI5OAnryaBHk6uxE7IpOvm2d9yEiFgcJd1OOGwspMXjsl7KRG5MlFp918
+        aDXaJ7He6onumPAFm0rUDXTQWqN0kzpWDR2NiKmrh1EukuydUNzeCY4beClBpRH0UuvrJno8BX/h
+        zzX5AvjpnSCPF0YkZm2BCFqs6P2KTjmTeG3y65Qs9hJt8gWWeplrC0QWeplrqiHzwnTxkrJ8HYru
+        9Bmtea03ba+jp2qhpVZd/lHgv6HXvQ3NARKZ/hUGwPsTNJBzTTOJIZoFy64D7IguNs6kTA9j6XUZ
+        g9qLjTOpiaEOoFNnIzJhU0QGz6TzMu5bRjXajN6gQWv973+J/n7WXqsu3mY1uizeLLzgx52v0ADl
+        GV2QJEWQuZR7bYiAyRh2ZvyiGGSvjVz22rhsXh41bzrnF9edWFjkzn+5N6hLPwjljPRJXA1S8XNs
+        bOHQcBFSiLTU7hUpRFr2ySWFSEs6t6QQKSlESgqRlqgQKbIa6Wdapccz+zJPkC1ilG5LKPELkooK
+        YAUuviSpxCK7X+LLtbdL516i2JvWW+9xmmsJ0e55867RPmnEAnd3OoYKdJXC0F3DQIvRDbnzqzG7
+        6SIMbtiGjme49f8Hhfhczse3AQA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:08 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['7088']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:05 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><s_keys>test</s_keys><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><request_custom_fields
-      /><request_cost_range /></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['759']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1d63bbNhL+v0/BzY/ttl2aAO/0qupxYjl1YudiyXHTPzwQCUmMKVLmxbb2dfZN
-        9sl2AFISdaFMKpJjJ8phXXEwBMDBYL4ZAAQav98PfeGWRrEXBr+9wAfohUADJ3S9oP/bi8vOiWi+
-        +L35twa9pUFix5REzsCOaJz6SbMRp103HBIvsNOYRrYX213iNsc0bkirkxpONB4lod31Q+e6eWmL
-        4u31qGddv7JGl9r7rtiPwp6Lk9d3zrsPn78o1Im/KMefsf7l4/V79PkqOL4ddt4O4iNlZN9f3hgX
-        ZyfjY0cTL1zc09/e9NLPpzf9o5P4/UVwN74hqIP192pkHw+Vs9PWx/FN1PpyY1p+JH84DSzl+Pqu
-        739uSHN1arhenJDAobFNImrfEt9zm0HYkFbRM6k0G0AhNsiMNltXDWl2lyW4NHaaLRDx+G5AI5oz
-        cGrD8Ukc5//LnkkGlCSMq0DL0/kjnfn0LBsQL5d1lh1vgHlSI2+5azqelCBBI82IrC1z1smTU8pc
-        fjO+FVkOvdhZnW32Inn6HG3Gwt/lHFiEqRDm02b3zfz9QTRhGiTROMsrvQZ6kTBN5s9fBl5CXeEt
-        6DYo54w1y9wlCbUjEvSpTQM3v+dJV9T9l4DjRHiTBlSQEdZBH6apGWOaOHbY68U0aSo6QjlDgTpj
-        i6kTBm7cxKquGqY1zz1JzNjH8G84dN0mKxTpCOecUzq0VmgC3eZkErh24g0pZxcRXLiDtUOE4PoV
-        4UNW0uoH8nwXXz+7B82Pkh9ZILkAMiPIFQvLKhRdIOSJXABHH06FTqvdOX33esKTCSb7DZZDOX/9
-        ZpI0NSS2D4oZzixAkTgxwAlJ0rjpe7fT9Jw0YQC7SxLCqsBqgPWjKV+ekjMm4TUN5uqRUSbJ4xFt
-        xt5w5FOQh3NNkykbS2kMSGwHoT2iUS/m9nGOwGwIWAHobFPjkd82AkpdkMYIBJqCIWVC5s+voufM
-        aUQSQKcC24SSMbAyw2jIrHNW3BJ1YqsmRty+HjbRAZqaqiK9EQ/CO/50pggZnM3TGnGYRsCeWWwu
-        nv+EAUiKxiCnYuKEM7PdnPMv4BQ6Rc5MOUC6af6Uhs2GVLjP07K+1zp/edb6LLQ7R8enl+cTvtxA
-        5oi0BEwYIbMEmtrjOKFD4SfG8tMenZ4dOrVJAsZYTQbCORlv1RgrMtbVysZYw2otY6yJWO1gtH10
-        aqdBhk7bloeMLEWuLo+a4KRxcKovjxXgBD35UNVL8eml1xcuaAyO+S0oXGaKVsPU6TneJUxJC2hU
-        KO5x0GhI7u0oDQKofCZZHWS+RGwMwbQssy0Sv0Nsi6irY/sGQIMExCVrsO2CcQofj4RXnFNgUCjE
-        HFrKcY4rqqxKmcKqpZjHFPYTuz0U2M/2iDi0IvCBF1SCe0zvhbPQ4eLe496zw71OSsHMox3gnmyh
-        OnYeo7q4hzrY2j7u/WgCWQY+2TTlctQ7vTj+LIz8NBbiEXU84gv9FGxAXAZ+Z68+Pib4FYrbh2Kb
-        wRU0QwR+TWhDiLUGq345O/3U+kU4zbmF9wXuJYzq/GlInVJk4iDC74U3J3tI+sEhiUceBhjgo7Sf
-        QlNu0QYbSNON6iNjJjJq2WBTREYHyzsIxlh0qu9IJKqJq8OSifS6ItE3EclKWCofLHxF0v4gEbpj
-        pszCBaBGJHQGZEjX4NLF4+LSxR6XniIuWVVxSThJfdAo4QPx94HTHqW4SZYDV3iT+tuNEwzVVKsb
-        ZAPJtQyyISKZxQnKTjDqBxLIKoQyrFKEagH3QLjyQED/IMPRv4UTL6JCOTq1Hxed2nt0eoropFZG
-        J6ZZcRjVgyfNKEGn04T443lU8pLcfg7hT0BED3RhRszSM2vN0/PEUkiDV47LAa2Yugmcsee3CmY8
-        w3zEYx2azVjWARp/P0EU2vkQymmQ0CibzKwHbrwRysEtb8baSzTO2esxG26steEVDbhpKnLlKTAD
-        KXWmfMB6K2zKB+VTPn9taRRwkObTgUejyPMfhrOqWIY0C6CsKpapNWcDVTYbWE8UyzCmG9j8gLVS
-        JDuhUUQij/nDvnBMxkLrHmyiR8FyCnceiIwZJvE4KoDQIry9f/96E3gbUtcjoOJkxOw+gNggjJOm
-        Q5wBFfsRGQ08J/a97sGtR5IwOnCYP8dZGl4AYmaIAjQAMyb6yG8OkmR0KEnrMpAKZHEUUQatUjJI
-        h90Y/JJ7VdUlJi+pfcr7tNTLhCP2QDiiS8YinQpHZMIR2ZSO6DLhiF4g5rZUtiAGNw6+jPrQZiur
-        2gggmG360IYxvD6Ih983RiQZNB+/jrzYxrMR6UqBxuloFEZJbLMqT9ZbFknzHJl/s0CaaGmumHst
-        5VoZ36Qk2qvos1HRehZ98tAPp9ZJ5DFS5uDvdfup6vamMXDBJ6kVA/dpyPwrKN+HcDRJwVtS1QNd
-        1XVwY6ekhh8G/ewnRgeWrMuqBclTYkOa5VM5qmZpzzmo5k26JqbOlHZNNP1pnmEpgJY1c80i0Emg
-        WilUtuSyWPkDjdKSUNn3hkRk3trKQPkMUvdh8mOEybwJysPkrAVrLZmR2QqRY+rQYZdGWwsPTRnX
-        CA+xLNdaI4JlUUbbjpRPIg8iZW0HkbJumNXXzaosYK0XKWtfHSmDFUfaB1y+WuYP4ve4Q/XJi71E
-        SEI+PXkOcBpyn8oLQuE8jWk6LI2UO8r3EylzeU0diwEIhzsUt0w4YhKK8EbikAmH+xQgHHHIhcP8
-        Cm5KZdMyNGWHcfJWa7hrN22rld3HyI+on5tFyHvl/CbR8by5/uf5Uaf189RqP61o+NEU+Cti4b0W
-        P/E4eOZxfG0cDB7nAVIV9m91KCwaxgGSzZxhHwzvNBi25PJQOAtFKwXCdb/O73r9dMS+9U/5pyoN
-        qUgoxsrg24eByJfrrIyWefpD8fJzXil17bnxuqA5T18XMZ+QocdmfKvEx3GSBTbQRGC7sgZhERmN
-        oFW7ceinYKNicgtxRRMrTIsXqQ02JsjsWdcLoM9pMmOap2UsrFNCdAg9RDWmPDNizgRqOyARVEib
-        8UxpDV6zWcaKxZgWiDnTLGdFm3EVyssJ08zVAtesROiIDig/6U9fWIYgc5kKKr0kQPb520Jd50ic
-        IXt+L/ONZL4sQE5ZqMY8LWOZr8I8iX+lOH03nHEUSTkDtHdJs6kVWg2bD7dagae81VCFVsNqlVYr
-        cq1pNVS11eSSVluQHrtfrMQ8LWOZr8A8qQHuQAzZ+zS292Ztb9aetcz3Zm1v1vLib1ISJMzbDfkY
-        AzhtfMcse0JvYnDZ5ymLHPKDHMqDHOqDHNqDHPoyh7T8etk4OwTJEQ0cYJn8ylzdfncE3uscacbR
-        Iw4EP1mAsUiccQUpm65pmrJe4MqJM64RW0EbM9ktkgo8rLHj8bAb+lKRDCFlRm3+77/F52f0hrT4
-        mkk4srlS7E3mRiZzSX5SiUOw71D7DrXvUJt0qGIv2t7XVU7kJZ5jR/TWo3zci9UkV7mVSetm5fmK
-        bXM338hiTdWqr9rma05qfSOLzZ18ksVlIrMF/RXn5mt8lIVlXakxPS/X28ZJFWW8nY+y3l12Xl0c
-        vXrbuiidpT8nSTKgd8LLMI0C+lMsvIPXiYhzTaO/l8zL66cn25uW59SDbEw9vvMSZ1Btvig+lKTV
-        z0ox9HnqFqcFoEeFI+hHkqXA5SC120OurNKe4iKNmj3aU7vEMJDl9pCqqJRgxdl4on2bxa+f4nkk
-        GVSYulmal1mauVme3Kk1O/64amJQuJBqOrqm9QzLxYQirGLLsWRVRqaO3R7W9K6p9CqoyZBENymt
-        riS1C9+FktSuxI+nJBqFCyG1J2tdjZCu3lMV2XENqpuK1YWOpMquSbQeNrqbLYrYZtm70JHalXgK
-        OuLiu3v1TtHS7tD17g8cP0zdXhQGyUHAJnUrLFNYm8MqedH7hO/riqRfs+3s7BmFvYjv0aiChuSc
-        D+pI9eIeVoodvut2FgQ8K4vRs+AiBIAW4Fc1DEdBimuYXUfDyHAcZGiq2zNVnThm9VUoPb7GoaLd
-        qF2DXdiN2pV4Cnbje9AUcPH3mvI9IkwuL5tzSpYGV9dyuiqxzB4xuhpWu6qqq8gyCDKNXrdrdA2M
-        HYd8xWK37VdjB3D0lTV6Ehj1zfVJ1uBCuuZaju4S2dF1AysW3BsGUV1VVXRLd7BmuUoNfUoGUfWY
-        aNOK7FyjatfoSWjUd4BlyV24h7ItQtmGC2YLQ4G11stmv9NRTH3f9r04mRtebC0PL5YNOzL628si
-        XVqR94rluRo+0ErW5aID9j3VV67IfXCfeCxX2yg+43siO8WziapsIewrfCGonXfQWSakne4wNY0i
-        1x2OwvaEys8i+YtGYflq4PbR8Vnron3VOjtrly4LbhPXp9FPsXAFihRXXCAsW3L1XaW+rxW833qv
-        w+1uB8WnjxT2oWv1E6oq7+knKzU24tWVepuh66KCOsjMd53lx4Fs8WtXWeMiyXY5VLclEqTLilV1
-        m0MVGXKND15Vts2hrG0iklWndimtk9LJNGahhBO/ZN5MfqkebTJxtiE2F4v7RmehqBUxTn1KGLdL
-        GEujLgls4jJpQ9Xjh877umT8wtGU/4FTv0y9FM2WcvrniR+yJSP054rQxrb0WHv8l473h389w718
-        2Y7zSnYU45b3rrUsQ6mOc4ZSb5mEISq7OZtytnJk+xLBqMbhlEbNhSMGXziyjcMpdXwoy1b5lvOd
-        iMTZzljCcToceuVbzb9DG53/9WSGwtLApVEXIoCxpGO4bMVmfyRZRvcYa9tcJVKpqB0MaVUq90kM
-        XD2h9gcv9B7+29rMfqVyHrHx58p95MavfEbtFdY7F0ftP9afUFswQfszAWuP9LRbWDD//POxBnpm
-        +rjOLZ4yCdme4uUuMSCZIrE/5Z9/82+rhauQZdqPwG1yDwXwRIX2yKN96iegEatd5InWzZ1p/3/z
-        U2BoEH8AAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3712']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:08 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/CoreTests.test_search_events_cities.yaml
+++ b/tests/interface_objects/cassettes/CoreTests.test_search_events_cities.yaml
@@ -1,139 +1,167 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxyZXF1ZXN0
+      X2N1c3RvbV9maWVsZHMgLz48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJl
+      cXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0
+      X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVl
+      c3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9t
+      ZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48c19rZXlzPnRlc3Q8L3Nfa2V5cz48cHV6emxl
+      ZD55ZXM8L3B1enpsZWQ+PHJlcXVlc3RfY29zdF9yYW5nZSAvPjx1c2VyX2lkPmRlbW88L3VzZXJf
+      aWQ+PC9ldmVudF9zZWFyY2g+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['588']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1dS3PjSHK++1cg5rCP2AaJwhttLjcoiXp0U5RWpKTRXBggURQxAgEOHurWHmcO
+        doRP/gF72ptjwxE+esPhw/4Ut8O/w1UAKIIPgAAJiCRUHZwYsZBEAVUFZOaXX2bV/vB1bFDP0HZ0
+        y/z9d6DCfEdBc2Bpuvn4++9uu6e0/N0f6v9Qg8/QdHsOVO3BqGdDxzPces3x+po1VnWz5znQ7ulO
+        r69qddOqVVcfqQ3sl4lr9fqGNXiqD3o0LdJ958f7qx+Nm0cb0s5J/9ONcnU0GMqjz+LXnzrt4Znb
+        7lwfXfdFYDAvDb0/Oe0+ukf9n/oPA1E+9oTW0bU6uu1c3yi9Y+f7ux++On9yOt6J2GUnPGv2n+4v
+        WvQzcwq/3H4941+On0YjVtWHisFpwvClP7oU/ihctg1mcsTTD7Xq3PXVNN1xVXMAnZ5qw96zaujB
+        za1qDwaoXkMtag8NH6w372vV2bfggAadQb2JRvvlywjaMBTwW2sD3X0JZA3dMCA9tNH1vLYFh33J
+        Fj4cHgt/aqiOE/4vEFdd11YHLppTB0nO2kMZ/2eNZZngdGi2/KkLTvsC0eH5plq4Dp7gS7SnKpr3
+        2QG8OkLx6a9fW+bOOZOLOa07gmM4Ue0nZ3UHwa3NSc0dmQn699fFgtSv1PHkH6l71YU2db3wq2AY
+        qrMLq05H2HLcnq2aj+ikY/UrOv24r5tQq/NChalV55p8AXS57sTWB7DOM1OJWVsg4qEbUm10ytdz
+        zJpqYzzoC71Em3yBpV7m2gKRhV7mmmqm1XPQA29APGLlvMWfPNV08SNjTfxVVa/5D25v2l4HtepC
+        y6IEu1aCWyvBr5UQ1kqIyxLV5dvz57A38Gwbvc+RyPSv4JmAHn69zDXNJIboybPsOmCYiEzYOJMy
+        vXEf2nVFkiNSYeNMamKo6E2Jx26xKSKD15zzMu5bRjXajN6uQWv9f37+a/QEswO16uJ9VmMWM1kA
+        72UBRGd9YHmma4c36KvUaMPrYf+Nf2pjrT4TCdSAhlREcLYeNLXwu3/o0jI/UMBxqU+q6an2C8Uy
+        AA3FTCCQ9dxBzxoOHejWmfBopGkm48CBZWpOHQiAlwUAFCUiPT0YiL+gf+OxptVxjwxgQCj52o5U
+        riWLDOj5zaqp9Vx9DH1xmgHo02W5j4KCPj9gRbxKNjzl4p0H35EBZLvRseiOvA+U4I6oS9UfBzGH
+        ceBFlmdEnmFSjYPICIyQfhxEmhHQp8swH/1PunEI7zuwhv0ldNJ46F58X6tGmsLD/q0D+gQNSFcf
+        PEF3KhSMSfA3Mh3Fz53pkVdDsmegN5gVsYKmEkF7KDSGmq6iRaz6jzx6ckZo5dc18OUr/4UTvP5Y
+        079WBoblaUPbMt2Kia/Bl6npJhpJDz1GSM1ODIhH1zbqI9edfKxWE89QdZBGhVo1cglV+NXtudBx
+        mWrzvsqyzFcAhMqPk0c0piv7qZkqGlkDjbGDLh49cv732kR1R/Vs5/d/Uou7Fyffm1l5K443mVi2
+        6/Rwh4FlO980L+GsEMEW5tyM7vP0SgzzlWOY9dM7Vu2fPJhxcufOXvTkznVGJheNSPP25urkotNu
+        PlQBj1Y+n2KeHWR62BmnOa6fomc8rl8y+b9zXhwXjnuzFnwjhg7tFCsglMywBtZ1V+hCWNf5e10N
+        A9uaTKDd8yWrQwV9VHXI9wcMz0vSgGM4TZL7AwEw0mDASAKvDWVeVAfy+iXi2jpu6lnm+jfFlpdR
+        wNLZ8oreeD0FA4vMShrQmvpCu771WZ3KBuMTArqu6npO3dCf4fRw2DQV8PrI/FWr0++u9QTNqMka
+        NEyPvkzQ20DHt9lz52xe/0jtEVrYukZXaqjIWfWQsSwwFQmZ7a/fa4ZlPgZ/chjGmX2tVWc/H6lO
+        D/n5aE6Gjo/JzjVgwBGDQzDAa2ffaiaEGrK/J8iKxzOCLftgXFcdCKU9W8XPpX+q+ZZAAPdp2WPs
+        O85koo1TXHOKG/eexnUfxFrRXnNG1hf/14H34YPp8001x/LsAQzd+OkrDIlFmqcyAeD81YW2qRpU
+        FwlSRyqaF1OjZr8I/BE0TV7465mWrFUjzaGIL36iOyZ8wRb83/8d46e6MxUNwdMQD88RFh96ptpX
+        nZFO/ziJgcZPpyIEHt8NPB7BVvxJigdbPqkT1SRYC8FaMmAt4KTxcN3odK6vbrrxiMu3X/7p2y//
+        9e2Xf/32839+++XP/t//TP3myoQUxmKu0VLFKvS3MXBM40wuCxwDCoZjls9foNm+3Nl7NdPnRqQw
+        OGb57EVPLoFjFkekKAxm+eRFzy1BW+ZGZBGBAEWiLeu7K3T213W+E+8YaXkaYH8P/cRyLdoyoe8r
+        T0LrIE9vOWJRbOstc0JF5LDBt8pfBpxSkWXh0Hzm2bne2mkGmZ1mEO80d68+P6zzmv/vz//xv3/7
+        KzZQf/7Lt5//9u2Xf/Gt03/79vN/T83UrvX0YlGBe03dQCewVAt2rQnjbH9d6hg6FmDW8rEAkwMh
+        a9pPAiNr2k8RrLMS3CYhHr0X4hFhnr3zBUCYZwQNfTM0lDtpPJxfXV83b2KxUM5nn537wctY9lm3
+        LHAnYZ+VGjUh7LOyTy5hn73XySfsM8I+I+yzUrHPujTnI+oj/+LzZZ91CfuMsM/eln2GVoJmmbT3
+        FIeR+8fXgOTIn3qGRiw+3p07vAE0Hpw/T1Q8POPIcqGRCIa/SiQB4eeLQumoZP6gx6Mnt6aOHi/q
+        M3JONWucHkXpevADxaLF2PAePbQ214IHnMikxA8kBnCCmBo/kBk2E34g0wzbBWyAH/yOAR9xT28P
+        pqQfD5HleSRcKJ6ywXgsgyo3V1eXsXBKwx1BU4XeOAZLueBiM/n8x4PAKARG2Y/pJTBKiSe3UOzk
+        TQETgpIQlISgJAQlKStKggxGWp0alXlCJBFLdBki8W3Rnm1Z4/X4CKgIDLLeYxiHNFNBvg6nsHkj
+        JZiqY3umiQzlwGwHbEjgmWv12Tcr5BZbVyIvM0QlEXiJADSZOYyYXeB7EffgEyUdfUILf9pycLBM
+        o3vebDeat5exqEzEPSJgDAFjCBhDwJgCwZhjy/Yc6vxFgz6bNhaSiaW3EEiGQDJ7NL0Ekinx5BJI
+        pqRzSyAZAskQSKZUkEyXHmDTkh4h05LG6V35AjMJ3JWMwAyyn5QEYEaSOEzPJ8BMIjDDUlzr7JBx
+        meOrm9vO+XUsKhP6SXhpRb2lghGaCeZf2Wie40Ga66nIB6qNns0R9WDZT85It1Ommr5NmmkBKaZV
+        F00lWkaJuaWvIomJpYEUNXfHKfCc/LGw8DWRExQWPVsSEvanse4MkoZxKpA0iFcuWseVSmWrdFyR
+        XZemKshrs1T5dVmqYS8JSaphL0k5qvyGqbgHfoskC3Mu5fKxP8kpC1PG0aGiszD//heShUvmf7sk
+        3IIiF/dQ+0BxOBv3Cg0QuvncsnF5wCAfKW02LhLOlI0LGJoj2bh5ZeOeNi4vWg+x0YpTdawbazeC
+        uCWpuCRgscdIFwlYvJfJJQGLks4tCVjsWcDiy5cvlaGBzAOkz7EirAysCrZUUyyD1T+toltGFja6
+        4er0YA8fRZc2NoSqPlYf0aGJaquGoX6d1TqjkTXEVw3r0apMzE3jEjn1nbwsCr/1fBZGsBFu+ozZ
+        W3roW4mFbNhwGx92yJgyy1dYRpAVmZVjYw8yIzPoH/cWCbQpowVbVKJ8jQ08XAGJEm+/P+RwwWnr
+        on121WrExgtOI09VUWECUj1yBxsyeE4a+KPj4tcnZQ2pxhja+kAlVckIDpIBBxHWVyU7Rcor3IrB
+        fgqrkyUjI8r392VBRsieDKV2sMieDGWfXLInQ0nnluzJsOM9GZCWp4fINgg3YkBueVA7qgB/OGJQ
+        ZPKH97Xy0zrP9bihsDL2x9/Ucc11f4WgJFSr0T5JURYq3DmB0k3qWDV0NCKmrpK0RJKWSNISSVpi
+        oWmJ57rhWib1GZqYhOTO3NKlxMTYYD9JTCRx/j2aXhLnL/Hkkjh/SeeWxPn3LM5PEhNJYuJ2iYm3
+        9Mg3LumnV+My39TEBI5A1ppRaOji6QEs4FhRIqmJ62pGAYq/bR0y2eDz+UWre9WOBWxCZynAReZ8
+        pjfnHaShHYRB+I7+OHIdCHVMFcqBiFAMD6HqRC8zHpSZF1uXbbiHtIPMEA3NgiwgjcQKBYM0wkf0
+        YRiaEXcE0mQZEZHlBY4tmIQgBTBNhhFZhmkuLq+bNxeNVixUczFG70Idvc7OoaEPrAmm1uA1HoPY
+        nFwrcYiNG/nVfgM2hH5QSkuf0A/ey+QS+kFJ55bQD3ZMP0D6ndZDk4AevZoENFbuefrZETtiWy4+
+        J1QUEcT42QCwFcCJQslI+MgQZPMiMgQr5K2ZDJ/PjuNd4jMb0xeOVfMFecQN3caLtwzVegi1P29q
+        f0yZFqCsK9MCxLVlWrh1ZVrCXhLKtIS9JJVp4TasRHPgt0gqkbyTSiSkEs37nn9SiYZUonn7DKzO
+        Rfus1YxHPU1Nf9Y1DxusydVo7sqSc0VYaqXGTghLreyTS1hqJZ1bwlLbM5YaqUZDqtEE1WjuaP3V
+        UiykIs1dXij4vlWkecvEPlKSJm8s3EAT/wwfVYf2mUsr8/hUh7rDIu8J+h6ofTReiUXrZyJJoPdx
+        IBXC3ie6aUKb6qBFVw5umcCm55axDJueSbURt4xlP3IBk0raGbcs/YiIrMBw6VMiN4JXWGbKLUs9
+        IssYS6tx2ry8jAdZWip1CsdjGIettOKpZCOkWWx4GMAKYZOV2j8jbLKyTy5hk5V0bgmbbMdsMqTi
+        aUOlh9gKyNVvbuXHHhMrgOH4WPqYUAESu/0OclM3Y+s8LSXvNK08HPD2nawARjloQtrl2eXZTaN9
+        0rqLdcGRCBVQ0yLOb9GeeB7ldND0Jzjf6GDohx57Bl4n2/jg6GS5Ot/4fBpeKUk+91QgyeM+Ug1j
+        5nAv/CA7w0xYuxEYL62lXwnr6FcsWEu/Wr8R2KYMswO/RcIweicMI8Iwe9/zXwzDbGDryITs2fBZ
+        h74lMsA6PRihlYeSEFQMFmJKWgdOkJEektJyq6HGSgKfHjBUslQGF2lGwZXBgRJAqAdSQ03iiq6h
+        ln08lgHU9m33+KZx/DmhTPil6roj+IU6QlarCX/tUG10Oza2Zm2q2+x047DVi9O9wVa3KU5SVTj0
+        GTB8f8hoLA+HnMYIUB7CId9XJYlRtCHDczxUATfIE3vduPvi6rRkv5YULv9SPHzP8J+tBkyC6MPw
+        8kAUhKGkaECFDOCBMlBYnmVkEWhDIIh9mRumWDtpgd2NOy9w5WS+lhKsnO0rIrEK+kg8FGRJkVT0
+        0ClAEti+xGkqpzAqFIfyUBUhL4tsCjgRvXQxXIMsITNjrajM11F4rajMV1QGKHqrJ1CA6MMw/JAV
+        +oKq9sUhz7EDTYKizCl99PLmWU1WhSGQ+rmFITbuu8A3UeZreadvIkIO3Vty6C5fI4VULxz6wZeU
+        L5M9KlxYSMnCfX+Z7OHy8cs+keVzEMtne9uPgejDCoLGDxWxrzFsX1Wl/lBjWfTfQO0rzEAeigOo
+        cXyRBVQzX0bhRnHmKyqDNtt+2AaoQWU1XpAVVVZ4mREAjzwKZBkO4EBWFZkVBZaVGUbh0q8n94uV
+        cT1lvozC11PmK9oNw+PilB4HGCXd9zFK2qHNV4ySxmZcrsyPGbCZifkR/O1NHGgYPUN33DmwtLkM
+        lqK/Ls+ZaHt1xTliKv+yiggAJ8UmYgBGZIAgsvtDK8m//G8evJLmMbih+G77rYkl22d2eA56kFfF
+        jlYdiNJQOo2TVvOmc99stTqxRJSOqhnQ/rVD3aOl+P44KGH6US4UlOi59pOBsrw51jSCE7c71vzx
+        DVg8YQ+57o8VnvJJ1xLLRoXHk8bx1N8gfiv2Dieso7ZwYC21hV9LbeHWUVtYpjD2zoHfImFvvBP2
+        BmHvvO/5f+v6UMVzcTLURtqIizNN3jsQLo4gF5zMCIQcuDid+0a71fgcn824xMTpfFFNqqU+QQq7
+        DLFEnBW+5QEmOfp1W6K+SXU6YIXXlErRa9EFa1JcwntF81KMk2MUW5cqVa+7WSILF0EWSexIFVrd
+        KkWXu1kfJGGTkB1KTHYo6KnhRfRO5UU6Q4QxVZQ6e9e7eWssXARZKWtHCuQbi87e824XCiALJeVI
+        ZQkyj+x8LNWFvne7VHYTTD6kpYL9fuz2T0csBfs7Cy9h8yvYzcKJuZgdsRGay2wEB10gbaArLICM
+        0CyAjLAic8uvRH777kkKe1n74nA5CvvOOsivBqVrq8/QiA+Yzx3eJF7unyDXcHlwRn/H8cR4+atE
+        UsT8fFHoUCtLZgjEMIAT0gceNtuzmD2oQAzOES82EJN9PJYDMTdXV5fxQZjXCjyNATItLE2NbsCx
+        EHu54G7iYi/+U3MYkRdSXrLUjgYpL1n2ySXlJUs6t6S85I7LSyIFT48fx/QjtghoNWIR5OnlR8yI
+        ZS/fNyR6toUZSFEXf3eVJhf2ZtijjIDIlhD7Umoy7VYP5a002dcfvUnvWTU8WJfQ4ox+j26OrNq6
+        Qw/tuI2R8WGyEcTbbwSxNMpDy9Jih/cUHfxAndi6+UThxdXWH0euoQ+3yLbA/eWYbeGfTvNHITHd
+        YiqRNLRb7arhL/V47OPUDvI30iIdHc/8QHG2Rn3yjBR+vZR+twhJEIX0+2dIePefDH69RDMcLnYW
+        +vXsjnCODOPBoiEpmnCafTyWcY6Ti3a7edM5v7qPRzssz9BN6sbyHiH1m8hy/m0M4nFy9EMp2KYE
+        8yi560Qwj3JPLsE8Sjq3BPPYMeaBVDw99u0C2sZ2AR2YwjT2YvNEPSKmxLZbbPByRZZjcA+2wnGs
+        tD8Ug/2sgyAJDJAPe3eNq9vWRfvm6vasGQt6HKHzaR4VtXqLIhkkgBNpsInQW+9g99mBUMcb1OaA
+        VhQDVlSd6GXG+9TzYkmOdRdNchnYBDQLsvAJZDZ9YudmfAJ5uiujuLN9KtOPCE7t5NIjDxt52v72
+        lNlGZEWZ9aub7nmsk91GendEHavmi2VS59DQB9bExdXV/YyB1W729VGsmx35FfGxiY9NfGziYxMf
+        m/jYxMc+JB/7+og2sVlAD3yzgB69mgU0VvC5+tkzW2LrrSyFiiKCWH4BWwGcKOTNL9ixZ4ysQZY7
+        aM/489lxO9YlDjgAoXHa0G28gAsn3uca6y+fOx29t3hvek4qyZmeozzsNkjtO9C4NFLoK8qJvmI6
+        N1FgBRYoSLunchNl5CZmqIgk+24i6LLcRwHHZH/Ix2e+h9oHik/rM6d2l7GznMFd5rO6y3yXCStD
+        pRuHFTHpu5NYP7ljeeiLblMRoQW/+OyuEecXRx8H4h0T73gfppd4xyWeXOIdl3RuiXe8Y+8YaXna
+        CY0BWnvW8vSGIxbEsjc81p1BT0fjsQ8R57d1g19lio8P74YSv1/h4Xwr35Ps882yzwuq/0tyzknO
+        eZac845LNe2xbv7aic0zvytBnjlTsMe7fP6i6xURj3dxRIqtw/um9XaJx7s4IoVW0H3TWrnE4yVV
+        cUlV3LkRmt8bsJCNXLNvwrlHu7luekU7qltwRzsuDbFVSTv51iq4i8dPMtQqEECFVxQgyfHVATme
+        FxRSrSCZntC5B+cU88f7N8Zm8q0N2G3eXF60m/GFAT9ZhvFCRf2kVLDMUbMVg8scQWOo4j1VUnL2
+        S1BQYDjd1C4Waxkubnu37d54xWMtHdX9QHGYUXACByn3WkqJLcgcC/jUfHzAcpk2WgIszc02WtoJ
+        rSALzMLJcvrUhI2YBRvsObUMswAO7z0WA7P4r6Mm/k7RVBcpJowXr8RbuON4nkFSmnugfPGv/UrA
+        tN9KYx1IgzyVcPT6tuX0AV81rIxjBEfyzZvbMZvvqAso9qj5Vnw+tDhs6DgWNn19vZmgNi9C2Xg9
+        2Xg4q3bjoxeBSvPTShyq5WpvpCQPerNYZJZDLVEpvkok1thZFNqpUvTVAMcgPdC2nnNWiozApQfc
+        AeCYTEoR0BxTiFJ8L6OxSiUqShaVyFC/0eKqvyC9E5+XlkYvHi3rRYbONb4fvUSiGolqJKpxU9Wo
+        2epYTSyRFgokVkhbkCmzs8imDsxv5iwCJdiF9gCcRTFLfbQNnMXpUGznLPKMlFEzwgTNeLyVZjxe
+        pRlhzprxmGhGohmJZtxWMz7pWiJnLTx+OCiqrwowYy1VWlZqVYAzs0RJTqkKcGZWBrpakJnFdgGf
+        WRUQ1bheNXJcFtXIxavFs63U4tmyWuRyVopnRCkSpbgXShHNWEKcER0M05iPPQNP7TbhRnSyXOOM
+        +HwWmrpEh3EqkKQYrxZkdq8Xi4MOlfQO42bQITiU6KLCFpy3PB2KLbUiYLJoRT7ZYTzZSjOeLGtG
+        PneH8YToRqIbiW7cXjc+qoYB7cRA40wkST+e+VI6nN7vpedAb7w3uU8BxIo1ZhRilfIo84F3ogBp
+        q0EiySwaU/IhVqQx2Vw1ZsGAM5PWtd4ccN4u9MgDkEVfCsn6srmVvmwu60shd3252W7dRF8SfUn0
+        5dz5tKCuVELwMRRI0pVHWFe+bny18IOdqslLy/xAseKCmsxHMbCSzGSIRLJiRsXAigcUiZSUgmmr
+        QMoHbmUzKEolXkeebqUjT5d0pJKzgjwlCpIoyFwUZJ47MpQguwM932O8DJ8SI5NzUokbMGDBUHPe
+        q7ha/fXCr1Lqz6K3ZPA1KfawPqmmp9r5VZVEmlQAAHMnU8UuQcaqkmBWVVJQctKj2apspC+xwYhZ
+        lOgmmzBsyXFlTxoP51fX182beC36xaI0NCx4GY/8hM4YJap8/0BKTJISk9EZ3efpJSUmSzy5pMRk
+        SeeWlJjccYlJpOVp94tFI5OAnryaBHk6uxE7IpOvm2d9yEiFgcJd1OOGwspMXjsl7KRG5MlFp918
+        aDXaJ7He6onumPAFm0rUDXTQWqN0kzpWDR2NiKmrh1EukuydUNzeCY4beClBpRH0UuvrJno8BX/h
+        zzX5AvjpnSCPF0YkZm2BCFqs6P2KTjmTeG3y65Qs9hJt8gWWeplrC0QWeplrqiHzwnTxkrJ8HYru
+        9Bmtea03ba+jp2qhpVZd/lHgv6HXvQ3NARKZ/hUGwPsTNJBzTTOJIZoFy64D7IguNs6kTA9j6XUZ
+        g9qLjTOpiaEOoFNnIzJhU0QGz6TzMu5bRjXajN6gQWv973+J/n7WXqsu3mY1uizeLLzgx52v0ADl
+        GV2QJEWQuZR7bYiAyRh2ZvyiGGSvjVz22rhsXh41bzrnF9edWFjkzn+5N6hLPwjljPRJXA1S8XNs
+        bOHQcBFSiLTU7hUpRFr2ySWFSEs6t6QQKSlESgqRlqgQKbIa6Wdapccz+zJPkC1ilG5LKPELkooK
+        YAUuviSpxCK7X+LLtbdL516i2JvWW+9xmmsJ0e55867RPmnEAnd3OoYKdJXC0F3DQIvRDbnzqzG7
+        6SIMbtiGjme49f8Hhfhczse3AQA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:08 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['7088']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:07 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><s_keys>test</s_keys><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><request_custom_fields
-      /><request_cost_range /></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['759']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1d63bbNhL+v0/BzY/ttl2aAO/0qupxYjl1YudiyXHTPzwQCUmMKVLmxbb2dfZN
-        9sl2AFISdaFMKpJjJ8phXXEwBMDBYL4ZAAQav98PfeGWRrEXBr+9wAfohUADJ3S9oP/bi8vOiWi+
-        +L35twa9pUFix5REzsCOaJz6SbMRp103HBIvsNOYRrYX213iNsc0bkirkxpONB4lod31Q+e6eWmL
-        4u31qGddv7JGl9r7rtiPwp6Lk9d3zrsPn78o1Im/KMefsf7l4/V79PkqOL4ddt4O4iNlZN9f3hgX
-        ZyfjY0cTL1zc09/e9NLPpzf9o5P4/UVwN74hqIP192pkHw+Vs9PWx/FN1PpyY1p+JH84DSzl+Pqu
-        739uSHN1arhenJDAobFNImrfEt9zm0HYkFbRM6k0G0AhNsiMNltXDWl2lyW4NHaaLRDx+G5AI5oz
-        cGrD8Ukc5//LnkkGlCSMq0DL0/kjnfn0LBsQL5d1lh1vgHlSI2+5azqelCBBI82IrC1z1smTU8pc
-        fjO+FVkOvdhZnW32Inn6HG3Gwt/lHFiEqRDm02b3zfz9QTRhGiTROMsrvQZ6kTBN5s9fBl5CXeEt
-        6DYo54w1y9wlCbUjEvSpTQM3v+dJV9T9l4DjRHiTBlSQEdZBH6apGWOaOHbY68U0aSo6QjlDgTpj
-        i6kTBm7cxKquGqY1zz1JzNjH8G84dN0mKxTpCOecUzq0VmgC3eZkErh24g0pZxcRXLiDtUOE4PoV
-        4UNW0uoH8nwXXz+7B82Pkh9ZILkAMiPIFQvLKhRdIOSJXABHH06FTqvdOX33esKTCSb7DZZDOX/9
-        ZpI0NSS2D4oZzixAkTgxwAlJ0rjpe7fT9Jw0YQC7SxLCqsBqgPWjKV+ekjMm4TUN5uqRUSbJ4xFt
-        xt5w5FOQh3NNkykbS2kMSGwHoT2iUS/m9nGOwGwIWAHobFPjkd82AkpdkMYIBJqCIWVC5s+voufM
-        aUQSQKcC24SSMbAyw2jIrHNW3BJ1YqsmRty+HjbRAZqaqiK9EQ/CO/50pggZnM3TGnGYRsCeWWwu
-        nv+EAUiKxiCnYuKEM7PdnPMv4BQ6Rc5MOUC6af6Uhs2GVLjP07K+1zp/edb6LLQ7R8enl+cTvtxA
-        5oi0BEwYIbMEmtrjOKFD4SfG8tMenZ4dOrVJAsZYTQbCORlv1RgrMtbVysZYw2otY6yJWO1gtH10
-        aqdBhk7bloeMLEWuLo+a4KRxcKovjxXgBD35UNVL8eml1xcuaAyO+S0oXGaKVsPU6TneJUxJC2hU
-        KO5x0GhI7u0oDQKofCZZHWS+RGwMwbQssy0Sv0Nsi6irY/sGQIMExCVrsO2CcQofj4RXnFNgUCjE
-        HFrKcY4rqqxKmcKqpZjHFPYTuz0U2M/2iDi0IvCBF1SCe0zvhbPQ4eLe496zw71OSsHMox3gnmyh
-        OnYeo7q4hzrY2j7u/WgCWQY+2TTlctQ7vTj+LIz8NBbiEXU84gv9FGxAXAZ+Z68+Pib4FYrbh2Kb
-        wRU0QwR+TWhDiLUGq345O/3U+kU4zbmF9wXuJYzq/GlInVJk4iDC74U3J3tI+sEhiUceBhjgo7Sf
-        QlNu0QYbSNON6iNjJjJq2WBTREYHyzsIxlh0qu9IJKqJq8OSifS6ItE3EclKWCofLHxF0v4gEbpj
-        pszCBaBGJHQGZEjX4NLF4+LSxR6XniIuWVVxSThJfdAo4QPx94HTHqW4SZYDV3iT+tuNEwzVVKsb
-        ZAPJtQyyISKZxQnKTjDqBxLIKoQyrFKEagH3QLjyQED/IMPRv4UTL6JCOTq1Hxed2nt0eoropFZG
-        J6ZZcRjVgyfNKEGn04T443lU8pLcfg7hT0BED3RhRszSM2vN0/PEUkiDV47LAa2Yugmcsee3CmY8
-        w3zEYx2azVjWARp/P0EU2vkQymmQ0CibzKwHbrwRysEtb8baSzTO2esxG26steEVDbhpKnLlKTAD
-        KXWmfMB6K2zKB+VTPn9taRRwkObTgUejyPMfhrOqWIY0C6CsKpapNWcDVTYbWE8UyzCmG9j8gLVS
-        JDuhUUQij/nDvnBMxkLrHmyiR8FyCnceiIwZJvE4KoDQIry9f/96E3gbUtcjoOJkxOw+gNggjJOm
-        Q5wBFfsRGQ08J/a97sGtR5IwOnCYP8dZGl4AYmaIAjQAMyb6yG8OkmR0KEnrMpAKZHEUUQatUjJI
-        h90Y/JJ7VdUlJi+pfcr7tNTLhCP2QDiiS8YinQpHZMIR2ZSO6DLhiF4g5rZUtiAGNw6+jPrQZiur
-        2gggmG360IYxvD6Ih983RiQZNB+/jrzYxrMR6UqBxuloFEZJbLMqT9ZbFknzHJl/s0CaaGmumHst
-        5VoZ36Qk2qvos1HRehZ98tAPp9ZJ5DFS5uDvdfup6vamMXDBJ6kVA/dpyPwrKN+HcDRJwVtS1QNd
-        1XVwY6ekhh8G/ewnRgeWrMuqBclTYkOa5VM5qmZpzzmo5k26JqbOlHZNNP1pnmEpgJY1c80i0Emg
-        WilUtuSyWPkDjdKSUNn3hkRk3trKQPkMUvdh8mOEybwJysPkrAVrLZmR2QqRY+rQYZdGWwsPTRnX
-        CA+xLNdaI4JlUUbbjpRPIg8iZW0HkbJumNXXzaosYK0XKWtfHSmDFUfaB1y+WuYP4ve4Q/XJi71E
-        SEI+PXkOcBpyn8oLQuE8jWk6LI2UO8r3EylzeU0diwEIhzsUt0w4YhKK8EbikAmH+xQgHHHIhcP8
-        Cm5KZdMyNGWHcfJWa7hrN22rld3HyI+on5tFyHvl/CbR8by5/uf5Uaf189RqP61o+NEU+Cti4b0W
-        P/E4eOZxfG0cDB7nAVIV9m91KCwaxgGSzZxhHwzvNBi25PJQOAtFKwXCdb/O73r9dMS+9U/5pyoN
-        qUgoxsrg24eByJfrrIyWefpD8fJzXil17bnxuqA5T18XMZ+QocdmfKvEx3GSBTbQRGC7sgZhERmN
-        oFW7ceinYKNicgtxRRMrTIsXqQ02JsjsWdcLoM9pMmOap2UsrFNCdAg9RDWmPDNizgRqOyARVEib
-        8UxpDV6zWcaKxZgWiDnTLGdFm3EVyssJ08zVAtesROiIDig/6U9fWIYgc5kKKr0kQPb520Jd50ic
-        IXt+L/ONZL4sQE5ZqMY8LWOZr8I8iX+lOH03nHEUSTkDtHdJs6kVWg2bD7dagae81VCFVsNqlVYr
-        cq1pNVS11eSSVluQHrtfrMQ8LWOZr8A8qQHuQAzZ+zS292Ztb9aetcz3Zm1v1vLib1ISJMzbDfkY
-        AzhtfMcse0JvYnDZ5ymLHPKDHMqDHOqDHNqDHPoyh7T8etk4OwTJEQ0cYJn8ylzdfncE3uscacbR
-        Iw4EP1mAsUiccQUpm65pmrJe4MqJM64RW0EbM9ktkgo8rLHj8bAb+lKRDCFlRm3+77/F52f0hrT4
-        mkk4srlS7E3mRiZzSX5SiUOw71D7DrXvUJt0qGIv2t7XVU7kJZ5jR/TWo3zci9UkV7mVSetm5fmK
-        bXM338hiTdWqr9rma05qfSOLzZ18ksVlIrMF/RXn5mt8lIVlXakxPS/X28ZJFWW8nY+y3l12Xl0c
-        vXrbuiidpT8nSTKgd8LLMI0C+lMsvIPXiYhzTaO/l8zL66cn25uW59SDbEw9vvMSZ1Btvig+lKTV
-        z0ox9HnqFqcFoEeFI+hHkqXA5SC120OurNKe4iKNmj3aU7vEMJDl9pCqqJRgxdl4on2bxa+f4nkk
-        GVSYulmal1mauVme3Kk1O/64amJQuJBqOrqm9QzLxYQirGLLsWRVRqaO3R7W9K6p9CqoyZBENymt
-        riS1C9+FktSuxI+nJBqFCyG1J2tdjZCu3lMV2XENqpuK1YWOpMquSbQeNrqbLYrYZtm70JHalXgK
-        OuLiu3v1TtHS7tD17g8cP0zdXhQGyUHAJnUrLFNYm8MqedH7hO/riqRfs+3s7BmFvYjv0aiChuSc
-        D+pI9eIeVoodvut2FgQ8K4vRs+AiBIAW4Fc1DEdBimuYXUfDyHAcZGiq2zNVnThm9VUoPb7GoaLd
-        qF2DXdiN2pV4Cnbje9AUcPH3mvI9IkwuL5tzSpYGV9dyuiqxzB4xuhpWu6qqq8gyCDKNXrdrdA2M
-        HYd8xWK37VdjB3D0lTV6Ehj1zfVJ1uBCuuZaju4S2dF1AysW3BsGUV1VVXRLd7BmuUoNfUoGUfWY
-        aNOK7FyjatfoSWjUd4BlyV24h7ItQtmGC2YLQ4G11stmv9NRTH3f9r04mRtebC0PL5YNOzL628si
-        XVqR94rluRo+0ErW5aID9j3VV67IfXCfeCxX2yg+43siO8WziapsIewrfCGonXfQWSakne4wNY0i
-        1x2OwvaEys8i+YtGYflq4PbR8Vnron3VOjtrly4LbhPXp9FPsXAFihRXXCAsW3L1XaW+rxW833qv
-        w+1uB8WnjxT2oWv1E6oq7+knKzU24tWVepuh66KCOsjMd53lx4Fs8WtXWeMiyXY5VLclEqTLilV1
-        m0MVGXKND15Vts2hrG0iklWndimtk9LJNGahhBO/ZN5MfqkebTJxtiE2F4v7RmehqBUxTn1KGLdL
-        GEujLgls4jJpQ9Xjh877umT8wtGU/4FTv0y9FM2WcvrniR+yJSP054rQxrb0WHv8l473h389w718
-        2Y7zSnYU45b3rrUsQ6mOc4ZSb5mEISq7OZtytnJk+xLBqMbhlEbNhSMGXziyjcMpdXwoy1b5lvOd
-        iMTZzljCcToceuVbzb9DG53/9WSGwtLApVEXIoCxpGO4bMVmfyRZRvcYa9tcJVKpqB0MaVUq90kM
-        XD2h9gcv9B7+29rMfqVyHrHx58p95MavfEbtFdY7F0ftP9afUFswQfszAWuP9LRbWDD//POxBnpm
-        +rjOLZ4yCdme4uUuMSCZIrE/5Z9/82+rhauQZdqPwG1yDwXwRIX2yKN96iegEatd5InWzZ1p/3/z
-        U2BoEH8AAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3712']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:08 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/CoreTests.test_search_events_contains_event.yaml
+++ b/tests/interface_objects/cassettes/CoreTests.test_search_events_contains_event.yaml
@@ -1,139 +1,167 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxyZXF1ZXN0
+      X2N1c3RvbV9maWVsZHMgLz48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJl
+      cXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0
+      X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVl
+      c3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9t
+      ZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48c19rZXlzPnRlc3Q8L3Nfa2V5cz48cHV6emxl
+      ZD55ZXM8L3B1enpsZWQ+PHJlcXVlc3RfY29zdF9yYW5nZSAvPjx1c2VyX2lkPmRlbW88L3VzZXJf
+      aWQ+PC9ldmVudF9zZWFyY2g+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['588']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1dS3PqSJbez69Q1KIf0Veg1Ft3aDqwwY97MXYDtsu1IQRKjMpCoiThe93LqsVM
+        xKzmB/SqdxMdEzHL6ZiYRf+UuRPzOyZTEkY8JCSQDMh5g4oyqYNSykzpnPOd75ys/OHr2KCeoe3o
+        lvn770CJ+Y6C5sDSdPPx99/dds9o+bs/VP+hAp+h6fYcqNqDUc+GztRwqxVn2tessaqbvakD7Z7u
+        9PqqVjWtSnn9kcrAfpm4Vq9vWIOn6qBH0yLdd368v/7RaD/akHbq/U9t5fpkMJRHn8WvP3Vaw3O3
+        1bk5uemLwGBeanp/ctZ9dE/6P/UfBqJ8OhWaJzfq6LZz01Z6p873dz98df7kdKZ1sctOeNbsT/rt
+        L5/+ePKp8emHr+f8y+nTaMSq+lAxOE0YvvRHV8IfhauWwUxOePqhUl64voqmO65qDqDTU23Ye1YN
+        3b+5de3+AFUrqEXtoeGD1cZ9pTz/5h/QoDOoNtBov3wZQRsGAl5rZaC7L76soRsGpIc2up7XNv+w
+        J9nEh4NjwU8N1XGC//niquva6sBFc+ogyXl7IOP9rLYq458OzZY3df5pXyA6vNhUCdbBE3wJ91RG
+        8z4/gFdHID779WvLwjnnchGndUdwDCeq/eSs78C/tQWphSNzQe/+uliQ+pU6nvwjda+60KZuln7l
+        D0N5fmHl2QhbjtuzVfMRnXSsfkWnH/d1E2pVXigxlfJCkyeALted2PoAVnlmJjFv80Wm6IZUG53y
+        9RzzpsoYD/pSL+EmT2Cll4U2X2Spl4Wmimn1HPTAGxCPWDFv8aeparr4kbEm3qqqVrwHtzdrr4JK
+        eallWYLdKMFtlOA3SggbJcRVifLq7Xlz2BtMbRu9z5HI7C//mYBT/HpZaJpLDNGTZ9lVwDAhmaBx
+        LmVOx31oVxVJDkkFjXOpiaGiNyUeu+WmkAxec87LuG8Z5XAzerv6rdX/+fmv4RPMD1TKy/dZjljM
+        ZAG8lwUQnvWBNTVdO7hBT6WGG14Pe2/8Mxtr9bmIrwY0pCL8s/WgqQXfvUNXlvmBAo5LfVLNqWq/
+        UCwD0FDMBXzZqTvoWcOhA90qExwNNc1lHDiwTM2pAgHwsgCAooSkZwd98Rf0bzzWtCrukQEMCCRf
+        25HKtWSRAT2vWTW1nquPoSdOMwB9uiz3UVDQ5wesiNfJBqdcvnP/OzKAbDc8Ft3R9AMluCPqSvXG
+        QcxgHHiR5RmRZ5hE4yAyAiMkHweRZgT06TLMR++TbByC+/atYW8J1WsP3cvvK+VQU3DYu3VA19GA
+        dPXBE3RnQv6Y+H8j01H83JkdeTUkewZ6g1khK2gm4bcHQmOo6SpaxKr3yKMnZ4RWflUDX77yXzhh
+        2h9r+tfSwLCm2tC2TLdk4mvwZCq6iUZyih4jpGYnBsSjaxvVketOPpbLsWcoO0ijQq0cuoQy/Or2
+        XOi4TLlxX2ZZ5isAQunHySMa07X9VEwVjayBxthBF48eOe97ZaK6o2q683s/qUTdi5Ptzay9FWc6
+        mVi26/Rwh75lu9i0KOGsEcEW5sKMHvL0SgzzlWOYzdM7Vu2fpjDl5C6cPe/JXeiMTC4akcZt+7p+
+        2Wk1HsqARyufTzDPDjI97JTTHNVP3jMe1S+Z/N85L44Lx715C74RQ4d2ghUQSKZYA5u6y3UhbOr8
+        va6GgW1NJtDueZLloYI+qjrk+wOG5yVpwDGcJsn9gQAYaTBgJIHXhjIvqgN58xJxbR039Sxz85ti
+        x8vIYenseEVvvJ78gUVmJQ1oTX2hXc/6LM9k/fEJAF1XdadO1dCf4exw0DQTmPaR+auWZ99d6wma
+        YZPVb5gdfZmgt4GOb7PnLti83pHKI7SwdY2u1FCRszpFxrLAlCRktr9+rxiW+ej/yWEYZ/61Up7/
+        fKQ6PeTnozkZOh4mu9CAAUcMDkEfr51/q5gQasj+niArHs8Ituz9cV13IJCe2ip+Lr1TLbb4ArhP
+        yx5j33EuE26c4Zoz3Lj3NK56INaa9oozsr54v/a9Dw9MX2yqONbUHsDAjZ+9wpBYqHkm4wPOX11o
+        m6pBdZEgdaKieTE1av4L3x9B0zQNfj3XkpVyqDkQ8cTrumPCF2zB//3fMX6qOzPRADwN8PAMYfHh
+        1FT7qjPS6R8nEdD42UyEwOP7gcdD2Io3SdFgyyd1opoEayFYSwqsBdRrDze1Tufmut2NRly+/fJP
+        3375r2+//Ou3n//z2y9/9v7+Z+o31yakMBZzg5YqVqG/jYBjaudyUeAYkDMcs3r+HM321c7eq5m+
+        MCK5wTGrZ897cgkcszwieWEwqyfPe24J2rIwIssIBMgTbdncXa6zv6nzvXjHSMvTAPt76CeWa9GW
+        CT1feRJYB1l6yyGLYldvmRNKIocNvnX+MuCUkiwLx+Yzz8/11k4zSO00g2inuXv9+WGT1/x/f/6P
+        //3bX7GB+vNfvv38t2+//Itnnf7bt5//e2amdq2nF4vy3WuqDR3fUs3ZtSaMs8N1qSPoWIDZyMcC
+        TAaErFk/MYysWT95sM4KcJuEePReiEeEefbOFwBhnhE09M3QUK5ee7i4vrlptCOxUM5jn114wctI
+        9lm3KHAnYZ8VGjUh7LOiTy5hn73XySfsM8I+I+yzQrHPujTnIeoj7+KzZZ91CfuMsM/eln2GVoJm
+        mfT0KQoj945vAMmRP/UMjUh8vLtweAto3D9/lqh4cMaR5UIjFgx/lYgDwi+WhZJRybxBj0ZPbk0d
+        PV7UZ+ScatY4OYrSncIPFIsWY236OEVrcyN4wIlMQvxAYgAniInxA5lhU+EHMs2wXcD6+MHvGPAR
+        9/T2YEry8RBZnkfCueIpW4zHKqjSvr6+ioRTau4ImiqcjiOwlEsuMpPPezwIjEJglMOYXgKjFHhy
+        c8VO3hQwISgJQUkISkJQkqKiJMhgpNWZUZklRBKyRFchEs8W7dmWNd6Mj4CSwCDrPYJxSDMl5Otw
+        Cps1UoKpOvbUNJGh7JvtgA0IPAutHvtmjdxy61rkZY6oxAIvIYAmNYcRsws8L+IefKKkk09o4c9a
+        jg6WqXUvGq1a4/YqEpUJuUcEjCFgDAFjCBiTIxhzatlTh7p40aDHpo2EZCLpLQSSIZDMAU0vgWQK
+        PLkEkino3BJIhkAyBJIpFCTTpQfYtKRHyLSkcXpXtsBMDHclJTCD7CclBpiRJA7T8wkwEwvMsBTX
+        PD9mXOb0un3bubiJRGUCPwkvrbC3lDNCM8H8KxvNczRIczMT+UC10LM5oh4s+8kZ6XbCVNO3STPN
+        IcW07KKpRMsoNrf0VSQ2sdSXohbuOAGekz0WFrwmMoLCwmeLQ8L+NNadQdwwzgTiBvHaReu4VCrt
+        lI4rspvSVAV5Y5YqvylLNeglJkk16CUuR5XfMhX3yG+RZGEupFw+9icZZWHKODqUdxbm3/9CsnDJ
+        /O+WhJtT5OIeah8oDmfjXqMBQjefWTYuDxjkIyXNxkXCqbJxAUNzJBs3q2zcs9rVZfMhMlpxpo51
+        Y+NGELckFZcELA4Y6SIBi/cyuSRgUdC5JQGLAwtYfPnypTQ0kHmA9DlWhKWBVcKWaoJlsP6nZXTL
+        yMJGN1yeHezho+jSxoZQ1sfqIzo0UW3VMNSv81pnNLKG+LJhPVqlibltXCKjvuOXRe63ns3C8DfC
+        TZ4xe0sPPSsxlw0bbqPDDilTZvkSywiyIrNyZOxBZmQG/ePeIoE2YbRgh0qUr7GBh2sgUeLt98cc
+        LjhrXrbOr5u1yHjBWeipyitMQKpH7mFDhqmTBP7ouPj1SVlDqjaGtj5QSVUygoOkwEGEzVXJzpDy
+        CrZisJ+C6mTxyIjy/X1RkBGyJ0OhHSyyJ0PRJ5fsyVDQuSV7Mux5Twak5ekhsg2CjRiQW+7XjsrB
+        Hw4ZFKn84UOt/LTJcz2tKayM/fE3dVwz3V/BLwnVrLXqCcpCBTsnULpJnaqGjkbE1FWSlkjSEkla
+        IklLzDUt8UI3XMukPkMTk5DcuVu6kpgYGewniYkkzn9A00vi/AWeXBLnL+jckjj/gcX5SWIiSUzc
+        LTHxlh55xiX99GpcZpuaGMMRSFszCg1dND2ABRwrSiQ1cVPNKEDxt81jJht8vrhsdq9bkYBN4Cz5
+        uMiCz/TmvIMktIMgCN/RH0euA6GOqUIZEBHy4SGUnfBlRoMyi2Kbsg0PkHaQGqKhWZAGpJFYIWeQ
+        RviIPgxDM+KeQJo0IyKyvMCxOZMQJB+mSTEiqzDN5dVNo31Za0ZCNZdj9C7U0evsAhr6wJpgag1e
+        4xGITf1GiUJs3NCvDhuwIfSDQlr6hH7wXiaX0A8KOreEfrBn+gHS77QemAT06NUkoLFyz9LPDtkR
+        u3LxOaGkiCDCzwaALQFOFApGwkeGIJsVkcFfIW/NZPh8fhrtEp/bmL5wqpovyCOu6TZevEWo1kOo
+        /VlT+yPKtABlU5kWIG4s08JtKtMS9BJTpiXoJa5MC7dlJZojv0VSieSdVCIhlWje9/yTSjSkEs3b
+        Z2B1LlvnzUY06mlq+rOuTbHBGl+N5q4oOVeEpVZo7ISw1Io+uYSlVtC5JSy1A2OpkWo0pBqNX43m
+        jtZfLcVcKtLcZYWCH1pFmrdM7CMlabLGwg008c/wUXVoj7m0No9Pdag7LPKeoO+B2kfjFVu0fi4S
+        B3qf+lIB7F3XTRPaVActumJwywQ2ObeMZdjkTKqtuGUs+5HzmVTS3rhlyUdEZAWGS54SuRW8wjIz
+        blniEVnFWJq1s8bVVTTI0lSpMzgewyhspRlNJRshzWLD4wBWCJus0P4ZYZMVfXIJm6ygc0vYZHtm
+        kyEVTxsqPcRWQKZ+czM79phYAgzHR9LHhBKQ2N13kJu5GTvnaSlZp2ll4YC37mQFMMpRE9Kuzq/O
+        27VWvXkX6YIjEcqnpoWc37w98SzK6aDpj3G+0cHADz2dGnid7OKDo5Nl6nzj82l4pcT53DOBOI/7
+        RDWMucO99IP0DDNh40ZgvLSRfiVsol+xYCP9avNGYNsyzI78FgnD6J0wjAjD7H3Pfz4Ms4GtIxOy
+        Z8NnHXqWyADrdH+E1h6KQ1AxWIgpaR04QUZ6QErLrIYaKwl8csBQSVMZXKQZBVcGB4oPoR5JDTWJ
+        y7uGWvrxWAVQW7fd03bt9HNMmfAr1XVH8At1gqxWE/7aoVrodmxszdpUt9HpRmGrl2cHg63uUpyk
+        rHDoM2D4/pDRWB4OOY0RoDyEQ76vShKjaEOG53ioAm6QJfa6dff51WlJfy0JXP6VePiB4T87DZgE
+        0Yfh5YEoCENJ0YAKGcADZaCwPMvIItCGQBD7MjdMsHaSArtbd57jykl9LQVYObtXRGIV9JF4KMiS
+        IqnooVOAJLB9idNUTmFUKA7loSpCXhbZBHAieuliuAZZQmbKWlGpryP3WlGpr6gIUPROT6AA0Ydh
+        +CEr9AVV7YtDnmMHmgRFmVP66OXNs5qsCkMg9TMLQ2zdd45votTX8k7fRIQcerDk0H2+RnKpXjj0
+        gi8JXyYHVLgwl5KFh/4yOcDl45V9IsvnKJbP7rYfA9GHFQSNHypiX2PYvqpK/aHGsui/gdpXmIE8
+        FAdQ4/g8C6imvozcjeLUV1QEbbb7sA1Qg8pqvCArqqzwMiMAHnkUyDIcwIGsKjIrCiwrM4zCJV9P
+        7hcr5XpKfRm5r6fUV7QfhsflGT32MUq672GUtEObrxgljc24TJkfc2AzFfPD/3s6caBh9AzdcRfA
+        0sYqWIr+urpgwu3lNeeIqPzLKiIAnBSZiAEYkQGCyB4OrST78r9Z8Eoap6BN8d3WWxNLds/smDro
+        QV4XO1p3IExD6dTqzUa7c99oNjuRRJSOqhnQ/rVD3aOl+P44KEH6USYUlPC5DpOBsro51iyCE7U7
+        1uLxLVg8QQ+Z7o8VnPJJ12LLRgXH48bxzNsgfif2DidsorZwYCO1hd9IbeE2UVtYJjf2zpHfImFv
+        vBP2BmHvvO/5f+v6UPlzcVLURtqKizNL3jsSLo4g55zMCIQMuDid+1qrWfscnc24wsTpfFFNqqk+
+        QQq7DJFEnDW+5REmOXp1W8K+SXk2YLnXlErQa94FaxJcwntF8xKMk2PkW5cqUa/7WSJLF0EWSeRI
+        5VrdKkGX+1kfJGGTkB0KTHbI6anhRfRO5UU6RYQxUZQ6fdf7eWssXQRZKRtHCmQbi07f834XCiAL
+        JeFIpQkyj+xsLNWlvve7VPYTTD6mpYL9fuz2z0YsAfs7DS9h+yvYz8KJuJg9sREaq2wEB10gbaAr
+        zIGM0MiBjLAmc8urRH777kkKB1n74ng5CofOOsiuBqVrq8/QiA6YLxzeJl7unSDTcLl/Rm/H8dh4
+        +atEXMT8YlnoWCtLpgjEMIATkgcettuzmD2qQAzOEc83EJN+PFYDMe3r66voIMxrBZ7aAJkWlqaG
+        N+BYir1ccu2o2Iv31BxH5IWUlyy0o0HKSxZ9ckl5yYLOLSkvuefykkjB0+PHMf2ILQJaDVkEWXr5
+        ITNi1cv3DImebWEGUtjF31+lyaW9GQ4oIyC0JcShlJpMutVDcStN9vXH6aT3rBpTWJXQ4gx/D2+O
+        rNq6Qw/tqI2R8WGyEcTbbwSxMspDy9Iih/cMHfxA1W3dfKLw4mrpjyPX0Ic7ZFvg/jLMtvBOp3mj
+        EJtuMZOIG9qddtXwlno09nFm+/kbSZGOztT8QHG2Rn2aGgn8ein5bhGSIArJ98+Q8O4/Kfx6iWY4
+        XOws8OvZPeEcKcaDRUOSN+E0/Xis4hz1y1ar0e5cXN9Hox3W1NBNqm1NHyH1m9By/m0E4lE/+aEQ
+        bFOCeRTcdSKYR7Enl2AeBZ1bgnnsGfNAKp4ee3YBbWO7gPZNYRp7sVmiHiFTYtctNni5JMsRuAdb
+        4jhWOhyKwWHWQZAEBsjHvbvG9W3zstW+vj1vRIIeJ+h82pQKW715kQxiwIkk2ETgrXew++xAqOMN
+        ajNAK/IBK8pO+DKjfepFsTjHuosmuQhsApoFafgEMps8sXM7PoE825VR3Ns+lclHBKd2csmRh608
+        bW97ynQjsqbM+nW7exHpZLeQ3h1Rp6r5YpnUBTT0gTVxcXV1L2NgvZt9cxLpZod+RXxs4mMTH5v4
+        2MTHJj428bGPyce+OaFNbBbQA88soEevZgGNFXymfvbclth5K0uhpIggkl/AlgAnClnzC/bsGSNr
+        kOWO2jP+fH7ainSJfQ5AYJzWdBsv4NyJ95nG+ovnTofvLdqbXpCKc6YXKA/7DVJ7DjQujRT4inKs
+        r5jMTRRYgQUK0u6J3EQZuYkpKiLJnpsIuiz3UcAx2R+y8ZnvofaB4pP6zIndZewsp3CX+bTuMt9l
+        gspQycZhTUz6rh7pJ3esKfqi21RIaMkvPr+rRfnF4ceBeMfEOz6E6SXecYEnl3jHBZ1b4h3v2TtG
+        Wp52AmOA1p61LL3hkAWx6g2PdWfQ09F4HELE+W3d4FeZ/OPD+6HEH1Z4ONvK9yT7fLvs85zq/5Kc
+        c5JznibnvONSDXusm792IvPM7wqQZ87k7PGunj/vekXE410ekXzr8L5pvV3i8S6PSK4VdN+0Vi7x
+        eElVXFIVd2GEFvcGzGUj1/SbcB7Qbq7bXtGe6hbc0Y5LQ2xV0k62tQruovGTFLUKBFDiFQVIcnR1
+        QI7nBYVUK4inJ3TuwQXF/PH+jbGZbGsDdhvtq8tWI7ow4CfLMF6osJ+UCJY5aTQjcJkTaAxVvKdK
+        Qs5+AQoKDGeb2kViLcPlbe923Rsvf6ylo7ofKA4zCupwkHCvpYTYgsyxgE/Mxwcsl2qjJcDS3Hyj
+        pb3QCtLALJwsJ09N2IpZsMWeU6swC+Dw3mMRMIv3Omrg7xRNdZFiwnjxWryFO43mGcSlufvKF//a
+        qwRMe6001oE0yFIJh69vV04f8FTD2jiGfyTbvLk9s/lOuoBiTxpvxedDi8OGjmNh09fTmzFq8zKQ
+        jdaTtYfzcjc6euGrNC+txKGarvZGSvKoN4tFZjnUYpXiq0RsjZ1lob0qRU8NcAzSAy3rOWOlyAhc
+        csAdAI5JpRQBzTG5KMX3MhrrVKKipFGJDPUbLar6C9I70XlpSfTiyapeZOhM4/vhSySqkahGohq3
+        VY2arY7V2BJpgUBshbQlmSI7i2ziwPx2ziJQ/F1oj8BZFNPUR9vCWZwNxW7OIs9IKTUjjNGMpztp
+        xtN1mhFmrBlPiWYkmpFoxl0145OuxXLWguPHg6J6qgAz1hKlZSVWBTgzS5TkhKoAZ2aloKv5mVls
+        F/CpVQFRjZtVI8elUY1ctFo830ktnq+qRS5jpXhOlCJRigehFNGMxcQZ0cEgjfl0auCp3SXciE6W
+        aZwRn89CUxfrMM4E4hTj9ZLM/vViftChktxh3A46BMcSXVTYnPOWZ0Oxo1YETBqtyMc7jPWdNGN9
+        VTPymTuMdaIbiW4kunF33fioGga0YwONc5E4/XjuSelwdr9XUwdOxweT++RDrFhjhiFWKYsyH3gn
+        CpC0GiSSTKMxJQ9iRRqTzVRj5gw4M0ld6+0B591CjzwAafSlEK8vGzvpy8aqvhQy15fb7dZN9CXR
+        l0RfLpxP8+tKxQQfA4E4XXmCdeXrxldLP9irmryyzA8UKy6pyWwUAyvJTIpIJCumVAyseESRSEnJ
+        mbYKpGzgVjaFolSideTZTjrybEVHKhkryDOiIImCzERBZrkjQwGyO9DzPcbL8Ck2MrkgFbsBAxYM
+        NOe9iqvV3yz9KqH+zHtLBk+TYg/rk2pOVTu7qpJIkwoAYO5kotglSFlVEsyrSgpKRno0XZWN5CU2
+        GDGNEt1mE4YdOa5svfZwcX1z02hHa9EvFqWhYcHLeOQldEYoUeX7B1JikpSYDM/oIU8vKTFZ4Mkl
+        JSYLOrekxOSeS0wiLU+7XywamQT05NUkyNLZDdkRqXzdLOtDhioM5O6intYUVmay2ilhLzUi65ed
+        VuOhWWvVI73Vuu6Y8AWbSlQbOmitUbpJnaqGjkbE1NXjKBdJ9k7Ib+8Ex/W9FL/SCHqp9XUTPZ6C
+        t/AXmjwB/PROkMcLQxLzNl8ELVb0fkWnnEu8Nnl1SpZ7CTd5Aiu9LLT5Iku9LDRVkHlhunhJWZ4O
+        RXf6jNa81pu1V9FTtdRSKa/+yPff0OvehuYAicz+CgLg/QkayIWmucQQzYJlVwF2RJcb51LmFGPp
+        VRmD2suNc6mJoQ6gU2VDMkFTSAbPpPMy7ltGOdyM3qB+a/Xvfwn/ft5eKS/fZjm8LN4svODFna/R
+        AGUZXZAkRZC5hHttiIBJGXZmvKIYZK+NTPbauGpcnTTanYvLm04kLHLnvdxr1JUXhHJG+iSqBqn4
+        OTK2cGy4CClEWmj3ihQiLfrkkkKkBZ1bUoiUFCIlhUgLVIgUWY30M63S47l9mSXIFjJKdyWUeAVJ
+        RQWwAhddklRikd0v8cXa26VzL1Fsu/nWe5xmWkK0e9G4q7XqtUjg7k7HUIGuUhi6qxloMboBd349
+        ZjdbhP4N29CZGm71/wHkx+a/x7cBAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:09 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['7090']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:08 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><s_keys>test</s_keys><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><request_custom_fields
-      /><request_cost_range /></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['759']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1d63bbNhL+v0/BzY/ttl2aAO/0qupxYjl1YudiyXHTPzwQCUmMKVLmxbb2dfZN
-        9sl2AFISdaFMKpJjJ8phXXEwBMDBYL4ZAAQav98PfeGWRrEXBr+9wAfohUADJ3S9oP/bi8vOiWi+
-        +L35twa9pUFix5REzsCOaJz6SbMRp103HBIvsNOYRrYX213iNsc0bkirkxpONB4lod31Q+e6eWmL
-        4u31qGddv7JGl9r7rtiPwp6Lk9d3zrsPn78o1Im/KMefsf7l4/V79PkqOL4ddt4O4iNlZN9f3hgX
-        ZyfjY0cTL1zc09/e9NLPpzf9o5P4/UVwN74hqIP192pkHw+Vs9PWx/FN1PpyY1p+JH84DSzl+Pqu
-        739uSHN1arhenJDAobFNImrfEt9zm0HYkFbRM6k0G0AhNsiMNltXDWl2lyW4NHaaLRDx+G5AI5oz
-        cGrD8Ukc5//LnkkGlCSMq0DL0/kjnfn0LBsQL5d1lh1vgHlSI2+5azqelCBBI82IrC1z1smTU8pc
-        fjO+FVkOvdhZnW32Inn6HG3Gwt/lHFiEqRDm02b3zfz9QTRhGiTROMsrvQZ6kTBN5s9fBl5CXeEt
-        6DYo54w1y9wlCbUjEvSpTQM3v+dJV9T9l4DjRHiTBlSQEdZBH6apGWOaOHbY68U0aSo6QjlDgTpj
-        i6kTBm7cxKquGqY1zz1JzNjH8G84dN0mKxTpCOecUzq0VmgC3eZkErh24g0pZxcRXLiDtUOE4PoV
-        4UNW0uoH8nwXXz+7B82Pkh9ZILkAMiPIFQvLKhRdIOSJXABHH06FTqvdOX33esKTCSb7DZZDOX/9
-        ZpI0NSS2D4oZzixAkTgxwAlJ0rjpe7fT9Jw0YQC7SxLCqsBqgPWjKV+ekjMm4TUN5uqRUSbJ4xFt
-        xt5w5FOQh3NNkykbS2kMSGwHoT2iUS/m9nGOwGwIWAHobFPjkd82AkpdkMYIBJqCIWVC5s+voufM
-        aUQSQKcC24SSMbAyw2jIrHNW3BJ1YqsmRty+HjbRAZqaqiK9EQ/CO/50pggZnM3TGnGYRsCeWWwu
-        nv+EAUiKxiCnYuKEM7PdnPMv4BQ6Rc5MOUC6af6Uhs2GVLjP07K+1zp/edb6LLQ7R8enl+cTvtxA
-        5oi0BEwYIbMEmtrjOKFD4SfG8tMenZ4dOrVJAsZYTQbCORlv1RgrMtbVysZYw2otY6yJWO1gtH10
-        aqdBhk7bloeMLEWuLo+a4KRxcKovjxXgBD35UNVL8eml1xcuaAyO+S0oXGaKVsPU6TneJUxJC2hU
-        KO5x0GhI7u0oDQKofCZZHWS+RGwMwbQssy0Sv0Nsi6irY/sGQIMExCVrsO2CcQofj4RXnFNgUCjE
-        HFrKcY4rqqxKmcKqpZjHFPYTuz0U2M/2iDi0IvCBF1SCe0zvhbPQ4eLe496zw71OSsHMox3gnmyh
-        OnYeo7q4hzrY2j7u/WgCWQY+2TTlctQ7vTj+LIz8NBbiEXU84gv9FGxAXAZ+Z68+Pib4FYrbh2Kb
-        wRU0QwR+TWhDiLUGq345O/3U+kU4zbmF9wXuJYzq/GlInVJk4iDC74U3J3tI+sEhiUceBhjgo7Sf
-        QlNu0QYbSNON6iNjJjJq2WBTREYHyzsIxlh0qu9IJKqJq8OSifS6ItE3EclKWCofLHxF0v4gEbpj
-        pszCBaBGJHQGZEjX4NLF4+LSxR6XniIuWVVxSThJfdAo4QPx94HTHqW4SZYDV3iT+tuNEwzVVKsb
-        ZAPJtQyyISKZxQnKTjDqBxLIKoQyrFKEagH3QLjyQED/IMPRv4UTL6JCOTq1Hxed2nt0eoropFZG
-        J6ZZcRjVgyfNKEGn04T443lU8pLcfg7hT0BED3RhRszSM2vN0/PEUkiDV47LAa2Yugmcsee3CmY8
-        w3zEYx2azVjWARp/P0EU2vkQymmQ0CibzKwHbrwRysEtb8baSzTO2esxG26steEVDbhpKnLlKTAD
-        KXWmfMB6K2zKB+VTPn9taRRwkObTgUejyPMfhrOqWIY0C6CsKpapNWcDVTYbWE8UyzCmG9j8gLVS
-        JDuhUUQij/nDvnBMxkLrHmyiR8FyCnceiIwZJvE4KoDQIry9f/96E3gbUtcjoOJkxOw+gNggjJOm
-        Q5wBFfsRGQ08J/a97sGtR5IwOnCYP8dZGl4AYmaIAjQAMyb6yG8OkmR0KEnrMpAKZHEUUQatUjJI
-        h90Y/JJ7VdUlJi+pfcr7tNTLhCP2QDiiS8YinQpHZMIR2ZSO6DLhiF4g5rZUtiAGNw6+jPrQZiur
-        2gggmG360IYxvD6Ih983RiQZNB+/jrzYxrMR6UqBxuloFEZJbLMqT9ZbFknzHJl/s0CaaGmumHst
-        5VoZ36Qk2qvos1HRehZ98tAPp9ZJ5DFS5uDvdfup6vamMXDBJ6kVA/dpyPwrKN+HcDRJwVtS1QNd
-        1XVwY6ekhh8G/ewnRgeWrMuqBclTYkOa5VM5qmZpzzmo5k26JqbOlHZNNP1pnmEpgJY1c80i0Emg
-        WilUtuSyWPkDjdKSUNn3hkRk3trKQPkMUvdh8mOEybwJysPkrAVrLZmR2QqRY+rQYZdGWwsPTRnX
-        CA+xLNdaI4JlUUbbjpRPIg8iZW0HkbJumNXXzaosYK0XKWtfHSmDFUfaB1y+WuYP4ve4Q/XJi71E
-        SEI+PXkOcBpyn8oLQuE8jWk6LI2UO8r3EylzeU0diwEIhzsUt0w4YhKK8EbikAmH+xQgHHHIhcP8
-        Cm5KZdMyNGWHcfJWa7hrN22rld3HyI+on5tFyHvl/CbR8by5/uf5Uaf189RqP61o+NEU+Cti4b0W
-        P/E4eOZxfG0cDB7nAVIV9m91KCwaxgGSzZxhHwzvNBi25PJQOAtFKwXCdb/O73r9dMS+9U/5pyoN
-        qUgoxsrg24eByJfrrIyWefpD8fJzXil17bnxuqA5T18XMZ+QocdmfKvEx3GSBTbQRGC7sgZhERmN
-        oFW7ceinYKNicgtxRRMrTIsXqQ02JsjsWdcLoM9pMmOap2UsrFNCdAg9RDWmPDNizgRqOyARVEib
-        8UxpDV6zWcaKxZgWiDnTLGdFm3EVyssJ08zVAtesROiIDig/6U9fWIYgc5kKKr0kQPb520Jd50ic
-        IXt+L/ONZL4sQE5ZqMY8LWOZr8I8iX+lOH03nHEUSTkDtHdJs6kVWg2bD7dagae81VCFVsNqlVYr
-        cq1pNVS11eSSVluQHrtfrMQ8LWOZr8A8qQHuQAzZ+zS292Ztb9aetcz3Zm1v1vLib1ISJMzbDfkY
-        AzhtfMcse0JvYnDZ5ymLHPKDHMqDHOqDHNqDHPoyh7T8etk4OwTJEQ0cYJn8ylzdfncE3uscacbR
-        Iw4EP1mAsUiccQUpm65pmrJe4MqJM64RW0EbM9ktkgo8rLHj8bAb+lKRDCFlRm3+77/F52f0hrT4
-        mkk4srlS7E3mRiZzSX5SiUOw71D7DrXvUJt0qGIv2t7XVU7kJZ5jR/TWo3zci9UkV7mVSetm5fmK
-        bXM338hiTdWqr9rma05qfSOLzZ18ksVlIrMF/RXn5mt8lIVlXakxPS/X28ZJFWW8nY+y3l12Xl0c
-        vXrbuiidpT8nSTKgd8LLMI0C+lMsvIPXiYhzTaO/l8zL66cn25uW59SDbEw9vvMSZ1Btvig+lKTV
-        z0ox9HnqFqcFoEeFI+hHkqXA5SC120OurNKe4iKNmj3aU7vEMJDl9pCqqJRgxdl4on2bxa+f4nkk
-        GVSYulmal1mauVme3Kk1O/64amJQuJBqOrqm9QzLxYQirGLLsWRVRqaO3R7W9K6p9CqoyZBENymt
-        riS1C9+FktSuxI+nJBqFCyG1J2tdjZCu3lMV2XENqpuK1YWOpMquSbQeNrqbLYrYZtm70JHalXgK
-        OuLiu3v1TtHS7tD17g8cP0zdXhQGyUHAJnUrLFNYm8MqedH7hO/riqRfs+3s7BmFvYjv0aiChuSc
-        D+pI9eIeVoodvut2FgQ8K4vRs+AiBIAW4Fc1DEdBimuYXUfDyHAcZGiq2zNVnThm9VUoPb7GoaLd
-        qF2DXdiN2pV4Cnbje9AUcPH3mvI9IkwuL5tzSpYGV9dyuiqxzB4xuhpWu6qqq8gyCDKNXrdrdA2M
-        HYd8xWK37VdjB3D0lTV6Ehj1zfVJ1uBCuuZaju4S2dF1AysW3BsGUV1VVXRLd7BmuUoNfUoGUfWY
-        aNOK7FyjatfoSWjUd4BlyV24h7ItQtmGC2YLQ4G11stmv9NRTH3f9r04mRtebC0PL5YNOzL628si
-        XVqR94rluRo+0ErW5aID9j3VV67IfXCfeCxX2yg+43siO8WziapsIewrfCGonXfQWSakne4wNY0i
-        1x2OwvaEys8i+YtGYflq4PbR8Vnron3VOjtrly4LbhPXp9FPsXAFihRXXCAsW3L1XaW+rxW833qv
-        w+1uB8WnjxT2oWv1E6oq7+knKzU24tWVepuh66KCOsjMd53lx4Fs8WtXWeMiyXY5VLclEqTLilV1
-        m0MVGXKND15Vts2hrG0iklWndimtk9LJNGahhBO/ZN5MfqkebTJxtiE2F4v7RmehqBUxTn1KGLdL
-        GEujLgls4jJpQ9Xjh877umT8wtGU/4FTv0y9FM2WcvrniR+yJSP054rQxrb0WHv8l473h389w718
-        2Y7zSnYU45b3rrUsQ6mOc4ZSb5mEISq7OZtytnJk+xLBqMbhlEbNhSMGXziyjcMpdXwoy1b5lvOd
-        iMTZzljCcToceuVbzb9DG53/9WSGwtLApVEXIoCxpGO4bMVmfyRZRvcYa9tcJVKpqB0MaVUq90kM
-        XD2h9gcv9B7+29rMfqVyHrHx58p95MavfEbtFdY7F0ftP9afUFswQfszAWuP9LRbWDD//POxBnpm
-        +rjOLZ4yCdme4uUuMSCZIrE/5Z9/82+rhauQZdqPwG1yDwXwRIX2yKN96iegEatd5InWzZ1p/3/z
-        U2BoEH8AAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3712']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:09 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/CoreTests.test_search_events_countries.yaml
+++ b/tests/interface_objects/cassettes/CoreTests.test_search_events_countries.yaml
@@ -1,139 +1,167 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxyZXF1ZXN0
+      X2N1c3RvbV9maWVsZHMgLz48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJl
+      cXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0
+      X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVl
+      c3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9t
+      ZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48c19rZXlzPnRlc3Q8L3Nfa2V5cz48cHV6emxl
+      ZD55ZXM8L3B1enpsZWQ+PHJlcXVlc3RfY29zdF9yYW5nZSAvPjx1c2VyX2lkPmRlbW88L3VzZXJf
+      aWQ+PC9ldmVudF9zZWFyY2g+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['588']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1dS3PqSJbez69Q1KIf0Veg1Ft3aDqwwY97MXYDtsu1IQRKjMpCoiThe93LqsVM
+        xKzmB/SqdxMdEzHL6ZiYRf+UuRPzOyZTEkY8JCSQDMh5g4oyqYNSykzpnPOd75ys/OHr2KCeoe3o
+        lvn770CJ+Y6C5sDSdPPx99/dds9o+bs/VP+hAp+h6fYcqNqDUc+GztRwqxVn2tessaqbvakD7Z7u
+        9PqqVjWtSnn9kcrAfpm4Vq9vWIOn6qBH0yLdd368v/7RaD/akHbq/U9t5fpkMJRHn8WvP3Vaw3O3
+        1bk5uemLwGBeanp/ctZ9dE/6P/UfBqJ8OhWaJzfq6LZz01Z6p873dz98df7kdKZ1sctOeNbsT/rt
+        L5/+ePKp8emHr+f8y+nTaMSq+lAxOE0YvvRHV8IfhauWwUxOePqhUl64voqmO65qDqDTU23Ye1YN
+        3b+5de3+AFUrqEXtoeGD1cZ9pTz/5h/QoDOoNtBov3wZQRsGAl5rZaC7L76soRsGpIc2up7XNv+w
+        J9nEh4NjwU8N1XGC//niquva6sBFc+ogyXl7IOP9rLYq458OzZY3df5pXyA6vNhUCdbBE3wJ91RG
+        8z4/gFdHID779WvLwjnnchGndUdwDCeq/eSs78C/tQWphSNzQe/+uliQ+pU6nvwjda+60KZuln7l
+        D0N5fmHl2QhbjtuzVfMRnXSsfkWnH/d1E2pVXigxlfJCkyeALted2PoAVnlmJjFv80Wm6IZUG53y
+        9RzzpsoYD/pSL+EmT2Cll4U2X2Spl4Wmimn1HPTAGxCPWDFv8aeparr4kbEm3qqqVrwHtzdrr4JK
+        eallWYLdKMFtlOA3SggbJcRVifLq7Xlz2BtMbRu9z5HI7C//mYBT/HpZaJpLDNGTZ9lVwDAhmaBx
+        LmVOx31oVxVJDkkFjXOpiaGiNyUeu+WmkAxec87LuG8Z5XAzerv6rdX/+fmv4RPMD1TKy/dZjljM
+        ZAG8lwUQnvWBNTVdO7hBT6WGG14Pe2/8Mxtr9bmIrwY0pCL8s/WgqQXfvUNXlvmBAo5LfVLNqWq/
+        UCwD0FDMBXzZqTvoWcOhA90qExwNNc1lHDiwTM2pAgHwsgCAooSkZwd98Rf0bzzWtCrukQEMCCRf
+        25HKtWSRAT2vWTW1nquPoSdOMwB9uiz3UVDQ5wesiNfJBqdcvnP/OzKAbDc8Ft3R9AMluCPqSvXG
+        QcxgHHiR5RmRZ5hE4yAyAiMkHweRZgT06TLMR++TbByC+/atYW8J1WsP3cvvK+VQU3DYu3VA19GA
+        dPXBE3RnQv6Y+H8j01H83JkdeTUkewZ6g1khK2gm4bcHQmOo6SpaxKr3yKMnZ4RWflUDX77yXzhh
+        2h9r+tfSwLCm2tC2TLdk4mvwZCq6iUZyih4jpGYnBsSjaxvVketOPpbLsWcoO0ijQq0cuoQy/Or2
+        XOi4TLlxX2ZZ5isAQunHySMa07X9VEwVjayBxthBF48eOe97ZaK6o2q683s/qUTdi5Ptzay9FWc6
+        mVi26/Rwh75lu9i0KOGsEcEW5sKMHvL0SgzzlWOYzdM7Vu2fpjDl5C6cPe/JXeiMTC4akcZt+7p+
+        2Wk1HsqARyufTzDPDjI97JTTHNVP3jMe1S+Z/N85L44Lx715C74RQ4d2ghUQSKZYA5u6y3UhbOr8
+        va6GgW1NJtDueZLloYI+qjrk+wOG5yVpwDGcJsn9gQAYaTBgJIHXhjIvqgN58xJxbR039Sxz85ti
+        x8vIYenseEVvvJ78gUVmJQ1oTX2hXc/6LM9k/fEJAF1XdadO1dCf4exw0DQTmPaR+auWZ99d6wma
+        YZPVb5gdfZmgt4GOb7PnLti83pHKI7SwdY2u1FCRszpFxrLAlCRktr9+rxiW+ej/yWEYZ/61Up7/
+        fKQ6PeTnozkZOh4mu9CAAUcMDkEfr51/q5gQasj+niArHs8Ituz9cV13IJCe2ip+Lr1TLbb4ArhP
+        yx5j33EuE26c4Zoz3Lj3NK56INaa9oozsr54v/a9Dw9MX2yqONbUHsDAjZ+9wpBYqHkm4wPOX11o
+        m6pBdZEgdaKieTE1av4L3x9B0zQNfj3XkpVyqDkQ8cTrumPCF2zB//3fMX6qOzPRADwN8PAMYfHh
+        1FT7qjPS6R8nEdD42UyEwOP7gcdD2Io3SdFgyyd1opoEayFYSwqsBdRrDze1Tufmut2NRly+/fJP
+        3375r2+//Ou3n//z2y9/9v7+Z+o31yakMBZzg5YqVqG/jYBjaudyUeAYkDMcs3r+HM321c7eq5m+
+        MCK5wTGrZ897cgkcszwieWEwqyfPe24J2rIwIssIBMgTbdncXa6zv6nzvXjHSMvTAPt76CeWa9GW
+        CT1feRJYB1l6yyGLYldvmRNKIocNvnX+MuCUkiwLx+Yzz8/11k4zSO00g2inuXv9+WGT1/x/f/6P
+        //3bX7GB+vNfvv38t2+//Itnnf7bt5//e2amdq2nF4vy3WuqDR3fUs3ZtSaMs8N1qSPoWIDZyMcC
+        TAaErFk/MYysWT95sM4KcJuEePReiEeEefbOFwBhnhE09M3QUK5ee7i4vrlptCOxUM5jn114wctI
+        9lm3KHAnYZ8VGjUh7LOiTy5hn73XySfsM8I+I+yzQrHPujTnIeoj7+KzZZ91CfuMsM/eln2GVoJm
+        mfT0KQoj945vAMmRP/UMjUh8vLtweAto3D9/lqh4cMaR5UIjFgx/lYgDwi+WhZJRybxBj0ZPbk0d
+        PV7UZ+ScatY4OYrSncIPFIsWY236OEVrcyN4wIlMQvxAYgAniInxA5lhU+EHMs2wXcD6+MHvGPAR
+        9/T2YEry8RBZnkfCueIpW4zHKqjSvr6+ioRTau4ImiqcjiOwlEsuMpPPezwIjEJglMOYXgKjFHhy
+        c8VO3hQwISgJQUkISkJQkqKiJMhgpNWZUZklRBKyRFchEs8W7dmWNd6Mj4CSwCDrPYJxSDMl5Otw
+        Cps1UoKpOvbUNJGh7JvtgA0IPAutHvtmjdxy61rkZY6oxAIvIYAmNYcRsws8L+IefKKkk09o4c9a
+        jg6WqXUvGq1a4/YqEpUJuUcEjCFgDAFjCBiTIxhzatlTh7p40aDHpo2EZCLpLQSSIZDMAU0vgWQK
+        PLkEkino3BJIhkAyBJIpFCTTpQfYtKRHyLSkcXpXtsBMDHclJTCD7CclBpiRJA7T8wkwEwvMsBTX
+        PD9mXOb0un3bubiJRGUCPwkvrbC3lDNCM8H8KxvNczRIczMT+UC10LM5oh4s+8kZ6XbCVNO3STPN
+        IcW07KKpRMsoNrf0VSQ2sdSXohbuOAGekz0WFrwmMoLCwmeLQ8L+NNadQdwwzgTiBvHaReu4VCrt
+        lI4rspvSVAV5Y5YqvylLNeglJkk16CUuR5XfMhX3yG+RZGEupFw+9icZZWHKODqUdxbm3/9CsnDJ
+        /O+WhJtT5OIeah8oDmfjXqMBQjefWTYuDxjkIyXNxkXCqbJxAUNzJBs3q2zcs9rVZfMhMlpxpo51
+        Y+NGELckFZcELA4Y6SIBi/cyuSRgUdC5JQGLAwtYfPnypTQ0kHmA9DlWhKWBVcKWaoJlsP6nZXTL
+        yMJGN1yeHezho+jSxoZQ1sfqIzo0UW3VMNSv81pnNLKG+LJhPVqlibltXCKjvuOXRe63ns3C8DfC
+        TZ4xe0sPPSsxlw0bbqPDDilTZvkSywiyIrNyZOxBZmQG/ePeIoE2YbRgh0qUr7GBh2sgUeLt98cc
+        LjhrXrbOr5u1yHjBWeipyitMQKpH7mFDhqmTBP7ouPj1SVlDqjaGtj5QSVUygoOkwEGEzVXJzpDy
+        CrZisJ+C6mTxyIjy/X1RkBGyJ0OhHSyyJ0PRJ5fsyVDQuSV7Mux5Twak5ekhsg2CjRiQW+7XjsrB
+        Hw4ZFKn84UOt/LTJcz2tKayM/fE3dVwz3V/BLwnVrLXqCcpCBTsnULpJnaqGjkbE1FWSlkjSEkla
+        IklLzDUt8UI3XMukPkMTk5DcuVu6kpgYGewniYkkzn9A00vi/AWeXBLnL+jckjj/gcX5SWIiSUzc
+        LTHxlh55xiX99GpcZpuaGMMRSFszCg1dND2ABRwrSiQ1cVPNKEDxt81jJht8vrhsdq9bkYBN4Cz5
+        uMiCz/TmvIMktIMgCN/RH0euA6GOqUIZEBHy4SGUnfBlRoMyi2Kbsg0PkHaQGqKhWZAGpJFYIWeQ
+        RviIPgxDM+KeQJo0IyKyvMCxOZMQJB+mSTEiqzDN5dVNo31Za0ZCNZdj9C7U0evsAhr6wJpgag1e
+        4xGITf1GiUJs3NCvDhuwIfSDQlr6hH7wXiaX0A8KOreEfrBn+gHS77QemAT06NUkoLFyz9LPDtkR
+        u3LxOaGkiCDCzwaALQFOFApGwkeGIJsVkcFfIW/NZPh8fhrtEp/bmL5wqpovyCOu6TZevEWo1kOo
+        /VlT+yPKtABlU5kWIG4s08JtKtMS9BJTpiXoJa5MC7dlJZojv0VSieSdVCIhlWje9/yTSjSkEs3b
+        Z2B1LlvnzUY06mlq+rOuTbHBGl+N5q4oOVeEpVZo7ISw1Io+uYSlVtC5JSy1A2OpkWo0pBqNX43m
+        jtZfLcVcKtLcZYWCH1pFmrdM7CMlabLGwg008c/wUXVoj7m0No9Pdag7LPKeoO+B2kfjFVu0fi4S
+        B3qf+lIB7F3XTRPaVActumJwywQ2ObeMZdjkTKqtuGUs+5HzmVTS3rhlyUdEZAWGS54SuRW8wjIz
+        blniEVnFWJq1s8bVVTTI0lSpMzgewyhspRlNJRshzWLD4wBWCJus0P4ZYZMVfXIJm6ygc0vYZHtm
+        kyEVTxsqPcRWQKZ+czM79phYAgzHR9LHhBKQ2N13kJu5GTvnaSlZp2ll4YC37mQFMMpRE9Kuzq/O
+        27VWvXkX6YIjEcqnpoWc37w98SzK6aDpj3G+0cHADz2dGnid7OKDo5Nl6nzj82l4pcT53DOBOI/7
+        RDWMucO99IP0DDNh40ZgvLSRfiVsol+xYCP9avNGYNsyzI78FgnD6J0wjAjD7H3Pfz4Ms4GtIxOy
+        Z8NnHXqWyADrdH+E1h6KQ1AxWIgpaR04QUZ6QErLrIYaKwl8csBQSVMZXKQZBVcGB4oPoR5JDTWJ
+        y7uGWvrxWAVQW7fd03bt9HNMmfAr1XVH8At1gqxWE/7aoVrodmxszdpUt9HpRmGrl2cHg63uUpyk
+        rHDoM2D4/pDRWB4OOY0RoDyEQ76vShKjaEOG53ioAm6QJfa6dff51WlJfy0JXP6VePiB4T87DZgE
+        0Yfh5YEoCENJ0YAKGcADZaCwPMvIItCGQBD7MjdMsHaSArtbd57jykl9LQVYObtXRGIV9JF4KMiS
+        IqnooVOAJLB9idNUTmFUKA7loSpCXhbZBHAieuliuAZZQmbKWlGpryP3WlGpr6gIUPROT6AA0Ydh
+        +CEr9AVV7YtDnmMHmgRFmVP66OXNs5qsCkMg9TMLQ2zdd45votTX8k7fRIQcerDk0H2+RnKpXjj0
+        gi8JXyYHVLgwl5KFh/4yOcDl45V9IsvnKJbP7rYfA9GHFQSNHypiX2PYvqpK/aHGsui/gdpXmIE8
+        FAdQ4/g8C6imvozcjeLUV1QEbbb7sA1Qg8pqvCArqqzwMiMAHnkUyDIcwIGsKjIrCiwrM4zCJV9P
+        7hcr5XpKfRm5r6fUV7QfhsflGT32MUq672GUtEObrxgljc24TJkfc2AzFfPD/3s6caBh9AzdcRfA
+        0sYqWIr+urpgwu3lNeeIqPzLKiIAnBSZiAEYkQGCyB4OrST78r9Z8Eoap6BN8d3WWxNLds/smDro
+        QV4XO1p3IExD6dTqzUa7c99oNjuRRJSOqhnQ/rVD3aOl+P44KEH6USYUlPC5DpOBsro51iyCE7U7
+        1uLxLVg8QQ+Z7o8VnPJJ12LLRgXH48bxzNsgfif2DidsorZwYCO1hd9IbeE2UVtYJjf2zpHfImFv
+        vBP2BmHvvO/5f+v6UPlzcVLURtqKizNL3jsSLo4g55zMCIQMuDid+1qrWfscnc24wsTpfFFNqqk+
+        QQq7DJFEnDW+5REmOXp1W8K+SXk2YLnXlErQa94FaxJcwntF8xKMk2PkW5cqUa/7WSJLF0EWSeRI
+        5VrdKkGX+1kfJGGTkB0KTHbI6anhRfRO5UU6RYQxUZQ6fdf7eWssXQRZKRtHCmQbi07f834XCiAL
+        JeFIpQkyj+xsLNWlvve7VPYTTD6mpYL9fuz2z0YsAfs7DS9h+yvYz8KJuJg9sREaq2wEB10gbaAr
+        zIGM0MiBjLAmc8urRH777kkKB1n74ng5CofOOsiuBqVrq8/QiA6YLxzeJl7unSDTcLl/Rm/H8dh4
+        +atEXMT8YlnoWCtLpgjEMIATkgcettuzmD2qQAzOEc83EJN+PFYDMe3r66voIMxrBZ7aAJkWlqaG
+        N+BYir1ccu2o2Iv31BxH5IWUlyy0o0HKSxZ9ckl5yYLOLSkvuefykkjB0+PHMf2ILQJaDVkEWXr5
+        ITNi1cv3DImebWEGUtjF31+lyaW9GQ4oIyC0JcShlJpMutVDcStN9vXH6aT3rBpTWJXQ4gx/D2+O
+        rNq6Qw/tqI2R8WGyEcTbbwSxMspDy9Iih/cMHfxA1W3dfKLw4mrpjyPX0Ic7ZFvg/jLMtvBOp3mj
+        EJtuMZOIG9qddtXwlno09nFm+/kbSZGOztT8QHG2Rn2aGgn8ein5bhGSIArJ98+Q8O4/Kfx6iWY4
+        XOws8OvZPeEcKcaDRUOSN+E0/Xis4hz1y1ar0e5cXN9Hox3W1NBNqm1NHyH1m9By/m0E4lE/+aEQ
+        bFOCeRTcdSKYR7Enl2AeBZ1bgnnsGfNAKp4ee3YBbWO7gPZNYRp7sVmiHiFTYtctNni5JMsRuAdb
+        4jhWOhyKwWHWQZAEBsjHvbvG9W3zstW+vj1vRIIeJ+h82pQKW715kQxiwIkk2ETgrXew++xAqOMN
+        ajNAK/IBK8pO+DKjfepFsTjHuosmuQhsApoFafgEMps8sXM7PoE825VR3Ns+lclHBKd2csmRh608
+        bW97ynQjsqbM+nW7exHpZLeQ3h1Rp6r5YpnUBTT0gTVxcXV1L2NgvZt9cxLpZod+RXxs4mMTH5v4
+        2MTHJj428bGPyce+OaFNbBbQA88soEevZgGNFXymfvbclth5K0uhpIggkl/AlgAnClnzC/bsGSNr
+        kOWO2jP+fH7ainSJfQ5AYJzWdBsv4NyJ95nG+ovnTofvLdqbXpCKc6YXKA/7DVJ7DjQujRT4inKs
+        r5jMTRRYgQUK0u6J3EQZuYkpKiLJnpsIuiz3UcAx2R+y8ZnvofaB4pP6zIndZewsp3CX+bTuMt9l
+        gspQycZhTUz6rh7pJ3esKfqi21RIaMkvPr+rRfnF4ceBeMfEOz6E6SXecYEnl3jHBZ1b4h3v2TtG
+        Wp52AmOA1p61LL3hkAWx6g2PdWfQ09F4HELE+W3d4FeZ/OPD+6HEH1Z4ONvK9yT7fLvs85zq/5Kc
+        c5JznibnvONSDXusm792IvPM7wqQZ87k7PGunj/vekXE410ekXzr8L5pvV3i8S6PSK4VdN+0Vi7x
+        eElVXFIVd2GEFvcGzGUj1/SbcB7Qbq7bXtGe6hbc0Y5LQ2xV0k62tQruovGTFLUKBFDiFQVIcnR1
+        QI7nBYVUK4inJ3TuwQXF/PH+jbGZbGsDdhvtq8tWI7ow4CfLMF6osJ+UCJY5aTQjcJkTaAxVvKdK
+        Qs5+AQoKDGeb2kViLcPlbe923Rsvf6ylo7ofKA4zCupwkHCvpYTYgsyxgE/Mxwcsl2qjJcDS3Hyj
+        pb3QCtLALJwsJ09N2IpZsMWeU6swC+Dw3mMRMIv3Omrg7xRNdZFiwnjxWryFO43mGcSlufvKF//a
+        qwRMe6001oE0yFIJh69vV04f8FTD2jiGfyTbvLk9s/lOuoBiTxpvxedDi8OGjmNh09fTmzFq8zKQ
+        jdaTtYfzcjc6euGrNC+txKGarvZGSvKoN4tFZjnUYpXiq0RsjZ1lob0qRU8NcAzSAy3rOWOlyAhc
+        csAdAI5JpRQBzTG5KMX3MhrrVKKipFGJDPUbLar6C9I70XlpSfTiyapeZOhM4/vhSySqkahGohq3
+        VY2arY7V2BJpgUBshbQlmSI7i2ziwPx2ziJQ/F1oj8BZFNPUR9vCWZwNxW7OIs9IKTUjjNGMpztp
+        xtN1mhFmrBlPiWYkmpFoxl0145OuxXLWguPHg6J6qgAz1hKlZSVWBTgzS5TkhKoAZ2aloKv5mVls
+        F/CpVQFRjZtVI8elUY1ctFo830ktnq+qRS5jpXhOlCJRigehFNGMxcQZ0cEgjfl0auCp3SXciE6W
+        aZwRn89CUxfrMM4E4hTj9ZLM/vViftChktxh3A46BMcSXVTYnPOWZ0Oxo1YETBqtyMc7jPWdNGN9
+        VTPymTuMdaIbiW4kunF33fioGga0YwONc5E4/XjuSelwdr9XUwdOxweT++RDrFhjhiFWKYsyH3gn
+        CpC0GiSSTKMxJQ9iRRqTzVRj5gw4M0ld6+0B591CjzwAafSlEK8vGzvpy8aqvhQy15fb7dZN9CXR
+        l0RfLpxP8+tKxQQfA4E4XXmCdeXrxldLP9irmryyzA8UKy6pyWwUAyvJTIpIJCumVAyseESRSEnJ
+        mbYKpGzgVjaFolSideTZTjrybEVHKhkryDOiIImCzERBZrkjQwGyO9DzPcbL8Ck2MrkgFbsBAxYM
+        NOe9iqvV3yz9KqH+zHtLBk+TYg/rk2pOVTu7qpJIkwoAYO5kotglSFlVEsyrSgpKRno0XZWN5CU2
+        GDGNEt1mE4YdOa5svfZwcX1z02hHa9EvFqWhYcHLeOQldEYoUeX7B1JikpSYDM/oIU8vKTFZ4Mkl
+        JSYLOrekxOSeS0wiLU+7XywamQT05NUkyNLZDdkRqXzdLOtDhioM5O6intYUVmay2ilhLzUi65ed
+        VuOhWWvVI73Vuu6Y8AWbSlQbOmitUbpJnaqGjkbE1NXjKBdJ9k7Ib+8Ex/W9FL/SCHqp9XUTPZ6C
+        t/AXmjwB/PROkMcLQxLzNl8ELVb0fkWnnEu8Nnl1SpZ7CTd5Aiu9LLT5Iku9LDRVkHlhunhJWZ4O
+        RXf6jNa81pu1V9FTtdRSKa/+yPff0OvehuYAicz+CgLg/QkayIWmucQQzYJlVwF2RJcb51LmFGPp
+        VRmD2suNc6mJoQ6gU2VDMkFTSAbPpPMy7ltGOdyM3qB+a/Xvfwn/ft5eKS/fZjm8LN4svODFna/R
+        AGUZXZAkRZC5hHttiIBJGXZmvKIYZK+NTPbauGpcnTTanYvLm04kLHLnvdxr1JUXhHJG+iSqBqn4
+        OTK2cGy4CClEWmj3ihQiLfrkkkKkBZ1bUoiUFCIlhUgLVIgUWY30M63S47l9mSXIFjJKdyWUeAVJ
+        RQWwAhddklRikd0v8cXa26VzL1Fsu/nWe5xmWkK0e9G4q7XqtUjg7k7HUIGuUhi6qxloMboBd349
+        ZjdbhP4N29CZGm71/wHkx+a/x7cBAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:09 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['7090']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:10 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><s_keys>test</s_keys><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><request_custom_fields
-      /><request_cost_range /></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['759']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1d63bbNhL+v0/BzY/ttl2aAO/0qupxYjl1YudiyXHTPzwQCUmMKVLmxbb2dfZN
-        9sl2AFISdaFMKpJjJ8phXXEwBMDBYL4ZAAQav98PfeGWRrEXBr+9wAfohUADJ3S9oP/bi8vOiWi+
-        +L35twa9pUFix5REzsCOaJz6SbMRp103HBIvsNOYRrYX213iNsc0bkirkxpONB4lod31Q+e6eWmL
-        4u31qGddv7JGl9r7rtiPwp6Lk9d3zrsPn78o1Im/KMefsf7l4/V79PkqOL4ddt4O4iNlZN9f3hgX
-        ZyfjY0cTL1zc09/e9NLPpzf9o5P4/UVwN74hqIP192pkHw+Vs9PWx/FN1PpyY1p+JH84DSzl+Pqu
-        739uSHN1arhenJDAobFNImrfEt9zm0HYkFbRM6k0G0AhNsiMNltXDWl2lyW4NHaaLRDx+G5AI5oz
-        cGrD8Ukc5//LnkkGlCSMq0DL0/kjnfn0LBsQL5d1lh1vgHlSI2+5azqelCBBI82IrC1z1smTU8pc
-        fjO+FVkOvdhZnW32Inn6HG3Gwt/lHFiEqRDm02b3zfz9QTRhGiTROMsrvQZ6kTBN5s9fBl5CXeEt
-        6DYo54w1y9wlCbUjEvSpTQM3v+dJV9T9l4DjRHiTBlSQEdZBH6apGWOaOHbY68U0aSo6QjlDgTpj
-        i6kTBm7cxKquGqY1zz1JzNjH8G84dN0mKxTpCOecUzq0VmgC3eZkErh24g0pZxcRXLiDtUOE4PoV
-        4UNW0uoH8nwXXz+7B82Pkh9ZILkAMiPIFQvLKhRdIOSJXABHH06FTqvdOX33esKTCSb7DZZDOX/9
-        ZpI0NSS2D4oZzixAkTgxwAlJ0rjpe7fT9Jw0YQC7SxLCqsBqgPWjKV+ekjMm4TUN5uqRUSbJ4xFt
-        xt5w5FOQh3NNkykbS2kMSGwHoT2iUS/m9nGOwGwIWAHobFPjkd82AkpdkMYIBJqCIWVC5s+voufM
-        aUQSQKcC24SSMbAyw2jIrHNW3BJ1YqsmRty+HjbRAZqaqiK9EQ/CO/50pggZnM3TGnGYRsCeWWwu
-        nv+EAUiKxiCnYuKEM7PdnPMv4BQ6Rc5MOUC6af6Uhs2GVLjP07K+1zp/edb6LLQ7R8enl+cTvtxA
-        5oi0BEwYIbMEmtrjOKFD4SfG8tMenZ4dOrVJAsZYTQbCORlv1RgrMtbVysZYw2otY6yJWO1gtH10
-        aqdBhk7bloeMLEWuLo+a4KRxcKovjxXgBD35UNVL8eml1xcuaAyO+S0oXGaKVsPU6TneJUxJC2hU
-        KO5x0GhI7u0oDQKofCZZHWS+RGwMwbQssy0Sv0Nsi6irY/sGQIMExCVrsO2CcQofj4RXnFNgUCjE
-        HFrKcY4rqqxKmcKqpZjHFPYTuz0U2M/2iDi0IvCBF1SCe0zvhbPQ4eLe496zw71OSsHMox3gnmyh
-        OnYeo7q4hzrY2j7u/WgCWQY+2TTlctQ7vTj+LIz8NBbiEXU84gv9FGxAXAZ+Z68+Pib4FYrbh2Kb
-        wRU0QwR+TWhDiLUGq345O/3U+kU4zbmF9wXuJYzq/GlInVJk4iDC74U3J3tI+sEhiUceBhjgo7Sf
-        QlNu0QYbSNON6iNjJjJq2WBTREYHyzsIxlh0qu9IJKqJq8OSifS6ItE3EclKWCofLHxF0v4gEbpj
-        pszCBaBGJHQGZEjX4NLF4+LSxR6XniIuWVVxSThJfdAo4QPx94HTHqW4SZYDV3iT+tuNEwzVVKsb
-        ZAPJtQyyISKZxQnKTjDqBxLIKoQyrFKEagH3QLjyQED/IMPRv4UTL6JCOTq1Hxed2nt0eoropFZG
-        J6ZZcRjVgyfNKEGn04T443lU8pLcfg7hT0BED3RhRszSM2vN0/PEUkiDV47LAa2Yugmcsee3CmY8
-        w3zEYx2azVjWARp/P0EU2vkQymmQ0CibzKwHbrwRysEtb8baSzTO2esxG26steEVDbhpKnLlKTAD
-        KXWmfMB6K2zKB+VTPn9taRRwkObTgUejyPMfhrOqWIY0C6CsKpapNWcDVTYbWE8UyzCmG9j8gLVS
-        JDuhUUQij/nDvnBMxkLrHmyiR8FyCnceiIwZJvE4KoDQIry9f/96E3gbUtcjoOJkxOw+gNggjJOm
-        Q5wBFfsRGQ08J/a97sGtR5IwOnCYP8dZGl4AYmaIAjQAMyb6yG8OkmR0KEnrMpAKZHEUUQatUjJI
-        h90Y/JJ7VdUlJi+pfcr7tNTLhCP2QDiiS8YinQpHZMIR2ZSO6DLhiF4g5rZUtiAGNw6+jPrQZiur
-        2gggmG360IYxvD6Ih983RiQZNB+/jrzYxrMR6UqBxuloFEZJbLMqT9ZbFknzHJl/s0CaaGmumHst
-        5VoZ36Qk2qvos1HRehZ98tAPp9ZJ5DFS5uDvdfup6vamMXDBJ6kVA/dpyPwrKN+HcDRJwVtS1QNd
-        1XVwY6ekhh8G/ewnRgeWrMuqBclTYkOa5VM5qmZpzzmo5k26JqbOlHZNNP1pnmEpgJY1c80i0Emg
-        WilUtuSyWPkDjdKSUNn3hkRk3trKQPkMUvdh8mOEybwJysPkrAVrLZmR2QqRY+rQYZdGWwsPTRnX
-        CA+xLNdaI4JlUUbbjpRPIg8iZW0HkbJumNXXzaosYK0XKWtfHSmDFUfaB1y+WuYP4ve4Q/XJi71E
-        SEI+PXkOcBpyn8oLQuE8jWk6LI2UO8r3EylzeU0diwEIhzsUt0w4YhKK8EbikAmH+xQgHHHIhcP8
-        Cm5KZdMyNGWHcfJWa7hrN22rld3HyI+on5tFyHvl/CbR8by5/uf5Uaf189RqP61o+NEU+Cti4b0W
-        P/E4eOZxfG0cDB7nAVIV9m91KCwaxgGSzZxhHwzvNBi25PJQOAtFKwXCdb/O73r9dMS+9U/5pyoN
-        qUgoxsrg24eByJfrrIyWefpD8fJzXil17bnxuqA5T18XMZ+QocdmfKvEx3GSBTbQRGC7sgZhERmN
-        oFW7ceinYKNicgtxRRMrTIsXqQ02JsjsWdcLoM9pMmOap2UsrFNCdAg9RDWmPDNizgRqOyARVEib
-        8UxpDV6zWcaKxZgWiDnTLGdFm3EVyssJ08zVAtesROiIDig/6U9fWIYgc5kKKr0kQPb520Jd50ic
-        IXt+L/ONZL4sQE5ZqMY8LWOZr8I8iX+lOH03nHEUSTkDtHdJs6kVWg2bD7dagae81VCFVsNqlVYr
-        cq1pNVS11eSSVluQHrtfrMQ8LWOZr8A8qQHuQAzZ+zS292Ztb9aetcz3Zm1v1vLib1ISJMzbDfkY
-        AzhtfMcse0JvYnDZ5ymLHPKDHMqDHOqDHNqDHPoyh7T8etk4OwTJEQ0cYJn8ylzdfncE3uscacbR
-        Iw4EP1mAsUiccQUpm65pmrJe4MqJM64RW0EbM9ktkgo8rLHj8bAb+lKRDCFlRm3+77/F52f0hrT4
-        mkk4srlS7E3mRiZzSX5SiUOw71D7DrXvUJt0qGIv2t7XVU7kJZ5jR/TWo3zci9UkV7mVSetm5fmK
-        bXM338hiTdWqr9rma05qfSOLzZ18ksVlIrMF/RXn5mt8lIVlXakxPS/X28ZJFWW8nY+y3l12Xl0c
-        vXrbuiidpT8nSTKgd8LLMI0C+lMsvIPXiYhzTaO/l8zL66cn25uW59SDbEw9vvMSZ1Btvig+lKTV
-        z0ox9HnqFqcFoEeFI+hHkqXA5SC120OurNKe4iKNmj3aU7vEMJDl9pCqqJRgxdl4on2bxa+f4nkk
-        GVSYulmal1mauVme3Kk1O/64amJQuJBqOrqm9QzLxYQirGLLsWRVRqaO3R7W9K6p9CqoyZBENymt
-        riS1C9+FktSuxI+nJBqFCyG1J2tdjZCu3lMV2XENqpuK1YWOpMquSbQeNrqbLYrYZtm70JHalXgK
-        OuLiu3v1TtHS7tD17g8cP0zdXhQGyUHAJnUrLFNYm8MqedH7hO/riqRfs+3s7BmFvYjv0aiChuSc
-        D+pI9eIeVoodvut2FgQ8K4vRs+AiBIAW4Fc1DEdBimuYXUfDyHAcZGiq2zNVnThm9VUoPb7GoaLd
-        qF2DXdiN2pV4Cnbje9AUcPH3mvI9IkwuL5tzSpYGV9dyuiqxzB4xuhpWu6qqq8gyCDKNXrdrdA2M
-        HYd8xWK37VdjB3D0lTV6Ehj1zfVJ1uBCuuZaju4S2dF1AysW3BsGUV1VVXRLd7BmuUoNfUoGUfWY
-        aNOK7FyjatfoSWjUd4BlyV24h7ItQtmGC2YLQ4G11stmv9NRTH3f9r04mRtebC0PL5YNOzL628si
-        XVqR94rluRo+0ErW5aID9j3VV67IfXCfeCxX2yg+43siO8WziapsIewrfCGonXfQWSakne4wNY0i
-        1x2OwvaEys8i+YtGYflq4PbR8Vnron3VOjtrly4LbhPXp9FPsXAFihRXXCAsW3L1XaW+rxW833qv
-        w+1uB8WnjxT2oWv1E6oq7+knKzU24tWVepuh66KCOsjMd53lx4Fs8WtXWeMiyXY5VLclEqTLilV1
-        m0MVGXKND15Vts2hrG0iklWndimtk9LJNGahhBO/ZN5MfqkebTJxtiE2F4v7RmehqBUxTn1KGLdL
-        GEujLgls4jJpQ9Xjh877umT8wtGU/4FTv0y9FM2WcvrniR+yJSP054rQxrb0WHv8l473h389w718
-        2Y7zSnYU45b3rrUsQ6mOc4ZSb5mEISq7OZtytnJk+xLBqMbhlEbNhSMGXziyjcMpdXwoy1b5lvOd
-        iMTZzljCcToceuVbzb9DG53/9WSGwtLApVEXIoCxpGO4bMVmfyRZRvcYa9tcJVKpqB0MaVUq90kM
-        XD2h9gcv9B7+29rMfqVyHrHx58p95MavfEbtFdY7F0ftP9afUFswQfszAWuP9LRbWDD//POxBnpm
-        +rjOLZ4yCdme4uUuMSCZIrE/5Z9/82+rhauQZdqPwG1yDwXwRIX2yKN96iegEatd5InWzZ1p/3/z
-        U2BoEH8AAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3712']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:10 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/CoreTests.test_search_events_keyword.yaml
+++ b/tests/interface_objects/cassettes/CoreTests.test_search_events_keyword.yaml
@@ -1,139 +1,167 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxyZXF1ZXN0
+      X2N1c3RvbV9maWVsZHMgLz48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJl
+      cXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0
+      X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVl
+      c3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9t
+      ZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48c19rZXlzPnRlc3Q8L3Nfa2V5cz48cHV6emxl
+      ZD55ZXM8L3B1enpsZWQ+PHJlcXVlc3RfY29zdF9yYW5nZSAvPjx1c2VyX2lkPmRlbW88L3VzZXJf
+      aWQ+PC9ldmVudF9zZWFyY2g+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['588']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1dS3PqSJbez69Q1KIf0Veg1Ft3aDqwwY97MXYDtsu1IQRKjMpCoiThe93LqsVM
+        xKzmB/SqdxMdEzHL6ZiYRf+UuRPzOyZTEkY8JCSQDMh5g4oyqYNSykzpnPOd75ys/OHr2KCeoe3o
+        lvn770CJ+Y6C5sDSdPPx99/dds9o+bs/VP+hAp+h6fYcqNqDUc+GztRwqxVn2tessaqbvakD7Z7u
+        9PqqVjWtSnn9kcrAfpm4Vq9vWIOn6qBH0yLdd368v/7RaD/akHbq/U9t5fpkMJRHn8WvP3Vaw3O3
+        1bk5uemLwGBeanp/ctZ9dE/6P/UfBqJ8OhWaJzfq6LZz01Z6p873dz98df7kdKZ1sctOeNbsT/rt
+        L5/+ePKp8emHr+f8y+nTaMSq+lAxOE0YvvRHV8IfhauWwUxOePqhUl64voqmO65qDqDTU23Ye1YN
+        3b+5de3+AFUrqEXtoeGD1cZ9pTz/5h/QoDOoNtBov3wZQRsGAl5rZaC7L76soRsGpIc2up7XNv+w
+        J9nEh4NjwU8N1XGC//niquva6sBFc+ogyXl7IOP9rLYq458OzZY3df5pXyA6vNhUCdbBE3wJ91RG
+        8z4/gFdHID779WvLwjnnchGndUdwDCeq/eSs78C/tQWphSNzQe/+uliQ+pU6nvwjda+60KZuln7l
+        D0N5fmHl2QhbjtuzVfMRnXSsfkWnH/d1E2pVXigxlfJCkyeALted2PoAVnlmJjFv80Wm6IZUG53y
+        9RzzpsoYD/pSL+EmT2Cll4U2X2Spl4Wmimn1HPTAGxCPWDFv8aeparr4kbEm3qqqVrwHtzdrr4JK
+        eallWYLdKMFtlOA3SggbJcRVifLq7Xlz2BtMbRu9z5HI7C//mYBT/HpZaJpLDNGTZ9lVwDAhmaBx
+        LmVOx31oVxVJDkkFjXOpiaGiNyUeu+WmkAxec87LuG8Z5XAzerv6rdX/+fmv4RPMD1TKy/dZjljM
+        ZAG8lwUQnvWBNTVdO7hBT6WGG14Pe2/8Mxtr9bmIrwY0pCL8s/WgqQXfvUNXlvmBAo5LfVLNqWq/
+        UCwD0FDMBXzZqTvoWcOhA90qExwNNc1lHDiwTM2pAgHwsgCAooSkZwd98Rf0bzzWtCrukQEMCCRf
+        25HKtWSRAT2vWTW1nquPoSdOMwB9uiz3UVDQ5wesiNfJBqdcvnP/OzKAbDc8Ft3R9AMluCPqSvXG
+        QcxgHHiR5RmRZ5hE4yAyAiMkHweRZgT06TLMR++TbByC+/atYW8J1WsP3cvvK+VQU3DYu3VA19GA
+        dPXBE3RnQv6Y+H8j01H83JkdeTUkewZ6g1khK2gm4bcHQmOo6SpaxKr3yKMnZ4RWflUDX77yXzhh
+        2h9r+tfSwLCm2tC2TLdk4mvwZCq6iUZyih4jpGYnBsSjaxvVketOPpbLsWcoO0ijQq0cuoQy/Or2
+        XOi4TLlxX2ZZ5isAQunHySMa07X9VEwVjayBxthBF48eOe97ZaK6o2q683s/qUTdi5Ptzay9FWc6
+        mVi26/Rwh75lu9i0KOGsEcEW5sKMHvL0SgzzlWOYzdM7Vu2fpjDl5C6cPe/JXeiMTC4akcZt+7p+
+        2Wk1HsqARyufTzDPDjI97JTTHNVP3jMe1S+Z/N85L44Lx715C74RQ4d2ghUQSKZYA5u6y3UhbOr8
+        va6GgW1NJtDueZLloYI+qjrk+wOG5yVpwDGcJsn9gQAYaTBgJIHXhjIvqgN58xJxbR039Sxz85ti
+        x8vIYenseEVvvJ78gUVmJQ1oTX2hXc/6LM9k/fEJAF1XdadO1dCf4exw0DQTmPaR+auWZ99d6wma
+        YZPVb5gdfZmgt4GOb7PnLti83pHKI7SwdY2u1FCRszpFxrLAlCRktr9+rxiW+ej/yWEYZ/61Up7/
+        fKQ6PeTnozkZOh4mu9CAAUcMDkEfr51/q5gQasj+niArHs8Ituz9cV13IJCe2ip+Lr1TLbb4ArhP
+        yx5j33EuE26c4Zoz3Lj3NK56INaa9oozsr54v/a9Dw9MX2yqONbUHsDAjZ+9wpBYqHkm4wPOX11o
+        m6pBdZEgdaKieTE1av4L3x9B0zQNfj3XkpVyqDkQ8cTrumPCF2zB//3fMX6qOzPRADwN8PAMYfHh
+        1FT7qjPS6R8nEdD42UyEwOP7gcdD2Io3SdFgyyd1opoEayFYSwqsBdRrDze1Tufmut2NRly+/fJP
+        3375r2+//Ou3n//z2y9/9v7+Z+o31yakMBZzg5YqVqG/jYBjaudyUeAYkDMcs3r+HM321c7eq5m+
+        MCK5wTGrZ897cgkcszwieWEwqyfPe24J2rIwIssIBMgTbdncXa6zv6nzvXjHSMvTAPt76CeWa9GW
+        CT1feRJYB1l6yyGLYldvmRNKIocNvnX+MuCUkiwLx+Yzz8/11k4zSO00g2inuXv9+WGT1/x/f/6P
+        //3bX7GB+vNfvv38t2+//Itnnf7bt5//e2amdq2nF4vy3WuqDR3fUs3ZtSaMs8N1qSPoWIDZyMcC
+        TAaErFk/MYysWT95sM4KcJuEePReiEeEefbOFwBhnhE09M3QUK5ee7i4vrlptCOxUM5jn114wctI
+        9lm3KHAnYZ8VGjUh7LOiTy5hn73XySfsM8I+I+yzQrHPujTnIeoj7+KzZZ91CfuMsM/eln2GVoJm
+        mfT0KQoj945vAMmRP/UMjUh8vLtweAto3D9/lqh4cMaR5UIjFgx/lYgDwi+WhZJRybxBj0ZPbk0d
+        PV7UZ+ScatY4OYrSncIPFIsWY236OEVrcyN4wIlMQvxAYgAniInxA5lhU+EHMs2wXcD6+MHvGPAR
+        9/T2YEry8RBZnkfCueIpW4zHKqjSvr6+ioRTau4ImiqcjiOwlEsuMpPPezwIjEJglMOYXgKjFHhy
+        c8VO3hQwISgJQUkISkJQkqKiJMhgpNWZUZklRBKyRFchEs8W7dmWNd6Mj4CSwCDrPYJxSDMl5Otw
+        Cps1UoKpOvbUNJGh7JvtgA0IPAutHvtmjdxy61rkZY6oxAIvIYAmNYcRsws8L+IefKKkk09o4c9a
+        jg6WqXUvGq1a4/YqEpUJuUcEjCFgDAFjCBiTIxhzatlTh7p40aDHpo2EZCLpLQSSIZDMAU0vgWQK
+        PLkEkino3BJIhkAyBJIpFCTTpQfYtKRHyLSkcXpXtsBMDHclJTCD7CclBpiRJA7T8wkwEwvMsBTX
+        PD9mXOb0un3bubiJRGUCPwkvrbC3lDNCM8H8KxvNczRIczMT+UC10LM5oh4s+8kZ6XbCVNO3STPN
+        IcW07KKpRMsoNrf0VSQ2sdSXohbuOAGekz0WFrwmMoLCwmeLQ8L+NNadQdwwzgTiBvHaReu4VCrt
+        lI4rspvSVAV5Y5YqvylLNeglJkk16CUuR5XfMhX3yG+RZGEupFw+9icZZWHKODqUdxbm3/9CsnDJ
+        /O+WhJtT5OIeah8oDmfjXqMBQjefWTYuDxjkIyXNxkXCqbJxAUNzJBs3q2zcs9rVZfMhMlpxpo51
+        Y+NGELckFZcELA4Y6SIBi/cyuSRgUdC5JQGLAwtYfPnypTQ0kHmA9DlWhKWBVcKWaoJlsP6nZXTL
+        yMJGN1yeHezho+jSxoZQ1sfqIzo0UW3VMNSv81pnNLKG+LJhPVqlibltXCKjvuOXRe63ns3C8DfC
+        TZ4xe0sPPSsxlw0bbqPDDilTZvkSywiyIrNyZOxBZmQG/ePeIoE2YbRgh0qUr7GBh2sgUeLt98cc
+        LjhrXrbOr5u1yHjBWeipyitMQKpH7mFDhqmTBP7ouPj1SVlDqjaGtj5QSVUygoOkwEGEzVXJzpDy
+        CrZisJ+C6mTxyIjy/X1RkBGyJ0OhHSyyJ0PRJ5fsyVDQuSV7Mux5Twak5ekhsg2CjRiQW+7XjsrB
+        Hw4ZFKn84UOt/LTJcz2tKayM/fE3dVwz3V/BLwnVrLXqCcpCBTsnULpJnaqGjkbE1FWSlkjSEkla
+        IklLzDUt8UI3XMukPkMTk5DcuVu6kpgYGewniYkkzn9A00vi/AWeXBLnL+jckjj/gcX5SWIiSUzc
+        LTHxlh55xiX99GpcZpuaGMMRSFszCg1dND2ABRwrSiQ1cVPNKEDxt81jJht8vrhsdq9bkYBN4Cz5
+        uMiCz/TmvIMktIMgCN/RH0euA6GOqUIZEBHy4SGUnfBlRoMyi2Kbsg0PkHaQGqKhWZAGpJFYIWeQ
+        RviIPgxDM+KeQJo0IyKyvMCxOZMQJB+mSTEiqzDN5dVNo31Za0ZCNZdj9C7U0evsAhr6wJpgag1e
+        4xGITf1GiUJs3NCvDhuwIfSDQlr6hH7wXiaX0A8KOreEfrBn+gHS77QemAT06NUkoLFyz9LPDtkR
+        u3LxOaGkiCDCzwaALQFOFApGwkeGIJsVkcFfIW/NZPh8fhrtEp/bmL5wqpovyCOu6TZevEWo1kOo
+        /VlT+yPKtABlU5kWIG4s08JtKtMS9BJTpiXoJa5MC7dlJZojv0VSieSdVCIhlWje9/yTSjSkEs3b
+        Z2B1LlvnzUY06mlq+rOuTbHBGl+N5q4oOVeEpVZo7ISw1Io+uYSlVtC5JSy1A2OpkWo0pBqNX43m
+        jtZfLcVcKtLcZYWCH1pFmrdM7CMlabLGwg008c/wUXVoj7m0No9Pdag7LPKeoO+B2kfjFVu0fi4S
+        B3qf+lIB7F3XTRPaVActumJwywQ2ObeMZdjkTKqtuGUs+5HzmVTS3rhlyUdEZAWGS54SuRW8wjIz
+        blniEVnFWJq1s8bVVTTI0lSpMzgewyhspRlNJRshzWLD4wBWCJus0P4ZYZMVfXIJm6ygc0vYZHtm
+        kyEVTxsqPcRWQKZ+czM79phYAgzHR9LHhBKQ2N13kJu5GTvnaSlZp2ll4YC37mQFMMpRE9Kuzq/O
+        27VWvXkX6YIjEcqnpoWc37w98SzK6aDpj3G+0cHADz2dGnid7OKDo5Nl6nzj82l4pcT53DOBOI/7
+        RDWMucO99IP0DDNh40ZgvLSRfiVsol+xYCP9avNGYNsyzI78FgnD6J0wjAjD7H3Pfz4Ms4GtIxOy
+        Z8NnHXqWyADrdH+E1h6KQ1AxWIgpaR04QUZ6QErLrIYaKwl8csBQSVMZXKQZBVcGB4oPoR5JDTWJ
+        y7uGWvrxWAVQW7fd03bt9HNMmfAr1XVH8At1gqxWE/7aoVrodmxszdpUt9HpRmGrl2cHg63uUpyk
+        rHDoM2D4/pDRWB4OOY0RoDyEQ76vShKjaEOG53ioAm6QJfa6dff51WlJfy0JXP6VePiB4T87DZgE
+        0Yfh5YEoCENJ0YAKGcADZaCwPMvIItCGQBD7MjdMsHaSArtbd57jykl9LQVYObtXRGIV9JF4KMiS
+        IqnooVOAJLB9idNUTmFUKA7loSpCXhbZBHAieuliuAZZQmbKWlGpryP3WlGpr6gIUPROT6AA0Ydh
+        +CEr9AVV7YtDnmMHmgRFmVP66OXNs5qsCkMg9TMLQ2zdd45votTX8k7fRIQcerDk0H2+RnKpXjj0
+        gi8JXyYHVLgwl5KFh/4yOcDl45V9IsvnKJbP7rYfA9GHFQSNHypiX2PYvqpK/aHGsui/gdpXmIE8
+        FAdQ4/g8C6imvozcjeLUV1QEbbb7sA1Qg8pqvCArqqzwMiMAHnkUyDIcwIGsKjIrCiwrM4zCJV9P
+        7hcr5XpKfRm5r6fUV7QfhsflGT32MUq672GUtEObrxgljc24TJkfc2AzFfPD/3s6caBh9AzdcRfA
+        0sYqWIr+urpgwu3lNeeIqPzLKiIAnBSZiAEYkQGCyB4OrST78r9Z8Eoap6BN8d3WWxNLds/smDro
+        QV4XO1p3IExD6dTqzUa7c99oNjuRRJSOqhnQ/rVD3aOl+P44KEH6USYUlPC5DpOBsro51iyCE7U7
+        1uLxLVg8QQ+Z7o8VnPJJ12LLRgXH48bxzNsgfif2DidsorZwYCO1hd9IbeE2UVtYJjf2zpHfImFv
+        vBP2BmHvvO/5f+v6UPlzcVLURtqKizNL3jsSLo4g55zMCIQMuDid+1qrWfscnc24wsTpfFFNqqk+
+        QQq7DJFEnDW+5REmOXp1W8K+SXk2YLnXlErQa94FaxJcwntF8xKMk2PkW5cqUa/7WSJLF0EWSeRI
+        5VrdKkGX+1kfJGGTkB0KTHbI6anhRfRO5UU6RYQxUZQ6fdf7eWssXQRZKRtHCmQbi07f834XCiAL
+        JeFIpQkyj+xsLNWlvve7VPYTTD6mpYL9fuz2z0YsAfs7DS9h+yvYz8KJuJg9sREaq2wEB10gbaAr
+        zIGM0MiBjLAmc8urRH777kkKB1n74ng5CofOOsiuBqVrq8/QiA6YLxzeJl7unSDTcLl/Rm/H8dh4
+        +atEXMT8YlnoWCtLpgjEMIATkgcettuzmD2qQAzOEc83EJN+PFYDMe3r66voIMxrBZ7aAJkWlqaG
+        N+BYir1ccu2o2Iv31BxH5IWUlyy0o0HKSxZ9ckl5yYLOLSkvuefykkjB0+PHMf2ILQJaDVkEWXr5
+        ITNi1cv3DImebWEGUtjF31+lyaW9GQ4oIyC0JcShlJpMutVDcStN9vXH6aT3rBpTWJXQ4gx/D2+O
+        rNq6Qw/tqI2R8WGyEcTbbwSxMspDy9Iih/cMHfxA1W3dfKLw4mrpjyPX0Ic7ZFvg/jLMtvBOp3mj
+        EJtuMZOIG9qddtXwlno09nFm+/kbSZGOztT8QHG2Rn2aGgn8ein5bhGSIArJ98+Q8O4/Kfx6iWY4
+        XOws8OvZPeEcKcaDRUOSN+E0/Xis4hz1y1ar0e5cXN9Hox3W1NBNqm1NHyH1m9By/m0E4lE/+aEQ
+        bFOCeRTcdSKYR7Enl2AeBZ1bgnnsGfNAKp4ee3YBbWO7gPZNYRp7sVmiHiFTYtctNni5JMsRuAdb
+        4jhWOhyKwWHWQZAEBsjHvbvG9W3zstW+vj1vRIIeJ+h82pQKW715kQxiwIkk2ETgrXew++xAqOMN
+        ajNAK/IBK8pO+DKjfepFsTjHuosmuQhsApoFafgEMps8sXM7PoE825VR3Ns+lclHBKd2csmRh608
+        bW97ynQjsqbM+nW7exHpZLeQ3h1Rp6r5YpnUBTT0gTVxcXV1L2NgvZt9cxLpZod+RXxs4mMTH5v4
+        2MTHJj428bGPyce+OaFNbBbQA88soEevZgGNFXymfvbclth5K0uhpIggkl/AlgAnClnzC/bsGSNr
+        kOWO2jP+fH7ainSJfQ5AYJzWdBsv4NyJ95nG+ovnTofvLdqbXpCKc6YXKA/7DVJ7DjQujRT4inKs
+        r5jMTRRYgQUK0u6J3EQZuYkpKiLJnpsIuiz3UcAx2R+y8ZnvofaB4pP6zIndZewsp3CX+bTuMt9l
+        gspQycZhTUz6rh7pJ3esKfqi21RIaMkvPr+rRfnF4ceBeMfEOz6E6SXecYEnl3jHBZ1b4h3v2TtG
+        Wp52AmOA1p61LL3hkAWx6g2PdWfQ09F4HELE+W3d4FeZ/OPD+6HEH1Z4ONvK9yT7fLvs85zq/5Kc
+        c5JznibnvONSDXusm792IvPM7wqQZ87k7PGunj/vekXE410ekXzr8L5pvV3i8S6PSK4VdN+0Vi7x
+        eElVXFIVd2GEFvcGzGUj1/SbcB7Qbq7bXtGe6hbc0Y5LQ2xV0k62tQruovGTFLUKBFDiFQVIcnR1
+        QI7nBYVUK4inJ3TuwQXF/PH+jbGZbGsDdhvtq8tWI7ow4CfLMF6osJ+UCJY5aTQjcJkTaAxVvKdK
+        Qs5+AQoKDGeb2kViLcPlbe923Rsvf6ylo7ofKA4zCupwkHCvpYTYgsyxgE/Mxwcsl2qjJcDS3Hyj
+        pb3QCtLALJwsJ09N2IpZsMWeU6swC+Dw3mMRMIv3Omrg7xRNdZFiwnjxWryFO43mGcSlufvKF//a
+        qwRMe6001oE0yFIJh69vV04f8FTD2jiGfyTbvLk9s/lOuoBiTxpvxedDi8OGjmNh09fTmzFq8zKQ
+        jdaTtYfzcjc6euGrNC+txKGarvZGSvKoN4tFZjnUYpXiq0RsjZ1lob0qRU8NcAzSAy3rOWOlyAhc
+        csAdAI5JpRQBzTG5KMX3MhrrVKKipFGJDPUbLar6C9I70XlpSfTiyapeZOhM4/vhSySqkahGohq3
+        VY2arY7V2BJpgUBshbQlmSI7i2ziwPx2ziJQ/F1oj8BZFNPUR9vCWZwNxW7OIs9IKTUjjNGMpztp
+        xtN1mhFmrBlPiWYkmpFoxl0145OuxXLWguPHg6J6qgAz1hKlZSVWBTgzS5TkhKoAZ2aloKv5mVls
+        F/CpVQFRjZtVI8elUY1ctFo830ktnq+qRS5jpXhOlCJRigehFNGMxcQZ0cEgjfl0auCp3SXciE6W
+        aZwRn89CUxfrMM4E4hTj9ZLM/vViftChktxh3A46BMcSXVTYnPOWZ0Oxo1YETBqtyMc7jPWdNGN9
+        VTPymTuMdaIbiW4kunF33fioGga0YwONc5E4/XjuSelwdr9XUwdOxweT++RDrFhjhiFWKYsyH3gn
+        CpC0GiSSTKMxJQ9iRRqTzVRj5gw4M0ld6+0B591CjzwAafSlEK8vGzvpy8aqvhQy15fb7dZN9CXR
+        l0RfLpxP8+tKxQQfA4E4XXmCdeXrxldLP9irmryyzA8UKy6pyWwUAyvJTIpIJCumVAyseESRSEnJ
+        mbYKpGzgVjaFolSideTZTjrybEVHKhkryDOiIImCzERBZrkjQwGyO9DzPcbL8Ck2MrkgFbsBAxYM
+        NOe9iqvV3yz9KqH+zHtLBk+TYg/rk2pOVTu7qpJIkwoAYO5kotglSFlVEsyrSgpKRno0XZWN5CU2
+        GDGNEt1mE4YdOa5svfZwcX1z02hHa9EvFqWhYcHLeOQldEYoUeX7B1JikpSYDM/oIU8vKTFZ4Mkl
+        JSYLOrekxOSeS0wiLU+7XywamQT05NUkyNLZDdkRqXzdLOtDhioM5O6intYUVmay2ilhLzUi65ed
+        VuOhWWvVI73Vuu6Y8AWbSlQbOmitUbpJnaqGjkbE1NXjKBdJ9k7Ib+8Ex/W9FL/SCHqp9XUTPZ6C
+        t/AXmjwB/PROkMcLQxLzNl8ELVb0fkWnnEu8Nnl1SpZ7CTd5Aiu9LLT5Iku9LDRVkHlhunhJWZ4O
+        RXf6jNa81pu1V9FTtdRSKa/+yPff0OvehuYAicz+CgLg/QkayIWmucQQzYJlVwF2RJcb51LmFGPp
+        VRmD2suNc6mJoQ6gU2VDMkFTSAbPpPMy7ltGOdyM3qB+a/Xvfwn/ft5eKS/fZjm8LN4svODFna/R
+        AGUZXZAkRZC5hHttiIBJGXZmvKIYZK+NTPbauGpcnTTanYvLm04kLHLnvdxr1JUXhHJG+iSqBqn4
+        OTK2cGy4CClEWmj3ihQiLfrkkkKkBZ1bUoiUFCIlhUgLVIgUWY30M63S47l9mSXIFjJKdyWUeAVJ
+        RQWwAhddklRikd0v8cXa26VzL1Fsu/nWe5xmWkK0e9G4q7XqtUjg7k7HUIGuUhi6qxloMboBd349
+        ZjdbhP4N29CZGm71/wHkx+a/x7cBAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:10 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['7090']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:11 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><s_keys>test</s_keys><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><request_custom_fields
-      /><request_cost_range /></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['759']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1d63bbNhL+v0/BzY/ttl2aAO/0qupxYjl1YudiyXHTPzwQCUmMKVLmxbb2dfZN
-        9sl2AFISdaFMKpJjJ8phXXEwBMDBYL4ZAAQav98PfeGWRrEXBr+9wAfohUADJ3S9oP/bi8vOiWi+
-        +L35twa9pUFix5REzsCOaJz6SbMRp103HBIvsNOYRrYX213iNsc0bkirkxpONB4lod31Q+e6eWmL
-        4u31qGddv7JGl9r7rtiPwp6Lk9d3zrsPn78o1Im/KMefsf7l4/V79PkqOL4ddt4O4iNlZN9f3hgX
-        ZyfjY0cTL1zc09/e9NLPpzf9o5P4/UVwN74hqIP192pkHw+Vs9PWx/FN1PpyY1p+JH84DSzl+Pqu
-        739uSHN1arhenJDAobFNImrfEt9zm0HYkFbRM6k0G0AhNsiMNltXDWl2lyW4NHaaLRDx+G5AI5oz
-        cGrD8Ukc5//LnkkGlCSMq0DL0/kjnfn0LBsQL5d1lh1vgHlSI2+5azqelCBBI82IrC1z1smTU8pc
-        fjO+FVkOvdhZnW32Inn6HG3Gwt/lHFiEqRDm02b3zfz9QTRhGiTROMsrvQZ6kTBN5s9fBl5CXeEt
-        6DYo54w1y9wlCbUjEvSpTQM3v+dJV9T9l4DjRHiTBlSQEdZBH6apGWOaOHbY68U0aSo6QjlDgTpj
-        i6kTBm7cxKquGqY1zz1JzNjH8G84dN0mKxTpCOecUzq0VmgC3eZkErh24g0pZxcRXLiDtUOE4PoV
-        4UNW0uoH8nwXXz+7B82Pkh9ZILkAMiPIFQvLKhRdIOSJXABHH06FTqvdOX33esKTCSb7DZZDOX/9
-        ZpI0NSS2D4oZzixAkTgxwAlJ0rjpe7fT9Jw0YQC7SxLCqsBqgPWjKV+ekjMm4TUN5uqRUSbJ4xFt
-        xt5w5FOQh3NNkykbS2kMSGwHoT2iUS/m9nGOwGwIWAHobFPjkd82AkpdkMYIBJqCIWVC5s+voufM
-        aUQSQKcC24SSMbAyw2jIrHNW3BJ1YqsmRty+HjbRAZqaqiK9EQ/CO/50pggZnM3TGnGYRsCeWWwu
-        nv+EAUiKxiCnYuKEM7PdnPMv4BQ6Rc5MOUC6af6Uhs2GVLjP07K+1zp/edb6LLQ7R8enl+cTvtxA
-        5oi0BEwYIbMEmtrjOKFD4SfG8tMenZ4dOrVJAsZYTQbCORlv1RgrMtbVysZYw2otY6yJWO1gtH10
-        aqdBhk7bloeMLEWuLo+a4KRxcKovjxXgBD35UNVL8eml1xcuaAyO+S0oXGaKVsPU6TneJUxJC2hU
-        KO5x0GhI7u0oDQKofCZZHWS+RGwMwbQssy0Sv0Nsi6irY/sGQIMExCVrsO2CcQofj4RXnFNgUCjE
-        HFrKcY4rqqxKmcKqpZjHFPYTuz0U2M/2iDi0IvCBF1SCe0zvhbPQ4eLe496zw71OSsHMox3gnmyh
-        OnYeo7q4hzrY2j7u/WgCWQY+2TTlctQ7vTj+LIz8NBbiEXU84gv9FGxAXAZ+Z68+Pib4FYrbh2Kb
-        wRU0QwR+TWhDiLUGq345O/3U+kU4zbmF9wXuJYzq/GlInVJk4iDC74U3J3tI+sEhiUceBhjgo7Sf
-        QlNu0QYbSNON6iNjJjJq2WBTREYHyzsIxlh0qu9IJKqJq8OSifS6ItE3EclKWCofLHxF0v4gEbpj
-        pszCBaBGJHQGZEjX4NLF4+LSxR6XniIuWVVxSThJfdAo4QPx94HTHqW4SZYDV3iT+tuNEwzVVKsb
-        ZAPJtQyyISKZxQnKTjDqBxLIKoQyrFKEagH3QLjyQED/IMPRv4UTL6JCOTq1Hxed2nt0eoropFZG
-        J6ZZcRjVgyfNKEGn04T443lU8pLcfg7hT0BED3RhRszSM2vN0/PEUkiDV47LAa2Yugmcsee3CmY8
-        w3zEYx2azVjWARp/P0EU2vkQymmQ0CibzKwHbrwRysEtb8baSzTO2esxG26steEVDbhpKnLlKTAD
-        KXWmfMB6K2zKB+VTPn9taRRwkObTgUejyPMfhrOqWIY0C6CsKpapNWcDVTYbWE8UyzCmG9j8gLVS
-        JDuhUUQij/nDvnBMxkLrHmyiR8FyCnceiIwZJvE4KoDQIry9f/96E3gbUtcjoOJkxOw+gNggjJOm
-        Q5wBFfsRGQ08J/a97sGtR5IwOnCYP8dZGl4AYmaIAjQAMyb6yG8OkmR0KEnrMpAKZHEUUQatUjJI
-        h90Y/JJ7VdUlJi+pfcr7tNTLhCP2QDiiS8YinQpHZMIR2ZSO6DLhiF4g5rZUtiAGNw6+jPrQZiur
-        2gggmG360IYxvD6Ih983RiQZNB+/jrzYxrMR6UqBxuloFEZJbLMqT9ZbFknzHJl/s0CaaGmumHst
-        5VoZ36Qk2qvos1HRehZ98tAPp9ZJ5DFS5uDvdfup6vamMXDBJ6kVA/dpyPwrKN+HcDRJwVtS1QNd
-        1XVwY6ekhh8G/ewnRgeWrMuqBclTYkOa5VM5qmZpzzmo5k26JqbOlHZNNP1pnmEpgJY1c80i0Emg
-        WilUtuSyWPkDjdKSUNn3hkRk3trKQPkMUvdh8mOEybwJysPkrAVrLZmR2QqRY+rQYZdGWwsPTRnX
-        CA+xLNdaI4JlUUbbjpRPIg8iZW0HkbJumNXXzaosYK0XKWtfHSmDFUfaB1y+WuYP4ve4Q/XJi71E
-        SEI+PXkOcBpyn8oLQuE8jWk6LI2UO8r3EylzeU0diwEIhzsUt0w4YhKK8EbikAmH+xQgHHHIhcP8
-        Cm5KZdMyNGWHcfJWa7hrN22rld3HyI+on5tFyHvl/CbR8by5/uf5Uaf189RqP61o+NEU+Cti4b0W
-        P/E4eOZxfG0cDB7nAVIV9m91KCwaxgGSzZxhHwzvNBi25PJQOAtFKwXCdb/O73r9dMS+9U/5pyoN
-        qUgoxsrg24eByJfrrIyWefpD8fJzXil17bnxuqA5T18XMZ+QocdmfKvEx3GSBTbQRGC7sgZhERmN
-        oFW7ceinYKNicgtxRRMrTIsXqQ02JsjsWdcLoM9pMmOap2UsrFNCdAg9RDWmPDNizgRqOyARVEib
-        8UxpDV6zWcaKxZgWiDnTLGdFm3EVyssJ08zVAtesROiIDig/6U9fWIYgc5kKKr0kQPb520Jd50ic
-        IXt+L/ONZL4sQE5ZqMY8LWOZr8I8iX+lOH03nHEUSTkDtHdJs6kVWg2bD7dagae81VCFVsNqlVYr
-        cq1pNVS11eSSVluQHrtfrMQ8LWOZr8A8qQHuQAzZ+zS292Ztb9aetcz3Zm1v1vLib1ISJMzbDfkY
-        AzhtfMcse0JvYnDZ5ymLHPKDHMqDHOqDHNqDHPoyh7T8etk4OwTJEQ0cYJn8ylzdfncE3uscacbR
-        Iw4EP1mAsUiccQUpm65pmrJe4MqJM64RW0EbM9ktkgo8rLHj8bAb+lKRDCFlRm3+77/F52f0hrT4
-        mkk4srlS7E3mRiZzSX5SiUOw71D7DrXvUJt0qGIv2t7XVU7kJZ5jR/TWo3zci9UkV7mVSetm5fmK
-        bXM338hiTdWqr9rma05qfSOLzZ18ksVlIrMF/RXn5mt8lIVlXakxPS/X28ZJFWW8nY+y3l12Xl0c
-        vXrbuiidpT8nSTKgd8LLMI0C+lMsvIPXiYhzTaO/l8zL66cn25uW59SDbEw9vvMSZ1Btvig+lKTV
-        z0ox9HnqFqcFoEeFI+hHkqXA5SC120OurNKe4iKNmj3aU7vEMJDl9pCqqJRgxdl4on2bxa+f4nkk
-        GVSYulmal1mauVme3Kk1O/64amJQuJBqOrqm9QzLxYQirGLLsWRVRqaO3R7W9K6p9CqoyZBENymt
-        riS1C9+FktSuxI+nJBqFCyG1J2tdjZCu3lMV2XENqpuK1YWOpMquSbQeNrqbLYrYZtm70JHalXgK
-        OuLiu3v1TtHS7tD17g8cP0zdXhQGyUHAJnUrLFNYm8MqedH7hO/riqRfs+3s7BmFvYjv0aiChuSc
-        D+pI9eIeVoodvut2FgQ8K4vRs+AiBIAW4Fc1DEdBimuYXUfDyHAcZGiq2zNVnThm9VUoPb7GoaLd
-        qF2DXdiN2pV4Cnbje9AUcPH3mvI9IkwuL5tzSpYGV9dyuiqxzB4xuhpWu6qqq8gyCDKNXrdrdA2M
-        HYd8xWK37VdjB3D0lTV6Ehj1zfVJ1uBCuuZaju4S2dF1AysW3BsGUV1VVXRLd7BmuUoNfUoGUfWY
-        aNOK7FyjatfoSWjUd4BlyV24h7ItQtmGC2YLQ4G11stmv9NRTH3f9r04mRtebC0PL5YNOzL628si
-        XVqR94rluRo+0ErW5aID9j3VV67IfXCfeCxX2yg+43siO8WziapsIewrfCGonXfQWSakne4wNY0i
-        1x2OwvaEys8i+YtGYflq4PbR8Vnron3VOjtrly4LbhPXp9FPsXAFihRXXCAsW3L1XaW+rxW833qv
-        w+1uB8WnjxT2oWv1E6oq7+knKzU24tWVepuh66KCOsjMd53lx4Fs8WtXWeMiyXY5VLclEqTLilV1
-        m0MVGXKND15Vts2hrG0iklWndimtk9LJNGahhBO/ZN5MfqkebTJxtiE2F4v7RmehqBUxTn1KGLdL
-        GEujLgls4jJpQ9Xjh877umT8wtGU/4FTv0y9FM2WcvrniR+yJSP054rQxrb0WHv8l473h389w718
-        2Y7zSnYU45b3rrUsQ6mOc4ZSb5mEISq7OZtytnJk+xLBqMbhlEbNhSMGXziyjcMpdXwoy1b5lvOd
-        iMTZzljCcToceuVbzb9DG53/9WSGwtLApVEXIoCxpGO4bMVmfyRZRvcYa9tcJVKpqB0MaVUq90kM
-        XD2h9gcv9B7+29rMfqVyHrHx58p95MavfEbtFdY7F0ftP9afUFswQfszAWuP9LRbWDD//POxBnpm
-        +rjOLZ4yCdme4uUuMSCZIrE/5Z9/82+rhauQZdqPwG1yDwXwRIX2yKN96iegEatd5InWzZ1p/3/z
-        U2BoEH8AAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3712']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:10 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/CoreTests.test_search_events_keyword_empty.yaml
+++ b/tests/interface_objects/cassettes/CoreTests.test_search_events_keyword_empty.yaml
@@ -1,78 +1,47 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxyZXF1ZXN0
+      X2N1c3RvbV9maWVsZHMgLz48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJl
+      cXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0
+      X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVl
+      c3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9t
+      ZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48c19rZXlzPmFiYzI0MzgyaGdnZW91aCUkPC9z
+      X2tleXM+PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48dXNlcl9p
+      ZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['601']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA22QT2+CMByG7/sUhjvzz4RIUjFDpwmbiqDb9NK0pUi1FuyvIOzT77DTEq7vc3me
+        F82am+zVXIMo1NQaPg+sHlesSIU6T63DfmlPrJn/hHjNlcHAiWY51hwqaXwEFU2LGxEKV8A1FoAp
+        SX1VoH43QUy3pSkwlQW7+gzbtmtTuHxtLzI+a27Dgoaxtw1YNsnf3eaebLKV2SRREFF3KAftq6Dl
+        cn82Ab3TI3Mn88r5CCKSH5Io9vAcvj9PDfxAUi3c/agcjxQtafwId0H4Fp6a1bidX/N8RETmyZfU
+        yVqar52ds97IQRmM7SPq//NDqQBDFOOAiea4JlL8xXXtqN/10C8KwKxeXgEAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:10 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['274']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:11 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><s_keys>abc24382hggeouh%$</s_keys><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><request_custom_fields
-      /><request_cost_range /></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['772']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA22QTWuDMABA7/sVxbuzztVVSC1l1iEtsxVleAoxiVaNiUn8qP++54HX9y6PB47P
-        jm0mqnQt+MGw37fGhnIsSM2rg5Globk3jv4boBPlA9QUKfyAiuqRDT7QY0FEh2oOR00VrDUsEPEX
-        qoG1rgBWSz8IWDCBWz+Dpjm1fem1316f7eLCrJQoiT38zPj3ljcOxbpxgtx2m3sbb/M/Hkxdenno
-        k9PDZya/kmu4BHhnJsQu3YssxzyS1SnUccLnRaJtarvxp4JB51yj832R6tzIvcfUxy3inhO0c8Vy
-        YP1rAqTWA+KYaogUhRNiNfG5ANYaB9balhd8tZf/UwEAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['262']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:11 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/CoreTests.test_search_events_keyword_paging.yaml
+++ b/tests/interface_objects/cassettes/CoreTests.test_search_events_keyword_paging.yaml
@@ -1,90 +1,75 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxyZXF1ZXN0
+      X2N1c3RvbV9maWVsZHMgLz48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJl
+      cXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0
+      X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVl
+      c3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9t
+      ZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48c19rZXlzPnRlc3Q8L3Nfa2V5cz48cGFnZV9s
+      ZW5ndGg+MjwvcGFnZV9sZW5ndGg+PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjxyZXF1ZXN0X2Nvc3Rf
+      cmFuZ2UgLz48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxwYWdlX251bWJlcj4xPC9wYWdlX251bWJl
+      cj48L2V2ZW50X3NlYXJjaD4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['644']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XKbSBa+36dQ5WJvJphGAiRlGabsWJmMM/4ZW15vckM10DLE0JDuxpbmcp9n
+        ax9iH2WfZA/dYECWLHnGTs1m5KLK4jsf/XPO6eb0Vzg/zNOkd0sYjzP6/StjD73qERpkYUyvv391
+        OX2njV794P7FIbeECo8TzILIY4QXiXAdXvhhluKYegUnzIu55+PQpZmjr7Y4AVvkIvP8JAtu3MDT
+        NFvz+eer08/J+TUjGj/0j87HpwfBbBR9sOdfLk5mP4qTi7ODM982ErTYj/383fRaHPhf/I+BPXpb
+        WD8fnOHo8uLsfOy95f/4+6c5/5VfFIf2tJ+bfern/vnd0S8HR5OjT/MfzcXbmyjq43g2TgahNVv4
+        0bH1i3V8kqD8wNQ+OnpnfE4Yc4FpQLiHGfFucRKrya3ClYNcBxDsgfuIO7ly9OZOGULCA3cC3l7c
+        RYSRiiBRJ4jFQnGTOEmINmMwnntMmSXz59Jc2apHE8x59U/RsRAMBwJiyoHZ4BVHPrb/kKOag2jJ
+        0KlmFwTMXcip8uCGLNo96RD3xlBmR0Wvn75HOm02vDXNioikJMfshq/uQE2tw+pYGqKc37Qk9v6K
+        0/xvvSssCOudLT2l3KA3A9NrD2dceAzTa2g0xXNoPvVjSkLXQNYecvQOJhkwXpGzOCBAQTWlARWn
+        gClhBo3eN9JATlq6fbmfNiYZD/vpgIqz1E8HcmjmcVj0CSm99u1O80uBqSiXTpbL7HIduYC9GncN
+        R19Clhn9jYzBRoa5kWFtZNgPGfrD6ck4ekHBGOzrQKl/qbVBinKb6UANYwYrMGOlq1ucCmxYtEh9
+        wtzxcNRiVWDDyhMMO2bpu2WoxSnzji9SP0v0Ngy7rELd//7zX+0GGoOjL89TX5PQuwT4syRAO+pB
+        VlDBqgnKV2sbuDfLnf8dK9/uDUW9DkJ4VajWPELD6l6ajjP6umdw0TvCtMBs0esjA1zREBS3EIGX
+        zWacCBdV1hbUcDgJMhpy17AMc2QZxnjcYtdGRV/AX5qGoVv2iAxkVMx7HF692chGhidhTENPxCmR
+        dA0ZcE37gzfWGK5P5Qt5Fbdqcnnm6h4KISbavphGxeueJaLeMZZ+sJ/BD6bdN5FtIrSVH2xkIWt7
+        P9gasuCaIvRGXtv5oZq3qoplCg0O9z++Pz07m5w7eguuKHL6A+0QnPI+y3PCapLyi/oNZaT9YVpb
+        7otKL4FdLGtVRDVD4RUpJWGMIZGxXPaweiLIfjc07ubm3cAq/DSM53tBkhXhjGVU7FEiHF1ynJiC
+        NwtYSvCuzRNSepglbiRE/kbXH21B5/BWJaHeGoJO5sIThAukT670fh/NDcPa+5xfg19X9uNQDN5N
+        wM8cBg/LTt47ORaR+7T25SPOurnw553MyqnwIs8zJrhXdqiq3C7UZfAVlLLa7ET0jxzeIULzARRi
+        G8ObYvalIE8Mbqf1lw5up7NdcMEjk8vz08OfLk4mH3XDhMw3t4gzh/KDPTHM6/p56Yiv63cX/O/4
+        gguSeg1STiSJCdsiAyrmE3JgU3cvmgibOv+zZkPAZJ3iSaY+G8OF8cz0A2Saw2EwQINwOPIDy0DD
+        IEBDywxnI9PGwWhziggWl5CX0c07xe8cxgukzu8c0VfOJ+VYKCu1gRbihRbJwes1V/mnEncFFgV3
+        k/iW1OYKqgmFDyUw1ut7kd0Q2i5ZFVBbFznsBnE5TSigg5syUVsW55pkZYUNI00wHFgLKJYttDeE
+        0v3+3kkyeq1+Dkopp7l19ObxCHMPzvowrRmX+mwHKMXHUiAiSrtt7hxKSAj1dw6VfBmRsrpXfl1l
+        qNgFw+W6lE11EUUo+8xYWp4fG04brDXOWkP2blJXClkrcIdH2Z18Wp1ApLDehRyeFSwg1VG+3sKA
+        1oJrjhKf54IwipPeFIi9AwxxoWGveUKdRyBMRfV085Z09BZcUST9MOaULMoK/j//LrXUmNfUSkit
+        tPHnlMjh8JdRrbhZp5FL+waRHM5TtyRZq49PO+bfII2r9p9TFa9ajDJBkkfF8HvGY0L4+2XSI7p3
+        SyyRTl+vnlzSGJZX7wMcTsMs3V5FmRbkda8PybhfXBeQmxvFg4GNttQPhsgYWPbW+sEI9Z+kH4w0
+        1J8afaUffIeMN2VPX19M2d4fdt80gfyiespv8MdDUeX89PR4rZyyLyJCMSnSNVrKT4OLdVqKXB47
+        GWUno/wxwruTUb7h4L6odvJVBZOdSrJTSXYqyU4l+VZVEigYNVwXlc8pkbQq0YcSiaxFPZZl6WZ9
+        xNizEFTv9mqNREN7cNYZjPvPrZSUn+qwglIolFXZbvSrD3g6qPz6ZgVvGV2pvDSKyqPCS0ugWa+8
+        NKSO9FJ+XSBPEVfGUW94cASJXyP/d7LM/vT95GR/cnm8VpVpHY9WiTF1+na+6PwftUGlkg4qAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:11 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1823']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:12 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><s_keys>test</s_keys><page_number>1</page_number><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><page_length>2</page_length></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['815']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1XXY/iNhR976+w5nE7LA7MBFhls5oOQ0WHLTMMtOXJMomBTBI7+IPZ/Ps6sZOQ
-        llaz1baqtIuQwOceX+Nzb84V3odPaQKOhIuI0fcXzlt4AQgNWBjR3fuL1XLSGV588L/zyJFQiQTB
-        PNgjToRKpO8JtQlZiiOKlCAcRQJtcOjnRHjd8yEv4HkmGdokLIj9Fep0jnG2HcW3o2x1Pd90dpxt
-        Q0f++BL8/LB+7pNAPPfHa8d9fozncP0rHR/T5f1e3PQz9Gl1GCxmk3wcXHcWobN17w9btZ4edjcT
-        MV/Ql/yA4dJx51ccjdP+bHr3mB/43fNhOEp472FKR/1x/LJL1l639Zu8MBIS04AIhDlBR5xEoU+Z
-        1z2HG1V8TyMYac2Iv7x78rrN0kRCIgJ/SYQEMxZgqYW2nDLgBQkWwn6YbXJPsORE/7QGs3GTqx03
-        abTEpd4mXVmENuTZ6sUkr07o6kI1YFFPS6121kgrX8M7kzKNRHA+rbmIjbewhlLe5aOmgFqEdqxZ
-        +/b+WhqmqOS5yaVijZ8Cdbjcv6KRJCG41/2tG7ShmuQhlgRxTHcEERratdFckUvgQLkHH3EOetBx
-        dU/UUUNUMkBsuxVE+n0XQks4QRuaIAGjofCdK7c3gv1ei10FDT3XrzQNQ784FF47FbPGdbXY0IUO
-        KmFMQySjlJT0DrzuOPo5GL2DUL+/h8674qTzG2zeP17frHX3c/k1C2IFMEZYNlZvOOx53RPABksB
-        fpguxmuQJUoAkZEgwgnYKe0BotphZDLftZf0Z7ePVai2FpToNmWNH5yClSVLLJXwk+hYxy1UEbQT
-        Y4m71VqymNDWcQapwnlGfBGlWUK0CEFMZE0rIt4eC0QZygjfitIYW0BhHPrR109Y7Rh26VFCQn3p
-        TKuotIMWypb7z+GWrHjplie0CjGE4kzG08KWzXF/QiuDqtwbxakP38Lan05xT+zZS7nbVN/MsTbm
-        Caa4ppfl1mXQk1AwxGhhUyeRilbW+M1s+svdGzC1bDA/YZsm0PIqu3P526C79LoniI02Q6Rcg58m
-        Fcvaop1F30bSVzOSnhS9BANtwDdqp3Qpv6AHD+C1O3Bf7cFDOPgsDx524GDp9L78UHrC8hK4/5Ik
-        V0Pn9WNpCN3PlcT9J5KcHUvOX46lW6x2ewk2edHMYKGnBgfLPU7J38ylxX87lxbf5tL/cS6NXjuX
-        wEQluqPAA05wQM5PqaojWv8nfwe3D64zjA4AAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['940']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:11 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/CoreTests.test_search_events_price_range.yaml
+++ b/tests/interface_objects/cassettes/CoreTests.test_search_events_price_range.yaml
@@ -1,139 +1,167 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxyZXF1ZXN0
+      X2N1c3RvbV9maWVsZHMgLz48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJl
+      cXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0
+      X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVl
+      c3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9t
+      ZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48c19rZXlzPnRlc3Q8L3Nfa2V5cz48cHV6emxl
+      ZD55ZXM8L3B1enpsZWQ+PHJlcXVlc3RfY29zdF9yYW5nZSAvPjx1c2VyX2lkPmRlbW88L3VzZXJf
+      aWQ+PC9ldmVudF9zZWFyY2g+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['588']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1dS3PqSJbez69Q1KIf0Veg1Ft3aDqwwY97MXYDtsu1IQRKjMpCoiThe93LqsVM
+        xKzmB/SqdxMdEzHL6ZiYRf+UuRPzOyZTEkY8JCSQDMh5g4oyqYNSykzpnPOd75ys/OHr2KCeoe3o
+        lvn770CJ+Y6C5sDSdPPx99/dds9o+bs/VP+hAp+h6fYcqNqDUc+GztRwqxVn2tessaqbvakD7Z7u
+        9PqqVjWtSnn9kcrAfpm4Vq9vWIOn6qBH0yLdd368v/7RaD/akHbq/U9t5fpkMJRHn8WvP3Vaw3O3
+        1bk5uemLwGBeanp/ctZ9dE/6P/UfBqJ8OhWaJzfq6LZz01Z6p873dz98df7kdKZ1sctOeNbsT/rt
+        L5/+ePKp8emHr+f8y+nTaMSq+lAxOE0YvvRHV8IfhauWwUxOePqhUl64voqmO65qDqDTU23Ye1YN
+        3b+5de3+AFUrqEXtoeGD1cZ9pTz/5h/QoDOoNtBov3wZQRsGAl5rZaC7L76soRsGpIc2up7XNv+w
+        J9nEh4NjwU8N1XGC//niquva6sBFc+ogyXl7IOP9rLYq458OzZY3df5pXyA6vNhUCdbBE3wJ91RG
+        8z4/gFdHID779WvLwjnnchGndUdwDCeq/eSs78C/tQWphSNzQe/+uliQ+pU6nvwjda+60KZuln7l
+        D0N5fmHl2QhbjtuzVfMRnXSsfkWnH/d1E2pVXigxlfJCkyeALted2PoAVnlmJjFv80Wm6IZUG53y
+        9RzzpsoYD/pSL+EmT2Cll4U2X2Spl4Wmimn1HPTAGxCPWDFv8aeparr4kbEm3qqqVrwHtzdrr4JK
+        eallWYLdKMFtlOA3SggbJcRVifLq7Xlz2BtMbRu9z5HI7C//mYBT/HpZaJpLDNGTZ9lVwDAhmaBx
+        LmVOx31oVxVJDkkFjXOpiaGiNyUeu+WmkAxec87LuG8Z5XAzerv6rdX/+fmv4RPMD1TKy/dZjljM
+        ZAG8lwUQnvWBNTVdO7hBT6WGG14Pe2/8Mxtr9bmIrwY0pCL8s/WgqQXfvUNXlvmBAo5LfVLNqWq/
+        UCwD0FDMBXzZqTvoWcOhA90qExwNNc1lHDiwTM2pAgHwsgCAooSkZwd98Rf0bzzWtCrukQEMCCRf
+        25HKtWSRAT2vWTW1nquPoSdOMwB9uiz3UVDQ5wesiNfJBqdcvnP/OzKAbDc8Ft3R9AMluCPqSvXG
+        QcxgHHiR5RmRZ5hE4yAyAiMkHweRZgT06TLMR++TbByC+/atYW8J1WsP3cvvK+VQU3DYu3VA19GA
+        dPXBE3RnQv6Y+H8j01H83JkdeTUkewZ6g1khK2gm4bcHQmOo6SpaxKr3yKMnZ4RWflUDX77yXzhh
+        2h9r+tfSwLCm2tC2TLdk4mvwZCq6iUZyih4jpGYnBsSjaxvVketOPpbLsWcoO0ijQq0cuoQy/Or2
+        XOi4TLlxX2ZZ5isAQunHySMa07X9VEwVjayBxthBF48eOe97ZaK6o2q683s/qUTdi5Ptzay9FWc6
+        mVi26/Rwh75lu9i0KOGsEcEW5sKMHvL0SgzzlWOYzdM7Vu2fpjDl5C6cPe/JXeiMTC4akcZt+7p+
+        2Wk1HsqARyufTzDPDjI97JTTHNVP3jMe1S+Z/N85L44Lx715C74RQ4d2ghUQSKZYA5u6y3UhbOr8
+        va6GgW1NJtDueZLloYI+qjrk+wOG5yVpwDGcJsn9gQAYaTBgJIHXhjIvqgN58xJxbR039Sxz85ti
+        x8vIYenseEVvvJ78gUVmJQ1oTX2hXc/6LM9k/fEJAF1XdadO1dCf4exw0DQTmPaR+auWZ99d6wma
+        YZPVb5gdfZmgt4GOb7PnLti83pHKI7SwdY2u1FCRszpFxrLAlCRktr9+rxiW+ej/yWEYZ/61Up7/
+        fKQ6PeTnozkZOh4mu9CAAUcMDkEfr51/q5gQasj+niArHs8Ituz9cV13IJCe2ip+Lr1TLbb4ArhP
+        yx5j33EuE26c4Zoz3Lj3NK56INaa9oozsr54v/a9Dw9MX2yqONbUHsDAjZ+9wpBYqHkm4wPOX11o
+        m6pBdZEgdaKieTE1av4L3x9B0zQNfj3XkpVyqDkQ8cTrumPCF2zB//3fMX6qOzPRADwN8PAMYfHh
+        1FT7qjPS6R8nEdD42UyEwOP7gcdD2Io3SdFgyyd1opoEayFYSwqsBdRrDze1Tufmut2NRly+/fJP
+        3375r2+//Ou3n//z2y9/9v7+Z+o31yakMBZzg5YqVqG/jYBjaudyUeAYkDMcs3r+HM321c7eq5m+
+        MCK5wTGrZ897cgkcszwieWEwqyfPe24J2rIwIssIBMgTbdncXa6zv6nzvXjHSMvTAPt76CeWa9GW
+        CT1feRJYB1l6yyGLYldvmRNKIocNvnX+MuCUkiwLx+Yzz8/11k4zSO00g2inuXv9+WGT1/x/f/6P
+        //3bX7GB+vNfvv38t2+//Itnnf7bt5//e2amdq2nF4vy3WuqDR3fUs3ZtSaMs8N1qSPoWIDZyMcC
+        TAaErFk/MYysWT95sM4KcJuEePReiEeEefbOFwBhnhE09M3QUK5ee7i4vrlptCOxUM5jn114wctI
+        9lm3KHAnYZ8VGjUh7LOiTy5hn73XySfsM8I+I+yzQrHPujTnIeoj7+KzZZ91CfuMsM/eln2GVoJm
+        mfT0KQoj945vAMmRP/UMjUh8vLtweAto3D9/lqh4cMaR5UIjFgx/lYgDwi+WhZJRybxBj0ZPbk0d
+        PV7UZ+ScatY4OYrSncIPFIsWY236OEVrcyN4wIlMQvxAYgAniInxA5lhU+EHMs2wXcD6+MHvGPAR
+        9/T2YEry8RBZnkfCueIpW4zHKqjSvr6+ioRTau4ImiqcjiOwlEsuMpPPezwIjEJglMOYXgKjFHhy
+        c8VO3hQwISgJQUkISkJQkqKiJMhgpNWZUZklRBKyRFchEs8W7dmWNd6Mj4CSwCDrPYJxSDMl5Otw
+        Cps1UoKpOvbUNJGh7JvtgA0IPAutHvtmjdxy61rkZY6oxAIvIYAmNYcRsws8L+IefKKkk09o4c9a
+        jg6WqXUvGq1a4/YqEpUJuUcEjCFgDAFjCBiTIxhzatlTh7p40aDHpo2EZCLpLQSSIZDMAU0vgWQK
+        PLkEkino3BJIhkAyBJIpFCTTpQfYtKRHyLSkcXpXtsBMDHclJTCD7CclBpiRJA7T8wkwEwvMsBTX
+        PD9mXOb0un3bubiJRGUCPwkvrbC3lDNCM8H8KxvNczRIczMT+UC10LM5oh4s+8kZ6XbCVNO3STPN
+        IcW07KKpRMsoNrf0VSQ2sdSXohbuOAGekz0WFrwmMoLCwmeLQ8L+NNadQdwwzgTiBvHaReu4VCrt
+        lI4rspvSVAV5Y5YqvylLNeglJkk16CUuR5XfMhX3yG+RZGEupFw+9icZZWHKODqUdxbm3/9CsnDJ
+        /O+WhJtT5OIeah8oDmfjXqMBQjefWTYuDxjkIyXNxkXCqbJxAUNzJBs3q2zcs9rVZfMhMlpxpo51
+        Y+NGELckFZcELA4Y6SIBi/cyuSRgUdC5JQGLAwtYfPnypTQ0kHmA9DlWhKWBVcKWaoJlsP6nZXTL
+        yMJGN1yeHezho+jSxoZQ1sfqIzo0UW3VMNSv81pnNLKG+LJhPVqlibltXCKjvuOXRe63ns3C8DfC
+        TZ4xe0sPPSsxlw0bbqPDDilTZvkSywiyIrNyZOxBZmQG/ePeIoE2YbRgh0qUr7GBh2sgUeLt98cc
+        LjhrXrbOr5u1yHjBWeipyitMQKpH7mFDhqmTBP7ouPj1SVlDqjaGtj5QSVUygoOkwEGEzVXJzpDy
+        CrZisJ+C6mTxyIjy/X1RkBGyJ0OhHSyyJ0PRJ5fsyVDQuSV7Mux5Twak5ekhsg2CjRiQW+7XjsrB
+        Hw4ZFKn84UOt/LTJcz2tKayM/fE3dVwz3V/BLwnVrLXqCcpCBTsnULpJnaqGjkbE1FWSlkjSEkla
+        IklLzDUt8UI3XMukPkMTk5DcuVu6kpgYGewniYkkzn9A00vi/AWeXBLnL+jckjj/gcX5SWIiSUzc
+        LTHxlh55xiX99GpcZpuaGMMRSFszCg1dND2ABRwrSiQ1cVPNKEDxt81jJht8vrhsdq9bkYBN4Cz5
+        uMiCz/TmvIMktIMgCN/RH0euA6GOqUIZEBHy4SGUnfBlRoMyi2Kbsg0PkHaQGqKhWZAGpJFYIWeQ
+        RviIPgxDM+KeQJo0IyKyvMCxOZMQJB+mSTEiqzDN5dVNo31Za0ZCNZdj9C7U0evsAhr6wJpgag1e
+        4xGITf1GiUJs3NCvDhuwIfSDQlr6hH7wXiaX0A8KOreEfrBn+gHS77QemAT06NUkoLFyz9LPDtkR
+        u3LxOaGkiCDCzwaALQFOFApGwkeGIJsVkcFfIW/NZPh8fhrtEp/bmL5wqpovyCOu6TZevEWo1kOo
+        /VlT+yPKtABlU5kWIG4s08JtKtMS9BJTpiXoJa5MC7dlJZojv0VSieSdVCIhlWje9/yTSjSkEs3b
+        Z2B1LlvnzUY06mlq+rOuTbHBGl+N5q4oOVeEpVZo7ISw1Io+uYSlVtC5JSy1A2OpkWo0pBqNX43m
+        jtZfLcVcKtLcZYWCH1pFmrdM7CMlabLGwg008c/wUXVoj7m0No9Pdag7LPKeoO+B2kfjFVu0fi4S
+        B3qf+lIB7F3XTRPaVActumJwywQ2ObeMZdjkTKqtuGUs+5HzmVTS3rhlyUdEZAWGS54SuRW8wjIz
+        blniEVnFWJq1s8bVVTTI0lSpMzgewyhspRlNJRshzWLD4wBWCJus0P4ZYZMVfXIJm6ygc0vYZHtm
+        kyEVTxsqPcRWQKZ+czM79phYAgzHR9LHhBKQ2N13kJu5GTvnaSlZp2ll4YC37mQFMMpRE9Kuzq/O
+        27VWvXkX6YIjEcqnpoWc37w98SzK6aDpj3G+0cHADz2dGnid7OKDo5Nl6nzj82l4pcT53DOBOI/7
+        RDWMucO99IP0DDNh40ZgvLSRfiVsol+xYCP9avNGYNsyzI78FgnD6J0wjAjD7H3Pfz4Ms4GtIxOy
+        Z8NnHXqWyADrdH+E1h6KQ1AxWIgpaR04QUZ6QErLrIYaKwl8csBQSVMZXKQZBVcGB4oPoR5JDTWJ
+        y7uGWvrxWAVQW7fd03bt9HNMmfAr1XVH8At1gqxWE/7aoVrodmxszdpUt9HpRmGrl2cHg63uUpyk
+        rHDoM2D4/pDRWB4OOY0RoDyEQ76vShKjaEOG53ioAm6QJfa6dff51WlJfy0JXP6VePiB4T87DZgE
+        0Yfh5YEoCENJ0YAKGcADZaCwPMvIItCGQBD7MjdMsHaSArtbd57jykl9LQVYObtXRGIV9JF4KMiS
+        IqnooVOAJLB9idNUTmFUKA7loSpCXhbZBHAieuliuAZZQmbKWlGpryP3WlGpr6gIUPROT6AA0Ydh
+        +CEr9AVV7YtDnmMHmgRFmVP66OXNs5qsCkMg9TMLQ2zdd45votTX8k7fRIQcerDk0H2+RnKpXjj0
+        gi8JXyYHVLgwl5KFh/4yOcDl45V9IsvnKJbP7rYfA9GHFQSNHypiX2PYvqpK/aHGsui/gdpXmIE8
+        FAdQ4/g8C6imvozcjeLUV1QEbbb7sA1Qg8pqvCArqqzwMiMAHnkUyDIcwIGsKjIrCiwrM4zCJV9P
+        7hcr5XpKfRm5r6fUV7QfhsflGT32MUq672GUtEObrxgljc24TJkfc2AzFfPD/3s6caBh9AzdcRfA
+        0sYqWIr+urpgwu3lNeeIqPzLKiIAnBSZiAEYkQGCyB4OrST78r9Z8Eoap6BN8d3WWxNLds/smDro
+        QV4XO1p3IExD6dTqzUa7c99oNjuRRJSOqhnQ/rVD3aOl+P44KEH6USYUlPC5DpOBsro51iyCE7U7
+        1uLxLVg8QQ+Z7o8VnPJJ12LLRgXH48bxzNsgfif2DidsorZwYCO1hd9IbeE2UVtYJjf2zpHfImFv
+        vBP2BmHvvO/5f+v6UPlzcVLURtqKizNL3jsSLo4g55zMCIQMuDid+1qrWfscnc24wsTpfFFNqqk+
+        QQq7DJFEnDW+5REmOXp1W8K+SXk2YLnXlErQa94FaxJcwntF8xKMk2PkW5cqUa/7WSJLF0EWSeRI
+        5VrdKkGX+1kfJGGTkB0KTHbI6anhRfRO5UU6RYQxUZQ6fdf7eWssXQRZKRtHCmQbi07f834XCiAL
+        JeFIpQkyj+xsLNWlvve7VPYTTD6mpYL9fuz2z0YsAfs7DS9h+yvYz8KJuJg9sREaq2wEB10gbaAr
+        zIGM0MiBjLAmc8urRH777kkKB1n74ng5CofOOsiuBqVrq8/QiA6YLxzeJl7unSDTcLl/Rm/H8dh4
+        +atEXMT8YlnoWCtLpgjEMIATkgcettuzmD2qQAzOEc83EJN+PFYDMe3r66voIMxrBZ7aAJkWlqaG
+        N+BYir1ccu2o2Iv31BxH5IWUlyy0o0HKSxZ9ckl5yYLOLSkvuefykkjB0+PHMf2ILQJaDVkEWXr5
+        ITNi1cv3DImebWEGUtjF31+lyaW9GQ4oIyC0JcShlJpMutVDcStN9vXH6aT3rBpTWJXQ4gx/D2+O
+        rNq6Qw/tqI2R8WGyEcTbbwSxMspDy9Iih/cMHfxA1W3dfKLw4mrpjyPX0Ic7ZFvg/jLMtvBOp3mj
+        EJtuMZOIG9qddtXwlno09nFm+/kbSZGOztT8QHG2Rn2aGgn8ein5bhGSIArJ98+Q8O4/Kfx6iWY4
+        XOws8OvZPeEcKcaDRUOSN+E0/Xis4hz1y1ar0e5cXN9Hox3W1NBNqm1NHyH1m9By/m0E4lE/+aEQ
+        bFOCeRTcdSKYR7Enl2AeBZ1bgnnsGfNAKp4ee3YBbWO7gPZNYRp7sVmiHiFTYtctNni5JMsRuAdb
+        4jhWOhyKwWHWQZAEBsjHvbvG9W3zstW+vj1vRIIeJ+h82pQKW715kQxiwIkk2ETgrXew++xAqOMN
+        ajNAK/IBK8pO+DKjfepFsTjHuosmuQhsApoFafgEMps8sXM7PoE825VR3Ns+lclHBKd2csmRh608
+        bW97ynQjsqbM+nW7exHpZLeQ3h1Rp6r5YpnUBTT0gTVxcXV1L2NgvZt9cxLpZod+RXxs4mMTH5v4
+        2MTHJj428bGPyce+OaFNbBbQA88soEevZgGNFXymfvbclth5K0uhpIggkl/AlgAnClnzC/bsGSNr
+        kOWO2jP+fH7ainSJfQ5AYJzWdBsv4NyJ95nG+ovnTofvLdqbXpCKc6YXKA/7DVJ7DjQujRT4inKs
+        r5jMTRRYgQUK0u6J3EQZuYkpKiLJnpsIuiz3UcAx2R+y8ZnvofaB4pP6zIndZewsp3CX+bTuMt9l
+        gspQycZhTUz6rh7pJ3esKfqi21RIaMkvPr+rRfnF4ceBeMfEOz6E6SXecYEnl3jHBZ1b4h3v2TtG
+        Wp52AmOA1p61LL3hkAWx6g2PdWfQ09F4HELE+W3d4FeZ/OPD+6HEH1Z4ONvK9yT7fLvs85zq/5Kc
+        c5JznibnvONSDXusm792IvPM7wqQZ87k7PGunj/vekXE410ekXzr8L5pvV3i8S6PSK4VdN+0Vi7x
+        eElVXFIVd2GEFvcGzGUj1/SbcB7Qbq7bXtGe6hbc0Y5LQ2xV0k62tQruovGTFLUKBFDiFQVIcnR1
+        QI7nBYVUK4inJ3TuwQXF/PH+jbGZbGsDdhvtq8tWI7ow4CfLMF6osJ+UCJY5aTQjcJkTaAxVvKdK
+        Qs5+AQoKDGeb2kViLcPlbe923Rsvf6ylo7ofKA4zCupwkHCvpYTYgsyxgE/Mxwcsl2qjJcDS3Hyj
+        pb3QCtLALJwsJ09N2IpZsMWeU6swC+Dw3mMRMIv3Omrg7xRNdZFiwnjxWryFO43mGcSlufvKF//a
+        qwRMe6001oE0yFIJh69vV04f8FTD2jiGfyTbvLk9s/lOuoBiTxpvxedDi8OGjmNh09fTmzFq8zKQ
+        jdaTtYfzcjc6euGrNC+txKGarvZGSvKoN4tFZjnUYpXiq0RsjZ1lob0qRU8NcAzSAy3rOWOlyAhc
+        csAdAI5JpRQBzTG5KMX3MhrrVKKipFGJDPUbLar6C9I70XlpSfTiyapeZOhM4/vhSySqkahGohq3
+        VY2arY7V2BJpgUBshbQlmSI7i2ziwPx2ziJQ/F1oj8BZFNPUR9vCWZwNxW7OIs9IKTUjjNGMpztp
+        xtN1mhFmrBlPiWYkmpFoxl0145OuxXLWguPHg6J6qgAz1hKlZSVWBTgzS5TkhKoAZ2aloKv5mVls
+        F/CpVQFRjZtVI8elUY1ctFo830ktnq+qRS5jpXhOlCJRigehFNGMxcQZ0cEgjfl0auCp3SXciE6W
+        aZwRn89CUxfrMM4E4hTj9ZLM/vViftChktxh3A46BMcSXVTYnPOWZ0Oxo1YETBqtyMc7jPWdNGN9
+        VTPymTuMdaIbiW4kunF33fioGga0YwONc5E4/XjuSelwdr9XUwdOxweT++RDrFhjhiFWKYsyH3gn
+        CpC0GiSSTKMxJQ9iRRqTzVRj5gw4M0ld6+0B591CjzwAafSlEK8vGzvpy8aqvhQy15fb7dZN9CXR
+        l0RfLpxP8+tKxQQfA4E4XXmCdeXrxldLP9irmryyzA8UKy6pyWwUAyvJTIpIJCumVAyseESRSEnJ
+        mbYKpGzgVjaFolSideTZTjrybEVHKhkryDOiIImCzERBZrkjQwGyO9DzPcbL8Ck2MrkgFbsBAxYM
+        NOe9iqvV3yz9KqH+zHtLBk+TYg/rk2pOVTu7qpJIkwoAYO5kotglSFlVEsyrSgpKRno0XZWN5CU2
+        GDGNEt1mE4YdOa5svfZwcX1z02hHa9EvFqWhYcHLeOQldEYoUeX7B1JikpSYDM/oIU8vKTFZ4Mkl
+        JSYLOrekxOSeS0wiLU+7XywamQT05NUkyNLZDdkRqXzdLOtDhioM5O6intYUVmay2ilhLzUi65ed
+        VuOhWWvVI73Vuu6Y8AWbSlQbOmitUbpJnaqGjkbE1NXjKBdJ9k7Ib+8Ex/W9FL/SCHqp9XUTPZ6C
+        t/AXmjwB/PROkMcLQxLzNl8ELVb0fkWnnEu8Nnl1SpZ7CTd5Aiu9LLT5Iku9LDRVkHlhunhJWZ4O
+        RXf6jNa81pu1V9FTtdRSKa/+yPff0OvehuYAicz+CgLg/QkayIWmucQQzYJlVwF2RJcb51LmFGPp
+        VRmD2suNc6mJoQ6gU2VDMkFTSAbPpPMy7ltGOdyM3qB+a/Xvfwn/ft5eKS/fZjm8LN4svODFna/R
+        AGUZXZAkRZC5hHttiIBJGXZmvKIYZK+NTPbauGpcnTTanYvLm04kLHLnvdxr1JUXhHJG+iSqBqn4
+        OTK2cGy4CClEWmj3ihQiLfrkkkKkBZ1bUoiUFCIlhUgLVIgUWY30M63S47l9mSXIFjJKdyWUeAVJ
+        RQWwAhddklRikd0v8cXa26VzL1Fsu/nWe5xmWkK0e9G4q7XqtUjg7k7HUIGuUhi6qxloMboBd349
+        ZjdbhP4N29CZGm71/wHkx+a/x7cBAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:11 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['7090']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:12 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><s_keys>test</s_keys><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><request_custom_fields
-      /><request_cost_range /></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['759']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1d63bbNhL+v0/BzY/ttl2aAO/0qupxYjl1YudiyXHTPzwQCUmMKVLmxbb2dfZN
-        9sl2AFISdaFMKpJjJ8phXXEwBMDBYL4ZAAQav98PfeGWRrEXBr+9wAfohUADJ3S9oP/bi8vOiWi+
-        +L35twa9pUFix5REzsCOaJz6SbMRp103HBIvsNOYRrYX213iNsc0bkirkxpONB4lod31Q+e6eWmL
-        4u31qGddv7JGl9r7rtiPwp6Lk9d3zrsPn78o1Im/KMefsf7l4/V79PkqOL4ddt4O4iNlZN9f3hgX
-        ZyfjY0cTL1zc09/e9NLPpzf9o5P4/UVwN74hqIP192pkHw+Vs9PWx/FN1PpyY1p+JH84DSzl+Pqu
-        739uSHN1arhenJDAobFNImrfEt9zm0HYkFbRM6k0G0AhNsiMNltXDWl2lyW4NHaaLRDx+G5AI5oz
-        cGrD8Ukc5//LnkkGlCSMq0DL0/kjnfn0LBsQL5d1lh1vgHlSI2+5azqelCBBI82IrC1z1smTU8pc
-        fjO+FVkOvdhZnW32Inn6HG3Gwt/lHFiEqRDm02b3zfz9QTRhGiTROMsrvQZ6kTBN5s9fBl5CXeEt
-        6DYo54w1y9wlCbUjEvSpTQM3v+dJV9T9l4DjRHiTBlSQEdZBH6apGWOaOHbY68U0aSo6QjlDgTpj
-        i6kTBm7cxKquGqY1zz1JzNjH8G84dN0mKxTpCOecUzq0VmgC3eZkErh24g0pZxcRXLiDtUOE4PoV
-        4UNW0uoH8nwXXz+7B82Pkh9ZILkAMiPIFQvLKhRdIOSJXABHH06FTqvdOX33esKTCSb7DZZDOX/9
-        ZpI0NSS2D4oZzixAkTgxwAlJ0rjpe7fT9Jw0YQC7SxLCqsBqgPWjKV+ekjMm4TUN5uqRUSbJ4xFt
-        xt5w5FOQh3NNkykbS2kMSGwHoT2iUS/m9nGOwGwIWAHobFPjkd82AkpdkMYIBJqCIWVC5s+voufM
-        aUQSQKcC24SSMbAyw2jIrHNW3BJ1YqsmRty+HjbRAZqaqiK9EQ/CO/50pggZnM3TGnGYRsCeWWwu
-        nv+EAUiKxiCnYuKEM7PdnPMv4BQ6Rc5MOUC6af6Uhs2GVLjP07K+1zp/edb6LLQ7R8enl+cTvtxA
-        5oi0BEwYIbMEmtrjOKFD4SfG8tMenZ4dOrVJAsZYTQbCORlv1RgrMtbVysZYw2otY6yJWO1gtH10
-        aqdBhk7bloeMLEWuLo+a4KRxcKovjxXgBD35UNVL8eml1xcuaAyO+S0oXGaKVsPU6TneJUxJC2hU
-        KO5x0GhI7u0oDQKofCZZHWS+RGwMwbQssy0Sv0Nsi6irY/sGQIMExCVrsO2CcQofj4RXnFNgUCjE
-        HFrKcY4rqqxKmcKqpZjHFPYTuz0U2M/2iDi0IvCBF1SCe0zvhbPQ4eLe496zw71OSsHMox3gnmyh
-        OnYeo7q4hzrY2j7u/WgCWQY+2TTlctQ7vTj+LIz8NBbiEXU84gv9FGxAXAZ+Z68+Pib4FYrbh2Kb
-        wRU0QwR+TWhDiLUGq345O/3U+kU4zbmF9wXuJYzq/GlInVJk4iDC74U3J3tI+sEhiUceBhjgo7Sf
-        QlNu0QYbSNON6iNjJjJq2WBTREYHyzsIxlh0qu9IJKqJq8OSifS6ItE3EclKWCofLHxF0v4gEbpj
-        pszCBaBGJHQGZEjX4NLF4+LSxR6XniIuWVVxSThJfdAo4QPx94HTHqW4SZYDV3iT+tuNEwzVVKsb
-        ZAPJtQyyISKZxQnKTjDqBxLIKoQyrFKEagH3QLjyQED/IMPRv4UTL6JCOTq1Hxed2nt0eoropFZG
-        J6ZZcRjVgyfNKEGn04T443lU8pLcfg7hT0BED3RhRszSM2vN0/PEUkiDV47LAa2Yugmcsee3CmY8
-        w3zEYx2azVjWARp/P0EU2vkQymmQ0CibzKwHbrwRysEtb8baSzTO2esxG26steEVDbhpKnLlKTAD
-        KXWmfMB6K2zKB+VTPn9taRRwkObTgUejyPMfhrOqWIY0C6CsKpapNWcDVTYbWE8UyzCmG9j8gLVS
-        JDuhUUQij/nDvnBMxkLrHmyiR8FyCnceiIwZJvE4KoDQIry9f/96E3gbUtcjoOJkxOw+gNggjJOm
-        Q5wBFfsRGQ08J/a97sGtR5IwOnCYP8dZGl4AYmaIAjQAMyb6yG8OkmR0KEnrMpAKZHEUUQatUjJI
-        h90Y/JJ7VdUlJi+pfcr7tNTLhCP2QDiiS8YinQpHZMIR2ZSO6DLhiF4g5rZUtiAGNw6+jPrQZiur
-        2gggmG360IYxvD6Ih983RiQZNB+/jrzYxrMR6UqBxuloFEZJbLMqT9ZbFknzHJl/s0CaaGmumHst
-        5VoZ36Qk2qvos1HRehZ98tAPp9ZJ5DFS5uDvdfup6vamMXDBJ6kVA/dpyPwrKN+HcDRJwVtS1QNd
-        1XVwY6ekhh8G/ewnRgeWrMuqBclTYkOa5VM5qmZpzzmo5k26JqbOlHZNNP1pnmEpgJY1c80i0Emg
-        WilUtuSyWPkDjdKSUNn3hkRk3trKQPkMUvdh8mOEybwJysPkrAVrLZmR2QqRY+rQYZdGWwsPTRnX
-        CA+xLNdaI4JlUUbbjpRPIg8iZW0HkbJumNXXzaosYK0XKWtfHSmDFUfaB1y+WuYP4ve4Q/XJi71E
-        SEI+PXkOcBpyn8oLQuE8jWk6LI2UO8r3EylzeU0diwEIhzsUt0w4YhKK8EbikAmH+xQgHHHIhcP8
-        Cm5KZdMyNGWHcfJWa7hrN22rld3HyI+on5tFyHvl/CbR8by5/uf5Uaf189RqP61o+NEU+Cti4b0W
-        P/E4eOZxfG0cDB7nAVIV9m91KCwaxgGSzZxhHwzvNBi25PJQOAtFKwXCdb/O73r9dMS+9U/5pyoN
-        qUgoxsrg24eByJfrrIyWefpD8fJzXil17bnxuqA5T18XMZ+QocdmfKvEx3GSBTbQRGC7sgZhERmN
-        oFW7ceinYKNicgtxRRMrTIsXqQ02JsjsWdcLoM9pMmOap2UsrFNCdAg9RDWmPDNizgRqOyARVEib
-        8UxpDV6zWcaKxZgWiDnTLGdFm3EVyssJ08zVAtesROiIDig/6U9fWIYgc5kKKr0kQPb520Jd50ic
-        IXt+L/ONZL4sQE5ZqMY8LWOZr8I8iX+lOH03nHEUSTkDtHdJs6kVWg2bD7dagae81VCFVsNqlVYr
-        cq1pNVS11eSSVluQHrtfrMQ8LWOZr8A8qQHuQAzZ+zS292Ztb9aetcz3Zm1v1vLib1ISJMzbDfkY
-        AzhtfMcse0JvYnDZ5ymLHPKDHMqDHOqDHNqDHPoyh7T8etk4OwTJEQ0cYJn8ylzdfncE3uscacbR
-        Iw4EP1mAsUiccQUpm65pmrJe4MqJM64RW0EbM9ktkgo8rLHj8bAb+lKRDCFlRm3+77/F52f0hrT4
-        mkk4srlS7E3mRiZzSX5SiUOw71D7DrXvUJt0qGIv2t7XVU7kJZ5jR/TWo3zci9UkV7mVSetm5fmK
-        bXM338hiTdWqr9rma05qfSOLzZ18ksVlIrMF/RXn5mt8lIVlXakxPS/X28ZJFWW8nY+y3l12Xl0c
-        vXrbuiidpT8nSTKgd8LLMI0C+lMsvIPXiYhzTaO/l8zL66cn25uW59SDbEw9vvMSZ1Btvig+lKTV
-        z0ox9HnqFqcFoEeFI+hHkqXA5SC120OurNKe4iKNmj3aU7vEMJDl9pCqqJRgxdl4on2bxa+f4nkk
-        GVSYulmal1mauVme3Kk1O/64amJQuJBqOrqm9QzLxYQirGLLsWRVRqaO3R7W9K6p9CqoyZBENymt
-        riS1C9+FktSuxI+nJBqFCyG1J2tdjZCu3lMV2XENqpuK1YWOpMquSbQeNrqbLYrYZtm70JHalXgK
-        OuLiu3v1TtHS7tD17g8cP0zdXhQGyUHAJnUrLFNYm8MqedH7hO/riqRfs+3s7BmFvYjv0aiChuSc
-        D+pI9eIeVoodvut2FgQ8K4vRs+AiBIAW4Fc1DEdBimuYXUfDyHAcZGiq2zNVnThm9VUoPb7GoaLd
-        qF2DXdiN2pV4Cnbje9AUcPH3mvI9IkwuL5tzSpYGV9dyuiqxzB4xuhpWu6qqq8gyCDKNXrdrdA2M
-        HYd8xWK37VdjB3D0lTV6Ehj1zfVJ1uBCuuZaju4S2dF1AysW3BsGUV1VVXRLd7BmuUoNfUoGUfWY
-        aNOK7FyjatfoSWjUd4BlyV24h7ItQtmGC2YLQ4G11stmv9NRTH3f9r04mRtebC0PL5YNOzL628si
-        XVqR94rluRo+0ErW5aID9j3VV67IfXCfeCxX2yg+43siO8WziapsIewrfCGonXfQWSakne4wNY0i
-        1x2OwvaEys8i+YtGYflq4PbR8Vnron3VOjtrly4LbhPXp9FPsXAFihRXXCAsW3L1XaW+rxW833qv
-        w+1uB8WnjxT2oWv1E6oq7+knKzU24tWVepuh66KCOsjMd53lx4Fs8WtXWeMiyXY5VLclEqTLilV1
-        m0MVGXKND15Vts2hrG0iklWndimtk9LJNGahhBO/ZN5MfqkebTJxtiE2F4v7RmehqBUxTn1KGLdL
-        GEujLgls4jJpQ9Xjh877umT8wtGU/4FTv0y9FM2WcvrniR+yJSP054rQxrb0WHv8l473h389w718
-        2Y7zSnYU45b3rrUsQ6mOc4ZSb5mEISq7OZtytnJk+xLBqMbhlEbNhSMGXziyjcMpdXwoy1b5lvOd
-        iMTZzljCcToceuVbzb9DG53/9WSGwtLApVEXIoCxpGO4bMVmfyRZRvcYa9tcJVKpqB0MaVUq90kM
-        XD2h9gcv9B7+29rMfqVyHrHx58p95MavfEbtFdY7F0ftP9afUFswQfszAWuP9LRbWDD//POxBnpm
-        +rjOLZ4yCdme4uUuMSCZIrE/5Z9/82+rhauQZdqPwG1yDwXwRIX2yKN96iegEatd5InWzZ1p/3/z
-        U2BoEH8AAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3712']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:12 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/CoreTests.test_search_events_sort_critic_rating.yaml
+++ b/tests/interface_objects/cassettes/CoreTests.test_search_events_sort_critic_rating.yaml
@@ -1,140 +1,168 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxyZXF1ZXN0
+      X2N1c3RvbV9maWVsZHMgLz48c19jcml0aWNfcmF0aW5nIC8+PHJlcXVlc3RfbWVkaWE+c3F1YXJl
+      PC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPmxhbmRzY2FwZTwvcmVxdWVzdF9tZWRpYT48
+      cmVxdWVzdF9tZWRpYT50cmlwbGV0X29uZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50
+      cmlwbGV0X3R3bzwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X3RocmVlPC9y
+      ZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZm91cjwvcmVxdWVzdF9tZWRpYT48
+      cmVxdWVzdF9tZWRpYT50cmlwbGV0X2ZpdmU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+
+      bWFycXVlZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5zZWF0aW5nX3BsYW48L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+c3VwcGxpZXI8L3JlcXVlc3RfbWVkaWE+PHNfa2V5cz50
+      ZXN0PC9zX2tleXM+PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1dzXLjSHK++ykQc/CsYxsiCv8Yc7lBidRPN0VpSUoazYUBAkURIxDgAGCrtceZ
+        gx3hkx9gT3NzbDjCR284fJhHcTv8HK4CQBEkBRAgAZKCqkMTIxWS+KlKIjO/+jKz+scvY5P6DB3X
+        sK0/fAOOmG8oaGm2blgPf/jmpndKy9/8sfZ3VfgZWl7fhaqjjfoOdKemV6u604Fuj1XD6k9d6PQN
+        tz9Q9ZplVyuvH6lqzvPEs/sD09Yea1qfpkV64P54d/Wj2XlwIO02Bh87ytWxNpRHn8QvP3XbwzOv
+        3b0+vh6IwGSe68Zgctp78I4HPw3uNVE+mQqt42t1dNO97ij9E/f72x++uH92u9OG2GMnPGsNJoPO
+        08c/HX9sfvzhyxn/fPI4GrGqMVRMTheGz4PRpfAn4bJtMpNjnr6vVhbur6obrqdaGnT7qgP7n1XT
+        CB7utfFggmpVNKL20fTBWvOuWpn/FRzQoavVmmi2n59G0IGhgD9a1QzvOZA1bUu3LXr6iG7oZTA4
+        7ou2/OPhwfDDpuq64f8CedXxXCQyHwgP+vJ1dJD6e3U8+UfqBK3kFN9K5HAVrZe/eMFpnyE60+JQ
+        NdSER/jsX6mClnw+ghUjlJt97GVk4WRzueXz6XiCXz9p8DgzgYXBuYz/HMeqaUIvfNDG0geCJ63M
+        b6Eym0Tb9fqOaj2g843VL+jM44FhQb0msEdMtbIw5Augm/QmjqHBGi/NJOZjgcgUPYbqoFMKLxIv
+        Q9UxntfZKVngS0SHfIH5GYE8k4hexZ/O2Sm5F4n5VSy776JvtQnxZJXzEX+aqpaHvxX2xEPvM7SY
+        /rezPxuvgWplaWRZgl0rwa2V4NdKCGslxFWJyurj+WvY16aOg17aSGT2W/B1eBhMkFYvDM0lhqrm
+        2U4NMExEJhycS1nT8QA6NZkVI1Lh4FxqYqrodYjnbnkoIoN1zn0eD2yzEh1Gr9BgtPbbr9HPz8er
+        leXHrMToMln/d7L+0UXX7KnlOeHz+UYzOvBy2H/f31iGB3XqE9Id5J/MRUMr6hieoSH35rMBn/oT
+        6GjYpgcz9Oqhqq56MLiPPrT08G//ZL3R9AMFXI/qwokH8XxRLAPQLM5FAumpp/Xt4dCFXo0T8aWW
+        R+diLtSQ6XdrgJdYSeAXpWcHA/Fn9G881tG7Fl2UURgQSr6MI8tsyyID+v6waul9zxhDX5xmFJoB
+        PaB8xzHfMczvGfAdvtLrHwjPuzwHwd/IT3K8lVkRvBF1qT7nOR8iy0sck3o+BEbINB8C+tlkPsLn
+        D5xnXx3bN72TTv3kU7NTrUSGQxF/Gi5VzxvBJ+rYnjoW/Nal2uhxHFV7RCrUa3Z7sw8Gcxb8jjxQ
+        8eJ0duTFH+2bSNHtGjqd6mEfLzoYSoyhbqhI9VX/lYK+mSP01arp4OkL/8QJ08FYN74caaY91YeO
+        bXlHFvSqFV+malhojpHviK34BDlaaN4dszbyvIn7XaWSeIqKiyw21CuRe0BfMXuCvlgVhUM/GsMP
+        hozO8nDI6YwA5SEc8gNVkhhFHzI8x0MVcNrRj5MHtBCv3kfVUtFymGhhXPRw6OH9v6sT1RvVcr28
+        f8bqYUzFqxPhTicTGznVfXw/YXgWHVkUCF30pbFqZUFdDlV3JIh+GF7WREEYSooOVMgAHiiawvIs
+        I4tAHwJBHMjcMIXujFXnpylMrzmZL16g5mS+lxJozhbz1fclK6yCfiQeCrKkSCr60ilAEtiBxOkq
+        pzAqFIfyUBUhL4vsevXBkQt602JPyEqrQ5veR3GatOkdpdCnVW05MIXa6hsoQPTDMPyQFQaCqg7E
+        Ic+xmi5BUeaUAXp586wuq8IQSIMUuoRcfyf9myjztQt8E2W+l3f6JoJfvL4HXY+p/N59dlHI0J+P
+        4AcxDeikUJRQcq2qpL9cAbqR/uLv/jUyVNCPqiKPD/mBvCRpHMPpkjzQBMBImsagOFAfyryoavJ6
+        7fAcAw/1h8bn9C+TzHdQ4Msk872U4GVygOqDIlOiPm9Efbb3/RiIflhB0PmhIg50hh2oqjQY6iyL
+        /tPUgcJo8lDUoM7x6XXItlK/gTa9jcKd4sx3VAZrtv20aWhAZXVekBVVVniZEQCPIgrkGWpQk1VF
+        ZkWBZWWGUbj0+uQ92Rn1KfNtFK5Pme9ox/oUTKx4cUqPA4ySHvgYJe3S1gtGSWM3rjL7fDBnIXvA
+        U72pWzN952NhaCYwHeiqp1Zmf3v2I7SiwGYwMDv6PEH+roEfve8Z6NLeixg+EkpNJy40zb5puN4C
+        WNpcBUvRb5fnTHS88so5HqCNIV80KSaK772pDmsCOBJYRQSAk6qVl9GqaVsPwa80cwQYkQGCyCKB
+        l+FqZX6yker2LRvvLAxd36YsDOB9dIwnQP1lAz380997daaWhaEGH4EGbLj9ujDq756+Irc8WrUg
+        1Ps6nKgO5gX46LZ/P6+Nh8JTR8UvmIjYbCQQwM9gO2O8AR/c/spoFe8OBbSJE9Ch+F4bfd1mQzNy
+        wIx30X8c1xi8+/vKeNUd2f7+zDB4nEC3F8eqLtJaDQbI+0vggcQiwzOZgLHxxYOOpZpUDwlSx1jN
+        LZ2afyJA4n2my2t7R68dqCLFmobX6tYbrWane9dstbrVSuRAKOSfvqvqJnS+dak7pIruTCwkMYTk
+        kzw5KIZpQnroxFFQ8OF1DBTPQ28Ef6MynoiyKrMJA2V+llyJKJHTorfdGOv+o5tESlmQSmKm9LBg
+        SEy5Q98kh7pe+lR2egovrOVuMNtzN8KrJHA3wqskcTeEDekpb/wRCT1hgYsAcRSZCz1BkeTi6Qn/
+        8/NfCT+FKMCWBBXfpMYTVE6dgKa4SEyJp5lc2lZAM/moWlPV8UkVciKpIh2jAkUesgCAoqRiVMgM
+        yMIwkWkGYIYJy30nKOjnh32QS9IzSxiRL5ZZwmBaCfpJNw+rpJJG/b538X0soQTQDTQhvYUQaZk8
+        8qkbRx6Ze0G7449st6fQvKuwLPMFACFPfkj8+QvdIFm+2HuFkBZmRGKYLxzD5EfhiD970Yu7cDGy
+        uGhGmjedq8ZFt928rwAeaT6fYp1T7o+nuk7RKx53XbL4ZOO7XBvf2yPihWxfZt96OqA9zE3vaD9b
+        BZ+6NKB19ZkOAPpctwXmLmumbYHX8HvmSBJeR+79LKMtEXt8LALYvwakz1Hx7RH2F5kFgH0LDN3f
+        4d4JhB7BvudWMhYSbxiuBZ+xB//bv2P81CgeFh9OLXWguiOD/nESA42fzkQIPL4feDyCrfiLFA+2
+        fFQnmJpLsBaCtaTGWkCjfn9d73avrzq9eMTl6y//9PWX//r6y79+/fk/v/7yF//3f6Z+d2VBCmMx
+        10hVsQn9hxg4pn4mlwWOAQXDMavnL9BtX73Ye3XTF2akMDhm9exFLy6BY5ZnpCgMZvXkRa8tQVsW
+        ZmQZgQBFoi3rL1fo6q+7+F6iY2TlaYDjPfQR27Np24J+rDwJvYM8o+WIR7FttMwJRyKHHb7X4mXA
+        KUeyLLy1mDmGlbaDoBlkDppBfNDcu/p0vy5q/r+//Mf//u2v2EH9+devP//t6y//4nun//b15/+e
+        uak9+/HZpoLwmupAN/BUCePs3YbUMXQswKzlYwEmB0LW7DpJBYOY4lhnJXhMQjx6L8Qjwjx75wpA
+        mGcEDd0ZGso16vfnV9fXCeWMOJ99du5vXsayz3plgTsJ+6zUqAlhn5V9cQn77L0uPmGfEfYZYZ+V
+        in3WozkfUR8F5T9yZZ/1CPuMsM92yz7LpTEAiqc+QzMWH+8tHN4AGg/OnycqHp5xZHvQTATDXySS
+        gPDzZaF0VLKtCksnlImewg8Ui5SxPn2YIt3Ms0Y0AzghfY1omWEz4QcyzbA9wAb4wRupEY1LZhdb
+        Izr7fKyCKp2rq8tYOKXujaClwuk4Bku54GIz+fyvB4FRCIxyGMtLYJQSL26h2MlOAROCkhCUhKAk
+        BCUpK0qCHEZanTmVeUIkEU90FSLxfdG+Y9vj9fgIOBIY5L3HMA5xbT1e4pTtK+stISUHVFgvAtBs
+        XlnvDnykpOOPORXW2wssU++dN9v15s1lLCoTCY8IGEPAGALGEDCmQDDmxHamLnX+rEOfTRsLycTS
+        WwgkQyCZA1peAsmUeHEJJFPStSWQDIFkCCRTKkimR2vYtaRHyLWkcXpXvsBMAnclIzCD/CclAZiR
+        JA7T8wkwkwjMsBTXOnvLuMzJVeeme34di8qEcRJWrWi0VDBCM8H8KwetczxIcz0T+UC10XdzRN3b
+        zqM7MpyUqaa7STMtIMW04qGlRGqUmFv6IpKYWBpIUQtPnALPyR8LC18TOUFh0bMlIWF/HhuuljSN
+        M4GkSbzykB4fHR1tlY4rsuvSVAV5bZYqvy5LNbxKQpJqeJWkHFV+w1TcN/6IJAtzIeXyYTDJKQtT
+        xrtDRWdh/vYrycIl679dEm5BOxd3UP9AcTgb9wpNEHr43LJxecCgGCltNi4SzpSNCxiaI9m4eWXj
+        ntYvL1r3sbsVp+rYMNc2grghqbhkw+KAkS6yYfFeFpdsWJR0bcmGxYFtWDw9PR0NTeQeIHuODeGR
+        Zh9hTzWFGrz+0Qp6ZORhoweuzA728VF0a2NTqBhj9QEdmqiOaprql3mtMxp5Q3zFtB/so4m16b5E
+        TtdOVovCHz0fxVjpTr8mY/aGHvpeYiENG27itx0ypszyRywjyIrMyrF7DzIjM+gft4sE2h32R76/
+        AhIl3nz/lrcLTlsX7bOrVj12v+A08q0qapuAVI/cQ0OGqZsG/uh6+PVJ2UOqPoaOoamkKhnBQTLg
+        IML6qmSnyHiFrRicx7A6WTIyonx/VxZkhPRkKHWARXoylH1xSU+Gkq4t6cmw554MyMrTQ+QbhI0Y
+        UFge1I4qIB6OOBSZ4uFDrfy0LnI9qSusjOPxnQauufZXCEpCtertRoqyUGHnBMqwqBPVNNCMWIZK
+        0hJJWiJJSyRpiYWmJZ4bpmdb1CdoYRKSNw9LVxITYzf7SWIi2ec/oOUl+/wlXlyyz1/StSX7/Ae2
+        z08SE0li4naJiTf0yHcu6ccX5zLf1MQEjkDWmlFo6uLpASzgWFEiqYnrakYBir9pvWWywafzi1bv
+        qh0L2ITBUoCLLMRMO+cdpKEdhJvwXeNh5LkQGpgqlAMRoRgeQsWN3mY8KLMoti7b8ABpB5khGpoF
+        WUAaiRUKBmmE79APw9CMuCeQJsuMiCwvcGzBJAQpgGkyzMgqTHNxed3sXNRbsVDNxRi9Cw30OjuH
+        pqHZE0ytwToeg9g0rpU4xMaLfOqwARtCPyilp0/oB+9lcQn9oKRrS+gHe6YfIPtOG6FLQI9eXAIa
+        G/c84+yIH7EtF58TjhQRxMTZALBHgBOFkpHwkSPI5kVkCDRk10yGT2cn8SHxmYPpCyeq9Ywi4rrh
+        YOUtQ7UeQu3Pm9ofU6YFKOvKtABxbZkWbl2ZlvAqCWVawqsklWnhNqxE88YfkVQieSeVSEglmve9
+        /qQSDalEs/sMrO5F+6zVjEc9Ld34bOhT7LAmV6O5LUvOFWGplRo7ISy1si8uYamVdG0JS+3AWGqk
+        Gg2pRhNUo7mljRdPsZCKNLd5oeCHVpFml4l9pCRN3li4iRb+M3xQXdpnLr2ax6e61C0WeU/Qt6YO
+        0HwlFq2fiySB3ieBVAh7NwzLgg7VRUpXDm6ZwKbnlrEMm55JtRG3jGW/4wImlbQ3bln6GRFZgeHS
+        p0RuBK+wzIxblnpGVjGWVv20eXkZD7K0VOoUjscwDltpxVPJRsiyOPBtACuETVbq+Iywycq+uIRN
+        VtK1JWyyPbPJkImnTZUeYi8g17i5lR97TDwCDMfH0seEIyCx23eQm4UZW+dpKXmnaeURgLdvZQUw
+        ypsmpF2eXZ516u1G6zY2BEciVEBNiwS/RUfieZTTQcufEHyjg2EcejI1sZ5s3uMMXyjHDmf+6XSs
+        J0kR90wgKd4+Vk1zHm4vfSA+zl4tTDSLTOIqEy0e3wDFCK+Qa22i8JSPhp5I2QuPJ81j0MJlK24e
+        J6wjrnFg+xZqLLeOuMYyhXHz3vgjEm7WO+FmEW7e+17/XXPzfNAUU/O6cIKClZCcl1stOVYSMvDS
+        lCwV0kWaUfwK6cybqiUnyAUDyUAIoPWtasl17+rtVv1TPJJ8qXrIh3mijpHvbsFvXar7pFrICX+E
+        FI4D4gDmi2YpAGafM9OtN1rNTveu2Wp1K7MJK5zPl+KqRZOFUtzCe0e6EubJNYvlBKa66n5UZOkm
+        iJLEzlShzMIUl9yPfhCwnLAQD5mFeJjvCl5E71RepPn05fGGfmGY7d8ZS5fez1tj6SaIpqydKZBv
+        IcXsV96vogCiKClnikuvKN7IycdTXbr2flWFI6qyZqZw3I/D/tmMsRlU5snOQ2Fi7mA/ihNzM/vZ
+        679o0uMAp6EHPk5Du7SLbpA20R3S+ElypQDMwZ1MFIDg9+nEhabZNw3XWwCMTlcBIz8L9JU2Bei3
+        y3MmOl555dwxpWFZRQSAk2KZ+oARGSCILOEdJPIOmiegQ/G99q6JB7ky/6Nf7VjqQVfVTeh861J3
+        SLd2wDrIj/9PWvls1srn4Fj9pKnPFhsxJWjqM2c/1TXkWti6Gi1+sLT3csF14vZe3lBnH0LtL3Wg
+        Qaj9ZV9cQu0v6doSav+eqf3IwNPjhzH9gD0CWo14BPm2Y+nER/kZ2rHsiOVf8mYs+dL899JA96BY
+        /gPjYTrpf1bNKaxJSDmjf0cL06qO4dJDJ64oLT5MkvB3n4S/MstD29Zjp/cUHfxANRzDeqSwcrVx
+        yxnTGG6RbYGvl2O2hX863Z+FxHSLmUTS1G5V0cBX9Xjs49QJ8jfSIh3dqfWB4hyd+jg1U8T1UvpM
+        fUkQhfS1CyRceSVDXC/RDNcDyiyuZ/eEc2SYDxZNSdGE0+zzsYpzNC7a7Wane351F4922FPTsKiO
+        PX2A1O8i6vwPcZ1xjn8oBduUYB4lD50I5lHuxSWYR0nXlmAe+26Oc/wDPfb9AtrBfgEduMI0jmJz
+        bY4zdyW2LW/Ay0eyHIN7sEccx27fgTY3ikH+qEceHANJ8MvHv+XKBlc3rYt25+rmrBkLehyj8+lT
+        Kur1kv6z24MVpP9sTv1nZTZ9YudmfAI5c7dV0n92faTdvur0zmOD7KCJVtjnK20D2mPSgJbE2Afu
+        qpMYu9yLS2Lskq4tibH3HWNfH9MWdgtozXcLim1Ce5xXnE2a0L7FyPgAm9DmuddfvnA6+mzx0fSC
+        VFIwvUB52O8mtR9A49JIYayYS8dCVmCBgqx7uo6FKEzM1LEQh4mzjoVpO/WtjZn99o187h0LcbCc
+        IVzms4bL/NYdCxu3jdg4uWtP0R+GQ0WEluLis9t6WToVkui45E42iY7LvbgkOi7p2pLoeM/RMbLy
+        tBs6A7T+Wc8zGo54EKvR8Nhwtb6B5uMQdpx3Gwa/yBS/P7wfSvxhbQ/nW/meZJ9vln1eUP1fknNO
+        cs6z5Jx3ParpjA3rWzc2z/w2Lux9Q3nmq+3sC6jlu9OqvSTiTWxon3sd3p3W2yURb2JH+7wr6O60
+        Vi6JeElVXFIVd2GGNMeeoICs70tWhgr6UdUhP9AYnpckjWM4XZIHmgAYSdMYSeD1ocyLqibnW/h0
+        y9soQHW2vKM91S24pV2PhtirpN18axXcxuMnGWoVCOCIVxQgyfHVATmeFxRSrSCZntC9A+cU86e7
+        HWMz+dYG7DU7lxftZnxhwI+2aT5T0TgpFSxz3GzF4DLH0ByquKdKSs5+CQoKDGdN7WKxluFy27tt
+        e+MVj7V0Ve8DxWFGQQNqKXstpcQWZI4FfGo+PmC5TI2WAEtz80ZLe6EVZIFZOFlOn5qwEbNgg55T
+        qzAL4HDvsRiYxX8dNfHfFE31kGHCePGreAt3Es8zSEpzD4wv/rRfCZj2R2lsA2mQpxGO3t+2nD7g
+        m4ZX9zGCI/nmze2ZzXfcAxR73NwVnw8phwNd18aur283E8zmRSgbbyfr92eVXvzuRWDS/LQSl2p5
+        +o6M5JtuFovccqgnGsUXicQaO8tCezWKvhngGGQH2vbnnI0iI3DpAXcAOCaTUQQ0xxRiFN/LbLxm
+        EhUli0lkqN/pcdVfkN2Jz0tLYxePV+0iQ+e6vx+9RWIaiWkkpnFT06g76lhNLJEWCiRWSFuSKXOw
+        yKbemN8sWARK0IX2DQSLYpb6aBsEi7Op2C5Y5Bkpo2WECZbxZCvLePKaZYQ5W8YTYhmJZSSWcVvL
+        +GjoiZy18PjbQVF9U4AZa6nSslKbApyZJUpySlOAM7My0NWCzCy2B/jMpoCYxvWmkeOymEYu3iye
+        bWUWz1bNIpezUTwjRpEYxYMwimjFEvYZ0cEwjflkauKl3Wa7EZ0s131GfD4bLV1iwDgTSDKMV0sy
+        +7eLxUGHSvqAcTPoELyV3UWFLThveTYVW1pFwGSxinxywNjYyjI2Vi0jn3vA2CC2kdhGYhu3t40P
+        qmlCJ3GjcS6SZB/PfCkDzp73curC6fhgcp8CiBVbzCjEKuVR5gN3ogBpq0EiySwWU/IhVmQx2Vwt
+        ZsGAM5M2tN4ccN5u65EHIIu9FJLtZXMre9lctZdC7vZys27dxF4Se0ns5cL59KCuVMLmYyiQZCuP
+        sa18aXy19IG9mslL2/pAseKSmczHMLCSzGTYiWTFjIaBFd/QTqSkFExbBVI+cCubwVAq8TbydCsb
+        ebpiI5WcDeQpMZDEQOZiIPPsyFCC7A70/R5jNXxM3JlckEpswIAFQ8t5p+Jq9ddLn0ppP4tuyeBb
+        UhxhfVStqerkV1USWVIBAMydTLV3CTJWlQTzqpKCkpMdzVZlI32JDUbMYkQ3acKwJceVbdTvz6+u
+        r5udeCv6ZFM6mhasxiM/oTPGiCrf35MSk6TEZHRFD3l5SYnJEi8uKTFZ0rUlJSb3XGISWXnae7Jp
+        5BLQkxeXIM9gN+JHZIp186wPGakwUHiIelJXWJnJq1PCXmpENi667eZ9q95uxEarDcO14DN2lagO
+        dJGuUYZFnaimgWbEMtS3US6S9E4orneC6wVRSlBpBL3UBoaFvp6Cr/gLQ74A/vZOUMQLIxLzsUAE
+        KSt6v6JTziVehvw6JctXiQ75AitXWRgLRJausjBURe6F5WGVsn0bip70M9J5vT8br6Fv1dJItbL6
+        oSB+Q697B1oaEpn9Fm6ADyZoIheG5hJDtAq2UwM4EF0enEtZU4yl12QMai8PzqUmpqpBt8ZGZMKh
+        iAxeSfd5PLDNSnQYvUGD0dpvv0Y/Px+vVpYfsxJVi51tL/j7zldogvLcXZAkRZC5lL02RMBk3HZm
+        /KIYpNdGLr02LpuXx81O9/ziuhsLi9z6L/c6delvQrkjYxJXg1T8FLu38NZwEVKItNThFSlEWvbF
+        JYVIS7q2pBApKURKCpGWqBAp8hrpz7RKj+f+ZZ4gW8Qp3ZZQ4hckFRXAClx8SVKJRX6/xJert0v3
+        TqLYTmvXPU5zLSHaO2/e1tuNeixwd2tgqMBQKQzd1U2kjF7InX8ds5spYfDADnSnplf7f/Y7UcnH
+        twEA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:12 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['7128']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:14 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><s_keys>test</s_keys><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><s_critic_rating
-      /></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['778']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1da3ubOBb+vr+C7Yft3AgSd7KM50kbp5M26SV2mul84REg2zQYHARJvH9n/8n+
-        spUEtnFsHHDt1G3dx5MxRwddjo7OqyMdyfYf98NQuMUJCeLo92fwADwTcOTFfhD1f3922T0RzWd/
-        tP5h41scpQ7BKPEGToJJFqYtm2SuHw9REDkZwYkTEMdFfmuMiS0tT7K9ZDxKY8cNY++6demI4u31
-        qGddv7RGl9o7V+wncc+H6as77+37T58V7JHPyvEnqH/+cP0OfLqKjm+H3TcDcqSMnPvLG+Pi7GR8
-        7GnihQ97+pubXvbp9KZ/dELeXUR34xsEulB/pybO8VA5O21/GN8k7c83phUm8vvTyFKOr+/64Sdb
-        mquT7QckRZGHiYMS7NyiMPBbUWxLy+i5VFo2pSCHygy32le2NHvKE3xMvFabinh8N8AJLhg41XaD
-        fjZiuWW4BQGwpTLB9oJ0nOcUxpEfR2J2Tas7JebpPKMznl4k5ll7ISKk+F/Onw4wSlkFSrQinb/S
-        nU/Ps6E9x7sxz4737TzJLpTiGo8nJUi0/2dEpiYF6+TNKWUuvxnfkiyvA58szzZvSJE+R5ux8Lac
-        oGEQjktMeQulWbnSRGgxSZ0ERX2ah4vpd94hTtzr4YT2qkviMEuxQ9AtHSYtqBzQnntItXtZGNJ6
-        DN0gwn5LkxnTPC1noW1KR0ng4ZZqTHlmxIIpo+1GCa2QNuOZ0mxes1nGisWYHhALplnOijbjKpVX
-        EKaZqyWuWYkjnHhU+VF/2mBZs6VFKlXpBQEO0f3Dus6ROEP+/l7ma8l8UYCc8qAa87ScZb4K8yR7
-        yEb9pG0w5yiTCgba3xXdptboNWg+3mslnupeAzV6Dap1eq3MtaLXQN1ekyt67YH02PPDSszTcpb5
-        CsyT7Ch2CM0+xMTZm7W9WfumZb43a3uzVhR/k6EoZbPdeJRS14VO2vic3JnQW9CWHlAecsiPciiP
-        cqiPcmiPcuiLHNJi87jddrwsSah/Rlkm3/Kpbt8d0dnrHGnG0UNeGie5g/GQOOOKsqFLu8eU9RJX
-        QZxxjUJEnSAmu4ekEg/rbDIeunEolcnUccqprf/9t/z+jG5LD5uZxiOHK8XeZK5lMhfkJ1VMCPYD
-        aj+g9gNqnQFVHkVenEVpUigMX64pE6bJfOXhMgpS7AtvaL5+PJyxFus3SZAGnpPg2wDfOUVNCpVb
-        mmT7iHZX3t048ovnYmUn+02AZjoQjrJ+RlJBBpAq5Ywh581SjzWK4LSl6Kygh9QZG8FeHPmEorcB
-        NVUDc9yTxJx9TP8Nh77fYoUCE5oF55RuByQ2dQAdTkaR76TBEHN2EZgiNLvQOlTAIQC/AnjISlr+
-        QpHvQwnkzyRFSbogExlSYRzR7gw3KRIdyrqi1haJKsNGIlFFGa4jkkIE+VIu18e3l92XF0cv37Qv
-        bKlELli4GM5Rmg7wnfAizpIIPyfCW9qcBHnXOPnn5KVcXvn3wG/ppyeTlOkiqRNSLY9nS5BlYsEx
-        xH6AqN4jbqCpnRvQcdXi1AOq7tc4JXdB6g0OPDZYeKIdRFSwGTV3lDYKMRN2ErYGaToih5K0/F2J
-        0DGPfalUKh1R8YiOI8lS6McDqtsDvqzinuIDDZs93FNdZBjA8ntAVVSMoOIdfB71qdiXVsCOEBV+
-        SLuB0ObQ5vJne4TSQWujxfMc7a8sg6USINloFCcpcVhF+Ar6PGWegUx2DeZotjSnGbujJgamH6Ca
-        nq5pPcPyIcIAqtDyLFmVgalDvwc13TWVXg01GaLkJsP1laRx4dtQksaV+PGURMP0A4DakzVXQ8jV
-        e6oie76BdVOxXDqQVNk3kdaDhvu4khA6f03q60jjsrehI40rsQs64sO7e/VO0TJ36Af3B14YZ34v
-        iaP0IMLp46pCBbUyh2Xywvepk2KSAulXMiYpHjozCmtIGOCkhoYUnI/qSP3iHleKLba1hjIsdvW3
-        bTF6Fv0gRIGWwq9qGJ4CFN8wXU+DwPA8YGiq3zNVHXnm4/qQJgEjOb3gtr7daFyDbdiNxpXYBbvx
-        PWgKneLvNeV7RJhCXg7nlCyNflzLc1VkmT1kuBpUXVXVVWAZCJhGz3UN14DQ81B95Ymj2lZm3Wps
-        AY6+sEY7gVFfXZ9kjX6ArvmWp/tI9nTdgIpFnw0Dqb6qKrqle1CzfKWBPqWDpL5PtG5Ftq5RjWu0
-        Exr1HWBZehfvoWyDUEZSlGakFfLJ5BxpwpC5PkqRNHlO42sclZcCc8IkdTyiHkvAqu7kUpqysZSC
-        KxsRHIZOGJB0bnmxvbi8WLXsyOhvLst0aUnefRyzhVPa2hClQZr5uKXBA82Wpo92GEf9/KsIDiBL
-        mhJsafb+ABEnitmafI9w+c8RWAAk25rA/jTysXjkUQpJFkUstoEv3UK5CFSYo/Kd8SV8D6l2hLHv
-        +HiEkpSpCVsG5vVZRi+YswQxK1Bim1ByBtaGOBmyKNi8+gtUm21U5YGwL+GFoHbf0sEyIU2iOieR
-        tM71MN/ZX0K3ySDmOxu9vDm5ns7TbELnqx7Ol6ynXiRlK5EnPPmKP00XOtzrFP7GSTxlzdevqVpk
-        xWudo+Oz9kXnqn121rGlUkLBxF/oID/EyXMiXFFFIhO2Iqa0iAz+4gDh7yyKdxgQb1UUb5G+Kor3
-        nLIIUyHUieXd1I5c9f7aFfZ/E9hW0usswhvdSVIN09Jr7yTpoNlOEv3ALtQOwaY31340gSxurUFZ
-        hZWbakfvT4Vuu9M9ffuqYg9NOX/1ep1NtLo4zarAagD1oylfkTIH4OV6NELwtYHw6wDXNrEpF89/
-        qIfMIWoVQnHOvymn0C1zLgCUxnbRK3Dpqn3+4qz9Seh0j45PL89rAhMEwKyApgIynzOW53t0+ubQ
-        qYNSaozVdCCco/FGjbEiQ71+nIMG1UbGWBOh2oVg8+jUyaIcnTYtDxlYilxfHg3BSePg1FweS8CJ
-        juRDVa/EpxdBX7jAhODklipcboqWw9TpOdwmTD1wJ8vFPQ0aLThgej2vTN8hp2yb2JZgX4fODQUN
-        FCEfrcC2C8YpfDgSXnJOgUGhkO8BVuMcV1RZlXKFVSsxjynsR/Z4KLCvnRHycE3go7OgCtzj/uJZ
-        7HFx73Hvm8O9boapmQdbwD3ZAk3sPARNcQ+w+L6N496PJpBF4JNNU65GvdOL40/CKMyIQEbYC1Ao
-        9DNqA0gV+J29/PCU4Fcqbu+KrQdXtBsSOq+J8+3KSqz65ez0Y/sX4bTgFt6VuBcwqvuXIXUrkYmD
-        CH8WXp/sIekHhyTueRjbicMHmm7UXxkzgdEwDh8YXShvwRlj3qm+JZGoJqwPSybQm4pEX0ckS2Gp
-        erHwJcr6g1Rwx0yZhQuKGonQHaAhXoFLF0+LSxd7XNpFXLLq4pJwkoVUo4T3KNw7TnuU4iZZjnzh
-        dRZu1k8wVFOtb5ANIDcyyIYI5K2cFfvRBLIMoQyrEqHalHsgXAVUQP9Cw9G/hZMgwUI1OnWeFp06
-        e3TaRXRSa6MT0ywSJ83gSTMq0Ok0RewWsDIqTa9UG9I/ERKDtOKetXOe/tg9a7TJpBrQyqnrwBl7
-        f6NgxjMsVjxWodmMZRWg8fYJotApllBOoxQn+WZmM3DjnVANbkU3Ng7ROGfNYzbcWGnDaxpw01Tk
-        2ltgBlCabPlQ662wLR9QbPn8vcGDz3w7sObB57pYBjRLrn8QXG24G6iy3cBmoliEMd2A5nsWvVeB
-        ZCc4SVASsPlwKByjsdC+pzYxwNRyCncBFRkzTOJxUgKhh/D27t2rdeBteSSuh7wBFvsJGg0Cj4SB
-        e3AboDRO6sXjHkrSqgykElkcJZhBq5QOsqFL6LzkXlV1iclL6pzyMS31cuGI7LYG0UdjEU+FIzLh
-        iGxLR/SZcMQgEgtbKlvUBzfWPi395HVcHdy7cyLdTMD4QqRwo3jxH0hLl53D3avo7qpoM4s+eemH
-        U+vKU1x73d4l3V7XBy7NSRr5wEvORajqga7qOlx+NgKCA0vWZdX64vMRLO1bdqp5l67wqXOlXeFN
-        f5xnWHCgZc1cEQQ6cVRrucqWXOUrv8dJVuEqh8EQiWy2tvxCcpq6d5Ofwk3mXVDtJuc92ChkRmYR
-        IsfYw+ymuo25h6YMG7iHUJYbxYhAWZTBpj3lkySgnrK2BU9ZN8wG94Mxh7WZp6x9sadMrTjQ3sPq
-        aJk/UdjjE6qPAQlSIY359uQ5hdOYz6mCKBbOM4KzYaWn3FW+H0+Zy2s6sRhQ4fAJxS0TjpjGIm2R
-        OGTC4XMKKhxxyIXD5hXclMqmZWjKFv3kjdZw29O0jVZ27yM/oX6u5yHvlfOreMfz5vqn86Nu++ep
-        1d4tb/jJFPgLfOG9Fu+4HzybcXypH0xnnAdAVdi/imsCDOMAyGbBsHeGt+oMW3K1K5y7orUcYdmS
-        628a70OZNhnKtNndXr7HqTA/tv4B9NohO7LSIM5WV5qdddBFhfqxZhFUyk/7bdCZlTUukjyISd2U
-        SIAuK1bdKCYVGHIDf1ZlUUyyto5Ilh3KV9onlR4tgznhJKxwV+UX6tETxi2Vi/tKRx3VmjfQqLt0
-        A80246CyxEWRg3wmbVp18thx/kvGLxxN+R851G/qlRi2kNNPJ2HMftAB/1wT2tiK/crT/Trcn+3/
-        BkN12YESJb9pZcOhqZZlKPVxzlCaHWY3RGU7V8/Mftdh8xKBoMHdM0bDn3Uw+M86bOLuGR0eyrJV
-        faKkmyCSb3wLx9lwGFSfJHkL1jrevzMXVWaRjxMXh+FY0iH9OIrD/kiyDO4h1Db5Gw61itrChZO1
-        yt2JayV3qP/pLPSe/rexe/drlfOEnT9X7hN3fu0rqK6g3r046vy5+gKqkgnaX/nR+B7GThsK5l9/
-        PdU1jDN9XDUtnjIJ+ZGB6ikxRTJFYn+qV3f4L58LVzHLtJ/QaZN/KNCZqNAZBbiPw5RqxPIp8kTr
-        5n7T/v/RJjp4EH8AAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3718']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:12 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/CoreTests.test_search_events_sort_top.yaml
+++ b/tests/interface_objects/cassettes/CoreTests.test_search_events_sort_top.yaml
@@ -1,139 +1,169 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxzX3RvcCAv
+      PjxyZXF1ZXN0X2N1c3RvbV9maWVsZHMgLz48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3Rf
+      bWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21l
+      ZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdv
+      PC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVk
+      aWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21l
+      ZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9y
+      ZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48
+      cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48c19rZXlzPnRlc3Q8L3Nfa2V5
+      cz48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHJlcXVlc3RfY29zdF9yYW5nZSAvPjx1c2VyX2lkPmRl
+      bW88L3VzZXJfaWQ+PC9ldmVudF9zZWFyY2g+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['597']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1dS3PjSHK++1cg5rCP2AaJwhttrjYoiXp0U6SWpKTRXBggURQxAgEOALZae5w5
+        2BE++QfsaW+ODUf46A2HD/tT3A7/DlcBoAg+AAIkIJJgTWhjm4UkHlVJZOaXX2ZV/vB1ZFBfoO3o
+        lvn770CJ+Y6CZt/SdPPp99/ddS5o+bs/nPxDBX6Bptt1oGr3h10bOhPDPak4k55mjVTd7E4caHd1
+        p9tTtRPTqpRXH6n07dexa3V7htV/Pul3aVqke86PD80fjdaTDWnnvPeppTRP+wN5+Fn8+lO7Mbh0
+        G+3b09ueCAzmtar3xhedJ/e091PvsS/KZxOhfnqrDu/aty2le+Z8f//DV+dPTntyLnbYMc+avXGv
+        9fLpj6efap9++HrJv549D4esqg8Ug9OEwWtveCP8UbhpGMz4lKcfK+W5+6touuOqZh86XdWG3S+q
+        ofsPt2rcn6CTChpRu2j64EntoVKeffIPaNDpn9TQbL++DKENAwFvtNLX3Vdf1rBMzTLpyTO6obdB
+        /7gnWveOBweDLxuq4wT/58urtusgkdlAcNCTr6KD1K/U0fgfqTO0khN8K6HDFbRe3uL5p32F6Ezz
+        Q5VAE57hq3elMlry2QhWjEBu+rW3kbmTzeQWz6fhCV59Uv9xpgJzgzMZ7zlOVcOAbvCg5wtf8J+0
+        PLuF8nQSLcft2qr5hM43Ur+iM496ugm1E4EtMZXy3JAngG7SHdt6H57w0lRiNuaLTNBjqDY6pfAm
+        8TZUGeF5nZ6SBZ5EeMgTmJ0RyFOJ8FW86ZyeknuTmF3FtLoO+lUbEE9WMR/xp4lquvhXYY1d9D5D
+        i+n9OrvT8RNQKS+MLEqwayW4tRL8WglhrYS4LFFefjxvDbv9iW2jlzYSmf7L/zk89cZIq+eGZhID
+        te9a9glgmJBMMDiTMiejHrRPZFYMSQWDM6mxoaLXIZ67xaGQDNY553XUs4xyeBi9Qv3Rk7//Jfz9
+        2XilvPiY5QhdJut/JOsfXvS+NTFdO3g+z2iGB94Oe+/7O1N3oUZ9RrqD/JOZaGBFbd3V+8i9+aLD
+        l+4Y2n1s0/0ZWnmooqku9O+jC00t+OydrDOcfKCA41JtOHYhni+KZQCaxZmILz1x+11rMHCge8KJ
+        +FKLozMxB/aR6XdOAC+xksDPS08P+uKv6L/RSEPvWnRRRmFAIPk2jiyzJYsM6HrDqql1XX0EPXGa
+        UWgGdIDykWM+MszvGPARX2n1F4LzLs6B/xn5Sba7NCuCO6Ru1Ncs50NkeYljEs+HwAip5kNAf5vM
+        R/D8vvPsqWPjrnPWqp59rrUq5dBwIOJNw43qukP4Qp1aE9uEv3aoBnocW+0/IxXq1Nqd6Rf9OfP/
+        jTxQ8fpieuTNH+0aSNGtE3Q61cU+XngwkBhBTVeR6qveKwX9Mofop3WigZev/AsnTHojTf9a6hvW
+        RBvYlumWTOhWyp5MRTfRHCPfEVvxMXK00LzbxsnQdcfOx3I59hRlB1lsqJVD94B+YtYY/bDKCof+
+        +gzfGzAay8MBpzEClAdwwPdUSWIUbcDwHA9VwPVLP46f0EKsvI+KqaLlMNDCOOjh0MN7nytj1R2e
+        ZHp574yV/ZiKlRPhTMZjCznVXXw/QXgWHpkXCFz0hbFKeU5d9lV3JIj+GF7ui4IwkBQNqJABPFD6
+        CsuzjCwCbQAEsSdzgwS6M1LtnyYwueakvniOmpP6XgqgOVvMV9eTLLMK+pN4KMiSIqnoR6cASWB7
+        EqepnMKoUBzIA1WEvCyy69UHRy7oTYs9ITOpDm16H/lp0qZ3lECflrVlzxRqq1+gANEfw/ADVugJ
+        qtoTBzzH9jUJijKn9NDLm2c1WRUGQOol0CXk+tvJ30Spr53jmyj1vRzpmwh+dbsudFym/Dvn1UEh
+        Q3c2gh/E0KGdQFECybWqkvxyOehG8osf/WtkoKA/VUUeH/IDeUnqcwynSXKvLwBG6vcZFAdqA5kX
+        1b68XjtcW8dD3YH+JfnLJPUd5PgySX0vBXiZ7KH6oMiUqM+BqM/2vh8D0R8rCBo/UMSexrA9VZV6
+        A41l0f/6ak9h+vJA7EON45PrkGUmfgNtehu5O8Wp76gI1mz7aeujAZXVeEFWVFnhZUYAPIookGfY
+        h31ZVWRWFFhWZhiFS65P7ouVUp9S30bu+pT6jt5Zn/yJFa8v6JGPUdI9D6OkHdp8wyhp7MaVp9/3
+        5yxgD7iqO3FODM/5mBuaCkx6muqq5eln13qGZhjY9AemR1/HyN/V8aN3XR1d2n0Tw0cCqcnYgYbR
+        NXTHnQNLa8tgKfrXzRUTHi+vOMcTtDDkiybFQPG9O9HgiQBKAquIAHBSpfw2WjEs88n/J82UACMy
+        QBBZJPA2XCnPTjZUna5p4czCwPFsytwAzqNjPAFqbwn04KOXe7UnpomhBg+BBmyQfp0b9bKnK+QW
+        RysmhFpXg2PVxrwAD9327mfVeCA8sVX8ggmJTUd8AfwMlj3CCXj/9pdGKzg75NMmzkCL4jsN9HOb
+        Dk3JAVPeRfd5dMLg7O+K8YoztLz8zMB/HF+358cqDtLaPvSR97fAA4mFhqcyPmPjqwttUzWoDhKk
+        TrGamxo1+4aPxHtMl1W5o1UHKkixJsG12tXzeq3VfqjV6+1KOXQgEPJO31Y1A9q/dqgHpIrOVCwg
+        MQTkkwJzULBqZUVBCZ9rPxkoSzP5lsGJmMzO/PENWDzBFbIk8kxP+axrTtxEBsfj5vFCHenG61bs
+        HU5YR23hwFpqC7+W2sKto7awTG7snQN/RMLeOBL2BmHvHPf658Pe2SUXR+Tz5eKwmHhyOFwcQU7O
+        TdqMiyNkwMVpP1Qb9ernWnImTvtFNam6+gwpHDJEEnFWxJY7IuJsl5ypPZTDsUl5OmFllmW+AiBk
+        Sb9Je9Vcs1LJbuFY0bwE8+QYEsN85RgmO5ZN+qvuRkUWboIoSeRMAR79mPgEKpKQ/ZD2krvRj7lb
+        INpByA7FIjvk9KvhRfRO5UU6RYYxUZY6/aV389ZYuAmiKWtnCmSbi05/5d0qCiCKknCm0iSZh3Y2
+        nurCtXerKrtJJh+SquC4H4f90xlLwP5Ow0vY/A52ozgRN7MjNkJtmY3goBukDXSHOZARajmQEVZU
+        buHxz3dHT1JQCEchS47Cu7AOTmv1CNrBKTQGKgZOw5yDZdqA69pq38uRRLMHlmU2aV0xO0umHSxC
+        px1MM9eR6e/BYm572wR4/gmVtup+oDicUTmH/YQJlYTZA5ljAZ84mwJYLlU2BbA0N8um/JBNIuUB
+        ah8oPo9ECifLyRNLAsOnTaTwmySWlhMpgMMJxogkivc+quHPFE11kDGkQETihDu7r26SOfEdAfxt
+        z9zT3iiN7S4NsrT94ftLZfxXWGPgGYdVZtgnT2Rsf3dsME87gGJPa+9lL5Fy2NBxLBzYd/1MXaTd
+        vA5kow1l9fGy3Im0kIFJozro2w5Vd7WcqHk9/Wkyxs2mJvBEQj/08OcQbw+tpO7QAzuCtneLD69j
+        7RXJ/PbVHppEN87+zkTiDPCZLzWl8ummiYxeGymhk8goL83ywLK0yOm9QAc/UOe2bj5T6CVMNfSn
+        oWvogy0okvh6GVIkvdNp3izEciSnEnFTm3oyww6Np+rRHs6F7ZMuE3s2ExN5NrZGfZoYCYy5xCY2
+        5pIgCmxiYy4xXCpjLtEMhzuUBMac3RFLJMV8sGhK8maJpJ+PZefm/LrRQHHSVfMhmidiTZBDQrWs
+        yROkfhNS599GeDrnpz8UgiICMEaUIxlk+fw5Al7LFzt2RNSbkdyIHMtnz3txCTFjcUbyomAsnzzv
+        tSW0irkZWaQagDxpFesvl+vqr7v4TvISyMTTI88voG3sF9C+K0zjuDVLUCLkSmyLSfBySZb5CFSi
+        xHGstD95gf0sXpQEBsjvnRUAqbMCIBrsuGne1a8brebdZS0a8kDn0yZU2OvNvR5xjFUYxcNP0SWJ
+        t1ORD1QD/UaH1KNlPztD3SuLOxrAA8UPI6znz7Eld3NScbF5BwsGoMcD+tXY1O3Ct9JX4gFlXZka
+        ENeWqXHrytSCq8Q1mRZzq8Q78EcklVhHUolFKvGOe/3fuxLPS5V6ieMmmqAgbyxnkDcWeMBwDKco
+        ifBEGQmnyBvLNGC8vDH3UVDQX0Z543TQanJclUlRjbgRrsqkyp+vKLy7blzWo8vurk1N/6JrE+y2
+        zkUui4V2n++jUNSZR3QYQCqTM5C6fP68mYMESF2ckXwr4t618o0AqYszkmst27tWrREgldSn7XN9
+        2svLS2lgqCNsz7EhLPWtEvZWE6jB6q+W0SMjLxs9cHl6sIuPolsbGUJZH6lP6NBYtVXDUL/OABYa
+        eUR82bCerNLY3LTSKKNrx6tF7o+ejWIsdVKNJ/5/vqf1N0+R9jHuTKn+M/dyW2Rd4EssI8iKzMqR
+        3HuZkRn0H7c1xh5wd+KofzMcO39M/LEJJEq8+z4jWNxTkvfmyl/UUcTSrFcjIfGL0E/rMHrzofjo
+        CzSiG8rNHd4A6vbPn2k7Of+MQ8uFRiy4/SYRB2xfLQrtlFDfmcAPFIuUsDp5miCdzLI9EQM4ITnR
+        SmbYVICATDNsB7AH1Z4I75yWL/Es/XwsoyStZvMmEiM5s+yJQ129atBLyEQgJNdcJwoh8X4kBBwh
+        4Mh+LC8BRwq8uAQcKejaEnBkz8CRne/tkMt+M+n3CtmjTWc2vaOdsBaRw0j3sWtJD5FrSWOsJ0tI
+        JeSPLkMqnkfatS0cN63DU0BJQP6TIkZ3MpAkDjdazRZL2SO6YgjC2RybeWAprn55yMjMWbN11766
+        jQRmgjgJq1Y4WsoHoSHMwvdiFoYRGScJItN2McpNWQOqOoK23leTYzM3lul3j/6kmsg9fc2MsgJ4
+        Gb3FklJWGJCmcbRMM8BrHE0oK5lQVtjz6uNV8/Y2Zt/2zotFaWhasBoPPdMfgcoo3z8WhbdCCgAL
+        6dOTAsBjWVxSAFjQtSUFgDsuAERWnnZfLBq5BF4c7bsEWUbTIT8iFUHhUJkEZ1WFlTFB4l3D1UzL
+        686v243aY73aOI+MWM91x4Sv2FWiWtBBukbpJnWmGjqaEVNXD4NdEPZj18e9QRTYxl1uHAh1TCnK
+        IBLOJxAuh58tOg6ek4qLg+fi/y2q6gRmXcnZTCKy5IxZV3ImMOtKzoT1m78xGZWckUKenRXyeKDI
+        YiFPJmiAJCmCzPFJG0CmKuQR5wp5dtQAMnn3R5ZJw1PZoPvjtqjITe3mFPdGur5tR8Ii997LvUrd
+        eH1CnaE+diLreVb0QT5MXIRQVgodXhHKStEXl1BWCrq2hLJCKCuEslIgygryGukvtEqPZv5ltlVA
+        FxuBbKtZK7wiKoAVuBjeCov8ftzgOf8qoAwbY73JrEbu2g8SxbbqB71fRueqdl9tnEfXAN3rGCrQ
+        Va9jc9VAyuhSNxMHTkb5Y3ZICb7AJ9WhJ04UbKc61D0WOaZmWPvS/ftd+Sqpa4loVkjctlliWIZN
+        3sZ6o2oilvU396YZaUfVRGlmRGQFhsu5kfV0l44UM7IM1tSrF7Wbm+i2K3WVuoCjEYxCZ+oK6VlN
+        KCv76tMTysqxLC6hrBR0bQllZceUFWTiaUOlB9gLyDSGnrkO28bQnFgCDBfRpJrGVhBF0NvXfRR7
+        /8rGvawARjnsRtWXN5ctFI/X7yMDciRCXdo4Gg8Fv4fAniG9OUhvDtKb42B7c1RRPGyqHu63MpK+
+        5tpRkTTpykEoDnu0vITiUODFJRSHgq4toTgQigOhOBSI4oAcRlqdOpXZ9uNoRwMzKftxMMh7j+nH
+        wUucwpJ+HGv6cYBPlHT66ZAbclQ7V7VGtXZ3EwnLhMKjfMCYo6pGcsK3GY27zIvF9uVAC1sMVgNI
+        g8PIbPIOFJvhMPI0hy/ujNWQfEZElhe45DyPzXpySKlnZBmJaTRbnatIKMbfCPBMNV8tk7qCht63
+        xrjVDFbyqL25b08jeQ6hb+03OENIDoX06gnJ4VgWl5AcCrq2hOSw6425b09pE7sFdN9zC+jhm1tA
+        YwOf6ebcM19ia+KDUFJEEMl7YEuAE4UDqxpYFw4jb5DNqt3HblgKny/PGpGBsM9NCJzTqm5jBSYx
+        MYmJ9yYmllgh55hY+Ij+SEyccUx8fXNba11X69E7rI7QS1BH77GkIXE09Z+ExCQk3pvlJSFxgReX
+        hMQFXVsSEu88JFZoPXAJ8g2Hs6sDIOEwCYez4OvrhgHpgR1F18eHj6lifp82eYhodMkL6xpd8usb
+        XQrrGl0GV4lpdMmvb3QprGh0id4zDgqUDIhnrJiPuEkvz4XP7FoJbq0Ev1ZCWCshZtB1FOIQOZOu
+        o4ok59919H9+/mvitqMRykwU4FgUILLvrGdSo8HPCxt7JmQTHrIJTwpc87z62Ln+PhLVBPQ5mpDO
+        XACxgGSKnyNLr0iLWVJ/tW/LS+qvCry4tbtW098PIt9SrKjr5L3iUdcli08KtEiBFinQKlCBFnIr
+        aeDt9OTD19k2oI2p0UrZgJYpScJqzJzDME7+aHmW20Wt7jl7aPVSMyuZYEeov/87xk/1/NvYjLFC
+        2Sj+ie5kczsV+UD5VRaPlv3sDHU7IV7+Plh5Djh5GafFkBrFAuRvIutoZUiKSrsFVPYNg4Kfbkb9
+        gsJni2sX9KeR7vTjpnEqEDeJTRfpcalU2iqnILJrN8+S1wLu/DrAPbhK3OZZ8lrAnd8wp3Dgj0gg
+        5SPZyYykFI57/d97Jztv87bFnewySS3wgEHRStLUQrqd7OS5nexIamHb1MJF9ea6/hiZWrhQR7qx
+        NrdwR3ILJLewx5gTyS0cy+KS3m4FXVuSOtiz1MHLy0tpYCD3ANlzbAhLfauEPdUEarD6q2X0yMjD
+        Rg9cnh7s4qPo1kaGUNZH6hM6NFZt1TDUrzPCJo28Ib5sWE9WaWxumiHI6NrxapH7o2ejGB4cnCIF
+        cEcPPC8xlxzAXWY5AL7EMoKsyKwc2axNZmS88zRXMP78YxNIlHj3/SG3V7uoXzcum/XoXeguQr+q
+        3NMEg4mp9lRnqNM/jiPSBBdTEcKi3w2LPgSYeIsUjaB8UseqSSiZBDdJgZuA8+rjbbXdvm22OtHE
+        zG+//NO3X/7r2y//+u3n//z2y5+9f/8z9ZumCSlM2bxFqorN7G8jkJXqpVwUZIVUoRc6QCNV6EVf
+        XFKFXtC1JVXoO65CR1aeBjgKRF+xXIu2TOhR6saBd5BlQB3yKDKoRBc5ENH5HHBKSZbfpRA9S2pd
+        RCT9DsFypuXmnebnx3Xkuv/783/879/+ih3Un//y7ee/ffvlXzzv9N++/fzfUze1Yz2/WpTPwqNa
+        0PE91ZxDa1KYvr8hdQTDCjBry7YBk0Hd9vQ6MSSr6XXyKE4vwGMSMtGx1CcTNtmRKwApUCdo6Luh
+        odx59fGqeXtba0VioZxXpH7l1ThFEsk6RYE7CZGs0KgJIZIVfXFJkfqxLj5hmu0Z04wUqZMi9e2K
+        1Ds05yHqQ+/msyWodTIjqJEi9b1jne1VkTrBuXdAHct9LxOCnxD85ERYj59cIMsUkMbs5wBHia/L
+        U75/KAqcQthjhXSzCXvsWBaXsMcKuraEPbZj9hiy8vQA+QYBZcx+DqLcHKqxQg5FqmB3X2PUdXVT
+        Z1WFlZmsdh7ZCRPMD17r1cZ5ggA24HhRukmdqYaOZsTU1fxbruGYOZrwFYTUCQlfxdvTM/xs0XHx
+        nFRcXJy25VqOzAFvF08c+QbRXiZRLyuwQEH2OWHUK6SMeoVZ1Js02lsb9XqNePjMo168Y2eKqJdP
+        G/Xy27e1vz+PDHfb1gR90G0qJLQQ317eV0l8S+Lbg3CTSXxb7MUl8W1B15bEtzuOb5GVp53AGaC1
+        L1qWAW3Ig1gOaHEL3q6O5mNt5paXS7LMr07dsiWOY6UDayiyOnn7FgVLguesH25UfNO8q183Ws27
+        y1pkWHyKzqdNqBtrglxHqmVNnmD+tU/IP7fM6Nbjde/4mmB4657YayLetE2x10e7wRmHlguN2Ozv
+        m0RchHu1KJQw0ZtPl1UvyGWROlYnTxOknWvjO05kEoZ4EgM4QUwc4skMmyrEQ9Eu2wGsH+L9jgEf
+        8ZXeP8ubfD5ElufFNCHvBoneDeZjOe5tNZs30YGvS9XskW7+2okIe6+5+6iw1/t9HEbESwjyhXac
+        CUG+6ItLOq0WdG0J/53w3wn/vUD8d+Qw0o5LQ+xV0k6W+EnIFV3GTzxntGtb1noARQAlXlGAFN2Z
+        FXA8LyhZwyi4C4M9MU3kKfuOO2CD3gxzo15jhRVyi6PbwDIhXsPmhIX2A7iimD8+HHKj13an1rq5
+        btTakcjMJ8swXqlwnJQ3LIO06Qt8Uh164kQhM6pD3WMRAs7kAs7kzcInMA2BaVLBNDeXN9SljUlT
+        1T4y55amhtkGS5BNqwCQDSEpFNLXJySFY1lcQlIo6NoSksKOSQrIwNOjpxH9hD0CWg15BNmG261M
+        wm1OLAGGiyAs0NggAokFJNiOD7Yb97ICGOWgeRCXN5etauO8fh8ZbM/83FCIS2gQxY20CQ2CxNd7
+        EF9f6YZrmdRnaOI2pm5MaB25+ewBhdaEDVFoD52wIYq+uIQNUdC1JWwIwoYgbIhCsSHu6KHnXNLP
+        b85ltihNzJ616UgRyDcHTDQpggUcK2ZeW1I0nOYBAIq/qx8yJ+Lz1XW902xEgjRBsOTjInMxUyKk
+        5rRWj4BqTqExUB13TR9Cd4hUBzs1UVjL/PFNwBb/DJmiLcEp0dsHaq9xcMubRBzccrYotFO4xWsp
+        wDHukGpYXyDeiyKzxgIyI3DJ4QUAOCYNvAAAzTEdNlVjgWQNFo5lNlZsVcvhJpAROIv3CqrhzxRN
+        dZAtogBD/UaL2pGWO7s/jcJb3l4DKxAX3/bib9P47Uh7ozS2fTRg6EyLOsO3uG1PXuCZhZV1nUwG
+        PXmnb6k92Sf+tAMo9rSWkaX0/bIYU4n0w4aOY2Hn17OZMSbzOpCNtpHVx8tyJ7qa0zdkVAd926Hq
+        btIt4o/aNGq2OlLjLONUIM4wni/I7NQutlUXWQLcc+gc9jO2BBwL2MRpCMByKRoPIUvA0hzoAOUj
+        l7VdTNx4KE0GgpPF5BmZjXoPTadiqwwE4BkppWWEMZbxbCvLeLbKMsKMLeMZsYzEMu6FZUQrFtO1
+        Hh0M2vSdTQy8tNu06EMny7Q5Hz6fhZYu1jZOBeJsY3NBpsgxo5LcNm4WJYHsY8Z8bKPC5tyXbzoV
+        W9pGwKSxjXy8bTzfyjaeL9tGPnPbeE5sI7GNxDZubxufVMOAdiymOhOJs4+XnpQOp897M3HgZLQ3
+        pDY/msQWMxxNStls3iJKgE1oJpBkGospedEksphsphYz59iakXOPrbdDWXkA0thLId5e1rayl7Vl
+        eylkbi9rxF4Se0ns5fb2UvP7psfgrIFAnK08xbbSDR70fOELOzWT3g5nrLhgJrMxDKwkMylAV1ZM
+        aRhY8YBAV0lJs83ZJqCrlAnoyrEpDKUSbSMvtrKRF0s2UsnYQF4QA0kM5F4YyINOQz7rWmw5VHA8
+        zjheqCPd2C92Di6GSrTxSWITgPc+EaWkYRLe+yRFJZS/9wnbAXxqE0DykAlMIpcmduSibeLlVjbx
+        cjlu5DI2ipfEKBKjuIlRnKqZ/3ToiiiYO/l/fHc2Rse3AQA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:13 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['7217']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:15 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><s_top /><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><s_keys>test</s_keys><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['768']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1d63abSBL+v0/B5sdmbphu7ngZzXFiOePEzsWS48n84TTQkogRyDTY1r7Ovsk+
-        2XY3SEKWkEGRHCWRj44tqou+VBf1VXVXY/uP+2Eo3OKEBHH0+zN4AJ4JOPJiP4j6vz+77J6I5rM/
-        Wv+w8S2OUodglHgDJ8EkC9OWTTLXj4coiJyM4MQJiOMivzXGxJaWF9leMh6lseOGsXfdunRE8fZ6
-        1LOuX1qjS+2dK/aTuOfD9NWd9/b9p88K9shn5fgT1D9/uH4HPl1Fx7fD7psBOVJGzv3ljXFxdjI+
-        9jTxwoc9/c1NL/t0etM/OiHvLqK78Q0CXai/UxPneKicnbY/jG+S9ucb0woT+f1pZCnH13f98JMt
-        zfXJ9gOSosjDxEEJdm5RGPitKLalZfRcKi2bUpBDZYZb7Stbml3lBT4mXqtNRTy+G+AEFwycartB
-        Pxux2jLcggDYUplge0E6zmsK48iPIzG7pt2dEvNyXtEZLy8K86q9EBFS/Mn50wFGKetAiVaU81u6
-        8+V5NXTm+DTm1fG5nSfZhVJc4/GkBYnO/4zI1KRgndw5pczVN+NbUuV14JPl1eYDKcrnaDMWPpYT
-        NAzCcYkpH6E0a1eaCC0mqZOgqE/rcDH9zifEiXs9nNBZdUkcZil2CLqlj0kLKgd05h5S7V4WhrQf
-        QzeIsN/SZMY0T8tZ6JjSURJ4uKUaU54ZsWDK6LhRQjukzXimNJv3bFaxYjGmB8SCaVazos24Su0V
-        hGnlaolr1uIIJx5VftSfDljWbGmRSlV6QYBDdP+wr3MkzpDfv5f5WjJfFCCnPOjGPC1nme/CPMke
-        sqd+MjaYc5RJBQOd74ppU2vMGjQfn7UST/WsgRqzBtU6s1bmWjFroO6syRWz9kB67PphJ+ZpOct8
-        B+ZJdhQ7hFYfYuLszdrerH3TMt+btb1ZK5q/yVCUMm83HqU0dKFOG/fJnQm9BW3pAeUhh/woh/Io
-        h/ooh/Yoh77IIS0Oj9ttx8uShMZnlGXyLXd1++6Ieq9zpBlHD3lpnOQBxkPijCvKhi6dHlPWS1wF
-        ccY1ChENgpjsHpJKPGyyyXjoxqFUJtPAKae2/vff8v0zui09HGYajxyuFHuTuZbJXJCfVOEQ7B+o
-        /QO1f6DWeaDKT5EXZ1GaFArDl2vKhGkxX3m4jIIU+8IbWq8fD2esxfpNEqSB5yT4NsB3TtGTQuWW
-        Ftk+otOVTzeO/OK6WNnJfhOgmQ6Eo6yfkVSQAaRKOWPIebPUY4MiOG0pOmvoIXXGRrAXRz6h6G1A
-        TdXAHPekMGcf05/h0PdbrFFgQrPgnNLtgMSmDqDDySjynTQYYs4uAlOEZhdahwo4BOBXAA9ZS8tv
-        KOp9KIH8mqQoSRdkIkMqjCM6neEmRaJDWVfU2iJRZdhIJKoow3VEUoggX8rl+vj2svvy4ujlm/aF
-        LZXIBQsXwzlK0wG+E17EWRLh50R4S4eTIO8aJ/+c3JTLK/8e+C399GRSMl0kdUKq5fFsCbJMLDiG
-        2A8Q1XvEDTS1cwP6XLU49YCq+zVOyV2QeoMDjz0svNAOIirYjJo7ShuFmAk7CVuDNB2RQ0lafq9E
-        6DOPfanUKn2i4hF9jiRLoR8PqG4P+LKKe4oPNGz2cE91kWEAy+8BVVExgop38HnUp2Jf2gE7QlT4
-        IZ0GQodDh8uv7RFKB62NNs9rtL+yDJZKgGSjUZykxGEd4Svo85R5BjLZNZij2dKcZuyOmhiYfoBq
-        erqm9QzLhwgDqELLs2RVBqYO/R7UdNdUejXUZIiSmwzXV5LGjW9DSRp34sdTEg3TDwBqT9ZcDSFX
-        76mK7PkG1k3FcumDpMq+ibQeNNzHlYRQ/zWpryON296GjjTuxC7oiA/v7tU7RcvcoR/cH3hhnPm9
-        JI7Sgwinj6sKFdTKGpbJC9+nTopJCqRfyZikeOjMKGwgYYCTGhpScD6qI/Wbe1wptjjWGsqwONXf
-        tsXoWfSDEAVaCr+qYXgKUHzDdD0NAsPzgKGpfs9UdeSZj+tDmgSM5PSC2/p2o3EPtmE3GndiF+zG
-        96Ap1MXfa8r3iDCFvBzOKVka/biW56rIMnvIcDWouqqqq8AyEDCNnusargGh56H6yhNHta3Mut3Y
-        Ahx9YY92AqO+uj7JGv0AXfMtT/eR7Om6ARWLXhsGUn1VVXRL96Bm+UoDfUoHSf2YaN2ObF2jGvdo
-        JzTqO8Cy9C7eQ9kGoYykKM1IK+TO5BxpwpC5PkqRNLlO42sclZcCc8KkdDyiEUvAuu7kUpqysZKC
-        KxsRHIZOGJB0bnmxvbi8WLXsyOhvLst0aUndfRyzhVM62hClQZr5uKXBA82Wppd2GEf9/KsIDiAr
-        mhJsaXb/ABEnitmafI9w+c8RWAIk25rA/jTzsbjkWQpJFkUst4Ev3UK5SFSYo/Kd8SV8D6l2hLHv
-        +HiEkpSpCVsG5v1ZRi+YswQxK1Bim1ByBjaGOBmyLNi8+wtUm21U5YmwL+GFoHbf0odlQppkdU4y
-        aZ3rYb6zv4Ruk0HMdzZ6+XByPZ2n2YT6qx7Ol6ynUSRlK5EnPPmKPy0XOjzqFP7GSTxlzdevqVpk
-        xW2do+Oz9kXnqn121rGlUkHBxG/oID/EyXMiXFFFIhO2Iqe0yAxeSBCGAJgVKcJFz54zludzWcLf
-        WSrvMCDeqlTeonxVKu85ZRGmQqiT0LupbbnqTbYOSn8ToJoOhHM03uh2kiJDvf52EnVaG20naSJU
-        u5DtJW14h62TRVQg9JnbtDxkYClyfXmAZttrmgjgOvJY3F5jT/Khqlfurb0I+sIFJgQnt1ThmHmq
-        2FFTTs/hOltqa6J2ublGsL059NPrgZ++Q9i3TXijXqMOnRsKGihCPloBcheMU/hwJLzknAIDRSFf
-        aq3GO66osirlCqtWQh5T2I/s8lBgXzsj5OGawNdtdypwj8PyWexxce9x75vDvW6GqZkHW8A92QJN
-        7DwETXEPsDSKjePejyaQReCTTVOuRr3Ti+NPwijMiEBG2AtQKPQzagNIFfidvfzwlOBXau5pwO/7
-        gys6DQn1a+J8VbgSq345O/3Y/kU4LbiFdyXuBYzq/mVI3Upk4iDCr4XXJ3tI+sEhiUcexnbSHYGm
-        G3r9dEdgNEx3BEYXylsIxlh0qm9JJKoJ68OSCfSmItHXEclSWIKVsPQSZf1BKrhjpszCBUWNROgO
-        0BCvwKWLp8Wliz0u7SIuWXVxSTjJQqpRwnsU7gOnPUpxkyxHvvA6CzcbJxiqqdY3yAaQGxlkQwTy
-        VlLyfzSBLEMow6pEqDblHghXARXQv9Bw9G/hJEiwUI1OnadFp84enXYRndTa6MQ0i8RJM3hq+sab
-        PTR9C9B0hf186+Z1FuGNWmLVMK364ZPecO9G53s32ubDpx9NIEs2s2S1Ong6en8qUEe1e/r2VRUe
-        nb96vU08Yl1gPYD60ZSvKJkHqlI/9kC1HlDl4vkPhSmec7Eq5YJz/k05i+3NKpzS2LHQCpS6ap+/
-        OGt/Ejrdo+PTy/OawKTDR/IsdLjPsvj2kIkv7Sm5Jd5wkGBZhlLfEhtKM0tsiMp2oGl2kHnzEoGg
-        ATYZDc8xG/wc8yawSYeHsmxVw1M3QWTALZBwnA2HQfWa3luwVqLFzmRmZ5GPExeH4VjSIf04isN+
-        SbIM7iHUNnlouVZTW8iwrtXuTuRR79D8Q5UKRwUbO2haq50nnPy5dp948mu7qFdQ714cdf5c7aCW
-        TNA++apx4nGnDQXzr7+eKu94po8rvODLKZOQL95U+8EUyRSJ/ar0hvNX/QpXMau0n1C3yT8UqCcq
-        dEYB7uMwpRpR00XWjAoX+TRFbEBl53j61uEh/RUhMUgrXkV8zssfexUxHT6p9qvLpet41ez+jfrU
-        vMIiW2WVUz1jWeVX8/EJIp2xPP3lNEpxkodHzXxsPgnVPnYxjY0Xfc7Z8Jgjaax0JGt6kaapyLXT
-        lw2gNFnhMESgsBUOUKTr/r1Bl5qnctd8N1Bdhxpollz/XUlqw0xulWVyNxPFEl/agOZ7dsClwpc+
-        wUmCkoDtZYbCMRoL7XtqGwNMLahwF6S5my0eJyU0fOhkv3v3anNOtoe8ARb7CRoNAo+EgXtwG6A0
-        TuodWaM+yKoKpBJZHCWYYbyUDrKhS3RDvVdVXWLykjqn/JmWerlwRPZCM9FHYxFPhSMy4YhsvUT0
-        mXDEIBILWypbJpSNtX3zJ+/jar9u50S6GXdw4TBdo1DgB9LSZRHEXkV3V0WbWfTJTT+cWle+6GCv
-        27uk2+vmL5R8kkZR95Kjw6p6oKs6239YdnwYggNL1mXV+uIjxKzsW95n4lO6IrbOlXZFXP1xnmEh
-        mJY1c8W20iRQrRUqW3JVrPweJ1lFqBwGQyQyb235/+yhpfsw+SnCZD4F1WFyPoONjjvJ7HTPMfYw
-        e5nzxsJDU4YNwkMoy43O90BZlMGmI+WTJKCRsraFSFk3zAav0GUBa7NIWfviSJlacaC9h9Unnf5E
-        YY87VB8DEqRCGvPU8nMKpzH3qYIoFs4zgrNhZaTcVb6fSJnLa+pYDKhwuENxy4QjprFIRyQOmXC4
-        T0GFIw65cJhfwU2pbFqGpmwxTt5oD7ftpm20s/sY+Qn1c70Iea+cXyU6njfXP50fdds/T632bkXD
-        T6bAXxAL77V4x+PgmcfxpXEw9TgPgKqwn4o3aRnGAZDNgmEfDG81GLbk6lA4D0VrBcKyJdffNN5n
-        VG4yo3Kzu718j1NhcWz9lPbax61kpcEZaV1p9p4KXVRoHGsWeYP8TU0bDGZljYskz6RUNyUSoMuK
-        VfcEmgoMuUE8q/JUSm0dkSxL81faJ5URLYM54SSsCFflF+rROuHqmlhVbu4rZUqpNV/SqO7SSxq3
-        mg+VuChykM+kTbtOHjsgcMn4haMp/yPHBEy9EsMWavrpJIzZ/zzDPy+Htommzf1P+/8DEfwrChB/
-        AAA=
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3707']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:13 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/CoreTests.test_search_events_sort_user_rating.yaml
+++ b/tests/interface_objects/cassettes/CoreTests.test_search_events_sort_user_rating.yaml
@@ -1,139 +1,168 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxyZXF1ZXN0
+      X2N1c3RvbV9maWVsZHMgLz48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJl
+      cXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0
+      X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVl
+      c3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9t
+      ZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48c19rZXlzPnRlc3Q8L3Nfa2V5cz48c191c2Vy
+      X3JhdGluZyAvPjxwdXp6bGVkPnllczwvcHV6emxlZD48cmVxdWVzdF9jb3N0X3JhbmdlIC8+PHVz
+      ZXJfaWQ+ZGVtbzwvdXNlcl9pZD48L2V2ZW50X3NlYXJjaD4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['605']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1dzXLjSHK++ykQc/CsYxsiCv8Yc7lBidRPN0VpSUoazYUBAkURIxDgAGCrtceZ
+        gx3hkx9gT3NzbDjCR284fJhHcTv8HK4CQBEkBRAgAZKCqkMTIxWS+KlKIjO/+jKz+scvY5P6DB3X
+        sK0/fAOOmG8oaGm2blgPf/jmpndKy9/8sfZ3VfgZWl7fhaqjjfoOdKemV6u604Fuj1XD6k9d6PQN
+        tz9Q9ZplVyuvH6lqzvPEs/sD09Yea1qfpkV64P54d/Wj2XlwIO02Bh87ytWxNpRHn8QvP3XbwzOv
+        3b0+vh6IwGSe68Zgctp78I4HPw3uNVE+mQqt42t1dNO97ij9E/f72x++uH92u9OG2GMnPGsNJoPO
+        08c/HX9sfvzhyxn/fPI4GrGqMVRMTheGz4PRpfAn4bJtMpNjnr6vVhbur6obrqdaGnT7qgP7n1XT
+        CB7utfFggmpVNKL20fTBWvOuWpn/FRzQoavVmmi2n59G0IGhgD9a1QzvOZA1bUu3LXr6iG7oZTA4
+        7ou2/OPhwfDDpuq64f8CedXxXCQyHwgP+vJ1dJD6e3U8+UfqBK3kFN9K5HAVrZe/eMFpnyE60+JQ
+        NdSER/jsX6mClnw+ghUjlJt97GVk4WRzueXz6XiCXz9p8DgzgYXBuYz/HMeqaUIvfNDG0geCJ63M
+        b6Eym0Tb9fqOaj2g843VL+jM44FhQb0msEdMtbIw5Augm/QmjqHBGi/NJOZjgcgUPYbqoFMKLxIv
+        Q9UxntfZKVngS0SHfIH5GYE8k4hexZ/O2Sm5F4n5VSy776JvtQnxZJXzEX+aqpaHvxX2xEPvM7SY
+        /rezPxuvgWplaWRZgl0rwa2V4NdKCGslxFWJyurj+WvY16aOg17aSGT2W/B1eBhMkFYvDM0lhqrm
+        2U4NMExEJhycS1nT8QA6NZkVI1Lh4FxqYqrodYjnbnkoIoN1zn0eD2yzEh1Gr9BgtPbbr9HPz8er
+        leXHrMToMln/d7L+0UXX7KnlOeHz+UYzOvBy2H/f31iGB3XqE9Id5J/MRUMr6hieoSH35rMBn/oT
+        6GjYpgcz9Oqhqq56MLiPPrT08G//ZL3R9AMFXI/qwokH8XxRLAPQLM5FAumpp/Xt4dCFXo0T8aWW
+        R+diLtSQ6XdrgJdYSeAXpWcHA/Fn9G881tG7Fl2UURgQSr6MI8tsyyID+v6waul9zxhDX5xmFJoB
+        PaB8xzHfMczvGfAdvtLrHwjPuzwHwd/IT3K8lVkRvBF1qT7nOR8iy0sck3o+BEbINB8C+tlkPsLn
+        D5xnXx3bN72TTv3kU7NTrUSGQxF/Gi5VzxvBJ+rYnjoW/Nal2uhxHFV7RCrUa3Z7sw8Gcxb8jjxQ
+        8eJ0duTFH+2bSNHtGjqd6mEfLzoYSoyhbqhI9VX/lYK+mSP01arp4OkL/8QJ08FYN74caaY91YeO
+        bXlHFvSqFV+malhojpHviK34BDlaaN4dszbyvIn7XaWSeIqKiyw21CuRe0BfMXuCvlgVhUM/GsMP
+        hozO8nDI6YwA5SEc8gNVkhhFHzI8x0MVcNrRj5MHtBCv3kfVUtFymGhhXPRw6OH9v6sT1RvVcr28
+        f8bqYUzFqxPhTicTGznVfXw/YXgWHVkUCF30pbFqZUFdDlV3JIh+GF7WREEYSooOVMgAHiiawvIs
+        I4tAHwJBHMjcMIXujFXnpylMrzmZL16g5mS+lxJozhbz1fclK6yCfiQeCrKkSCr60ilAEtiBxOkq
+        pzAqFIfyUBUhL4vsevXBkQt602JPyEqrQ5veR3GatOkdpdCnVW05MIXa6hsoQPTDMPyQFQaCqg7E
+        Ic+xmi5BUeaUAXp586wuq8IQSIMUuoRcfyf9myjztQt8E2W+l3f6JoJfvL4HXY+p/N59dlHI0J+P
+        4AcxDeikUJRQcq2qpL9cAbqR/uLv/jUyVNCPqiKPD/mBvCRpHMPpkjzQBMBImsagOFAfyryoavJ6
+        7fAcAw/1h8bn9C+TzHdQ4Msk872U4GVygOqDIlOiPm9Efbb3/RiIflhB0PmhIg50hh2oqjQY6iyL
+        /tPUgcJo8lDUoM7x6XXItlK/gTa9jcKd4sx3VAZrtv20aWhAZXVekBVVVniZEQCPIgrkGWpQk1VF
+        ZkWBZWWGUbj0+uQ92Rn1KfNtFK5Pme9ox/oUTKx4cUqPA4ySHvgYJe3S1gtGSWM3rjL7fDBnIXvA
+        U72pWzN952NhaCYwHeiqp1Zmf3v2I7SiwGYwMDv6PEH+roEfve8Z6NLeixg+EkpNJy40zb5puN4C
+        WNpcBUvRb5fnTHS88so5HqCNIV80KSaK772pDmsCOBJYRQSAk6qVl9GqaVsPwa80cwQYkQGCyCKB
+        l+FqZX6yker2LRvvLAxd36YsDOB9dIwnQP1lAz380997daaWhaEGH4EGbLj9ujDq756+Irc8WrUg
+        1Ps6nKgO5gX46LZ/P6+Nh8JTR8UvmIjYbCQQwM9gO2O8AR/c/spoFe8OBbSJE9Ch+F4bfd1mQzNy
+        wIx30X8c1xi8+/vKeNUd2f7+zDB4nEC3F8eqLtJaDQbI+0vggcQiwzOZgLHxxYOOpZpUDwlSx1jN
+        LZ2afyJA4n2my2t7R68dqCLFmobX6tYbrWane9dstbrVSuRAKOSfvqvqJnS+dak7pIruTCwkMYTk
+        kzw5KIZpQnroxFFQ8OF1DBTPQ28Ef6MynoiyKrMJA2V+llyJKJHTorfdGOv+o5tESlmQSmKm9LBg
+        SEy5Q98kh7pe+lR2egovrOVuMNtzN8KrJHA3wqskcTeEDekpb/wRCT1hgYsAcRSZCz1BkeTi6Qn/
+        8/NfCT+FKMCWBBXfpMYTVE6dgKa4SEyJp5lc2lZAM/moWlPV8UkVciKpIh2jAkUesgCAoqRiVMgM
+        yMIwkWkGYIYJy30nKOjnh32QS9IzSxiRL5ZZwmBaCfpJNw+rpJJG/b538X0soQTQDTQhvYUQaZk8
+        8qkbRx6Ze0G7449st6fQvKuwLPMFACFPfkj8+QvdIFm+2HuFkBZmRGKYLxzD5EfhiD970Yu7cDGy
+        uGhGmjedq8ZFt928rwAeaT6fYp1T7o+nuk7RKx53XbL4ZOO7XBvf2yPihWxfZt96OqA9zE3vaD9b
+        BZ+6NKB19ZkOAPpctwXmLmumbYHX8HvmSBJeR+79LKMtEXt8LALYvwakz1Hx7RH2F5kFgH0LDN3f
+        4d4JhB7BvudWMhYSbxiuBZ+xB//bv2P81CgeFh9OLXWguiOD/nESA42fzkQIPL4feDyCrfiLFA+2
+        fFQnmJpLsBaCtaTGWkCjfn9d73avrzq9eMTl6y//9PWX//r6y79+/fk/v/7yF//3f6Z+d2VBCmMx
+        10hVsQn9hxg4pn4mlwWOAQXDMavnL9BtX73Ye3XTF2akMDhm9exFLy6BY5ZnpCgMZvXkRa8tQVsW
+        ZmQZgQBFoi3rL1fo6q+7+F6iY2TlaYDjPfQR27Np24J+rDwJvYM8o+WIR7FttMwJRyKHHb7X4mXA
+        KUeyLLy1mDmGlbaDoBlkDppBfNDcu/p0vy5q/r+//Mf//u2v2EH9+devP//t6y//4nun//b15/+e
+        uak9+/HZpoLwmupAN/BUCePs3YbUMXQswKzlYwEmB0LW7DpJBYOY4lhnJXhMQjx6L8Qjwjx75wpA
+        mGcEDd0ZGso16vfnV9fXCeWMOJ99du5vXsayz3plgTsJ+6zUqAlhn5V9cQn77L0uPmGfEfYZYZ+V
+        in3WozkfUR8F5T9yZZ/1CPuMsM92yz7LpTEAiqc+QzMWH+8tHN4AGg/OnycqHp5xZHvQTATDXySS
+        gPDzZaF0VLKtCksnlImewg8Ui5SxPn2YIt3Ms0Y0AzghfY1omWEz4QcyzbA9wAb4wRupEY1LZhdb
+        Izr7fKyCKp2rq8tYOKXujaClwuk4Bku54GIz+fyvB4FRCIxyGMtLYJQSL26h2MlOAROCkhCUhKAk
+        BCUpK0qCHEZanTmVeUIkEU90FSLxfdG+Y9vj9fgIOBIY5L3HMA5xbT1e4pTtK+stISUHVFgvAtBs
+        XlnvDnykpOOPORXW2wssU++dN9v15s1lLCoTCY8IGEPAGALGEDCmQDDmxHamLnX+rEOfTRsLycTS
+        WwgkQyCZA1peAsmUeHEJJFPStSWQDIFkCCRTKkimR2vYtaRHyLWkcXpXvsBMAnclIzCD/CclAZiR
+        JA7T8wkwkwjMsBTXOnvLuMzJVeeme34di8qEcRJWrWi0VDBCM8H8KwetczxIcz0T+UC10XdzRN3b
+        zqM7MpyUqaa7STMtIMW04qGlRGqUmFv6IpKYWBpIUQtPnALPyR8LC18TOUFh0bMlIWF/HhuuljSN
+        M4GkSbzykB4fHR1tlY4rsuvSVAV5bZYqvy5LNbxKQpJqeJWkHFV+w1TcN/6IJAtzIeXyYTDJKQtT
+        xrtDRWdh/vYrycIl679dEm5BOxd3UP9AcTgb9wpNEHr43LJxecCgGCltNi4SzpSNCxiaI9m4eWXj
+        ntYvL1r3sbsVp+rYMNc2grghqbhkw+KAkS6yYfFeFpdsWJR0bcmGxYFtWDw9PR0NTeQeIHuODeGR
+        Zh9hTzWFGrz+0Qp6ZORhoweuzA728VF0a2NTqBhj9QEdmqiOaprql3mtMxp5Q3zFtB/so4m16b5E
+        TtdOVovCHz0fxVjpTr8mY/aGHvpeYiENG27itx0ypszyRywjyIrMyrF7DzIjM+gft4sE2h32R76/
+        AhIl3nz/lrcLTlsX7bOrVj12v+A08q0qapuAVI/cQ0OGqZsG/uh6+PVJ2UOqPoaOoamkKhnBQTLg
+        IML6qmSnyHiFrRicx7A6WTIyonx/VxZkhPRkKHWARXoylH1xSU+Gkq4t6cmw554MyMrTQ+QbhI0Y
+        UFge1I4qIB6OOBSZ4uFDrfy0LnI9qSusjOPxnQauufZXCEpCtertRoqyUGHnBMqwqBPVNNCMWIZK
+        0hJJWiJJSyRpiYWmJZ4bpmdb1CdoYRKSNw9LVxITYzf7SWIi2ec/oOUl+/wlXlyyz1/StSX7/Ae2
+        z08SE0li4naJiTf0yHcu6ccX5zLf1MQEjkDWmlFo6uLpASzgWFEiqYnrakYBir9pvWWywafzi1bv
+        qh0L2ITBUoCLLMRMO+cdpKEdhJvwXeNh5LkQGpgqlAMRoRgeQsWN3mY8KLMoti7b8ABpB5khGpoF
+        WUAaiRUKBmmE79APw9CMuCeQJsuMiCwvcGzBJAQpgGkyzMgqTHNxed3sXNRbsVDNxRi9Cw30OjuH
+        pqHZE0ytwToeg9g0rpU4xMaLfOqwARtCPyilp0/oB+9lcQn9oKRrS+gHe6YfIPtOG6FLQI9eXAIa
+        G/c84+yIH7EtF58TjhQRxMTZALBHgBOFkpHwkSPI5kVkCDRk10yGT2cn8SHxmYPpCyeq9Ywi4rrh
+        YOUtQ7UeQu3Pm9ofU6YFKOvKtABxbZkWbl2ZlvAqCWVawqsklWnhNqxE88YfkVQieSeVSEglmve9
+        /qQSDalEs/sMrO5F+6zVjEc9Ld34bOhT7LAmV6O5LUvOFWGplRo7ISy1si8uYamVdG0JS+3AWGqk
+        Gg2pRhNUo7mljRdPsZCKNLd5oeCHVpFml4l9pCRN3li4iRb+M3xQXdpnLr2ax6e61C0WeU/Qt6YO
+        0HwlFq2fiySB3ieBVAh7NwzLgg7VRUpXDm6ZwKbnlrEMm55JtRG3jGW/4wImlbQ3bln6GRFZgeHS
+        p0RuBK+wzIxblnpGVjGWVv20eXkZD7K0VOoUjscwDltpxVPJRsiyOPBtACuETVbq+Iywycq+uIRN
+        VtK1JWyyPbPJkImnTZUeYi8g17i5lR97TDwCDMfH0seEIyCx23eQm4UZW+dpKXmnaeURgLdvZQUw
+        ypsmpF2eXZ516u1G6zY2BEciVEBNiwS/RUfieZTTQcufEHyjg2EcejI1sZ5s3uMMXyjHDmf+6XSs
+        J0kR90wgKd4+Vk1zHm4vfSA+zl4tTDSLTOIqEy0e3wDFCK+Qa22i8JSPhp5I2QuPJ81j0MJlK24e
+        J6wjrnFg+xZqLLeOuMYyhXHz3vgjEm7WO+FmEW7e+17/XXPzfNAUU/O6cIKClZCcl1stOVYSMvDS
+        lCwV0kWaUfwK6cybqiUnyAUDyUAIoPWtasl17+rtVv1TPJJ8qXrIh3mijpHvbsFvXar7pFrICX+E
+        FI4D4gDmi2YpAGafM9OtN1rNTveu2Wp1K7MJK5zPl+KqRZOFUtzCe0e6EubJNYvlBKa66n5UZOkm
+        iJLEzlShzMIUl9yPfhCwnLAQD5mFeJjvCl5E71RepPn05fGGfmGY7d8ZS5fez1tj6SaIpqydKZBv
+        IcXsV96vogCiKClnikuvKN7IycdTXbr2flWFI6qyZqZw3I/D/tmMsRlU5snOQ2Fi7mA/ihNzM/vZ
+        679o0uMAp6EHPk5Du7SLbpA20R3S+ElypQDMwZ1MFIDg9+nEhabZNw3XWwCMTlcBIz8L9JU2Bei3
+        y3MmOl555dwxpWFZRQSAk2KZ+oARGSCILOEdJPIOmiegQ/G99q6JB7ky/6Nf7VjqQVfVTeh861J3
+        SLd2wDrIj/9PWvls1srn4Fj9pKnPFhsxJWjqM2c/1TXkWti6Gi1+sLT3csF14vZe3lBnH0LtL3Wg
+        Qaj9ZV9cQu0v6doSav+eqf3IwNPjhzH9gD0CWo14BPm2Y+nER/kZ2rHsiOVf8mYs+dL899JA96BY
+        /gPjYTrpf1bNKaxJSDmjf0cL06qO4dJDJ64oLT5MkvB3n4S/MstD29Zjp/cUHfxANRzDeqSwcrVx
+        yxnTGG6RbYGvl2O2hX863Z+FxHSLmUTS1G5V0cBX9Xjs49QJ8jfSIh3dqfWB4hyd+jg1U8T1UvpM
+        fUkQhfS1CyRceSVDXC/RDNcDyiyuZ/eEc2SYDxZNSdGE0+zzsYpzNC7a7Wane351F4922FPTsKiO
+        PX2A1O8i6vwPcZ1xjn8oBduUYB4lD50I5lHuxSWYR0nXlmAe+26Oc/wDPfb9AtrBfgEduMI0jmJz
+        bY4zdyW2LW/Ay0eyHIN7sEccx27fgTY3ikH+qEceHANJ8MvHv+XKBlc3rYt25+rmrBkLehyj8+lT
+        Kur1kv6z24MVpP9sTv1nZTZ9YudmfAI5c7dV0n92faTdvur0zmOD7KCJVtjnK20D2mPSgJbE2Afu
+        qpMYu9yLS2Lskq4tibH3HWNfH9MWdgtozXcLim1Ce5xXnE2a0L7FyPgAm9DmuddfvnA6+mzx0fSC
+        VFIwvUB52O8mtR9A49JIYayYS8dCVmCBgqx7uo6FKEzM1LEQh4mzjoVpO/WtjZn99o187h0LcbCc
+        IVzms4bL/NYdCxu3jdg4uWtP0R+GQ0WEluLis9t6WToVkui45E42iY7LvbgkOi7p2pLoeM/RMbLy
+        tBs6A7T+Wc8zGo54EKvR8Nhwtb6B5uMQdpx3Gwa/yBS/P7wfSvxhbQ/nW/meZJ9vln1eUP1fknNO
+        cs6z5Jx3ParpjA3rWzc2z/w2Lux9Q3nmq+3sC6jlu9OqvSTiTWxon3sd3p3W2yURb2JH+7wr6O60
+        Vi6JeElVXFIVd2GGNMeeoICs70tWhgr6UdUhP9AYnpckjWM4XZIHmgAYSdMYSeD1ocyLqibnW/h0
+        y9soQHW2vKM91S24pV2PhtirpN18axXcxuMnGWoVCOCIVxQgyfHVATmeFxRSrSCZntC9A+cU86e7
+        HWMz+dYG7DU7lxftZnxhwI+2aT5T0TgpFSxz3GzF4DLH0ByquKdKSs5+CQoKDGdN7WKxluFy27tt
+        e+MVj7V0Ve8DxWFGQQNqKXstpcQWZI4FfGo+PmC5TI2WAEtz80ZLe6EVZIFZOFlOn5qwEbNgg55T
+        qzAL4HDvsRiYxX8dNfHfFE31kGHCePGreAt3Es8zSEpzD4wv/rRfCZj2R2lsA2mQpxGO3t+2nD7g
+        m4ZX9zGCI/nmze2ZzXfcAxR73NwVnw8phwNd18aur283E8zmRSgbbyfr92eVXvzuRWDS/LQSl2p5
+        +o6M5JtuFovccqgnGsUXicQaO8tCezWKvhngGGQH2vbnnI0iI3DpAXcAOCaTUQQ0xxRiFN/LbLxm
+        EhUli0lkqN/pcdVfkN2Jz0tLYxePV+0iQ+e6vx+9RWIaiWkkpnFT06g76lhNLJEWCiRWSFuSKXOw
+        yKbemN8sWARK0IX2DQSLYpb6aBsEi7Op2C5Y5Bkpo2WECZbxZCvLePKaZYQ5W8YTYhmJZSSWcVvL
+        +GjoiZy18PjbQVF9U4AZa6nSslKbApyZJUpySlOAM7My0NWCzCy2B/jMpoCYxvWmkeOymEYu3iye
+        bWUWz1bNIpezUTwjRpEYxYMwimjFEvYZ0cEwjflkauKl3Wa7EZ0s131GfD4bLV1iwDgTSDKMV0sy
+        +7eLxUGHSvqAcTPoELyV3UWFLThveTYVW1pFwGSxinxywNjYyjI2Vi0jn3vA2CC2kdhGYhu3t40P
+        qmlCJ3GjcS6SZB/PfCkDzp73curC6fhgcp8CiBVbzCjEKuVR5gN3ogBpq0EiySwWU/IhVmQx2Vwt
+        ZsGAM5M2tN4ccN5u65EHIIu9FJLtZXMre9lctZdC7vZys27dxF4Se0ns5cL59KCuVMLmYyiQZCuP
+        sa18aXy19IG9mslL2/pAseKSmczHMLCSzGTYiWTFjIaBFd/QTqSkFExbBVI+cCubwVAq8TbydCsb
+        ebpiI5WcDeQpMZDEQOZiIPPsyFCC7A70/R5jNXxM3JlckEpswIAFQ8t5p+Jq9ddLn0ppP4tuyeBb
+        UhxhfVStqerkV1USWVIBAMydTLV3CTJWlQTzqpKCkpMdzVZlI32JDUbMYkQ3acKwJceVbdTvz6+u
+        r5udeCv6ZFM6mhasxiM/oTPGiCrf35MSk6TEZHRFD3l5SYnJEi8uKTFZ0rUlJSb3XGISWXnae7Jp
+        5BLQkxeXIM9gN+JHZIp186wPGakwUHiIelJXWJnJq1PCXmpENi667eZ9q95uxEarDcO14DN2lagO
+        dJGuUYZFnaimgWbEMtS3US6S9E4orneC6wVRSlBpBL3UBoaFvp6Cr/gLQ74A/vZOUMQLIxLzsUAE
+        KSt6v6JTziVehvw6JctXiQ75AitXWRgLRJausjBURe6F5WGVsn0bip70M9J5vT8br6Fv1dJItbL6
+        oSB+Q697B1oaEpn9Fm6ADyZoIheG5hJDtAq2UwM4EF0enEtZU4yl12QMai8PzqUmpqpBt8ZGZMKh
+        iAxeSfd5PLDNSnQYvUGD0dpvv0Y/Px+vVpYfsxJVi51tL/j7zldogvLcXZAkRZC5lL02RMBk3HZm
+        /KIYpNdGLr02LpuXx81O9/ziuhsLi9z6L/c6delvQrkjYxJXg1T8FLu38NZwEVKItNThFSlEWvbF
+        JYVIS7q2pBApKURKCpGWqBAp8hrpz7RKj+f+ZZ4gW8Qp3ZZQ4hckFRXAClx8SVKJRX6/xJert0v3
+        TqLYTmvXPU5zLSHaO2/e1tuNeixwd2tgqMBQKQzd1U2kjF7InX8ds5spYfDADnSnplf7f/Y7UcnH
+        twEA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:13 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['7128']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:16 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><s_user_rating
-      /><s_keys>test</s_keys><request_cost_range /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['776']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1d63bbNhL+v0/BzY/ttl2aAO/0qupxYjl1YudiyXHTPzwQCUmMKVLmxbb2dfZN
-        9sl2AFISdaFMKpJjJ8phXXEwBMDBYL4ZAAQav98PfeGWRrEXBr+9wAfohUADJ3S9oP/bi8vOiWi+
-        +L35twa9pUFix5REzsCOaJz6SbMRp103HBIvsNOYRrYX213iNsc0bkirkxpONB4lod31Q+e6eWmL
-        4u31qGddv7JGl9r7rtiPwp6Lk9d3zrsPn78o1Im/KMefsf7l4/V79PkqOL4ddt4O4iNlZN9f3hgX
-        ZyfjY0cTL1zc09/e9NLPpzf9o5P4/UVwN74hqIP192pkHw+Vs9PWx/FN1PpyY1p+JH84DSzl+Pqu
-        739uSHN1arhenJDAobFNImrfEt9zm0HYkFbRM6k0G0AhNsiMNltXDWl2lyW4NHaaLRDx+G5AI5oz
-        cGrD8Ukc5//LnkkGlCSMq0DL0/kjnfn0LBsQL5d1lh1vgHlSI2+5azqelCBBI82IrC1z1smTU8pc
-        fjO+FVkOvdhZnW32Inn6HG3Gwt/lHFiEqRDm02b3zfz9QTRhGiTROMsrvQZ6kTBN5s9fBl5CXeEt
-        6DYo54w1y9wlCbUjEvSpTQM3v+dJV9T9l4DjRHiTBlSQEdZBH6apGWOaOHbY68U0aSo6QjlDgTpj
-        i6kTBm7cxKquGqY1zz1JzNjH8G84dN0mKxTpCOecUzq0VmgC3eZkErh24g0pZxcRXLiDtUOE4PoV
-        4UNW0uoH8nwXXz+7B82Pkh9ZILkAMiPIFQvLKhRdIOSJXABHH06FTqvdOX33esKTCSb7DZZDOX/9
-        ZpI0NSS2D4oZzixAkTgxwAlJ0rjpe7fT9Jw0YQC7SxLCqsBqgPWjKV+ekjMm4TUN5uqRUSbJ4xFt
-        xt5w5FOQh3NNkykbS2kMSGwHoT2iUS/m9nGOwGwIWAHobFPjkd82AkpdkMYIBJqCIWVC5s+voufM
-        aUQSQKcC24SSMbAyw2jIrHNW3BJ1YqsmRty+HjbRAZqaqiK9EQ/CO/50pggZnM3TGnGYRsCeWWwu
-        nv+EAUiKxiCnYuKEM7PdnPMv4BQ6Rc5MOUC6af6Uhs2GVLjP07K+1zp/edb6LLQ7R8enl+cTvtxA
-        5oi0BEwYIbMEmtrjOKFD4SfG8tMenZ4dOrVJAsZYTQbCORlv1RgrMtbVysZYw2otY6yJWO1gtH10
-        aqdBhk7bloeMLEWuLo+a4KRxcKovjxXgBD35UNVL8eml1xcuaAyO+S0oXGaKVsPU6TneJUxJC2hU
-        KO5x0GhI7u0oDQKofCZZHWS+RGwMwbQssy0Sv0Nsi6irY/sGQIMExCVrsO2CcQofj4RXnFNgUCjE
-        HFrKcY4rqqxKmcKqpZjHFPYTuz0U2M/2iDi0IvCBF1SCe0zvhbPQ4eLe496zw71OSsHMox3gnmyh
-        OnYeo7q4hzrY2j7u/WgCWQY+2TTlctQ7vTj+LIz8NBbiEXU84gv9FGxAXAZ+Z68+Pib4FYrbh2Kb
-        wRU0QwR+TWhDiLUGq345O/3U+kU4zbmF9wXuJYzq/GlInVJk4iDC74U3J3tI+sEhiUceBhjgo7Sf
-        QlNu0QYbSNON6iNjJjJq2WBTREYHyzsIxlh0qu9IJKqJq8OSifS6ItE3EclKWCofLHxF0v4gEbpj
-        pszCBaBGJHQGZEjX4NLF4+LSxR6XniIuWVVxSThJfdAo4QPx94HTHqW4SZYDV3iT+tuNEwzVVKsb
-        ZAPJtQyyISKZxQnKTjDqBxLIKoQyrFKEagH3QLjyQED/IMPRv4UTL6JCOTq1Hxed2nt0eoropFZG
-        J6ZZcRjVgyfNKEGn04T443lU8pLcfg7hT0BED3RhRszSM2vN0/PEUkiDV47LAa2Yugmcsee3CmY8
-        w3zEYx2azVjWARp/P0EU2vkQymmQ0CibzKwHbrwRysEtb8baSzTO2esxG26steEVDbhpKnLlKTAD
-        KXWmfMB6K2zKB+VTPn9taRRwkObTgUejyPMfhrOqWIY0C6CsKpapNWcDVTYbWE8UyzCmG9j8gLVS
-        JDuhUUQij/nDvnBMxkLrHmyiR8FyCnceiIwZJvE4KoDQIry9f/96E3gbUtcjoOJkxOw+gNggjJOm
-        Q5wBFfsRGQ08J/a97sGtR5IwOnCYP8dZGl4AYmaIAjQAMyb6yG8OkmR0KEnrMpAKZHEUUQatUjJI
-        h90Y/JJ7VdUlJi+pfcr7tNTLhCP2QDiiS8YinQpHZMIR2ZSO6DLhiF4g5rZUtiAGNw6+jPrQZiur
-        2gggmG360IYxvD6Ih983RiQZNB+/jrzYxrMR6UqBxuloFEZJbLMqT9ZbFknzHJl/s0CaaGmumHst
-        5VoZ36Qk2qvos1HRehZ98tAPp9ZJ5DFS5uDvdfup6vamMXDBJ6kVA/dpyPwrKN+HcDRJwVtS1QNd
-        1XVwY6ekhh8G/ewnRgeWrMuqBclTYkOa5VM5qmZpzzmo5k26JqbOlHZNNP1pnmEpgJY1c80i0Emg
-        WilUtuSyWPkDjdKSUNn3hkRk3trKQPkMUvdh8mOEybwJysPkrAVrLZmR2QqRY+rQYZdGWwsPTRnX
-        CA+xLNdaI4JlUUbbjpRPIg8iZW0HkbJumNXXzaosYK0XKWtfHSmDFUfaB1y+WuYP4ve4Q/XJi71E
-        SEI+PXkOcBpyn8oLQuE8jWk6LI2UO8r3EylzeU0diwEIhzsUt0w4YhKK8EbikAmH+xQgHHHIhcP8
-        Cm5KZdMyNGWHcfJWa7hrN22rld3HyI+on5tFyHvl/CbR8by5/uf5Uaf189RqP61o+NEU+Cti4b0W
-        P/E4eOZxfG0cDB7nAVIV9m91KCwaxgGSzZxhHwzvNBi25PJQOAtFKwXCdb/O73r9dMS+9U/5pyoN
-        qUgoxsrg24eByJfrrIyWefpD8fJzXil17bnxuqA5T18XMZ+QocdmfKvEx3GSBTbQRGC7sgZhERmN
-        oFW7ceinYKNicgtxRRMrTIsXqQ02JsjsWdcLoM9pMmOap2UsrFNCdAg9RDWmPDNizgRqOyARVEib
-        8UxpDV6zWcaKxZgWiDnTLGdFm3EVyssJ08zVAtesROiIDig/6U9fWIYgc5kKKr0kQPb520Jd50ic
-        IXt+L/ONZL4sQE5ZqMY8LWOZr8I8iX+lOH03nHEUSTkDtHdJs6kVWg2bD7dagae81VCFVsNqlVYr
-        cq1pNVS11eSSVluQHrtfrMQ8LWOZr8A8qQHuQAzZ+zS292Ztb9aetcz3Zm1v1vLib1ISJMzbDfkY
-        AzhtfMcse0JvYnDZ5ymLHPKDHMqDHOqDHNqDHPoyh7T8etk4OwTJEQ0cYJn8ylzdfncE3uscacbR
-        Iw4EP1mAsUiccQUpm65pmrJe4MqJM64RW0EbM9ktkgo8rLHj8bAb+lKRDCFlRm3+77/F52f0hrT4
-        mkk4srlS7E3mRiZzSX5SiUOw71D7DrXvUJt0qGIv2t7XVU7kJZ5jR/TWo3zci9UkV7mVSetm5fmK
-        bXM338hiTdWqr9rma05qfSOLzZ18ksVlIrMF/RXn5mt8lIVlXakxPS/X28ZJFWW8nY+y3l12Xl0c
-        vXrbuiidpT8nSTKgd8LLMI0C+lMsvIPXiYhzTaO/l8zL66cn25uW59SDbEw9vvMSZ1Btvig+lKTV
-        z0ox9HnqFqcFoEeFI+hHkqXA5SC120OurNKe4iKNmj3aU7vEMJDl9pCqqJRgxdl4on2bxa+f4nkk
-        GVSYulmal1mauVme3Kk1O/64amJQuJBqOrqm9QzLxYQirGLLsWRVRqaO3R7W9K6p9CqoyZBENymt
-        riS1C9+FktSuxI+nJBqFCyG1J2tdjZCu3lMV2XENqpuK1YWOpMquSbQeNrqbLYrYZtm70JHalXgK
-        OuLiu3v1TtHS7tD17g8cP0zdXhQGyUHAJnUrLFNYm8MqedH7hO/riqRfs+3s7BmFvYjv0aiChuSc
-        D+pI9eIeVoodvut2FgQ8K4vRs+AiBIAW4Fc1DEdBimuYXUfDyHAcZGiq2zNVnThm9VUoPb7GoaLd
-        qF2DXdiN2pV4Cnbje9AUcPH3mvI9IkwuL5tzSpYGV9dyuiqxzB4xuhpWu6qqq8gyCDKNXrdrdA2M
-        HYd8xWK37VdjB3D0lTV6Ehj1zfVJ1uBCuuZaju4S2dF1AysW3BsGUV1VVXRLd7BmuUoNfUoGUfWY
-        aNOK7FyjatfoSWjUd4BlyV24h7ItQtmGC2YLQ4G11stmv9NRTH3f9r04mRtebC0PL5YNOzL628si
-        XVqR94rluRo+0ErW5aID9j3VV67IfXCfeCxX2yg+43siO8WziapsIewrfCGonXfQWSakne4wNY0i
-        1x2OwvaEys8i+YtGYflq4PbR8Vnron3VOjtrly4LbhPXp9FPsXAFihRXXCAsW3L1XaW+rxW833qv
-        w+1uB8WnjxT2oWv1E6oq7+knKzU24tWVepuh66KCOsjMd53lx4Fs8WtXWeMiyXY5VLclEqTLilV1
-        m0MVGXKND15Vts2hrG0iklWndimtk9LJNGahhBO/ZN5MfqkebTJxtiE2F4v7RmehqBUxTn1KGLdL
-        GEujLgls4jJpQ9Xjh877umT8wtGU/4FTv0y9FM2WcvrniR+yJSP054rQxrb0WHv8l473h389w718
-        2Y7zSnYU45b3rrUsQ6mOc4ZSb5mEISq7OZtytnJk+xLBqMbhlEbNhSMGXziyjcMpdXwoy1b5lvOd
-        iMTZzljCcToceuVbzb9DG53/9WSGwtLApVEXIoCxpGO4bMVmfyRZRvcYa9tcJVKpqB0MaVUq90kM
-        XD2h9gcv9B7+29rMfqVyHrHx58p95MavfEbtFdY7F0ftP9afUFswQfszAWuP9LRbWDD//POxBnpm
-        +rjOLZ4yCdme4uUuMSCZIrE/5Z9/82+rhauQZdqPwG1yDwXwRIX2yKN96iegEatd5InWzZ1p/3/z
-        U2BoEH8AAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3712']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:13 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/DespatchMethodTests.test_despatch_methods.yaml
+++ b/tests/interface_objects/cassettes/DespatchMethodTests.test_despatch_methods.yaml
@@ -1,256 +1,218 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:13 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:34 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:13 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:34 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGRlc3BhdGNoX29wdGlvbnM+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQd2FPVGpVY2xx
+      M2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBrNkZMby1BQXpv
+      ck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1S0pkdUdsN0tn
+      WXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19ibG9jaz48c2Vs
+      Zl9wcmludF9tb2RlPmh0bWw8L3NlbGZfcHJpbnRfbW9kZT48dXNlcl9pZD5kZW1vPC91c2VyX2lk
+      PjxwZXJmX3Rva2VuPmstLS02U1lGOVo2MS1lMDk4TXhnb3ZVZXlNTlNaWnBSUHNEbEZtbDJFSzZy
+      aUdraWhfYTB0TDgyMFFmNGdYZUZnME5tWTwvcGVyZl90b2tlbj48cHV6emxlZD55ZXM8L3B1enps
+      ZWQ+PC9kZXNwYXRjaF9vcHRpb25zPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['421']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA7VY63LqOBL+v0/hOj9mdmvGwebOWY+nuBMugXAJCX9cxhbYwbdYcsC8zr7JPtm0
+        JYHNZfZkt2ZTqSB9/amlbrW6myi/H1xH+EQhtn3vt2/yg/RNQJ7hm7a3/e3bYt4Rq99+V/+mmAgH
+        OjEszQ8IMLEWIhw5RFVwtDZ9V7c9LcIo1GysrXVT9Xwld1+iGGEcEF9bO76xU8uSKLYPj6V8f9r8
+        EPdy7XlxbHr2q4Y7WPSG3cVYLg/046Fb6Q1K5OM4IrNy1yJ70hE3zmjQWMlkJUUTWUOeq0+7L8/a
+        0RktNk+LTXVSnJijp7k8x/bzqiX39823zg69e0G7hwbavmmhqjV+HKEJ2pm7TTGevJtLS3tvye3O
+        +FA9ypXg+LrZ1pA2eNNMsiVi0XWmn6vHUVWyykdRFFdK7sIWxYjCEHwXpyMNHInU7ToA6gWUMja6
+        QfxQlSUpw+FgyvIid41CtZovZ1gcTFmBoxsIq/kMh0MZjo+JhmN37Tu5LBwijqr//ld2fYqnqHoT
+        DhnERcTyzQxADW6OG2Mld4llKZio8kPpggFQyoCBoTZ9x0EGETah7wrEQhC3XoQyiygrXZREoE50
+        9Wkxh/0zvJMgpRJ/hzzV0ESxE/dfWptqK263rNHborx5c3Z+Xe7Kx/eh92m+7K3KYNjfrcNX2xJX
+        cf4wC2bjltnTe0cz1rvvYhD2zGJlUPncNKed12jU7keL9+mggbvecvrh9kitKmJriKerx7ZXGzaW
+        heXLABcmorjve8+9sXYM4lUUL+y6+JY5Mzth5sRxgFSDeSRLS+DM/OY67t/PZDyb/+B+Cj+8nwlg
+        wt8XA+En3Q3+KTyGyNE9U/A9J/7Hl24JTvGFW8JwS90i2lfqh12hOKwM4/1ivl1O3uZD5+NgzqXp
+        Oq71ZmKxN3T6lcbbaC9uDG3ZrrzuO62W3O0PG08xDs3nRymUx0a9VtpVNPLYrjY/hpvKCpvLYvDy
+        ojeeXV9b+sb7xC6OC37xIO47h0F/63bG9aDcdfqOE9eO+c9udFihRs/wKut+GDaeOu3l0+GHN5e8
+        w5trC1Do2oQgE9wbeSS06dOlw/g8YJdjQ9xfAGcxdS/3fcphTs9dK7vSGu3+o9aFZ8PhhAEUB0jt
+        f648d9eQ26BMkXMeQfCmIbD0EOnsBO2lkktnTED3a0PVivcWChEnsFMYNuFnd3zP9D2R2nQGmZxS
+        h1TOhXyxo2PMPxhfDwkGSgpwIeXXQciDvQnVMEqOkhErUPNoAWRqYwSaLiEFIz0E83copjvloGym
+        SFJcOe+07IxcKEt51/pM3TPQfaXMnBPhAkw51I6GDlmGcENbVwv43adHyJ2c+JcFlhHaxDag5fi0
+        0V6D2DKSGGEl865IgbyBtFD3tgg6A5PPqbK5Ff0qyJCnZiggKCmgQl6SoaymFMaOiKH5mw1GkPnK
+        yVbXaErDyIBQwqpcrOQrpeIl+yRk9Bh+XNc01WRTqSbJnHnG4ab9almSNQrDE9aI7SJKF6WaKMlz
+        ufa9IH2XpF8k+Xuy0/0FXO+1D9gcEwiOG6+UiCWM9Piv9Ec5X6wUpC/7oySV/it/lOD3f/EHt5/m
+        GhaOSYswrTcH7amSy8CcQt0w0gn0HHuh4Uehh37GwhOYE+rGDkJo3k7KZ4bMF9qmWn7snCQw47gD
+        ge6roE4nSc7IgpwBadFSc7BYdNm+4pruK0JffN5XJAiT3Gk9XcKXg4Ukwqpjf57Vc+hEYMU1d5rT
+        AoRtN3AQOAyUk9M6VprYOAowchw4KSYXJrZvTYTRqCdl8dwdHVvka6zIOzqxSQQ+L0EjmK+VZblQ
+        UXJnVIFsvmVDUXqQJbjhUhk63RRWcqkyS8ea5yf5YIPpl5ELIMmmkBEh45zTKJ8qrn7Qwsjz4CpY
+        3Mh5sOEGVVzIund416jiIaiBJgog3qA60Jik57mHc3IU6kktzNBOCCMkNvihm6RhdvwbVEmaC1Y8
+        m/JUKM6foCKfoFOJMMH/CVvbuar0IJ1rRBZXsOXTrLph5tDtrjAFQ1wCnSpHB4gXiMlEXQY+cVjd
+        PhAUerojzIEoNJJAhiYxXcHeD/3OeC/j3xMo9IsA22tWbw3b09myPRxCM5kRcBJVP9NNB4XwhpcQ
+        ivhE46WMtyAXHk2z4RKZUEDk/0eurNXk4tdzpXxbO/4s6STRH/i+Q8Oc9w5XWPImHNtNyjCNvMz0
+        BylY/nJJokHDTifWpQltEynAJVj7tLG9dnigXYOMlSYuFoOQnXij+MKXpJBy+0Qvn2fyl11c5aEg
+        CZORkkshJrUs14V2Rq6xOpbF2H7nGLnpZk//JPkDm6R3XWURAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:13 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1748']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:35 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <despatch_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></despatch_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['441']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61Y3XajOBK+36dg+2Jn5uwSg39JL80c/yVOkziOg+3ENxwBssGARJCwTV5n32Se
-        bATCBsfu0917Ohcd9NUnqVT1qUpp9c99GAhbGBMPoy+f5CvpkwCRjR0Prb98mhk3ovLpT+0fqgNJ
-        BKjtmjiijEnMGJIkoJpKEsvBIfCQmRAYmx4xLeBoKSRq7bJJteM0oti0Amz7miiJojhO6974wcKA
-        vg3f3Ckw0Hw30f1J0/U2LzRSfA+6jeYAvxjzrauvTaM3cgd4MXod9pIJ3i17VtJ4qsv1kY22j2i0
-        aA7m5rT16id3SmMlvTVoaM82rZ1yN5U6vtHWb0z/oSebOwTAQHprGfWW/Kp79VbvZrGdpMZTpzmb
-        N0DqdLt7eaFbioXk93cqLuy+uFRrJ/6rdhLHLGBp+WWy6EFtbUWMegKVjBWwKY41WZIqnAIsWSgJ
-        LRhrSr1dYRVgyYoCYEOi1SucAqpwMKEmSUMLB7UqHMMC1f76X3V+iZeodqaBChJC6mKnAuQH7j/2
-        HtXaKValEKrJV60TBoNKBvuwtT4OAmhTYRXjUKAuZGJFCaxMylnlpEx1gAJtPDPY/hXewVBSKfYh
-        0mxTFCV9ZRrLNynSbf02Ttx96D91esHk9WWYbPcjW5Kl2ah/649bCDx4ewrSh85wOgiQ3Fu+DSao
-        HYwHFrCX7/TZMF/u2sv35ryz2ojXnfnqa7gPN6/1wAydx9s+Guikj7oTb7T0xuOQjnv39/YoIXZg
-        v0O3nZria8Vn7mHF4zSCms0jUqVlcGV8lo7L+Zk8PhvfyU/ju/mZMEz4faYL/wJh9F/hLoYBQI6A
-        UZD+8UNZYl78QJZ8lqXN6GmWoIcb66syVcjGmz6urK0VrY37xmbXWi8WZOfurv3Jy+zO2En27lG6
-        Dbvzl1jZg8aw0e+a2+EzvdGVepMsJrj/QqVb8dG3FctpbYcvm9vZdTTTodF832x2rvHWaywly/yq
-        1EXHUV5bX8ciWeB5F83xqwTnT+kb0XXjiRWw72Ysu39n6YpgHHqUQoeFNUE09vIrm3+mxw+eFI/p
-        /QQ4mvOwFjEvOTzYteNitYt7neulRI5XHLLrxnIOYgj41sOFWitH3JDvN2RdJN25MIYFgXtheesk
-        MrcgSCAveFVAtT1aHCnAyMFITHzm9xHk9nyh+9xeGPnSdgAIKX5xPqsPgGYOVLDCnk8xTu18GdaY
-        8i7Fl8tb1ymkEghiFhQfpocdaqy9lWDWBQvqYeYROVmv5F1Y0vcccnlZfpDCfoKVlPwsNyD0grRC
-        KpRQ7ls7BK0qpzzo39bXDHlMOoLO3gSsoX+UmR171LPZg2DrwZ3JlGZniuG97aJJZRccmjFAa2hC
-        5BTjIj/JfwRZoa7QTdYJKyx1SWbdryRwbkJtE69WBLIC1c42+oiWNAJtJhyiyc2O3Gq2pBP2wcjp
-        KfsJQ8fRsk0lRVYK5hFnycVKW5LNHGY3zqReCHO6KCmirBjy9eeG9FmS/i3Jn7OdLk8o1v0YAT4m
-        FMT0LCZ1mQWjG8Ve8CtD0pbr7Ubzh0PSrMs/FZKmWJf/n5AUIchLD9dj1syn3b4+nKq1ClxQ8jA8
-        AMou0k7o4SRG8DcijNlxYmD7MP7nYRKPF//2HK19d3OwsFGBB0zluCwkVbBgMPdoQrTA2x7tBXQg
-        8B5WO4zzek+8MAogOy3ziB7m8U7Av5OIwCBgWxF64uPw3Mdv+Z7h+qyK1y6svYbY5D02ANSjCQtk
-        K3+HHYcqK8Zr/ilKV3JmOgJqrZzvAmIinF3sFdEQVmsnQFYLWTVjpeNYBIuhGoK9GScIsbDy/Mt1
-        Jo0zVA1ZzbzA+4iqCLLW5sCI6SZhj9dMS7k/l/CCnMQga3EV2gHhhOwMOA4BsiF3/wxVs7bOe2Jf
-        ngpNY8wa7QE6FHiHhTxjm36oSVfSsb5XcZW4OC+PK34c/tfTKaYSpmtGzxeHeyYdSGi2XAU+cHjZ
-        YHbhOSUUhsISxvhI5Zcgf0Xzac/dwf1w+rwY3t+zl1jFUJDyCc/ACWDMrtWCCYkcaEV7KR4JJ8Ep
-        C9QCOqyAdbKi/usLWIfV6Z8oYJ2zAvatG5VJOcI4yDVbtPEPWCbwwAuz5pjLqDL8Xl3s/GhdzBXA
-        vRO71938KZcDhYWYW494VlCo5iPIWWVB4oJiVad4zM2LKSWknt+307uW/csT17lqSMLkQa2VELe6
-        bhiyR4Z83cj7bRXj+x1VcvbiPPzHwt9JMZh+mRAAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1684']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:14 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/DespatchMethodTests.test_despatch_methods_contains_despatch_method.yaml
+++ b/tests/interface_objects/cassettes/DespatchMethodTests.test_despatch_methods_contains_despatch_method.yaml
@@ -1,256 +1,218 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:14 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:36 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:14 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:37 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGRlc3BhdGNoX29wdGlvbnM+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQd2FPVGpVY2xx
+      M2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBrNkZMby1BQXpv
+      ck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1S0pkdUdsN0tn
+      WXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19ibG9jaz48c2Vs
+      Zl9wcmludF9tb2RlPmh0bWw8L3NlbGZfcHJpbnRfbW9kZT48dXNlcl9pZD5kZW1vPC91c2VyX2lk
+      PjxwZXJmX3Rva2VuPmstLS02U1lGOVo2MS1lMDk4TXhnb3ZVZXlNTlNaWnBSUHNEbEZtbDJFSzZy
+      aUdraWhfYTB0TDgyMFFmNGdYZUZnME5tWTwvcGVyZl90b2tlbj48cHV6emxlZD55ZXM8L3B1enps
+      ZWQ+PC9kZXNwYXRjaF9vcHRpb25zPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['421']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA7VY63LqOBL+v0/hOj9mdmvGwebOWY+nuBMugXAJCX9cxhbYwbdYcsC8zr7JPtm0
+        JYHNZfZkt2ZTqSB9/amlbrW6myi/H1xH+EQhtn3vt2/yg/RNQJ7hm7a3/e3bYt4Rq99+V/+mmAgH
+        OjEszQ8IMLEWIhw5RFVwtDZ9V7c9LcIo1GysrXVT9Xwld1+iGGEcEF9bO76xU8uSKLYPj6V8f9r8
+        EPdy7XlxbHr2q4Y7WPSG3cVYLg/046Fb6Q1K5OM4IrNy1yJ70hE3zmjQWMlkJUUTWUOeq0+7L8/a
+        0RktNk+LTXVSnJijp7k8x/bzqiX39823zg69e0G7hwbavmmhqjV+HKEJ2pm7TTGevJtLS3tvye3O
+        +FA9ypXg+LrZ1pA2eNNMsiVi0XWmn6vHUVWyykdRFFdK7sIWxYjCEHwXpyMNHInU7ToA6gWUMja6
+        QfxQlSUpw+FgyvIid41CtZovZ1gcTFmBoxsIq/kMh0MZjo+JhmN37Tu5LBwijqr//ld2fYqnqHoT
+        DhnERcTyzQxADW6OG2Mld4llKZio8kPpggFQyoCBoTZ9x0EGETah7wrEQhC3XoQyiygrXZREoE50
+        9Wkxh/0zvJMgpRJ/hzzV0ESxE/dfWptqK263rNHborx5c3Z+Xe7Kx/eh92m+7K3KYNjfrcNX2xJX
+        cf4wC2bjltnTe0cz1rvvYhD2zGJlUPncNKed12jU7keL9+mggbvecvrh9kitKmJriKerx7ZXGzaW
+        heXLABcmorjve8+9sXYM4lUUL+y6+JY5Mzth5sRxgFSDeSRLS+DM/OY67t/PZDyb/+B+Cj+8nwlg
+        wt8XA+En3Q3+KTyGyNE9U/A9J/7Hl24JTvGFW8JwS90i2lfqh12hOKwM4/1ivl1O3uZD5+NgzqXp
+        Oq71ZmKxN3T6lcbbaC9uDG3ZrrzuO62W3O0PG08xDs3nRymUx0a9VtpVNPLYrjY/hpvKCpvLYvDy
+        ojeeXV9b+sb7xC6OC37xIO47h0F/63bG9aDcdfqOE9eO+c9udFihRs/wKut+GDaeOu3l0+GHN5e8
+        w5trC1Do2oQgE9wbeSS06dOlw/g8YJdjQ9xfAGcxdS/3fcphTs9dK7vSGu3+o9aFZ8PhhAEUB0jt
+        f648d9eQ26BMkXMeQfCmIbD0EOnsBO2lkktnTED3a0PVivcWChEnsFMYNuFnd3zP9D2R2nQGmZxS
+        h1TOhXyxo2PMPxhfDwkGSgpwIeXXQciDvQnVMEqOkhErUPNoAWRqYwSaLiEFIz0E83copjvloGym
+        SFJcOe+07IxcKEt51/pM3TPQfaXMnBPhAkw51I6GDlmGcENbVwv43adHyJ2c+JcFlhHaxDag5fi0
+        0V6D2DKSGGEl865IgbyBtFD3tgg6A5PPqbK5Ff0qyJCnZiggKCmgQl6SoaymFMaOiKH5mw1GkPnK
+        yVbXaErDyIBQwqpcrOQrpeIl+yRk9Bh+XNc01WRTqSbJnHnG4ab9almSNQrDE9aI7SJKF6WaKMlz
+        ufa9IH2XpF8k+Xuy0/0FXO+1D9gcEwiOG6+UiCWM9Piv9Ec5X6wUpC/7oySV/it/lOD3f/EHt5/m
+        GhaOSYswrTcH7amSy8CcQt0w0gn0HHuh4Uehh37GwhOYE+rGDkJo3k7KZ4bMF9qmWn7snCQw47gD
+        ge6roE4nSc7IgpwBadFSc7BYdNm+4pruK0JffN5XJAiT3Gk9XcKXg4Ukwqpjf57Vc+hEYMU1d5rT
+        AoRtN3AQOAyUk9M6VprYOAowchw4KSYXJrZvTYTRqCdl8dwdHVvka6zIOzqxSQQ+L0EjmK+VZblQ
+        UXJnVIFsvmVDUXqQJbjhUhk63RRWcqkyS8ea5yf5YIPpl5ELIMmmkBEh45zTKJ8qrn7Qwsjz4CpY
+        3Mh5sOEGVVzIund416jiIaiBJgog3qA60Jik57mHc3IU6kktzNBOCCMkNvihm6RhdvwbVEmaC1Y8
+        m/JUKM6foCKfoFOJMMH/CVvbuar0IJ1rRBZXsOXTrLph5tDtrjAFQ1wCnSpHB4gXiMlEXQY+cVjd
+        PhAUerojzIEoNJJAhiYxXcHeD/3OeC/j3xMo9IsA22tWbw3b09myPRxCM5kRcBJVP9NNB4XwhpcQ
+        ivhE46WMtyAXHk2z4RKZUEDk/0eurNXk4tdzpXxbO/4s6STRH/i+Q8Oc9w5XWPImHNtNyjCNvMz0
+        BylY/nJJokHDTifWpQltEynAJVj7tLG9dnigXYOMlSYuFoOQnXij+MKXpJBy+0Qvn2fyl11c5aEg
+        CZORkkshJrUs14V2Rq6xOpbF2H7nGLnpZk//JPkDm6R3XWURAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:15 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1748']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:38 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <despatch_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></despatch_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['441']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61Y3XajOBK+36dg+2Jn5uwSg39JL80c/yVOkziOg+3ENxwBssGARJCwTV5n32Se
-        bATCBsfu0917Ohcd9NUnqVT1qUpp9c99GAhbGBMPoy+f5CvpkwCRjR0Prb98mhk3ovLpT+0fqgNJ
-        BKjtmjiijEnMGJIkoJpKEsvBIfCQmRAYmx4xLeBoKSRq7bJJteM0oti0Amz7miiJojhO6974wcKA
-        vg3f3Ckw0Hw30f1J0/U2LzRSfA+6jeYAvxjzrauvTaM3cgd4MXod9pIJ3i17VtJ4qsv1kY22j2i0
-        aA7m5rT16id3SmMlvTVoaM82rZ1yN5U6vtHWb0z/oSebOwTAQHprGfWW/Kp79VbvZrGdpMZTpzmb
-        N0DqdLt7eaFbioXk93cqLuy+uFRrJ/6rdhLHLGBp+WWy6EFtbUWMegKVjBWwKY41WZIqnAIsWSgJ
-        LRhrSr1dYRVgyYoCYEOi1SucAqpwMKEmSUMLB7UqHMMC1f76X3V+iZeodqaBChJC6mKnAuQH7j/2
-        HtXaKValEKrJV60TBoNKBvuwtT4OAmhTYRXjUKAuZGJFCaxMylnlpEx1gAJtPDPY/hXewVBSKfYh
-        0mxTFCV9ZRrLNynSbf02Ttx96D91esHk9WWYbPcjW5Kl2ah/649bCDx4ewrSh85wOgiQ3Fu+DSao
-        HYwHFrCX7/TZMF/u2sv35ryz2ojXnfnqa7gPN6/1wAydx9s+Guikj7oTb7T0xuOQjnv39/YoIXZg
-        v0O3nZria8Vn7mHF4zSCms0jUqVlcGV8lo7L+Zk8PhvfyU/ju/mZMEz4faYL/wJh9F/hLoYBQI6A
-        UZD+8UNZYl78QJZ8lqXN6GmWoIcb66syVcjGmz6urK0VrY37xmbXWi8WZOfurv3Jy+zO2En27lG6
-        Dbvzl1jZg8aw0e+a2+EzvdGVepMsJrj/QqVb8dG3FctpbYcvm9vZdTTTodF832x2rvHWaywly/yq
-        1EXHUV5bX8ciWeB5F83xqwTnT+kb0XXjiRWw72Ysu39n6YpgHHqUQoeFNUE09vIrm3+mxw+eFI/p
-        /QQ4mvOwFjEvOTzYteNitYt7neulRI5XHLLrxnIOYgj41sOFWitH3JDvN2RdJN25MIYFgXtheesk
-        MrcgSCAveFVAtT1aHCnAyMFITHzm9xHk9nyh+9xeGPnSdgAIKX5xPqsPgGYOVLDCnk8xTu18GdaY
-        8i7Fl8tb1ymkEghiFhQfpocdaqy9lWDWBQvqYeYROVmv5F1Y0vcccnlZfpDCfoKVlPwsNyD0grRC
-        KpRQ7ls7BK0qpzzo39bXDHlMOoLO3gSsoX+UmR171LPZg2DrwZ3JlGZniuG97aJJZRccmjFAa2hC
-        5BTjIj/JfwRZoa7QTdYJKyx1SWbdryRwbkJtE69WBLIC1c42+oiWNAJtJhyiyc2O3Gq2pBP2wcjp
-        KfsJQ8fRsk0lRVYK5hFnycVKW5LNHGY3zqReCHO6KCmirBjy9eeG9FmS/i3Jn7OdLk8o1v0YAT4m
-        FMT0LCZ1mQWjG8Ve8CtD0pbr7Ubzh0PSrMs/FZKmWJf/n5AUIchLD9dj1syn3b4+nKq1ClxQ8jA8
-        AMou0k7o4SRG8DcijNlxYmD7MP7nYRKPF//2HK19d3OwsFGBB0zluCwkVbBgMPdoQrTA2x7tBXQg
-        8B5WO4zzek+8MAogOy3ziB7m8U7Av5OIwCBgWxF64uPw3Mdv+Z7h+qyK1y6svYbY5D02ANSjCQtk
-        K3+HHYcqK8Zr/ilKV3JmOgJqrZzvAmIinF3sFdEQVmsnQFYLWTVjpeNYBIuhGoK9GScIsbDy/Mt1
-        Jo0zVA1ZzbzA+4iqCLLW5sCI6SZhj9dMS7k/l/CCnMQga3EV2gHhhOwMOA4BsiF3/wxVs7bOe2Jf
-        ngpNY8wa7QE6FHiHhTxjm36oSVfSsb5XcZW4OC+PK34c/tfTKaYSpmtGzxeHeyYdSGi2XAU+cHjZ
-        YHbhOSUUhsISxvhI5Zcgf0Xzac/dwf1w+rwY3t+zl1jFUJDyCc/ACWDMrtWCCYkcaEV7KR4JJ8Ep
-        C9QCOqyAdbKi/usLWIfV6Z8oYJ2zAvatG5VJOcI4yDVbtPEPWCbwwAuz5pjLqDL8Xl3s/GhdzBXA
-        vRO71938KZcDhYWYW494VlCo5iPIWWVB4oJiVad4zM2LKSWknt+307uW/csT17lqSMLkQa2VELe6
-        bhiyR4Z83cj7bRXj+x1VcvbiPPzHwt9JMZh+mRAAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1684']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:15 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/DespatchMethodTests.test_despatch_methods_is_list.yaml
+++ b/tests/interface_objects/cassettes/DespatchMethodTests.test_despatch_methods_is_list.yaml
@@ -1,256 +1,218 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:15 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:38 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:15 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:39 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGRlc3BhdGNoX29wdGlvbnM+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQd2FPVGpVY2xx
+      M2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBrNkZMby1BQXpv
+      ck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1S0pkdUdsN0tn
+      WXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19ibG9jaz48c2Vs
+      Zl9wcmludF9tb2RlPmh0bWw8L3NlbGZfcHJpbnRfbW9kZT48dXNlcl9pZD5kZW1vPC91c2VyX2lk
+      PjxwZXJmX3Rva2VuPmstLS02U1lGOVo2MS1lMDk4TXhnb3ZVZXlNTlNaWnBSUHNEbEZtbDJFSzZy
+      aUdraWhfYTB0TDgyMFFmNGdYZUZnME5tWTwvcGVyZl90b2tlbj48cHV6emxlZD55ZXM8L3B1enps
+      ZWQ+PC9kZXNwYXRjaF9vcHRpb25zPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['421']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA7VY63LqOBL+v0/hOj9mdmvGwebOWY+nuBMugXAJCX9cxhbYwbdYcsC8zr7JPtm0
+        JYHNZfZkt2ZTqSB9/amlbrW6myi/H1xH+EQhtn3vt2/yg/RNQJ7hm7a3/e3bYt4Rq99+V/+mmAgH
+        OjEszQ8IMLEWIhw5RFVwtDZ9V7c9LcIo1GysrXVT9Xwld1+iGGEcEF9bO76xU8uSKLYPj6V8f9r8
+        EPdy7XlxbHr2q4Y7WPSG3cVYLg/046Fb6Q1K5OM4IrNy1yJ70hE3zmjQWMlkJUUTWUOeq0+7L8/a
+        0RktNk+LTXVSnJijp7k8x/bzqiX39823zg69e0G7hwbavmmhqjV+HKEJ2pm7TTGevJtLS3tvye3O
+        +FA9ypXg+LrZ1pA2eNNMsiVi0XWmn6vHUVWyykdRFFdK7sIWxYjCEHwXpyMNHInU7ToA6gWUMja6
+        QfxQlSUpw+FgyvIid41CtZovZ1gcTFmBoxsIq/kMh0MZjo+JhmN37Tu5LBwijqr//ld2fYqnqHoT
+        DhnERcTyzQxADW6OG2Mld4llKZio8kPpggFQyoCBoTZ9x0EGETah7wrEQhC3XoQyiygrXZREoE50
+        9Wkxh/0zvJMgpRJ/hzzV0ESxE/dfWptqK263rNHborx5c3Z+Xe7Kx/eh92m+7K3KYNjfrcNX2xJX
+        cf4wC2bjltnTe0cz1rvvYhD2zGJlUPncNKed12jU7keL9+mggbvecvrh9kitKmJriKerx7ZXGzaW
+        heXLABcmorjve8+9sXYM4lUUL+y6+JY5Mzth5sRxgFSDeSRLS+DM/OY67t/PZDyb/+B+Cj+8nwlg
+        wt8XA+En3Q3+KTyGyNE9U/A9J/7Hl24JTvGFW8JwS90i2lfqh12hOKwM4/1ivl1O3uZD5+NgzqXp
+        Oq71ZmKxN3T6lcbbaC9uDG3ZrrzuO62W3O0PG08xDs3nRymUx0a9VtpVNPLYrjY/hpvKCpvLYvDy
+        ojeeXV9b+sb7xC6OC37xIO47h0F/63bG9aDcdfqOE9eO+c9udFihRs/wKut+GDaeOu3l0+GHN5e8
+        w5trC1Do2oQgE9wbeSS06dOlw/g8YJdjQ9xfAGcxdS/3fcphTs9dK7vSGu3+o9aFZ8PhhAEUB0jt
+        f648d9eQ26BMkXMeQfCmIbD0EOnsBO2lkktnTED3a0PVivcWChEnsFMYNuFnd3zP9D2R2nQGmZxS
+        h1TOhXyxo2PMPxhfDwkGSgpwIeXXQciDvQnVMEqOkhErUPNoAWRqYwSaLiEFIz0E83copjvloGym
+        SFJcOe+07IxcKEt51/pM3TPQfaXMnBPhAkw51I6GDlmGcENbVwv43adHyJ2c+JcFlhHaxDag5fi0
+        0V6D2DKSGGEl865IgbyBtFD3tgg6A5PPqbK5Ff0qyJCnZiggKCmgQl6SoaymFMaOiKH5mw1GkPnK
+        yVbXaErDyIBQwqpcrOQrpeIl+yRk9Bh+XNc01WRTqSbJnHnG4ab9almSNQrDE9aI7SJKF6WaKMlz
+        ufa9IH2XpF8k+Xuy0/0FXO+1D9gcEwiOG6+UiCWM9Piv9Ec5X6wUpC/7oySV/it/lOD3f/EHt5/m
+        GhaOSYswrTcH7amSy8CcQt0w0gn0HHuh4Uehh37GwhOYE+rGDkJo3k7KZ4bMF9qmWn7snCQw47gD
+        ge6roE4nSc7IgpwBadFSc7BYdNm+4pruK0JffN5XJAiT3Gk9XcKXg4Ukwqpjf57Vc+hEYMU1d5rT
+        AoRtN3AQOAyUk9M6VprYOAowchw4KSYXJrZvTYTRqCdl8dwdHVvka6zIOzqxSQQ+L0EjmK+VZblQ
+        UXJnVIFsvmVDUXqQJbjhUhk63RRWcqkyS8ea5yf5YIPpl5ELIMmmkBEh45zTKJ8qrn7Qwsjz4CpY
+        3Mh5sOEGVVzIund416jiIaiBJgog3qA60Jik57mHc3IU6kktzNBOCCMkNvihm6RhdvwbVEmaC1Y8
+        m/JUKM6foCKfoFOJMMH/CVvbuar0IJ1rRBZXsOXTrLph5tDtrjAFQ1wCnSpHB4gXiMlEXQY+cVjd
+        PhAUerojzIEoNJJAhiYxXcHeD/3OeC/j3xMo9IsA22tWbw3b09myPRxCM5kRcBJVP9NNB4XwhpcQ
+        ivhE46WMtyAXHk2z4RKZUEDk/0eurNXk4tdzpXxbO/4s6STRH/i+Q8Oc9w5XWPImHNtNyjCNvMz0
+        BylY/nJJokHDTifWpQltEynAJVj7tLG9dnigXYOMlSYuFoOQnXij+MKXpJBy+0Qvn2fyl11c5aEg
+        CZORkkshJrUs14V2Rq6xOpbF2H7nGLnpZk//JPkDm6R3XWURAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:16 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1748']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:39 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <despatch_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></despatch_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['441']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61Y3XajOBK+36dg+2Jn5uwSg39JL80c/yVOkziOg+3ENxwBssGARJCwTV5n32Se
-        bATCBsfu0917Ohcd9NUnqVT1qUpp9c99GAhbGBMPoy+f5CvpkwCRjR0Prb98mhk3ovLpT+0fqgNJ
-        BKjtmjiijEnMGJIkoJpKEsvBIfCQmRAYmx4xLeBoKSRq7bJJteM0oti0Amz7miiJojhO6974wcKA
-        vg3f3Ckw0Hw30f1J0/U2LzRSfA+6jeYAvxjzrauvTaM3cgd4MXod9pIJ3i17VtJ4qsv1kY22j2i0
-        aA7m5rT16id3SmMlvTVoaM82rZ1yN5U6vtHWb0z/oSebOwTAQHprGfWW/Kp79VbvZrGdpMZTpzmb
-        N0DqdLt7eaFbioXk93cqLuy+uFRrJ/6rdhLHLGBp+WWy6EFtbUWMegKVjBWwKY41WZIqnAIsWSgJ
-        LRhrSr1dYRVgyYoCYEOi1SucAqpwMKEmSUMLB7UqHMMC1f76X3V+iZeodqaBChJC6mKnAuQH7j/2
-        HtXaKValEKrJV60TBoNKBvuwtT4OAmhTYRXjUKAuZGJFCaxMylnlpEx1gAJtPDPY/hXewVBSKfYh
-        0mxTFCV9ZRrLNynSbf02Ttx96D91esHk9WWYbPcjW5Kl2ah/649bCDx4ewrSh85wOgiQ3Fu+DSao
-        HYwHFrCX7/TZMF/u2sv35ryz2ojXnfnqa7gPN6/1wAydx9s+Guikj7oTb7T0xuOQjnv39/YoIXZg
-        v0O3nZria8Vn7mHF4zSCms0jUqVlcGV8lo7L+Zk8PhvfyU/ju/mZMEz4faYL/wJh9F/hLoYBQI6A
-        UZD+8UNZYl78QJZ8lqXN6GmWoIcb66syVcjGmz6urK0VrY37xmbXWi8WZOfurv3Jy+zO2En27lG6
-        Dbvzl1jZg8aw0e+a2+EzvdGVepMsJrj/QqVb8dG3FctpbYcvm9vZdTTTodF832x2rvHWaywly/yq
-        1EXHUV5bX8ciWeB5F83xqwTnT+kb0XXjiRWw72Ysu39n6YpgHHqUQoeFNUE09vIrm3+mxw+eFI/p
-        /QQ4mvOwFjEvOTzYteNitYt7neulRI5XHLLrxnIOYgj41sOFWitH3JDvN2RdJN25MIYFgXtheesk
-        MrcgSCAveFVAtT1aHCnAyMFITHzm9xHk9nyh+9xeGPnSdgAIKX5xPqsPgGYOVLDCnk8xTu18GdaY
-        8i7Fl8tb1ymkEghiFhQfpocdaqy9lWDWBQvqYeYROVmv5F1Y0vcccnlZfpDCfoKVlPwsNyD0grRC
-        KpRQ7ls7BK0qpzzo39bXDHlMOoLO3gSsoX+UmR171LPZg2DrwZ3JlGZniuG97aJJZRccmjFAa2hC
-        5BTjIj/JfwRZoa7QTdYJKyx1SWbdryRwbkJtE69WBLIC1c42+oiWNAJtJhyiyc2O3Gq2pBP2wcjp
-        KfsJQ8fRsk0lRVYK5hFnycVKW5LNHGY3zqReCHO6KCmirBjy9eeG9FmS/i3Jn7OdLk8o1v0YAT4m
-        FMT0LCZ1mQWjG8Ve8CtD0pbr7Ubzh0PSrMs/FZKmWJf/n5AUIchLD9dj1syn3b4+nKq1ClxQ8jA8
-        AMou0k7o4SRG8DcijNlxYmD7MP7nYRKPF//2HK19d3OwsFGBB0zluCwkVbBgMPdoQrTA2x7tBXQg
-        8B5WO4zzek+8MAogOy3ziB7m8U7Av5OIwCBgWxF64uPw3Mdv+Z7h+qyK1y6svYbY5D02ANSjCQtk
-        K3+HHYcqK8Zr/ilKV3JmOgJqrZzvAmIinF3sFdEQVmsnQFYLWTVjpeNYBIuhGoK9GScIsbDy/Mt1
-        Jo0zVA1ZzbzA+4iqCLLW5sCI6SZhj9dMS7k/l/CCnMQga3EV2gHhhOwMOA4BsiF3/wxVs7bOe2Jf
-        ngpNY8wa7QE6FHiHhTxjm36oSVfSsb5XcZW4OC+PK34c/tfTKaYSpmtGzxeHeyYdSGi2XAU+cHjZ
-        YHbhOSUUhsISxvhI5Zcgf0Xzac/dwf1w+rwY3t+zl1jFUJDyCc/ACWDMrtWCCYkcaEV7KR4JJ8Ep
-        C9QCOqyAdbKi/usLWIfV6Z8oYJ2zAvatG5VJOcI4yDVbtPEPWCbwwAuz5pjLqDL8Xl3s/GhdzBXA
-        vRO71938KZcDhYWYW494VlCo5iPIWWVB4oJiVad4zM2LKSWknt+307uW/csT17lqSMLkQa2VELe6
-        bhiyR4Z83cj7bRXj+x1VcvbiPPzHwt9JMZh+mRAAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1684']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:16 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/DespatchMethodTests.test_despatch_methods_multi_returned.yaml
+++ b/tests/interface_objects/cassettes/DespatchMethodTests.test_despatch_methods_multi_returned.yaml
@@ -1,256 +1,218 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:16 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:39 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:17 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:40 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGRlc3BhdGNoX29wdGlvbnM+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQd2FPVGpVY2xx
+      M2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBrNkZMby1BQXpv
+      ck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1S0pkdUdsN0tn
+      WXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19ibG9jaz48c2Vs
+      Zl9wcmludF9tb2RlPmh0bWw8L3NlbGZfcHJpbnRfbW9kZT48dXNlcl9pZD5kZW1vPC91c2VyX2lk
+      PjxwZXJmX3Rva2VuPmstLS02U1lGOVo2MS1lMDk4TXhnb3ZVZXlNTlNaWnBSUHNEbEZtbDJFSzZy
+      aUdraWhfYTB0TDgyMFFmNGdYZUZnME5tWTwvcGVyZl90b2tlbj48cHV6emxlZD55ZXM8L3B1enps
+      ZWQ+PC9kZXNwYXRjaF9vcHRpb25zPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['421']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA7VY63LqOBL+v0/hOj9mdmvGwebOWY+nuBMugXAJCX9cxhbYwbdYcsC8zr7JPtm0
+        JYHNZfZkt2ZTqSB9/amlbrW6myi/H1xH+EQhtn3vt2/yg/RNQJ7hm7a3/e3bYt4Rq99+V/+mmAgH
+        OjEszQ8IMLEWIhw5RFVwtDZ9V7c9LcIo1GysrXVT9Xwld1+iGGEcEF9bO76xU8uSKLYPj6V8f9r8
+        EPdy7XlxbHr2q4Y7WPSG3cVYLg/046Fb6Q1K5OM4IrNy1yJ70hE3zmjQWMlkJUUTWUOeq0+7L8/a
+        0RktNk+LTXVSnJijp7k8x/bzqiX39823zg69e0G7hwbavmmhqjV+HKEJ2pm7TTGevJtLS3tvye3O
+        +FA9ypXg+LrZ1pA2eNNMsiVi0XWmn6vHUVWyykdRFFdK7sIWxYjCEHwXpyMNHInU7ToA6gWUMja6
+        QfxQlSUpw+FgyvIid41CtZovZ1gcTFmBoxsIq/kMh0MZjo+JhmN37Tu5LBwijqr//ld2fYqnqHoT
+        DhnERcTyzQxADW6OG2Mld4llKZio8kPpggFQyoCBoTZ9x0EGETah7wrEQhC3XoQyiygrXZREoE50
+        9Wkxh/0zvJMgpRJ/hzzV0ESxE/dfWptqK263rNHborx5c3Z+Xe7Kx/eh92m+7K3KYNjfrcNX2xJX
+        cf4wC2bjltnTe0cz1rvvYhD2zGJlUPncNKed12jU7keL9+mggbvecvrh9kitKmJriKerx7ZXGzaW
+        heXLABcmorjve8+9sXYM4lUUL+y6+JY5Mzth5sRxgFSDeSRLS+DM/OY67t/PZDyb/+B+Cj+8nwlg
+        wt8XA+En3Q3+KTyGyNE9U/A9J/7Hl24JTvGFW8JwS90i2lfqh12hOKwM4/1ivl1O3uZD5+NgzqXp
+        Oq71ZmKxN3T6lcbbaC9uDG3ZrrzuO62W3O0PG08xDs3nRymUx0a9VtpVNPLYrjY/hpvKCpvLYvDy
+        ojeeXV9b+sb7xC6OC37xIO47h0F/63bG9aDcdfqOE9eO+c9udFihRs/wKut+GDaeOu3l0+GHN5e8
+        w5trC1Do2oQgE9wbeSS06dOlw/g8YJdjQ9xfAGcxdS/3fcphTs9dK7vSGu3+o9aFZ8PhhAEUB0jt
+        f648d9eQ26BMkXMeQfCmIbD0EOnsBO2lkktnTED3a0PVivcWChEnsFMYNuFnd3zP9D2R2nQGmZxS
+        h1TOhXyxo2PMPxhfDwkGSgpwIeXXQciDvQnVMEqOkhErUPNoAWRqYwSaLiEFIz0E83copjvloGym
+        SFJcOe+07IxcKEt51/pM3TPQfaXMnBPhAkw51I6GDlmGcENbVwv43adHyJ2c+JcFlhHaxDag5fi0
+        0V6D2DKSGGEl865IgbyBtFD3tgg6A5PPqbK5Ff0qyJCnZiggKCmgQl6SoaymFMaOiKH5mw1GkPnK
+        yVbXaErDyIBQwqpcrOQrpeIl+yRk9Bh+XNc01WRTqSbJnHnG4ab9almSNQrDE9aI7SJKF6WaKMlz
+        ufa9IH2XpF8k+Xuy0/0FXO+1D9gcEwiOG6+UiCWM9Piv9Ec5X6wUpC/7oySV/it/lOD3f/EHt5/m
+        GhaOSYswrTcH7amSy8CcQt0w0gn0HHuh4Uehh37GwhOYE+rGDkJo3k7KZ4bMF9qmWn7snCQw47gD
+        ge6roE4nSc7IgpwBadFSc7BYdNm+4pruK0JffN5XJAiT3Gk9XcKXg4Ukwqpjf57Vc+hEYMU1d5rT
+        AoRtN3AQOAyUk9M6VprYOAowchw4KSYXJrZvTYTRqCdl8dwdHVvka6zIOzqxSQQ+L0EjmK+VZblQ
+        UXJnVIFsvmVDUXqQJbjhUhk63RRWcqkyS8ea5yf5YIPpl5ELIMmmkBEh45zTKJ8qrn7Qwsjz4CpY
+        3Mh5sOEGVVzIund416jiIaiBJgog3qA60Jik57mHc3IU6kktzNBOCCMkNvihm6RhdvwbVEmaC1Y8
+        m/JUKM6foCKfoFOJMMH/CVvbuar0IJ1rRBZXsOXTrLph5tDtrjAFQ1wCnSpHB4gXiMlEXQY+cVjd
+        PhAUerojzIEoNJJAhiYxXcHeD/3OeC/j3xMo9IsA22tWbw3b09myPRxCM5kRcBJVP9NNB4XwhpcQ
+        ivhE46WMtyAXHk2z4RKZUEDk/0eurNXk4tdzpXxbO/4s6STRH/i+Q8Oc9w5XWPImHNtNyjCNvMz0
+        BylY/nJJokHDTifWpQltEynAJVj7tLG9dnigXYOMlSYuFoOQnXij+MKXpJBy+0Qvn2fyl11c5aEg
+        CZORkkshJrUs14V2Rq6xOpbF2H7nGLnpZk//JPkDm6R3XWURAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:17 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1748']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:41 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <despatch_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></despatch_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['441']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61Y3XajOBK+36dg+2Jn5uwSg39JL80c/yVOkziOg+3ENxwBssGARJCwTV5n32Se
-        bATCBsfu0917Ohcd9NUnqVT1qUpp9c99GAhbGBMPoy+f5CvpkwCRjR0Prb98mhk3ovLpT+0fqgNJ
-        BKjtmjiijEnMGJIkoJpKEsvBIfCQmRAYmx4xLeBoKSRq7bJJteM0oti0Amz7miiJojhO6974wcKA
-        vg3f3Ckw0Hw30f1J0/U2LzRSfA+6jeYAvxjzrauvTaM3cgd4MXod9pIJ3i17VtJ4qsv1kY22j2i0
-        aA7m5rT16id3SmMlvTVoaM82rZ1yN5U6vtHWb0z/oSebOwTAQHprGfWW/Kp79VbvZrGdpMZTpzmb
-        N0DqdLt7eaFbioXk93cqLuy+uFRrJ/6rdhLHLGBp+WWy6EFtbUWMegKVjBWwKY41WZIqnAIsWSgJ
-        LRhrSr1dYRVgyYoCYEOi1SucAqpwMKEmSUMLB7UqHMMC1f76X3V+iZeodqaBChJC6mKnAuQH7j/2
-        HtXaKValEKrJV60TBoNKBvuwtT4OAmhTYRXjUKAuZGJFCaxMylnlpEx1gAJtPDPY/hXewVBSKfYh
-        0mxTFCV9ZRrLNynSbf02Ttx96D91esHk9WWYbPcjW5Kl2ah/649bCDx4ewrSh85wOgiQ3Fu+DSao
-        HYwHFrCX7/TZMF/u2sv35ryz2ojXnfnqa7gPN6/1wAydx9s+Guikj7oTb7T0xuOQjnv39/YoIXZg
-        v0O3nZria8Vn7mHF4zSCms0jUqVlcGV8lo7L+Zk8PhvfyU/ju/mZMEz4faYL/wJh9F/hLoYBQI6A
-        UZD+8UNZYl78QJZ8lqXN6GmWoIcb66syVcjGmz6urK0VrY37xmbXWi8WZOfurv3Jy+zO2En27lG6
-        Dbvzl1jZg8aw0e+a2+EzvdGVepMsJrj/QqVb8dG3FctpbYcvm9vZdTTTodF832x2rvHWaywly/yq
-        1EXHUV5bX8ciWeB5F83xqwTnT+kb0XXjiRWw72Ysu39n6YpgHHqUQoeFNUE09vIrm3+mxw+eFI/p
-        /QQ4mvOwFjEvOTzYteNitYt7neulRI5XHLLrxnIOYgj41sOFWitH3JDvN2RdJN25MIYFgXtheesk
-        MrcgSCAveFVAtT1aHCnAyMFITHzm9xHk9nyh+9xeGPnSdgAIKX5xPqsPgGYOVLDCnk8xTu18GdaY
-        8i7Fl8tb1ymkEghiFhQfpocdaqy9lWDWBQvqYeYROVmv5F1Y0vcccnlZfpDCfoKVlPwsNyD0grRC
-        KpRQ7ls7BK0qpzzo39bXDHlMOoLO3gSsoX+UmR171LPZg2DrwZ3JlGZniuG97aJJZRccmjFAa2hC
-        5BTjIj/JfwRZoa7QTdYJKyx1SWbdryRwbkJtE69WBLIC1c42+oiWNAJtJhyiyc2O3Gq2pBP2wcjp
-        KfsJQ8fRsk0lRVYK5hFnycVKW5LNHGY3zqReCHO6KCmirBjy9eeG9FmS/i3Jn7OdLk8o1v0YAT4m
-        FMT0LCZ1mQWjG8Ve8CtD0pbr7Ubzh0PSrMs/FZKmWJf/n5AUIchLD9dj1syn3b4+nKq1ClxQ8jA8
-        AMou0k7o4SRG8DcijNlxYmD7MP7nYRKPF//2HK19d3OwsFGBB0zluCwkVbBgMPdoQrTA2x7tBXQg
-        8B5WO4zzek+8MAogOy3ziB7m8U7Av5OIwCBgWxF64uPw3Mdv+Z7h+qyK1y6svYbY5D02ANSjCQtk
-        K3+HHYcqK8Zr/ilKV3JmOgJqrZzvAmIinF3sFdEQVmsnQFYLWTVjpeNYBIuhGoK9GScIsbDy/Mt1
-        Jo0zVA1ZzbzA+4iqCLLW5sCI6SZhj9dMS7k/l/CCnMQga3EV2gHhhOwMOA4BsiF3/wxVs7bOe2Jf
-        ngpNY8wa7QE6FHiHhTxjm36oSVfSsb5XcZW4OC+PK34c/tfTKaYSpmtGzxeHeyYdSGi2XAU+cHjZ
-        YHbhOSUUhsISxvhI5Zcgf0Xzac/dwf1w+rwY3t+zl1jFUJDyCc/ACWDMrtWCCYkcaEV7KR4JJ8Ep
-        C9QCOqyAdbKi/usLWIfV6Z8oYJ2zAvatG5VJOcI4yDVbtPEPWCbwwAuz5pjLqDL8Xl3s/GhdzBXA
-        vRO71938KZcDhYWYW494VlCo5iPIWWVB4oJiVad4zM2LKSWknt+307uW/csT17lqSMLkQa2VELe6
-        bhiyR4Z83cj7bRXj+x1VcvbiPPzHwt9JMZh+mRAAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1684']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:17 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/DespatchMethodTests.test_despatch_returned_event.yaml
+++ b/tests/interface_objects/cassettes/DespatchMethodTests.test_despatch_returned_event.yaml
@@ -1,256 +1,218 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:18 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:42 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:18 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:43 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGRlc3BhdGNoX29wdGlvbnM+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQd2FPVGpVY2xx
+      M2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBrNkZMby1BQXpv
+      ck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1S0pkdUdsN0tn
+      WXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19ibG9jaz48c2Vs
+      Zl9wcmludF9tb2RlPmh0bWw8L3NlbGZfcHJpbnRfbW9kZT48dXNlcl9pZD5kZW1vPC91c2VyX2lk
+      PjxwZXJmX3Rva2VuPmstLS02U1lGOVo2MS1lMDk4TXhnb3ZVZXlNTlNaWnBSUHNEbEZtbDJFSzZy
+      aUdraWhfYTB0TDgyMFFmNGdYZUZnME5tWTwvcGVyZl90b2tlbj48cHV6emxlZD55ZXM8L3B1enps
+      ZWQ+PC9kZXNwYXRjaF9vcHRpb25zPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['421']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA7VY63LqOBL+v0/hOj9mdmvGwebOWY+nuBMugXAJCX9cxhbYwbdYcsC8zr7JPtm0
+        JYHNZfZkt2ZTqSB9/amlbrW6myi/H1xH+EQhtn3vt2/yg/RNQJ7hm7a3/e3bYt4Rq99+V/+mmAgH
+        OjEszQ8IMLEWIhw5RFVwtDZ9V7c9LcIo1GysrXVT9Xwld1+iGGEcEF9bO76xU8uSKLYPj6V8f9r8
+        EPdy7XlxbHr2q4Y7WPSG3cVYLg/046Fb6Q1K5OM4IrNy1yJ70hE3zmjQWMlkJUUTWUOeq0+7L8/a
+        0RktNk+LTXVSnJijp7k8x/bzqiX39823zg69e0G7hwbavmmhqjV+HKEJ2pm7TTGevJtLS3tvye3O
+        +FA9ypXg+LrZ1pA2eNNMsiVi0XWmn6vHUVWyykdRFFdK7sIWxYjCEHwXpyMNHInU7ToA6gWUMja6
+        QfxQlSUpw+FgyvIid41CtZovZ1gcTFmBoxsIq/kMh0MZjo+JhmN37Tu5LBwijqr//ld2fYqnqHoT
+        DhnERcTyzQxADW6OG2Mld4llKZio8kPpggFQyoCBoTZ9x0EGETah7wrEQhC3XoQyiygrXZREoE50
+        9Wkxh/0zvJMgpRJ/hzzV0ESxE/dfWptqK263rNHborx5c3Z+Xe7Kx/eh92m+7K3KYNjfrcNX2xJX
+        cf4wC2bjltnTe0cz1rvvYhD2zGJlUPncNKed12jU7keL9+mggbvecvrh9kitKmJriKerx7ZXGzaW
+        heXLABcmorjve8+9sXYM4lUUL+y6+JY5Mzth5sRxgFSDeSRLS+DM/OY67t/PZDyb/+B+Cj+8nwlg
+        wt8XA+En3Q3+KTyGyNE9U/A9J/7Hl24JTvGFW8JwS90i2lfqh12hOKwM4/1ivl1O3uZD5+NgzqXp
+        Oq71ZmKxN3T6lcbbaC9uDG3ZrrzuO62W3O0PG08xDs3nRymUx0a9VtpVNPLYrjY/hpvKCpvLYvDy
+        ojeeXV9b+sb7xC6OC37xIO47h0F/63bG9aDcdfqOE9eO+c9udFihRs/wKut+GDaeOu3l0+GHN5e8
+        w5trC1Do2oQgE9wbeSS06dOlw/g8YJdjQ9xfAGcxdS/3fcphTs9dK7vSGu3+o9aFZ8PhhAEUB0jt
+        f648d9eQ26BMkXMeQfCmIbD0EOnsBO2lkktnTED3a0PVivcWChEnsFMYNuFnd3zP9D2R2nQGmZxS
+        h1TOhXyxo2PMPxhfDwkGSgpwIeXXQciDvQnVMEqOkhErUPNoAWRqYwSaLiEFIz0E83copjvloGym
+        SFJcOe+07IxcKEt51/pM3TPQfaXMnBPhAkw51I6GDlmGcENbVwv43adHyJ2c+JcFlhHaxDag5fi0
+        0V6D2DKSGGEl865IgbyBtFD3tgg6A5PPqbK5Ff0qyJCnZiggKCmgQl6SoaymFMaOiKH5mw1GkPnK
+        yVbXaErDyIBQwqpcrOQrpeIl+yRk9Bh+XNc01WRTqSbJnHnG4ab9almSNQrDE9aI7SJKF6WaKMlz
+        ufa9IH2XpF8k+Xuy0/0FXO+1D9gcEwiOG6+UiCWM9Piv9Ec5X6wUpC/7oySV/it/lOD3f/EHt5/m
+        GhaOSYswrTcH7amSy8CcQt0w0gn0HHuh4Uehh37GwhOYE+rGDkJo3k7KZ4bMF9qmWn7snCQw47gD
+        ge6roE4nSc7IgpwBadFSc7BYdNm+4pruK0JffN5XJAiT3Gk9XcKXg4Ukwqpjf57Vc+hEYMU1d5rT
+        AoRtN3AQOAyUk9M6VprYOAowchw4KSYXJrZvTYTRqCdl8dwdHVvka6zIOzqxSQQ+L0EjmK+VZblQ
+        UXJnVIFsvmVDUXqQJbjhUhk63RRWcqkyS8ea5yf5YIPpl5ELIMmmkBEh45zTKJ8qrn7Qwsjz4CpY
+        3Mh5sOEGVVzIund416jiIaiBJgog3qA60Jik57mHc3IU6kktzNBOCCMkNvihm6RhdvwbVEmaC1Y8
+        m/JUKM6foCKfoFOJMMH/CVvbuar0IJ1rRBZXsOXTrLph5tDtrjAFQ1wCnSpHB4gXiMlEXQY+cVjd
+        PhAUerojzIEoNJJAhiYxXcHeD/3OeC/j3xMo9IsA22tWbw3b09myPRxCM5kRcBJVP9NNB4XwhpcQ
+        ivhE46WMtyAXHk2z4RKZUEDk/0eurNXk4tdzpXxbO/4s6STRH/i+Q8Oc9w5XWPImHNtNyjCNvMz0
+        BylY/nJJokHDTifWpQltEynAJVj7tLG9dnigXYOMlSYuFoOQnXij+MKXpJBy+0Qvn2fyl11c5aEg
+        CZORkkshJrUs14V2Rq6xOpbF2H7nGLnpZk//JPkDm6R3XWURAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:18 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1748']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:44 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <despatch_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></despatch_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['441']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61Y3XajOBK+36dg+2Jn5uwSg39JL80c/yVOkziOg+3ENxwBssGARJCwTV5n32Se
-        bATCBsfu0917Ohcd9NUnqVT1qUpp9c99GAhbGBMPoy+f5CvpkwCRjR0Prb98mhk3ovLpT+0fqgNJ
-        BKjtmjiijEnMGJIkoJpKEsvBIfCQmRAYmx4xLeBoKSRq7bJJteM0oti0Amz7miiJojhO6974wcKA
-        vg3f3Ckw0Hw30f1J0/U2LzRSfA+6jeYAvxjzrauvTaM3cgd4MXod9pIJ3i17VtJ4qsv1kY22j2i0
-        aA7m5rT16id3SmMlvTVoaM82rZ1yN5U6vtHWb0z/oSebOwTAQHprGfWW/Kp79VbvZrGdpMZTpzmb
-        N0DqdLt7eaFbioXk93cqLuy+uFRrJ/6rdhLHLGBp+WWy6EFtbUWMegKVjBWwKY41WZIqnAIsWSgJ
-        LRhrSr1dYRVgyYoCYEOi1SucAqpwMKEmSUMLB7UqHMMC1f76X3V+iZeodqaBChJC6mKnAuQH7j/2
-        HtXaKValEKrJV60TBoNKBvuwtT4OAmhTYRXjUKAuZGJFCaxMylnlpEx1gAJtPDPY/hXewVBSKfYh
-        0mxTFCV9ZRrLNynSbf02Ttx96D91esHk9WWYbPcjW5Kl2ah/649bCDx4ewrSh85wOgiQ3Fu+DSao
-        HYwHFrCX7/TZMF/u2sv35ryz2ojXnfnqa7gPN6/1wAydx9s+Guikj7oTb7T0xuOQjnv39/YoIXZg
-        v0O3nZria8Vn7mHF4zSCms0jUqVlcGV8lo7L+Zk8PhvfyU/ju/mZMEz4faYL/wJh9F/hLoYBQI6A
-        UZD+8UNZYl78QJZ8lqXN6GmWoIcb66syVcjGmz6urK0VrY37xmbXWi8WZOfurv3Jy+zO2En27lG6
-        Dbvzl1jZg8aw0e+a2+EzvdGVepMsJrj/QqVb8dG3FctpbYcvm9vZdTTTodF832x2rvHWaywly/yq
-        1EXHUV5bX8ciWeB5F83xqwTnT+kb0XXjiRWw72Ysu39n6YpgHHqUQoeFNUE09vIrm3+mxw+eFI/p
-        /QQ4mvOwFjEvOTzYteNitYt7neulRI5XHLLrxnIOYgj41sOFWitH3JDvN2RdJN25MIYFgXtheesk
-        MrcgSCAveFVAtT1aHCnAyMFITHzm9xHk9nyh+9xeGPnSdgAIKX5xPqsPgGYOVLDCnk8xTu18GdaY
-        8i7Fl8tb1ymkEghiFhQfpocdaqy9lWDWBQvqYeYROVmv5F1Y0vcccnlZfpDCfoKVlPwsNyD0grRC
-        KpRQ7ls7BK0qpzzo39bXDHlMOoLO3gSsoX+UmR171LPZg2DrwZ3JlGZniuG97aJJZRccmjFAa2hC
-        5BTjIj/JfwRZoa7QTdYJKyx1SWbdryRwbkJtE69WBLIC1c42+oiWNAJtJhyiyc2O3Gq2pBP2wcjp
-        KfsJQ8fRsk0lRVYK5hFnycVKW5LNHGY3zqReCHO6KCmirBjy9eeG9FmS/i3Jn7OdLk8o1v0YAT4m
-        FMT0LCZ1mQWjG8Ve8CtD0pbr7Ubzh0PSrMs/FZKmWJf/n5AUIchLD9dj1syn3b4+nKq1ClxQ8jA8
-        AMou0k7o4SRG8DcijNlxYmD7MP7nYRKPF//2HK19d3OwsFGBB0zluCwkVbBgMPdoQrTA2x7tBXQg
-        8B5WO4zzek+8MAogOy3ziB7m8U7Av5OIwCBgWxF64uPw3Mdv+Z7h+qyK1y6svYbY5D02ANSjCQtk
-        K3+HHYcqK8Zr/ilKV3JmOgJqrZzvAmIinF3sFdEQVmsnQFYLWTVjpeNYBIuhGoK9GScIsbDy/Mt1
-        Jo0zVA1ZzbzA+4iqCLLW5sCI6SZhj9dMS7k/l/CCnMQga3EV2gHhhOwMOA4BsiF3/wxVs7bOe2Jf
-        ngpNY8wa7QE6FHiHhTxjm36oSVfSsb5XcZW4OC+PK34c/tfTKaYSpmtGzxeHeyYdSGi2XAU+cHjZ
-        YHbhOSUUhsISxvhI5Zcgf0Xzac/dwf1w+rwY3t+zl1jFUJDyCc/ACWDMrtWCCYkcaEV7KR4JJ8Ep
-        C9QCOqyAdbKi/usLWIfV6Z8oYJ2zAvatG5VJOcI4yDVbtPEPWCbwwAuz5pjLqDL8Xl3s/GhdzBXA
-        vRO71938KZcDhYWYW494VlCo5iPIWWVB4oJiVad4zM2LKSWknt+307uW/csT17lqSMLkQa2VELe6
-        bhiyR4Z83cj7bRXj+x1VcvbiPPzHwt9JMZh+mRAAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1684']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:18 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/DespatchMethodTests.test_string_properties.yaml
+++ b/tests/interface_objects/cassettes/DespatchMethodTests.test_string_properties.yaml
@@ -1,256 +1,218 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:19 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:45 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:19 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:45 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGRlc3BhdGNoX29wdGlvbnM+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQd2FPVGpVY2xx
+      M2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBrNkZMby1BQXpv
+      ck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1S0pkdUdsN0tn
+      WXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19ibG9jaz48c2Vs
+      Zl9wcmludF9tb2RlPmh0bWw8L3NlbGZfcHJpbnRfbW9kZT48dXNlcl9pZD5kZW1vPC91c2VyX2lk
+      PjxwZXJmX3Rva2VuPmstLS02U1lGOVo2MS1lMDk4TXhnb3ZVZXlNTlNaWnBSUHNEbEZtbDJFSzZy
+      aUdraWhfYTB0TDgyMFFmNGdYZUZnME5tWTwvcGVyZl90b2tlbj48cHV6emxlZD55ZXM8L3B1enps
+      ZWQ+PC9kZXNwYXRjaF9vcHRpb25zPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['421']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA7VY63LqOBL+v0/hOj9mdmvGwebOWY+nuBMugXAJCX9cxhbYwbdYcsC8zr7JPtm0
+        JYHNZfZkt2ZTqSB9/amlbrW6myi/H1xH+EQhtn3vt2/yg/RNQJ7hm7a3/e3bYt4Rq99+V/+mmAgH
+        OjEszQ8IMLEWIhw5RFVwtDZ9V7c9LcIo1GysrXVT9Xwld1+iGGEcEF9bO76xU8uSKLYPj6V8f9r8
+        EPdy7XlxbHr2q4Y7WPSG3cVYLg/046Fb6Q1K5OM4IrNy1yJ70hE3zmjQWMlkJUUTWUOeq0+7L8/a
+        0RktNk+LTXVSnJijp7k8x/bzqiX39823zg69e0G7hwbavmmhqjV+HKEJ2pm7TTGevJtLS3tvye3O
+        +FA9ypXg+LrZ1pA2eNNMsiVi0XWmn6vHUVWyykdRFFdK7sIWxYjCEHwXpyMNHInU7ToA6gWUMja6
+        QfxQlSUpw+FgyvIid41CtZovZ1gcTFmBoxsIq/kMh0MZjo+JhmN37Tu5LBwijqr//ld2fYqnqHoT
+        DhnERcTyzQxADW6OG2Mld4llKZio8kPpggFQyoCBoTZ9x0EGETah7wrEQhC3XoQyiygrXZREoE50
+        9Wkxh/0zvJMgpRJ/hzzV0ESxE/dfWptqK263rNHborx5c3Z+Xe7Kx/eh92m+7K3KYNjfrcNX2xJX
+        cf4wC2bjltnTe0cz1rvvYhD2zGJlUPncNKed12jU7keL9+mggbvecvrh9kitKmJriKerx7ZXGzaW
+        heXLABcmorjve8+9sXYM4lUUL+y6+JY5Mzth5sRxgFSDeSRLS+DM/OY67t/PZDyb/+B+Cj+8nwlg
+        wt8XA+En3Q3+KTyGyNE9U/A9J/7Hl24JTvGFW8JwS90i2lfqh12hOKwM4/1ivl1O3uZD5+NgzqXp
+        Oq71ZmKxN3T6lcbbaC9uDG3ZrrzuO62W3O0PG08xDs3nRymUx0a9VtpVNPLYrjY/hpvKCpvLYvDy
+        ojeeXV9b+sb7xC6OC37xIO47h0F/63bG9aDcdfqOE9eO+c9udFihRs/wKut+GDaeOu3l0+GHN5e8
+        w5trC1Do2oQgE9wbeSS06dOlw/g8YJdjQ9xfAGcxdS/3fcphTs9dK7vSGu3+o9aFZ8PhhAEUB0jt
+        f648d9eQ26BMkXMeQfCmIbD0EOnsBO2lkktnTED3a0PVivcWChEnsFMYNuFnd3zP9D2R2nQGmZxS
+        h1TOhXyxo2PMPxhfDwkGSgpwIeXXQciDvQnVMEqOkhErUPNoAWRqYwSaLiEFIz0E83copjvloGym
+        SFJcOe+07IxcKEt51/pM3TPQfaXMnBPhAkw51I6GDlmGcENbVwv43adHyJ2c+JcFlhHaxDag5fi0
+        0V6D2DKSGGEl865IgbyBtFD3tgg6A5PPqbK5Ff0qyJCnZiggKCmgQl6SoaymFMaOiKH5mw1GkPnK
+        yVbXaErDyIBQwqpcrOQrpeIl+yRk9Bh+XNc01WRTqSbJnHnG4ab9almSNQrDE9aI7SJKF6WaKMlz
+        ufa9IH2XpF8k+Xuy0/0FXO+1D9gcEwiOG6+UiCWM9Piv9Ec5X6wUpC/7oySV/it/lOD3f/EHt5/m
+        GhaOSYswrTcH7amSy8CcQt0w0gn0HHuh4Uehh37GwhOYE+rGDkJo3k7KZ4bMF9qmWn7snCQw47gD
+        ge6roE4nSc7IgpwBadFSc7BYdNm+4pruK0JffN5XJAiT3Gk9XcKXg4Ukwqpjf57Vc+hEYMU1d5rT
+        AoRtN3AQOAyUk9M6VprYOAowchw4KSYXJrZvTYTRqCdl8dwdHVvka6zIOzqxSQQ+L0EjmK+VZblQ
+        UXJnVIFsvmVDUXqQJbjhUhk63RRWcqkyS8ea5yf5YIPpl5ELIMmmkBEh45zTKJ8qrn7Qwsjz4CpY
+        3Mh5sOEGVVzIund416jiIaiBJgog3qA60Jik57mHc3IU6kktzNBOCCMkNvihm6RhdvwbVEmaC1Y8
+        m/JUKM6foCKfoFOJMMH/CVvbuar0IJ1rRBZXsOXTrLph5tDtrjAFQ1wCnSpHB4gXiMlEXQY+cVjd
+        PhAUerojzIEoNJJAhiYxXcHeD/3OeC/j3xMo9IsA22tWbw3b09myPRxCM5kRcBJVP9NNB4XwhpcQ
+        ivhE46WMtyAXHk2z4RKZUEDk/0eurNXk4tdzpXxbO/4s6STRH/i+Q8Oc9w5XWPImHNtNyjCNvMz0
+        BylY/nJJokHDTifWpQltEynAJVj7tLG9dnigXYOMlSYuFoOQnXij+MKXpJBy+0Qvn2fyl11c5aEg
+        CZORkkshJrUs14V2Rq6xOpbF2H7nGLnpZk//JPkDm6R3XWURAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:19 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1748']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:45 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <despatch_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></despatch_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['441']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61Y3XajOBK+36dg+2Jn5uwSg39JL80c/yVOkziOg+3ENxwBssGARJCwTV5n32Se
-        bATCBsfu0917Ohcd9NUnqVT1qUpp9c99GAhbGBMPoy+f5CvpkwCRjR0Prb98mhk3ovLpT+0fqgNJ
-        BKjtmjiijEnMGJIkoJpKEsvBIfCQmRAYmx4xLeBoKSRq7bJJteM0oti0Amz7miiJojhO6974wcKA
-        vg3f3Ckw0Hw30f1J0/U2LzRSfA+6jeYAvxjzrauvTaM3cgd4MXod9pIJ3i17VtJ4qsv1kY22j2i0
-        aA7m5rT16id3SmMlvTVoaM82rZ1yN5U6vtHWb0z/oSebOwTAQHprGfWW/Kp79VbvZrGdpMZTpzmb
-        N0DqdLt7eaFbioXk93cqLuy+uFRrJ/6rdhLHLGBp+WWy6EFtbUWMegKVjBWwKY41WZIqnAIsWSgJ
-        LRhrSr1dYRVgyYoCYEOi1SucAqpwMKEmSUMLB7UqHMMC1f76X3V+iZeodqaBChJC6mKnAuQH7j/2
-        HtXaKValEKrJV60TBoNKBvuwtT4OAmhTYRXjUKAuZGJFCaxMylnlpEx1gAJtPDPY/hXewVBSKfYh
-        0mxTFCV9ZRrLNynSbf02Ttx96D91esHk9WWYbPcjW5Kl2ah/649bCDx4ewrSh85wOgiQ3Fu+DSao
-        HYwHFrCX7/TZMF/u2sv35ryz2ojXnfnqa7gPN6/1wAydx9s+Guikj7oTb7T0xuOQjnv39/YoIXZg
-        v0O3nZria8Vn7mHF4zSCms0jUqVlcGV8lo7L+Zk8PhvfyU/ju/mZMEz4faYL/wJh9F/hLoYBQI6A
-        UZD+8UNZYl78QJZ8lqXN6GmWoIcb66syVcjGmz6urK0VrY37xmbXWi8WZOfurv3Jy+zO2En27lG6
-        Dbvzl1jZg8aw0e+a2+EzvdGVepMsJrj/QqVb8dG3FctpbYcvm9vZdTTTodF832x2rvHWaywly/yq
-        1EXHUV5bX8ciWeB5F83xqwTnT+kb0XXjiRWw72Ysu39n6YpgHHqUQoeFNUE09vIrm3+mxw+eFI/p
-        /QQ4mvOwFjEvOTzYteNitYt7neulRI5XHLLrxnIOYgj41sOFWitH3JDvN2RdJN25MIYFgXtheesk
-        MrcgSCAveFVAtT1aHCnAyMFITHzm9xHk9nyh+9xeGPnSdgAIKX5xPqsPgGYOVLDCnk8xTu18GdaY
-        8i7Fl8tb1ymkEghiFhQfpocdaqy9lWDWBQvqYeYROVmv5F1Y0vcccnlZfpDCfoKVlPwsNyD0grRC
-        KpRQ7ls7BK0qpzzo39bXDHlMOoLO3gSsoX+UmR171LPZg2DrwZ3JlGZniuG97aJJZRccmjFAa2hC
-        5BTjIj/JfwRZoa7QTdYJKyx1SWbdryRwbkJtE69WBLIC1c42+oiWNAJtJhyiyc2O3Gq2pBP2wcjp
-        KfsJQ8fRsk0lRVYK5hFnycVKW5LNHGY3zqReCHO6KCmirBjy9eeG9FmS/i3Jn7OdLk8o1v0YAT4m
-        FMT0LCZ1mQWjG8Ve8CtD0pbr7Ubzh0PSrMs/FZKmWJf/n5AUIchLD9dj1syn3b4+nKq1ClxQ8jA8
-        AMou0k7o4SRG8DcijNlxYmD7MP7nYRKPF//2HK19d3OwsFGBB0zluCwkVbBgMPdoQrTA2x7tBXQg
-        8B5WO4zzek+8MAogOy3ziB7m8U7Av5OIwCBgWxF64uPw3Mdv+Z7h+qyK1y6svYbY5D02ANSjCQtk
-        K3+HHYcqK8Zr/ilKV3JmOgJqrZzvAmIinF3sFdEQVmsnQFYLWTVjpeNYBIuhGoK9GScIsbDy/Mt1
-        Jo0zVA1ZzbzA+4iqCLLW5sCI6SZhj9dMS7k/l/CCnMQga3EV2gHhhOwMOA4BsiF3/wxVs7bOe2Jf
-        ngpNY8wa7QE6FHiHhTxjm36oSVfSsb5XcZW4OC+PK34c/tfTKaYSpmtGzxeHeyYdSGi2XAU+cHjZ
-        YHbhOSUUhsISxvhI5Zcgf0Xzac/dwf1w+rwY3t+zl1jFUJDyCc/ACWDMrtWCCYkcaEV7KR4JJ8Ep
-        C9QCOqyAdbKi/usLWIfV6Z8oYJ2zAvatG5VJOcI4yDVbtPEPWCbwwAuz5pjLqDL8Xl3s/GhdzBXA
-        vRO71938KZcDhYWYW494VlCo5iPIWWVB4oJiVad4zM2LKSWknt+307uW/csT17lqSMLkQa2VELe6
-        bhiyR4Z83cj7bRXj+x1VcvbiPPzHwt9JMZh+mRAAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1684']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:20 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/DespatchMethodTests.test_unicode_properties.yaml
+++ b/tests/interface_objects/cassettes/DespatchMethodTests.test_unicode_properties.yaml
@@ -1,256 +1,218 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:20 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:46 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:20 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:46 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGRlc3BhdGNoX29wdGlvbnM+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQd2FPVGpVY2xx
+      M2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBrNkZMby1BQXpv
+      ck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1S0pkdUdsN0tn
+      WXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19ibG9jaz48c2Vs
+      Zl9wcmludF9tb2RlPmh0bWw8L3NlbGZfcHJpbnRfbW9kZT48dXNlcl9pZD5kZW1vPC91c2VyX2lk
+      PjxwZXJmX3Rva2VuPmstLS02U1lGOVo2MS1lMDk4TXhnb3ZVZXlNTlNaWnBSUHNEbEZtbDJFSzZy
+      aUdraWhfYTB0TDgyMFFmNGdYZUZnME5tWTwvcGVyZl90b2tlbj48cHV6emxlZD55ZXM8L3B1enps
+      ZWQ+PC9kZXNwYXRjaF9vcHRpb25zPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['421']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA7VY63LqOBL+v0/hOj9mdmvGwebOWY+nuBMugXAJCX9cxhbYwbdYcsC8zr7JPtm0
+        JYHNZfZkt2ZTqSB9/amlbrW6myi/H1xH+EQhtn3vt2/yg/RNQJ7hm7a3/e3bYt4Rq99+V/+mmAgH
+        OjEszQ8IMLEWIhw5RFVwtDZ9V7c9LcIo1GysrXVT9Xwld1+iGGEcEF9bO76xU8uSKLYPj6V8f9r8
+        EPdy7XlxbHr2q4Y7WPSG3cVYLg/046Fb6Q1K5OM4IrNy1yJ70hE3zmjQWMlkJUUTWUOeq0+7L8/a
+        0RktNk+LTXVSnJijp7k8x/bzqiX39823zg69e0G7hwbavmmhqjV+HKEJ2pm7TTGevJtLS3tvye3O
+        +FA9ypXg+LrZ1pA2eNNMsiVi0XWmn6vHUVWyykdRFFdK7sIWxYjCEHwXpyMNHInU7ToA6gWUMja6
+        QfxQlSUpw+FgyvIid41CtZovZ1gcTFmBoxsIq/kMh0MZjo+JhmN37Tu5LBwijqr//ld2fYqnqHoT
+        DhnERcTyzQxADW6OG2Mld4llKZio8kPpggFQyoCBoTZ9x0EGETah7wrEQhC3XoQyiygrXZREoE50
+        9Wkxh/0zvJMgpRJ/hzzV0ESxE/dfWptqK263rNHborx5c3Z+Xe7Kx/eh92m+7K3KYNjfrcNX2xJX
+        cf4wC2bjltnTe0cz1rvvYhD2zGJlUPncNKed12jU7keL9+mggbvecvrh9kitKmJriKerx7ZXGzaW
+        heXLABcmorjve8+9sXYM4lUUL+y6+JY5Mzth5sRxgFSDeSRLS+DM/OY67t/PZDyb/+B+Cj+8nwlg
+        wt8XA+En3Q3+KTyGyNE9U/A9J/7Hl24JTvGFW8JwS90i2lfqh12hOKwM4/1ivl1O3uZD5+NgzqXp
+        Oq71ZmKxN3T6lcbbaC9uDG3ZrrzuO62W3O0PG08xDs3nRymUx0a9VtpVNPLYrjY/hpvKCpvLYvDy
+        ojeeXV9b+sb7xC6OC37xIO47h0F/63bG9aDcdfqOE9eO+c9udFihRs/wKut+GDaeOu3l0+GHN5e8
+        w5trC1Do2oQgE9wbeSS06dOlw/g8YJdjQ9xfAGcxdS/3fcphTs9dK7vSGu3+o9aFZ8PhhAEUB0jt
+        f648d9eQ26BMkXMeQfCmIbD0EOnsBO2lkktnTED3a0PVivcWChEnsFMYNuFnd3zP9D2R2nQGmZxS
+        h1TOhXyxo2PMPxhfDwkGSgpwIeXXQciDvQnVMEqOkhErUPNoAWRqYwSaLiEFIz0E83copjvloGym
+        SFJcOe+07IxcKEt51/pM3TPQfaXMnBPhAkw51I6GDlmGcENbVwv43adHyJ2c+JcFlhHaxDag5fi0
+        0V6D2DKSGGEl865IgbyBtFD3tgg6A5PPqbK5Ff0qyJCnZiggKCmgQl6SoaymFMaOiKH5mw1GkPnK
+        yVbXaErDyIBQwqpcrOQrpeIl+yRk9Bh+XNc01WRTqSbJnHnG4ab9almSNQrDE9aI7SJKF6WaKMlz
+        ufa9IH2XpF8k+Xuy0/0FXO+1D9gcEwiOG6+UiCWM9Piv9Ec5X6wUpC/7oySV/it/lOD3f/EHt5/m
+        GhaOSYswrTcH7amSy8CcQt0w0gn0HHuh4Uehh37GwhOYE+rGDkJo3k7KZ4bMF9qmWn7snCQw47gD
+        ge6roE4nSc7IgpwBadFSc7BYdNm+4pruK0JffN5XJAiT3Gk9XcKXg4Ukwqpjf57Vc+hEYMU1d5rT
+        AoRtN3AQOAyUk9M6VprYOAowchw4KSYXJrZvTYTRqCdl8dwdHVvka6zIOzqxSQQ+L0EjmK+VZblQ
+        UXJnVIFsvmVDUXqQJbjhUhk63RRWcqkyS8ea5yf5YIPpl5ELIMmmkBEh45zTKJ8qrn7Qwsjz4CpY
+        3Mh5sOEGVVzIund416jiIaiBJgog3qA60Jik57mHc3IU6kktzNBOCCMkNvihm6RhdvwbVEmaC1Y8
+        m/JUKM6foCKfoFOJMMH/CVvbuar0IJ1rRBZXsOXTrLph5tDtrjAFQ1wCnSpHB4gXiMlEXQY+cVjd
+        PhAUerojzIEoNJJAhiYxXcHeD/3OeC/j3xMo9IsA22tWbw3b09myPRxCM5kRcBJVP9NNB4XwhpcQ
+        ivhE46WMtyAXHk2z4RKZUEDk/0eurNXk4tdzpXxbO/4s6STRH/i+Q8Oc9w5XWPImHNtNyjCNvMz0
+        BylY/nJJokHDTifWpQltEynAJVj7tLG9dnigXYOMlSYuFoOQnXij+MKXpJBy+0Qvn2fyl11c5aEg
+        CZORkkshJrUs14V2Rq6xOpbF2H7nGLnpZk//JPkDm6R3XWURAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:20 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1748']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:46 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <despatch_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></despatch_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['441']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61Y3XajOBK+36dg+2Jn5uwSg39JL80c/yVOkziOg+3ENxwBssGARJCwTV5n32Se
-        bATCBsfu0917Ohcd9NUnqVT1qUpp9c99GAhbGBMPoy+f5CvpkwCRjR0Prb98mhk3ovLpT+0fqgNJ
-        BKjtmjiijEnMGJIkoJpKEsvBIfCQmRAYmx4xLeBoKSRq7bJJteM0oti0Amz7miiJojhO6974wcKA
-        vg3f3Ckw0Hw30f1J0/U2LzRSfA+6jeYAvxjzrauvTaM3cgd4MXod9pIJ3i17VtJ4qsv1kY22j2i0
-        aA7m5rT16id3SmMlvTVoaM82rZ1yN5U6vtHWb0z/oSebOwTAQHprGfWW/Kp79VbvZrGdpMZTpzmb
-        N0DqdLt7eaFbioXk93cqLuy+uFRrJ/6rdhLHLGBp+WWy6EFtbUWMegKVjBWwKY41WZIqnAIsWSgJ
-        LRhrSr1dYRVgyYoCYEOi1SucAqpwMKEmSUMLB7UqHMMC1f76X3V+iZeodqaBChJC6mKnAuQH7j/2
-        HtXaKValEKrJV60TBoNKBvuwtT4OAmhTYRXjUKAuZGJFCaxMylnlpEx1gAJtPDPY/hXewVBSKfYh
-        0mxTFCV9ZRrLNynSbf02Ttx96D91esHk9WWYbPcjW5Kl2ah/649bCDx4ewrSh85wOgiQ3Fu+DSao
-        HYwHFrCX7/TZMF/u2sv35ryz2ojXnfnqa7gPN6/1wAydx9s+Guikj7oTb7T0xuOQjnv39/YoIXZg
-        v0O3nZria8Vn7mHF4zSCms0jUqVlcGV8lo7L+Zk8PhvfyU/ju/mZMEz4faYL/wJh9F/hLoYBQI6A
-        UZD+8UNZYl78QJZ8lqXN6GmWoIcb66syVcjGmz6urK0VrY37xmbXWi8WZOfurv3Jy+zO2En27lG6
-        Dbvzl1jZg8aw0e+a2+EzvdGVepMsJrj/QqVb8dG3FctpbYcvm9vZdTTTodF832x2rvHWaywly/yq
-        1EXHUV5bX8ciWeB5F83xqwTnT+kb0XXjiRWw72Ysu39n6YpgHHqUQoeFNUE09vIrm3+mxw+eFI/p
-        /QQ4mvOwFjEvOTzYteNitYt7neulRI5XHLLrxnIOYgj41sOFWitH3JDvN2RdJN25MIYFgXtheesk
-        MrcgSCAveFVAtT1aHCnAyMFITHzm9xHk9nyh+9xeGPnSdgAIKX5xPqsPgGYOVLDCnk8xTu18GdaY
-        8i7Fl8tb1ymkEghiFhQfpocdaqy9lWDWBQvqYeYROVmv5F1Y0vcccnlZfpDCfoKVlPwsNyD0grRC
-        KpRQ7ls7BK0qpzzo39bXDHlMOoLO3gSsoX+UmR171LPZg2DrwZ3JlGZniuG97aJJZRccmjFAa2hC
-        5BTjIj/JfwRZoa7QTdYJKyx1SWbdryRwbkJtE69WBLIC1c42+oiWNAJtJhyiyc2O3Gq2pBP2wcjp
-        KfsJQ8fRsk0lRVYK5hFnycVKW5LNHGY3zqReCHO6KCmirBjy9eeG9FmS/i3Jn7OdLk8o1v0YAT4m
-        FMT0LCZ1mQWjG8Ve8CtD0pbr7Ubzh0PSrMs/FZKmWJf/n5AUIchLD9dj1syn3b4+nKq1ClxQ8jA8
-        AMou0k7o4SRG8DcijNlxYmD7MP7nYRKPF//2HK19d3OwsFGBB0zluCwkVbBgMPdoQrTA2x7tBXQg
-        8B5WO4zzek+8MAogOy3ziB7m8U7Av5OIwCBgWxF64uPw3Mdv+Z7h+qyK1y6svYbY5D02ANSjCQtk
-        K3+HHYcqK8Zr/ilKV3JmOgJqrZzvAmIinF3sFdEQVmsnQFYLWTVjpeNYBIuhGoK9GScIsbDy/Mt1
-        Jo0zVA1ZzbzA+4iqCLLW5sCI6SZhj9dMS7k/l/CCnMQga3EV2gHhhOwMOA4BsiF3/wxVs7bOe2Jf
-        ngpNY8wa7QE6FHiHhTxjm36oSVfSsb5XcZW4OC+PK34c/tfTKaYSpmtGzxeHeyYdSGi2XAU+cHjZ
-        YHbhOSUUhsISxvhI5Zcgf0Xzac/dwf1w+rwY3t+zl1jFUJDyCc/ACWDMrtWCCYkcaEV7KR4JJ8Ep
-        C9QCOqyAdbKi/usLWIfV6Z8oYJ2zAvatG5VJOcI4yDVbtPEPWCbwwAuz5pjLqDL8Xl3s/GhdzBXA
-        vRO71938KZcDhYWYW494VlCo5iPIWWVB4oJiVad4zM2LKSWknt+307uW/csT17lqSMLkQa2VELe6
-        bhiyR4Z83cj7bRXj+x1VcvbiPPzHwt9JMZh+mRAAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1684']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:21 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/EventReviewsTests.test_critic_review_percent.yaml
+++ b/tests/interface_objects/cassettes/EventReviewsTests.test_critic_review_percent.yaml
@@ -1,137 +1,114 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF92aWRlb19pZnJhbWUgLz48
+      cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNj
+      YXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21l
+      ZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9m
+      b3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlh
+      PnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVx
+      dWVzdF9tZWRpYT48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHJlcXVlc3RfcmV2aWV3cyAvPjxyZXF1
+      ZXN0X2N1c3RvbV9maWVsZHMgLz48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxtaW1lX3RleHRfdHlw
+      ZT5odG1sPC9taW1lX3RleHRfdHlwZT48cmVxdWVzdF9tZXRhX2NvbXBvbmVudHMgLz48cmVxdWVz
+      dF9leHRyYV9pbmZvIC8+PHJlcXVlc3Rfc291cmNlX2luZm8gLz48cmVxdWVzdF9jb3N0X3Jhbmdl
+      IC8+PC9ldmVudF9zZWFyY2g+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['759']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+077XbbuLH/8xTI3nM27aklkhKpj0TV1nacNF9Oaiubtn94QBIUGZOAQoCWta/T
+        P32Oe1/szgCkRMqyLSebnnQ3OUxCDgaYDwwGA8xo8tNVnpFLVshU8D//4HTtHwjjoYhSPv/zD+9n
+        zzqjH36aPpiwS8aVLxktwsQvmCwzNZ3IMohETlPul5IVfir9gEZTLibW7pZJWKwWSvhBJsKLaeh3
+        OoNOID9+ePsxO5sXrCOfBi/Pxm+PwniUvBpcfTo/jZ+r0/N3R++CgZPZq8M0WDybzdVR8Cn4RzgY
+        HZfe66N3NHl//u5s7B/Lv//8zyv5izwvnw5mvYXb48EiOFu+/NvRy5OX/7x67q6OL5KkR9N4nPUj
+        L14FyRvvb96b08xeHLmdf0ysFn+TKJWK8pBJnxbMv6RZaoTbBTcKmk4AQn1QH5uefJhYmy/TEDEZ
+        Tk9A26tlwgpWIWjoJEzVyuBmgkeCd8oLYGgNNO0a9bVurxqrzhmVsvrP4NNCSUDZAKpGjX8IjeRH
+        mi+e/E9/9IQcw2yWyE4DZQJzpifQDL1iMFobNKms4YKtNDULpn0DQeOo8Opua0hrsA3e9ngRKnn3
+        oEakGqEF3OBoOY5oljFlhCVPtzoYSa0NC1atSCGVX1A+h/FyegUj50HKWTT1el17YrVAGgGYVIsi
+        DdnUHdYYG5hBKUEMWsCQ3hpjDZrkqNd6yJ6jMZogjbAZ0RnVGE0qWp31kP01xoYKF76ElZ0xVNZv
+        U8RPJeUKV4ZYKPBpMJl6hfo1fOpMrC3INkbvToz+nRjunRjenRiD6xjWdfH0HPphWRTguAGlfjPL
+        YR4swKpboA1GTEMliqlj2w2cCrjB4mUesGI66g0aWBVwg7XIKLhE1N02qIGDNidXeSAyqwkGN2qg
+        0//9V7P/Bj6xtsW0brDl7/P/O5n/5qSHouSqqOTTG2cTsG7W/v49TxWLyCuwHYhRNqjVTlqkKg0h
+        xLlM2dJfsCLEfd1oaGfTJKKKGT58xqPqWw82S8oD4khFztlCMdQX6dkOaHGDYrBLFfoijiVT0/4A
+        SW1DN2iShbD9y6njDntDz21j140GfQV/8jwCXwtE7bHtVJhrOOzMYjSwHV+DKY98leZMo3fsccd2
+        Zs74cd9+bNt/sp3HSGl3h2rcbR2Yb4iVCnVNK55KyBu6+jX1Mei5w769tz4827uXPjx4Pkcflfwm
+        gNbmePp+dnx2ePzq5GxiNcAVilbDG6pUwpbkSJQFZ48kOQVxChpegAnNTs5ndUejM/MOUejgxbO6
+        ZR2T+imPxfTHTD2J0ssf5+oJvi7w5RoRqUrOYVmQRSGiMkT/QkTcoP2QFAwiRS5JymHq7BFRgpzT
+        KGMFdP/AskyShF7iEEEhLhgnEH2RQFzBMDHs39A9FEUkSVQWiATBliIriO+QOPTuiFLBC5WCd5FN
+        S/P5YM3xLEkliZlU6SUjCmJnRRBQAhHgExtVQSOW0+IChFllDMHLVB2QBVWJkASmiIDMVEE0QTOS
+        03kadlsCxiLLxFKS44wWFNj6qJWzInEhckJJkDF6QY6TAs4AOZUEgnkCXDwtuk8LIeUj8rZYJJTT
+        OTsAQoUo5wn0kkma50yLDFroyAuq8H0JxsmKDJnSjAnkjcgFCxUNS2CAhABfIU8XKMn5kjGVMuyw
+        Uz1vM9BLQeiSFlFnmZq5BBNJ5xzAhxxUwFfkA7RqejMImdILcSkvViBoXoZJJxOX4BolTBIjdVyG
+        CkyITH/5JcPxwgQaxbygi2RF5iVoiSsGs5GAGm4x24c4UxTUyGRyQLJ00ZE5NMCIBzDjhbYZEBHn
+        L0XDg9nZaDmGc9JOidsEwfaARpikDKUIBLANaw/GSEMtMEgEsxCmMLYsQ9iapJENDSdFW+BUWxaH
+        EasjsUSm9KFAG0ygTxOyS17Xlqs7v8vAlX2AodB+P2gLz8EOYeIKPaVnYgWdT2kl2ExbIFgILAeW
+        Iq9qKQjOXorzhNNnTBWGlqBula3QOAJcP5eI39CFfqtW9gOtmMTF96dlocnpdgN6sMsJHJLnIotS
+        PPHqZak7kQ7hAg5NgMRyxFJC6IHMF4ETKkzbrSia7wPysQQ9oQqKdJ4oQnPcbPVEg6PcQ4wPCTiR
+        Y8rJC+DzpzuF4Sscl6xECSZ2wR6SQ6mZJWAYCo/cj6RejmJJwMV092MA1kIkgIH53QzMrrlDNB8w
+        Tske7kOLqupUPn4iyQseZmXEojup6hsFleASQsk528tCngsBPkCQV1ws76IAPgOdyUPyBqYDfD8S
+        hCnEKdX/yj3onZepouA/yTNYFcdJmkUQyd1F+LzEdaKtCMwfPZv26WhRFFYXy2GHA4PFJbQvH8d4
+        CZBlxtDfiSwNVzdwcSpgwcUlRBAEWGZX4C9hRwcLuqRppkWhsYIVu9CnT1nZc01yvRPj/lvtxehB
+        xdTsQKxGMMAKI2dRSiEMpTq8hygZti01jZzllbvse2WQR+lVN8xEGcGOxFWXMzWxNM4k5RDvgL7w
+        RL0ANwUxUJFNE6UW8rFl3TqEJeH0zCKrwQOEu2IBQa417sMT2m4Q21HPZXE/sj02ilnsBnQ4tMdR
+        bLt9l1GnH3Y/LuYQFO3kY8IphEa4d0kQDoTX3xPcmKe/Knk94uTbUMVORchysQDnKH3kp7oubULa
+        CNV12RZsYrXM5Vu1nSGDx3ZH4cDz4uE4ciizHdcZh+Oe27NHAyeKHW8QjPrxHrYDYd2nku1vOfcm
+        /hUt5968/AYs5wv05WtMqzeGZ+gybzQcDyksurEz9HrBsB/R/timbBCPYjpg7mjQu9t88BYRPC3e
+        SvB9behz+fh6lvS5HO1hT9et5RszqC9agR6Dx7bduOcFHqXBIHb7vTAassGoPw7Aebu9aES92BkG
+        e9jSJzj47O+J7k37K3qie/PyO/VE7Er5ikllW3+SK6lY7m8gKEgGZ7U9DKXCvNNU9if3FWxjf+K/
+        ezcSj+GhFCI+iAPd4TDs2/1oOApCz7GHYWgPPTeKR+6AhqO7rUMVKYL8GA71ezuTe3PwFZ3JvXn5
+        DTiTb9B8RHm3g/luPt+G+Xx57GczeHqeF7nxeBBEdi+gdBjEUa8Hf0MajO1wFA9CFvXd/W1I8L09
+        0Oey8dWD4ntz9FvYzb5cbSEAaC9yvdGYjsbuyPYcF04UEBmGLBzR8ag38Hq9kW2P+/vbk1qKe9rT
+        vdn46vZ0b47+w/ZkFDt48ayTmzxIJ9B5kI7s8HXipYNhnFX3NzqrqvkUVaWcZjr4aIFqhDKIqKJW
+        /a0wpddMMhpA3bpaQLyboui+SoG0WqNhS4VVLjDR52epVK3E5cmOxGU0ffNXuwm3dowxZwLTr6AU
+        vNJVZcSmntP1euOB4/SHE2sNnWAiwLx27K5jD2zHG/QAYQ2eWJvBEip9LjDLH0u9p7QAWNOG9wks
+        WhezVZ+6DqoweVSTDXZ6VSlUC6ormXbgbUMneJvvR2xBC6zR05lmzc8ueIVcZXEaaDXEIKAMosjx
+        Htywfw06wUoNU8Z47JwRd3YKy60GTUwFhKxftDZ0nWf1jXS3QBWqT0uViGI6SxiZgXhAu91Q4wUi
+        Wk2PKcccEyaN85zp1K3JiC0J45hafbjurvHrzo1ag5IdEGeoEnIqLtcVGN66W6PwoAlpVgp4juMM
+        2x02BQMVNKN8PmV8jaW/60ZRpJhZzNAbWGsoTq6h7Nhd2yaHb9a9N00t5CTJcymxFEUXOexo2qCr
+        jE3f8zyVEtMUDxvY2DLBmgS/0NdhWIbU/KxRb5zc2t5vmV3MypLDLFsUTN4+w5jxqhJyDzEtSoBl
+        1mG8I8P/+zdnmADVOXqaHeicTyv5DI0mgx6XVbNUolhVnXiKFQdcVTl/IVmdIup2ScpDcP0p6KZL
+        XjzCGgVGgnKFGTTjumSVu63tjc5pyvVQ+u1Ou8Mal94I7O6wnGPyCgzJvY/VufaoN/pvtDpYs48U
+        mTN1bYnex/astYupqn/rmmv/Ip/aWPW5Az7BmdJuzLhOs4+2YRMJO2TITMXN+pID0BrgGsdUa18p
+        VuikPSCSI9xSwQg2PYzGGh8+VorAQDxO53v1bnWoR2L8U5kWKZM+y2maTc21jPwLqAkXleiGoot1
+        bjeg18OgzwYboFFUTDH/ysjQOyA/p1jhl1KsWwjBQWKmeonZ4HNVMKYOyBHLYixwOJo5PeI9+/ua
+        TnO8mkZ1Y2Qqp2uVrnu0WusuStdKhVPMBIMf0dl5VBBuvUTwbNV9AM4AGwpGzBYAOtSbvymMoHxF
+        wMmwfAEAJdYZWJKilkyxjlm81e0VWaZmlYcm+1uVtWC9BowPjqK75rhmDiy1KEPcXKMqhxs2Mseg
+        CswcV1HvjpxyHf1e0qxkFtYr7urd2JkRu67aaHWefmvFGrostdR1bmv252A/EA/6F1wsK2GaBQY3
+        CHSfuoIN1TYt2NgL4zU0ibfV5w0Uvxe9fS96+1709l9e9LZxBZvFjz8QwVNTxBTsgLJy2doHvDNN
+        pGoi2AQHnVsc7ZEQFyRYkb6NIRwMnWmxGkekapNxbPKyBE47+FbFeijEAnTDgXsYBynHYCzgV9bx
+        5C5Rdgsgq6opHwj7YVU1Vcm1s6LqBom+oJBqw+INzCxhGSC/plytYu6mYrYb+Lu9hm3DwjatZcK4
+        Dx7DT/25WJNuFg3etJd+fq1gk5sWdf2rPj8SW8w0CghvYGa/usEW3SYh61qo0jidtX/EsKthAoFV
+        yUxUdwYHJTgmwzZ8qKFIPSiIpV3QC4neUJmq0jXU/B6xBXr/CnjdDFoR0NH1+eHT1ydn5x9OXr8+
+        r5FM2G3edUDdVkaNZmJt867FnJ0d/nzyukW59XEKvgrjyve45cxhY+LRY9gS5iwjfzgFFwNa5DD5
+        nP3x7jHOYFE+1r8agX0St72tIdBZ6aFvGYuQWYnoLIawqtShleEG790w8NAOWw+uwzBBI9xo9ckX
+        oQgwJ9NzRV6KhFcRe5dsTxt6Ue1w6mBO+3z8rIoPCQ2QA7AJkjP4hvBELHmrT7fWuzGpyzRiYHBx
+        YQy48eVvbrRb4IThMNM+XrjsatjCxovu5XLZhRWpyoDBESff7qfvwlsgcweKVzuR9dx5uTj56/P0
+        lwt3q6O59myBrmeNbmm+pWt1X3sbQrs3HMh97Tfqa/T1dfWW8HdKdX2kGyj9WnR2UlmmESjXxdvL
+        HfA2sL7CXV/ltn9R/v+e+0Ywjj4AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:31 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3898']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:40 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_extra_info /><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_video_iframe
-      /><request_reviews /><request_cost_range /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><request_source_info
-      /><mime_text_type>html</mime_text_type></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['903']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1b63LbNhb+n6dAujPtj9oiKVG3hlXXtZ1sNmmS2s5ms384IAmKjEhCBkAr6uvs
-        m+yT7TkASZGSfMsm07TrjCYmDz6cO248pPfTxzwjV0zIlBc/fuP07G8IK0IepcX8x2/eXjw9nHzz
-        0+yRx65YoXzJqAgTXzBZZmrmyTKIeE7Twi8lE34q/YBGszWTnrW/yQvFeqm4H2Q8XMze+oeHV4tl
-        PF0cT5dvh6+Dw7ngceSoZ6vw1Zv3HwYslB8GJ++d0YdfF6/t9++Kk6v84kUijwZL/+Pby/HZy6fr
-        k3B4eBY58ejFZVy+f345P3oqX58Vq/UltS+c0WtX+Cf54OXz01/Xl+L0w+Vkmon+m+fFdHCyWM2z
-        957V0cmLUqloETLpU8H8K5ql0azgnrWPbrwy84BCffAZm52+86zNnWmImAxnp+Di9SphglUATfWC
-        dF4ukVvJZo5te1ab4IWpWhtOGS8iXhyWC1C3IZp2zeilbq8aDeswo1JWfwxeJYwqVKBFq9p1l4tu
-        u2EDkdNhNOx0bLskr0qKBVvXEiyI/4aIaVJB654NpcNvg9vDcpFGcj9bY0jV3qFtINqWpzRPs3UL
-        ZCy0NnKt2mlcKl/QYg48AgbXOiA+j2MmIKqB5FmpmC/pFQyTmTPoQeS2qV5cZhnokQdpwaLZsI+g
-        Ls1AwCa1FGnIZu64wWyIFagEu6kAhYYbTEPztGYbxoMpgraIFWjDeTDcoFryKkLD3G2hNhKXTISQ
-        /HTeGNwfetYuFVJ6x4E5/bita4ekAab/g88/yee7DtSULTW6NAPpqtAleTmO+to2xyDapAoA8b4m
-        bO4douZMbo9aC3N91Ow7RM1x7xK1NuqGqNl3jVr/mqhteQ/vt5Xo0gykq0CX5BXcl8A+Y9J/mNYe
-        prU/tM8fprWHaa0Sf1nSQuFuly8VHF1g06b35H5NnzmetUXZRvRvRQxuRbi3Ioa3Ika7CGvXPD1v
-        +2EpBJzPAFJfma3uPFjC7rVD2iBiGiouzAFjm7hBFWUeQHgm/VELVRE3qGVG4RCEvtsmtTAYbLnO
-        A55ZbTIcnAx19p9/t/tv6J61babiS18nxcOU+UlT5o7/rGs2BA8D6mFAPQyoTxlQ7VEU8rJQokoY
-        /bimTWia9ZOHt0WqWEReAN+I5xto9fxGpCoNfcGuUrbyK02qlNvb5EUUwmXCzYqouq+e7JQHxJmo
-        hByV81Iq0rcdSMoNwGBLFaJRkqnZYISCtqkbmGQhLyIJq/fYGbpDu4OuGw18Df/yPIpmKNSeOJMK
-        2dC9VPLJyHZ8TaZF5Ks0Zxp+aE8OncmFM/1hYP9g29/bzg8oaX+Hiu+2B8y9VFSoHZ/0HXDGEYQz
-        +5wuGTn90cC9s0vcvnMvl7iHfedTXFK5wDzK1fn46u3F8dnR8YvTM89qkSuIdsMvVKmErcjPvBQF
-        +06SV2COoOGCicd1J+Mvc51Gs9Hzp3VL85DUT4uYz77N1JMovfp2rp50+X5L8+WTvwymTySRqiwK
-        GBJkKXhUhjhZEx63xRLBFHSSJC0gavaEKE7OaZQx0WLzjmWZJIketSQQfMEKQrOMBPwjsIth/AKb
-        kItIkqgUCMoo5MKa0TYXCVwOeanggkpe9NCAQBALLXjUublIUkliOBOmV4woAfMPQQJMbKg9NipB
-        I5ZTsQAT1xlD8ipVB2RJVcIlgZgR87AzDWlGcjpPw17H7JhnGV9JcpxRQVtKftAuXJNY8JxQEmSM
-        LshxIlKpcirJKSgE2pyI3ongUjYdyWuxTGgBk9sBCBa8nCfQWyZpnjPtEPDRoVxQhdcryF4mMlRS
-        K8pRVyKXLFQ0LEEhEgJ9jTou0LLzFWMqZdjhBqe9zsBbgtAVFdHhKjVxh2xK5wWQjwpwTLEm76BV
-        S72A2Tpd8Cu5WLfMz8swOcz4FUylEgLKSL1EoHsTItPffsuQb5hAI58LukzWZF6CDwvFIFYJOOfa
-        bGz7H2JIwclMJgckS5eHMocG4HwA2SF0noHhGOUUkxZiuIlBTAW7wQ9d8ZC1IClMUoY2BRyMgIEL
-        nNJQuwHsgwiFKUiQZQg7BWksxSRLMW8KqrOwAI5VZUeiavrhtk6uAEYCU7JHXtY5rzu/ySh4G1hh
-        xr/TYyOHnIWgCh3uM76Gzq9oZV5VLzjAgcRS1FWtOMGYphg9DKpJa2AtwfkqW2PiBDjyrhCvPWJV
-        E8Ij7ZLExet3CYzWY1qQ5+QZ/0mjTMOj1gxyVKxxjiNrXkI4FuwxOZIk4xAGcJ/CUksrjpjYfEVg
-        CPdukgrZc8JvlIqXS7y4qCed7+rJBl0MAZTsse67rOH7ZVHVUu95EWZlxKLrpOrykUowx9Dcgt3g
-        vGecw1Dh5EXBV9ewgxGFQ+0x+QX8DLMocicqnSfK/C+vZX5eporCDEOeQk4cJ2kWwbbyGinnJSbH
-        B9xvQMxxkOtJDzOJQkqxHNYFyCTMmz1CmyUEF45qEcFxzDd1rDaxQuQsSilsnqje5cNmGaZWNdPU
-        HoyfBWQ9jJUw6YW449KNXlrA6gy64t5yCeMCVmyRzRKllvIHy9rf15KwcWSR1ZIK2zK+hM2YNR3A
-        L7TdILajvsviQWQP2SRmsRvQ8dieRrHtDlxGnUHY+7Ccw9q9VwGvoLCC4wwqwRwwV997uFzMPqt4
-        zdH7nX2w1wOyXC5h3pA+KqLLsF1KFyDr0nOH5lmdzPh60mTM4Ge7k3A0HMbjaeRQZjuuMw2nfbdv
-        T0ZOFDvDUTAZxHdIE9hXXJbs7klyb+FfIknurcT/X5IMGfxs2437w2BIaTCK3UE/jMZsNBlMAxhI
-        bj+a0GHsjIPbk0Rewq7n7jlyb9lfIkfurcTXkCORs/rorgbDMsij9GMvzHgZwe68UL2CqdtTBRx1
-        I4d9/mIfla/g+GFb38u1VCz3NxQ0JIM92R0ypELemiN3F3d7UnxBW++QDLuh/mPPGPEUfpTCQgvL
-        rzsehwN7EI0nQTh07HEY2uOhG8UTd0TDye35AIdRJPkxbNfvPG/cW4MvMW/cW4mvYd74M2QKnIAe
-        MuXPuMJU/vI10poO4RdMw8Cl00lMx8HQcQPXHbn2dEztyTgOgnEwdpwwpHdPHjgM3jV3PlWNL7Ac
-        /Y8afRVr1O+eT/0h/OzRMJqGo4j2w9Fo7AymcD8eUzdy3cFoOgqd4TQa3COfVCLufib6VEW+eEbd
-        W6OvIqP+BGuZWvGHpewzLmVSUVXKWaY3kx1SDSiDiCpq1fcKyzbtepIh1K3rJZxYUlTdN15qYNhS
-        ocolFnH8LJWqU6M63VOjuq52BfQXb9t0aw/vOeNYfQNrM6pSVUZsNnR6Q89qbj18Om0uD+2eg00N
-        wbM2/RMq/YJjYTeW2v8dAr5Fj/VtFjWvz1e3+lU3Ycpnpv7n9Ku33TpU/XrVHtw21cPnzH7EllQo
-        TBOsJWp99tErcCl0eaAFqykGgDZwkeOnFEb9HaqHbzuYrymOnTPiXryCwVKTPFP0lvWF9ob+xKS6
-        R7lbpArq01IlXOBnDuQCzAPZ3YYaF/BoPTumRcGVrhHmOdO1OVPGWBFWYK3scdNd4+vOrQJzyQ6I
-        M1YJecWvGL71gTXmYdOtVWpuU9q14aHjOONuh02JuKJmtJjPWNGg9H3dyEWK5aAMB7bVUDG4RvKw
-        15+SN780nTctHWyS5LmUM2fcn2KRfE/TBq4yNntb5KmUWCd43EJji4dFaF/ooiK+ydO+raHNxeZL
-        kPrrG3+Rm7cB99A9DI7OJJO9Zlrq0jwJxxOA01jh+x8UX4JiOU2zWVhKxXMmdCkvZPKvoJFgUnKY
-        c3v4Ise1PWueOj+bBxFNh+pLFHNjEgPaybl+cEH+xQRvoMbxrRsfS7rAoYjT+c3dOsiaBSsuy1Sk
-        97Zxu1/NLy3A9qIq//kx/Tj73nUhqQfEGYzHrtNvOOwi9/NYJrDl73Lp29dwMdiaT8bDirO9T4FN
-        c7eDYWLvk9YG1J1w3gEijSIxw9IXI+PhAflHim96pRQLpiEMciz/rbDqdq5gv6kOyM8si7Gy+vOF
-        0yfDp/9sZLT51TKqR1jm06M6f5oenda6i9JveIQzLMLBTKcLnpgduHwQXmTr3iOY5bBBMGKmMZoR
-        vWaZiiwt1oQqYLwEguJkqd+Egg5gYi7NmwRmwqsep5FVii9PMCzzh2BuVV3HQjHwh2TqNRrXysFQ
-        F2WIC0RUFfHQbIZm6D3Vkbmrd1jmm7emvHrGJQuwLHkEWuNM+lxioU/x4oCYr902RVb9uh9+MGc1
-        EuYQDtgt+IuCryp57bpoR6iFi28HD/O1MDORhr2ubnd6bXD4RhiumxFTMGJkZbCGvzFNpGoi2ARL
-        HWb1DsP9bGRVdPWhox9WRdeK+96C7A7fazisEqpQiCk+VxyvK03vMN3uvUpY4UN++Kk/5w2zdiV/
-        D4tOF/2BpB/xLQ6tqvw12XK3YvwmT7YEWTupqpPOjNN9xf/7ZOdWVbvFuZKiV4jzo5OXp2fn705f
-        vjyvQWbpMNd6bejaWMPMsmGum9estGhScSWaLXl+To7Im5dHx6cdn2w6eldpBLvQNBbGya07f3O8
-        65AThrX72QA3NvsattB4+FutVr01zBxlwMyRcBfS7WUOX7iFiqxnzt+Xp397lv62cLc6mgNVh7R7
-        krmh+Yau1RnnJkC3N2y3fJ3b9TGzOdRtGX+rVbucrpH0ueTslbJKI3CuXi330LvE+nTUnJK6X43/
-        F5UfhalyPgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3543']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:31 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/EventReviewsTests.test_critic_reviews.yaml
+++ b/tests/interface_objects/cassettes/EventReviewsTests.test_critic_reviews.yaml
@@ -1,137 +1,114 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF92aWRlb19pZnJhbWUgLz48
+      cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNj
+      YXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21l
+      ZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9m
+      b3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlh
+      PnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVx
+      dWVzdF9tZWRpYT48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHJlcXVlc3RfcmV2aWV3cyAvPjxyZXF1
+      ZXN0X2N1c3RvbV9maWVsZHMgLz48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxtaW1lX3RleHRfdHlw
+      ZT5odG1sPC9taW1lX3RleHRfdHlwZT48cmVxdWVzdF9tZXRhX2NvbXBvbmVudHMgLz48cmVxdWVz
+      dF9leHRyYV9pbmZvIC8+PHJlcXVlc3Rfc291cmNlX2luZm8gLz48cmVxdWVzdF9jb3N0X3Jhbmdl
+      IC8+PC9ldmVudF9zZWFyY2g+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['759']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+077XbbuLH/8xTI3nM27aklkhKpj0TV1nacNF9Oaiubtn94QBIUGZOAQoCWta/T
+        P32Oe1/szgCkRMqyLSebnnQ3OUxCDgaYDwwGA8xo8tNVnpFLVshU8D//4HTtHwjjoYhSPv/zD+9n
+        zzqjH36aPpiwS8aVLxktwsQvmCwzNZ3IMohETlPul5IVfir9gEZTLibW7pZJWKwWSvhBJsKLaeh3
+        OoNOID9+ePsxO5sXrCOfBi/Pxm+PwniUvBpcfTo/jZ+r0/N3R++CgZPZq8M0WDybzdVR8Cn4RzgY
+        HZfe66N3NHl//u5s7B/Lv//8zyv5izwvnw5mvYXb48EiOFu+/NvRy5OX/7x67q6OL5KkR9N4nPUj
+        L14FyRvvb96b08xeHLmdf0ysFn+TKJWK8pBJnxbMv6RZaoTbBTcKmk4AQn1QH5uefJhYmy/TEDEZ
+        Tk9A26tlwgpWIWjoJEzVyuBmgkeCd8oLYGgNNO0a9bVurxqrzhmVsvrP4NNCSUDZAKpGjX8IjeRH
+        mi+e/E9/9IQcw2yWyE4DZQJzpifQDL1iMFobNKms4YKtNDULpn0DQeOo8Opua0hrsA3e9ngRKnn3
+        oEakGqEF3OBoOY5oljFlhCVPtzoYSa0NC1atSCGVX1A+h/FyegUj50HKWTT1el17YrVAGgGYVIsi
+        DdnUHdYYG5hBKUEMWsCQ3hpjDZrkqNd6yJ6jMZogjbAZ0RnVGE0qWp31kP01xoYKF76ElZ0xVNZv
+        U8RPJeUKV4ZYKPBpMJl6hfo1fOpMrC3INkbvToz+nRjunRjenRiD6xjWdfH0HPphWRTguAGlfjPL
+        YR4swKpboA1GTEMliqlj2w2cCrjB4mUesGI66g0aWBVwg7XIKLhE1N02qIGDNidXeSAyqwkGN2qg
+        0//9V7P/Bj6xtsW0brDl7/P/O5n/5qSHouSqqOTTG2cTsG7W/v49TxWLyCuwHYhRNqjVTlqkKg0h
+        xLlM2dJfsCLEfd1oaGfTJKKKGT58xqPqWw82S8oD4khFztlCMdQX6dkOaHGDYrBLFfoijiVT0/4A
+        SW1DN2iShbD9y6njDntDz21j140GfQV/8jwCXwtE7bHtVJhrOOzMYjSwHV+DKY98leZMo3fsccd2
+        Zs74cd9+bNt/sp3HSGl3h2rcbR2Yb4iVCnVNK55KyBu6+jX1Mei5w769tz4827uXPjx4Pkcflfwm
+        gNbmePp+dnx2ePzq5GxiNcAVilbDG6pUwpbkSJQFZ48kOQVxChpegAnNTs5ndUejM/MOUejgxbO6
+        ZR2T+imPxfTHTD2J0ssf5+oJvi7w5RoRqUrOYVmQRSGiMkT/QkTcoP2QFAwiRS5JymHq7BFRgpzT
+        KGMFdP/AskyShF7iEEEhLhgnEH2RQFzBMDHs39A9FEUkSVQWiATBliIriO+QOPTuiFLBC5WCd5FN
+        S/P5YM3xLEkliZlU6SUjCmJnRRBQAhHgExtVQSOW0+IChFllDMHLVB2QBVWJkASmiIDMVEE0QTOS
+        03kadlsCxiLLxFKS44wWFNj6qJWzInEhckJJkDF6QY6TAs4AOZUEgnkCXDwtuk8LIeUj8rZYJJTT
+        OTsAQoUo5wn0kkma50yLDFroyAuq8H0JxsmKDJnSjAnkjcgFCxUNS2CAhABfIU8XKMn5kjGVMuyw
+        Uz1vM9BLQeiSFlFnmZq5BBNJ5xzAhxxUwFfkA7RqejMImdILcSkvViBoXoZJJxOX4BolTBIjdVyG
+        CkyITH/5JcPxwgQaxbygi2RF5iVoiSsGs5GAGm4x24c4UxTUyGRyQLJ00ZE5NMCIBzDjhbYZEBHn
+        L0XDg9nZaDmGc9JOidsEwfaARpikDKUIBLANaw/GSEMtMEgEsxCmMLYsQ9iapJENDSdFW+BUWxaH
+        EasjsUSm9KFAG0ygTxOyS17Xlqs7v8vAlX2AodB+P2gLz8EOYeIKPaVnYgWdT2kl2ExbIFgILAeW
+        Iq9qKQjOXorzhNNnTBWGlqBula3QOAJcP5eI39CFfqtW9gOtmMTF96dlocnpdgN6sMsJHJLnIotS
+        PPHqZak7kQ7hAg5NgMRyxFJC6IHMF4ETKkzbrSia7wPysQQ9oQqKdJ4oQnPcbPVEg6PcQ4wPCTiR
+        Y8rJC+DzpzuF4Sscl6xECSZ2wR6SQ6mZJWAYCo/cj6RejmJJwMV092MA1kIkgIH53QzMrrlDNB8w
+        Tske7kOLqupUPn4iyQseZmXEojup6hsFleASQsk528tCngsBPkCQV1ws76IAPgOdyUPyBqYDfD8S
+        hCnEKdX/yj3onZepouA/yTNYFcdJmkUQyd1F+LzEdaKtCMwfPZv26WhRFFYXy2GHA4PFJbQvH8d4
+        CZBlxtDfiSwNVzdwcSpgwcUlRBAEWGZX4C9hRwcLuqRppkWhsYIVu9CnT1nZc01yvRPj/lvtxehB
+        xdTsQKxGMMAKI2dRSiEMpTq8hygZti01jZzllbvse2WQR+lVN8xEGcGOxFWXMzWxNM4k5RDvgL7w
+        RL0ANwUxUJFNE6UW8rFl3TqEJeH0zCKrwQOEu2IBQa417sMT2m4Q21HPZXE/sj02ilnsBnQ4tMdR
+        bLt9l1GnH3Y/LuYQFO3kY8IphEa4d0kQDoTX3xPcmKe/Knk94uTbUMVORchysQDnKH3kp7oubULa
+        CNV12RZsYrXM5Vu1nSGDx3ZH4cDz4uE4ciizHdcZh+Oe27NHAyeKHW8QjPrxHrYDYd2nku1vOfcm
+        /hUt5968/AYs5wv05WtMqzeGZ+gybzQcDyksurEz9HrBsB/R/timbBCPYjpg7mjQu9t88BYRPC3e
+        SvB9behz+fh6lvS5HO1hT9et5RszqC9agR6Dx7bduOcFHqXBIHb7vTAassGoPw7Aebu9aES92BkG
+        e9jSJzj47O+J7k37K3qie/PyO/VE7Er5ikllW3+SK6lY7m8gKEgGZ7U9DKXCvNNU9if3FWxjf+K/
+        ezcSj+GhFCI+iAPd4TDs2/1oOApCz7GHYWgPPTeKR+6AhqO7rUMVKYL8GA71ezuTe3PwFZ3JvXn5
+        DTiTb9B8RHm3g/luPt+G+Xx57GczeHqeF7nxeBBEdi+gdBjEUa8Hf0MajO1wFA9CFvXd/W1I8L09
+        0Oey8dWD4ntz9FvYzb5cbSEAaC9yvdGYjsbuyPYcF04UEBmGLBzR8ag38Hq9kW2P+/vbk1qKe9rT
+        vdn46vZ0b47+w/ZkFDt48ayTmzxIJ9B5kI7s8HXipYNhnFX3NzqrqvkUVaWcZjr4aIFqhDKIqKJW
+        /a0wpddMMhpA3bpaQLyboui+SoG0WqNhS4VVLjDR52epVK3E5cmOxGU0ffNXuwm3dowxZwLTr6AU
+        vNJVZcSmntP1euOB4/SHE2sNnWAiwLx27K5jD2zHG/QAYQ2eWJvBEip9LjDLH0u9p7QAWNOG9wks
+        WhezVZ+6DqoweVSTDXZ6VSlUC6ormXbgbUMneJvvR2xBC6zR05lmzc8ueIVcZXEaaDXEIKAMosjx
+        Htywfw06wUoNU8Z47JwRd3YKy60GTUwFhKxftDZ0nWf1jXS3QBWqT0uViGI6SxiZgXhAu91Q4wUi
+        Wk2PKcccEyaN85zp1K3JiC0J45hafbjurvHrzo1ag5IdEGeoEnIqLtcVGN66W6PwoAlpVgp4juMM
+        2x02BQMVNKN8PmV8jaW/60ZRpJhZzNAbWGsoTq6h7Nhd2yaHb9a9N00t5CTJcymxFEUXOexo2qCr
+        jE3f8zyVEtMUDxvY2DLBmgS/0NdhWIbU/KxRb5zc2t5vmV3MypLDLFsUTN4+w5jxqhJyDzEtSoBl
+        1mG8I8P/+zdnmADVOXqaHeicTyv5DI0mgx6XVbNUolhVnXiKFQdcVTl/IVmdIup2ScpDcP0p6KZL
+        XjzCGgVGgnKFGTTjumSVu63tjc5pyvVQ+u1Ou8Mal94I7O6wnGPyCgzJvY/VufaoN/pvtDpYs48U
+        mTN1bYnex/astYupqn/rmmv/Ip/aWPW5Az7BmdJuzLhOs4+2YRMJO2TITMXN+pID0BrgGsdUa18p
+        VuikPSCSI9xSwQg2PYzGGh8+VorAQDxO53v1bnWoR2L8U5kWKZM+y2maTc21jPwLqAkXleiGoot1
+        bjeg18OgzwYboFFUTDH/ysjQOyA/p1jhl1KsWwjBQWKmeonZ4HNVMKYOyBHLYixwOJo5PeI9+/ua
+        TnO8mkZ1Y2Qqp2uVrnu0WusuStdKhVPMBIMf0dl5VBBuvUTwbNV9AM4AGwpGzBYAOtSbvymMoHxF
+        wMmwfAEAJdYZWJKilkyxjlm81e0VWaZmlYcm+1uVtWC9BowPjqK75rhmDiy1KEPcXKMqhxs2Mseg
+        CswcV1HvjpxyHf1e0qxkFtYr7urd2JkRu67aaHWefmvFGrostdR1bmv252A/EA/6F1wsK2GaBQY3
+        CHSfuoIN1TYt2NgL4zU0ibfV5w0Uvxe9fS96+1709l9e9LZxBZvFjz8QwVNTxBTsgLJy2doHvDNN
+        pGoi2AQHnVsc7ZEQFyRYkb6NIRwMnWmxGkekapNxbPKyBE47+FbFeijEAnTDgXsYBynHYCzgV9bx
+        5C5Rdgsgq6opHwj7YVU1Vcm1s6LqBom+oJBqw+INzCxhGSC/plytYu6mYrYb+Lu9hm3DwjatZcK4
+        Dx7DT/25WJNuFg3etJd+fq1gk5sWdf2rPj8SW8w0CghvYGa/usEW3SYh61qo0jidtX/EsKthAoFV
+        yUxUdwYHJTgmwzZ8qKFIPSiIpV3QC4neUJmq0jXU/B6xBXr/CnjdDFoR0NH1+eHT1ydn5x9OXr8+
+        r5FM2G3edUDdVkaNZmJt867FnJ0d/nzyukW59XEKvgrjyve45cxhY+LRY9gS5iwjfzgFFwNa5DD5
+        nP3x7jHOYFE+1r8agX0St72tIdBZ6aFvGYuQWYnoLIawqtShleEG790w8NAOWw+uwzBBI9xo9ckX
+        oQgwJ9NzRV6KhFcRe5dsTxt6Ue1w6mBO+3z8rIoPCQ2QA7AJkjP4hvBELHmrT7fWuzGpyzRiYHBx
+        YQy48eVvbrRb4IThMNM+XrjsatjCxovu5XLZhRWpyoDBESff7qfvwlsgcweKVzuR9dx5uTj56/P0
+        lwt3q6O59myBrmeNbmm+pWt1X3sbQrs3HMh97Tfqa/T1dfWW8HdKdX2kGyj9WnR2UlmmESjXxdvL
+        HfA2sL7CXV/ltn9R/v+e+0Ywjj4AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:31 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3898']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:40 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_extra_info /><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_video_iframe
-      /><request_reviews /><request_cost_range /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><request_source_info
-      /><mime_text_type>html</mime_text_type></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['903']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1b63LbNhb+n6dAujPtj9oiKVG3hlXXtZ1sNmmS2s5ms384IAmKjEhCBkAr6uvs
-        m+yT7TkASZGSfMsm07TrjCYmDz6cO248pPfTxzwjV0zIlBc/fuP07G8IK0IepcX8x2/eXjw9nHzz
-        0+yRx65YoXzJqAgTXzBZZmrmyTKIeE7Twi8lE34q/YBGszWTnrW/yQvFeqm4H2Q8XMze+oeHV4tl
-        PF0cT5dvh6+Dw7ngceSoZ6vw1Zv3HwYslB8GJ++d0YdfF6/t9++Kk6v84kUijwZL/+Pby/HZy6fr
-        k3B4eBY58ejFZVy+f345P3oqX58Vq/UltS+c0WtX+Cf54OXz01/Xl+L0w+Vkmon+m+fFdHCyWM2z
-        957V0cmLUqloETLpU8H8K5ql0azgnrWPbrwy84BCffAZm52+86zNnWmImAxnp+Di9SphglUATfWC
-        dF4ukVvJZo5te1ab4IWpWhtOGS8iXhyWC1C3IZp2zeilbq8aDeswo1JWfwxeJYwqVKBFq9p1l4tu
-        u2EDkdNhNOx0bLskr0qKBVvXEiyI/4aIaVJB654NpcNvg9vDcpFGcj9bY0jV3qFtINqWpzRPs3UL
-        ZCy0NnKt2mlcKl/QYg48AgbXOiA+j2MmIKqB5FmpmC/pFQyTmTPoQeS2qV5cZhnokQdpwaLZsI+g
-        Ls1AwCa1FGnIZu64wWyIFagEu6kAhYYbTEPztGYbxoMpgraIFWjDeTDcoFryKkLD3G2hNhKXTISQ
-        /HTeGNwfetYuFVJ6x4E5/bita4ekAab/g88/yee7DtSULTW6NAPpqtAleTmO+to2xyDapAoA8b4m
-        bO4douZMbo9aC3N91Ow7RM1x7xK1NuqGqNl3jVr/mqhteQ/vt5Xo0gykq0CX5BXcl8A+Y9J/mNYe
-        prU/tM8fprWHaa0Sf1nSQuFuly8VHF1g06b35H5NnzmetUXZRvRvRQxuRbi3Ioa3Ika7CGvXPD1v
-        +2EpBJzPAFJfma3uPFjC7rVD2iBiGiouzAFjm7hBFWUeQHgm/VELVRE3qGVG4RCEvtsmtTAYbLnO
-        A55ZbTIcnAx19p9/t/tv6J61babiS18nxcOU+UlT5o7/rGs2BA8D6mFAPQyoTxlQ7VEU8rJQokoY
-        /bimTWia9ZOHt0WqWEReAN+I5xto9fxGpCoNfcGuUrbyK02qlNvb5EUUwmXCzYqouq+e7JQHxJmo
-        hByV81Iq0rcdSMoNwGBLFaJRkqnZYISCtqkbmGQhLyIJq/fYGbpDu4OuGw18Df/yPIpmKNSeOJMK
-        2dC9VPLJyHZ8TaZF5Ks0Zxp+aE8OncmFM/1hYP9g29/bzg8oaX+Hiu+2B8y9VFSoHZ/0HXDGEYQz
-        +5wuGTn90cC9s0vcvnMvl7iHfedTXFK5wDzK1fn46u3F8dnR8YvTM89qkSuIdsMvVKmErcjPvBQF
-        +06SV2COoOGCicd1J+Mvc51Gs9Hzp3VL85DUT4uYz77N1JMovfp2rp50+X5L8+WTvwymTySRqiwK
-        GBJkKXhUhjhZEx63xRLBFHSSJC0gavaEKE7OaZQx0WLzjmWZJIketSQQfMEKQrOMBPwjsIth/AKb
-        kItIkqgUCMoo5MKa0TYXCVwOeanggkpe9NCAQBALLXjUublIUkliOBOmV4woAfMPQQJMbKg9NipB
-        I5ZTsQAT1xlD8ipVB2RJVcIlgZgR87AzDWlGcjpPw17H7JhnGV9JcpxRQVtKftAuXJNY8JxQEmSM
-        LshxIlKpcirJKSgE2pyI3ongUjYdyWuxTGgBk9sBCBa8nCfQWyZpnjPtEPDRoVxQhdcryF4mMlRS
-        K8pRVyKXLFQ0LEEhEgJ9jTou0LLzFWMqZdjhBqe9zsBbgtAVFdHhKjVxh2xK5wWQjwpwTLEm76BV
-        S72A2Tpd8Cu5WLfMz8swOcz4FUylEgLKSL1EoHsTItPffsuQb5hAI58LukzWZF6CDwvFIFYJOOfa
-        bGz7H2JIwclMJgckS5eHMocG4HwA2SF0noHhGOUUkxZiuIlBTAW7wQ9d8ZC1IClMUoY2BRyMgIEL
-        nNJQuwHsgwiFKUiQZQg7BWksxSRLMW8KqrOwAI5VZUeiavrhtk6uAEYCU7JHXtY5rzu/ySh4G1hh
-        xr/TYyOHnIWgCh3uM76Gzq9oZV5VLzjAgcRS1FWtOMGYphg9DKpJa2AtwfkqW2PiBDjyrhCvPWJV
-        E8Ij7ZLExet3CYzWY1qQ5+QZ/0mjTMOj1gxyVKxxjiNrXkI4FuwxOZIk4xAGcJ/CUksrjpjYfEVg
-        CPdukgrZc8JvlIqXS7y4qCed7+rJBl0MAZTsse67rOH7ZVHVUu95EWZlxKLrpOrykUowx9Dcgt3g
-        vGecw1Dh5EXBV9ewgxGFQ+0x+QX8DLMocicqnSfK/C+vZX5eporCDEOeQk4cJ2kWwbbyGinnJSbH
-        B9xvQMxxkOtJDzOJQkqxHNYFyCTMmz1CmyUEF45qEcFxzDd1rDaxQuQsSilsnqje5cNmGaZWNdPU
-        HoyfBWQ9jJUw6YW449KNXlrA6gy64t5yCeMCVmyRzRKllvIHy9rf15KwcWSR1ZIK2zK+hM2YNR3A
-        L7TdILajvsviQWQP2SRmsRvQ8dieRrHtDlxGnUHY+7Ccw9q9VwGvoLCC4wwqwRwwV997uFzMPqt4
-        zdH7nX2w1wOyXC5h3pA+KqLLsF1KFyDr0nOH5lmdzPh60mTM4Ge7k3A0HMbjaeRQZjuuMw2nfbdv
-        T0ZOFDvDUTAZxHdIE9hXXJbs7klyb+FfIknurcT/X5IMGfxs2437w2BIaTCK3UE/jMZsNBlMAxhI
-        bj+a0GHsjIPbk0Rewq7n7jlyb9lfIkfurcTXkCORs/rorgbDMsij9GMvzHgZwe68UL2CqdtTBRx1
-        I4d9/mIfla/g+GFb38u1VCz3NxQ0JIM92R0ypELemiN3F3d7UnxBW++QDLuh/mPPGPEUfpTCQgvL
-        rzsehwN7EI0nQTh07HEY2uOhG8UTd0TDye35AIdRJPkxbNfvPG/cW4MvMW/cW4mvYd74M2QKnIAe
-        MuXPuMJU/vI10poO4RdMw8Cl00lMx8HQcQPXHbn2dEztyTgOgnEwdpwwpHdPHjgM3jV3PlWNL7Ac
-        /Y8afRVr1O+eT/0h/OzRMJqGo4j2w9Fo7AymcD8eUzdy3cFoOgqd4TQa3COfVCLufib6VEW+eEbd
-        W6OvIqP+BGuZWvGHpewzLmVSUVXKWaY3kx1SDSiDiCpq1fcKyzbtepIh1K3rJZxYUlTdN15qYNhS
-        ocolFnH8LJWqU6M63VOjuq52BfQXb9t0aw/vOeNYfQNrM6pSVUZsNnR6Q89qbj18Om0uD+2eg00N
-        wbM2/RMq/YJjYTeW2v8dAr5Fj/VtFjWvz1e3+lU3Ycpnpv7n9Ku33TpU/XrVHtw21cPnzH7EllQo
-        TBOsJWp99tErcCl0eaAFqykGgDZwkeOnFEb9HaqHbzuYrymOnTPiXryCwVKTPFP0lvWF9ob+xKS6
-        R7lbpArq01IlXOBnDuQCzAPZ3YYaF/BoPTumRcGVrhHmOdO1OVPGWBFWYK3scdNd4+vOrQJzyQ6I
-        M1YJecWvGL71gTXmYdOtVWpuU9q14aHjOONuh02JuKJmtJjPWNGg9H3dyEWK5aAMB7bVUDG4RvKw
-        15+SN780nTctHWyS5LmUM2fcn2KRfE/TBq4yNntb5KmUWCd43EJji4dFaF/ooiK+ydO+raHNxeZL
-        kPrrG3+Rm7cB99A9DI7OJJO9Zlrq0jwJxxOA01jh+x8UX4JiOU2zWVhKxXMmdCkvZPKvoJFgUnKY
-        c3v4Ise1PWueOj+bBxFNh+pLFHNjEgPaybl+cEH+xQRvoMbxrRsfS7rAoYjT+c3dOsiaBSsuy1Sk
-        97Zxu1/NLy3A9qIq//kx/Tj73nUhqQfEGYzHrtNvOOwi9/NYJrDl73Lp29dwMdiaT8bDirO9T4FN
-        c7eDYWLvk9YG1J1w3gEijSIxw9IXI+PhAflHim96pRQLpiEMciz/rbDqdq5gv6kOyM8si7Gy+vOF
-        0yfDp/9sZLT51TKqR1jm06M6f5oenda6i9JveIQzLMLBTKcLnpgduHwQXmTr3iOY5bBBMGKmMZoR
-        vWaZiiwt1oQqYLwEguJkqd+Egg5gYi7NmwRmwqsep5FVii9PMCzzh2BuVV3HQjHwh2TqNRrXysFQ
-        F2WIC0RUFfHQbIZm6D3Vkbmrd1jmm7emvHrGJQuwLHkEWuNM+lxioU/x4oCYr902RVb9uh9+MGc1
-        EuYQDtgt+IuCryp57bpoR6iFi28HD/O1MDORhr2ubnd6bXD4RhiumxFTMGJkZbCGvzFNpGoi2ARL
-        HWb1DsP9bGRVdPWhox9WRdeK+96C7A7fazisEqpQiCk+VxyvK03vMN3uvUpY4UN++Kk/5w2zdiV/
-        D4tOF/2BpB/xLQ6tqvw12XK3YvwmT7YEWTupqpPOjNN9xf/7ZOdWVbvFuZKiV4jzo5OXp2fn705f
-        vjyvQWbpMNd6bejaWMPMsmGum9estGhScSWaLXl+To7Im5dHx6cdn2w6eldpBLvQNBbGya07f3O8
-        65AThrX72QA3NvsattB4+FutVr01zBxlwMyRcBfS7WUOX7iFiqxnzt+Xp397lv62cLc6mgNVh7R7
-        krmh+Yau1RnnJkC3N2y3fJ3b9TGzOdRtGX+rVbucrpH0ueTslbJKI3CuXi330LvE+nTUnJK6X43/
-        F5UfhalyPgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3543']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:31 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/EventReviewsTests.test_reviews_contains_review.yaml
+++ b/tests/interface_objects/cassettes/EventReviewsTests.test_reviews_contains_review.yaml
@@ -1,137 +1,114 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF92aWRlb19pZnJhbWUgLz48
+      cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNj
+      YXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21l
+      ZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9m
+      b3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlh
+      PnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVx
+      dWVzdF9tZWRpYT48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHJlcXVlc3RfcmV2aWV3cyAvPjxyZXF1
+      ZXN0X2N1c3RvbV9maWVsZHMgLz48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxtaW1lX3RleHRfdHlw
+      ZT5odG1sPC9taW1lX3RleHRfdHlwZT48cmVxdWVzdF9tZXRhX2NvbXBvbmVudHMgLz48cmVxdWVz
+      dF9leHRyYV9pbmZvIC8+PHJlcXVlc3Rfc291cmNlX2luZm8gLz48cmVxdWVzdF9jb3N0X3Jhbmdl
+      IC8+PC9ldmVudF9zZWFyY2g+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['759']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+077XbbuLH/8xTI3nM27aklkhKpj0TV1nacNF9Oaiubtn94QBIUGZOAQoCWta/T
+        P32Oe1/szgCkRMqyLSebnnQ3OUxCDgaYDwwGA8xo8tNVnpFLVshU8D//4HTtHwjjoYhSPv/zD+9n
+        zzqjH36aPpiwS8aVLxktwsQvmCwzNZ3IMohETlPul5IVfir9gEZTLibW7pZJWKwWSvhBJsKLaeh3
+        OoNOID9+ePsxO5sXrCOfBi/Pxm+PwniUvBpcfTo/jZ+r0/N3R++CgZPZq8M0WDybzdVR8Cn4RzgY
+        HZfe66N3NHl//u5s7B/Lv//8zyv5izwvnw5mvYXb48EiOFu+/NvRy5OX/7x67q6OL5KkR9N4nPUj
+        L14FyRvvb96b08xeHLmdf0ysFn+TKJWK8pBJnxbMv6RZaoTbBTcKmk4AQn1QH5uefJhYmy/TEDEZ
+        Tk9A26tlwgpWIWjoJEzVyuBmgkeCd8oLYGgNNO0a9bVurxqrzhmVsvrP4NNCSUDZAKpGjX8IjeRH
+        mi+e/E9/9IQcw2yWyE4DZQJzpifQDL1iMFobNKms4YKtNDULpn0DQeOo8Opua0hrsA3e9ngRKnn3
+        oEakGqEF3OBoOY5oljFlhCVPtzoYSa0NC1atSCGVX1A+h/FyegUj50HKWTT1el17YrVAGgGYVIsi
+        DdnUHdYYG5hBKUEMWsCQ3hpjDZrkqNd6yJ6jMZogjbAZ0RnVGE0qWp31kP01xoYKF76ElZ0xVNZv
+        U8RPJeUKV4ZYKPBpMJl6hfo1fOpMrC3INkbvToz+nRjunRjenRiD6xjWdfH0HPphWRTguAGlfjPL
+        YR4swKpboA1GTEMliqlj2w2cCrjB4mUesGI66g0aWBVwg7XIKLhE1N02qIGDNidXeSAyqwkGN2qg
+        0//9V7P/Bj6xtsW0brDl7/P/O5n/5qSHouSqqOTTG2cTsG7W/v49TxWLyCuwHYhRNqjVTlqkKg0h
+        xLlM2dJfsCLEfd1oaGfTJKKKGT58xqPqWw82S8oD4khFztlCMdQX6dkOaHGDYrBLFfoijiVT0/4A
+        SW1DN2iShbD9y6njDntDz21j140GfQV/8jwCXwtE7bHtVJhrOOzMYjSwHV+DKY98leZMo3fsccd2
+        Zs74cd9+bNt/sp3HSGl3h2rcbR2Yb4iVCnVNK55KyBu6+jX1Mei5w769tz4827uXPjx4Pkcflfwm
+        gNbmePp+dnx2ePzq5GxiNcAVilbDG6pUwpbkSJQFZ48kOQVxChpegAnNTs5ndUejM/MOUejgxbO6
+        ZR2T+imPxfTHTD2J0ssf5+oJvi7w5RoRqUrOYVmQRSGiMkT/QkTcoP2QFAwiRS5JymHq7BFRgpzT
+        KGMFdP/AskyShF7iEEEhLhgnEH2RQFzBMDHs39A9FEUkSVQWiATBliIriO+QOPTuiFLBC5WCd5FN
+        S/P5YM3xLEkliZlU6SUjCmJnRRBQAhHgExtVQSOW0+IChFllDMHLVB2QBVWJkASmiIDMVEE0QTOS
+        03kadlsCxiLLxFKS44wWFNj6qJWzInEhckJJkDF6QY6TAs4AOZUEgnkCXDwtuk8LIeUj8rZYJJTT
+        OTsAQoUo5wn0kkma50yLDFroyAuq8H0JxsmKDJnSjAnkjcgFCxUNS2CAhABfIU8XKMn5kjGVMuyw
+        Uz1vM9BLQeiSFlFnmZq5BBNJ5xzAhxxUwFfkA7RqejMImdILcSkvViBoXoZJJxOX4BolTBIjdVyG
+        CkyITH/5JcPxwgQaxbygi2RF5iVoiSsGs5GAGm4x24c4UxTUyGRyQLJ00ZE5NMCIBzDjhbYZEBHn
+        L0XDg9nZaDmGc9JOidsEwfaARpikDKUIBLANaw/GSEMtMEgEsxCmMLYsQ9iapJENDSdFW+BUWxaH
+        EasjsUSm9KFAG0ygTxOyS17Xlqs7v8vAlX2AodB+P2gLz8EOYeIKPaVnYgWdT2kl2ExbIFgILAeW
+        Iq9qKQjOXorzhNNnTBWGlqBula3QOAJcP5eI39CFfqtW9gOtmMTF96dlocnpdgN6sMsJHJLnIotS
+        PPHqZak7kQ7hAg5NgMRyxFJC6IHMF4ETKkzbrSia7wPysQQ9oQqKdJ4oQnPcbPVEg6PcQ4wPCTiR
+        Y8rJC+DzpzuF4Sscl6xECSZ2wR6SQ6mZJWAYCo/cj6RejmJJwMV092MA1kIkgIH53QzMrrlDNB8w
+        Tske7kOLqupUPn4iyQseZmXEojup6hsFleASQsk528tCngsBPkCQV1ws76IAPgOdyUPyBqYDfD8S
+        hCnEKdX/yj3onZepouA/yTNYFcdJmkUQyd1F+LzEdaKtCMwfPZv26WhRFFYXy2GHA4PFJbQvH8d4
+        CZBlxtDfiSwNVzdwcSpgwcUlRBAEWGZX4C9hRwcLuqRppkWhsYIVu9CnT1nZc01yvRPj/lvtxehB
+        xdTsQKxGMMAKI2dRSiEMpTq8hygZti01jZzllbvse2WQR+lVN8xEGcGOxFWXMzWxNM4k5RDvgL7w
+        RL0ANwUxUJFNE6UW8rFl3TqEJeH0zCKrwQOEu2IBQa417sMT2m4Q21HPZXE/sj02ilnsBnQ4tMdR
+        bLt9l1GnH3Y/LuYQFO3kY8IphEa4d0kQDoTX3xPcmKe/Knk94uTbUMVORchysQDnKH3kp7oubULa
+        CNV12RZsYrXM5Vu1nSGDx3ZH4cDz4uE4ciizHdcZh+Oe27NHAyeKHW8QjPrxHrYDYd2nku1vOfcm
+        /hUt5968/AYs5wv05WtMqzeGZ+gybzQcDyksurEz9HrBsB/R/timbBCPYjpg7mjQu9t88BYRPC3e
+        SvB9behz+fh6lvS5HO1hT9et5RszqC9agR6Dx7bduOcFHqXBIHb7vTAassGoPw7Aebu9aES92BkG
+        e9jSJzj47O+J7k37K3qie/PyO/VE7Er5ikllW3+SK6lY7m8gKEgGZ7U9DKXCvNNU9if3FWxjf+K/
+        ezcSj+GhFCI+iAPd4TDs2/1oOApCz7GHYWgPPTeKR+6AhqO7rUMVKYL8GA71ezuTe3PwFZ3JvXn5
+        DTiTb9B8RHm3g/luPt+G+Xx57GczeHqeF7nxeBBEdi+gdBjEUa8Hf0MajO1wFA9CFvXd/W1I8L09
+        0Oey8dWD4ntz9FvYzb5cbSEAaC9yvdGYjsbuyPYcF04UEBmGLBzR8ag38Hq9kW2P+/vbk1qKe9rT
+        vdn46vZ0b47+w/ZkFDt48ayTmzxIJ9B5kI7s8HXipYNhnFX3NzqrqvkUVaWcZjr4aIFqhDKIqKJW
+        /a0wpddMMhpA3bpaQLyboui+SoG0WqNhS4VVLjDR52epVK3E5cmOxGU0ffNXuwm3dowxZwLTr6AU
+        vNJVZcSmntP1euOB4/SHE2sNnWAiwLx27K5jD2zHG/QAYQ2eWJvBEip9LjDLH0u9p7QAWNOG9wks
+        WhezVZ+6DqoweVSTDXZ6VSlUC6ormXbgbUMneJvvR2xBC6zR05lmzc8ueIVcZXEaaDXEIKAMosjx
+        Htywfw06wUoNU8Z47JwRd3YKy60GTUwFhKxftDZ0nWf1jXS3QBWqT0uViGI6SxiZgXhAu91Q4wUi
+        Wk2PKcccEyaN85zp1K3JiC0J45hafbjurvHrzo1ag5IdEGeoEnIqLtcVGN66W6PwoAlpVgp4juMM
+        2x02BQMVNKN8PmV8jaW/60ZRpJhZzNAbWGsoTq6h7Nhd2yaHb9a9N00t5CTJcymxFEUXOexo2qCr
+        jE3f8zyVEtMUDxvY2DLBmgS/0NdhWIbU/KxRb5zc2t5vmV3MypLDLFsUTN4+w5jxqhJyDzEtSoBl
+        1mG8I8P/+zdnmADVOXqaHeicTyv5DI0mgx6XVbNUolhVnXiKFQdcVTl/IVmdIup2ScpDcP0p6KZL
+        XjzCGgVGgnKFGTTjumSVu63tjc5pyvVQ+u1Ou8Mal94I7O6wnGPyCgzJvY/VufaoN/pvtDpYs48U
+        mTN1bYnex/astYupqn/rmmv/Ip/aWPW5Az7BmdJuzLhOs4+2YRMJO2TITMXN+pID0BrgGsdUa18p
+        VuikPSCSI9xSwQg2PYzGGh8+VorAQDxO53v1bnWoR2L8U5kWKZM+y2maTc21jPwLqAkXleiGoot1
+        bjeg18OgzwYboFFUTDH/ysjQOyA/p1jhl1KsWwjBQWKmeonZ4HNVMKYOyBHLYixwOJo5PeI9+/ua
+        TnO8mkZ1Y2Qqp2uVrnu0WusuStdKhVPMBIMf0dl5VBBuvUTwbNV9AM4AGwpGzBYAOtSbvymMoHxF
+        wMmwfAEAJdYZWJKilkyxjlm81e0VWaZmlYcm+1uVtWC9BowPjqK75rhmDiy1KEPcXKMqhxs2Mseg
+        CswcV1HvjpxyHf1e0qxkFtYr7urd2JkRu67aaHWefmvFGrostdR1bmv252A/EA/6F1wsK2GaBQY3
+        CHSfuoIN1TYt2NgL4zU0ibfV5w0Uvxe9fS96+1709l9e9LZxBZvFjz8QwVNTxBTsgLJy2doHvDNN
+        pGoi2AQHnVsc7ZEQFyRYkb6NIRwMnWmxGkekapNxbPKyBE47+FbFeijEAnTDgXsYBynHYCzgV9bx
+        5C5Rdgsgq6opHwj7YVU1Vcm1s6LqBom+oJBqw+INzCxhGSC/plytYu6mYrYb+Lu9hm3DwjatZcK4
+        Dx7DT/25WJNuFg3etJd+fq1gk5sWdf2rPj8SW8w0CghvYGa/usEW3SYh61qo0jidtX/EsKthAoFV
+        yUxUdwYHJTgmwzZ8qKFIPSiIpV3QC4neUJmq0jXU/B6xBXr/CnjdDFoR0NH1+eHT1ydn5x9OXr8+
+        r5FM2G3edUDdVkaNZmJt867FnJ0d/nzyukW59XEKvgrjyve45cxhY+LRY9gS5iwjfzgFFwNa5DD5
+        nP3x7jHOYFE+1r8agX0St72tIdBZ6aFvGYuQWYnoLIawqtShleEG790w8NAOWw+uwzBBI9xo9ckX
+        oQgwJ9NzRV6KhFcRe5dsTxt6Ue1w6mBO+3z8rIoPCQ2QA7AJkjP4hvBELHmrT7fWuzGpyzRiYHBx
+        YQy48eVvbrRb4IThMNM+XrjsatjCxovu5XLZhRWpyoDBESff7qfvwlsgcweKVzuR9dx5uTj56/P0
+        lwt3q6O59myBrmeNbmm+pWt1X3sbQrs3HMh97Tfqa/T1dfWW8HdKdX2kGyj9WnR2UlmmESjXxdvL
+        HfA2sL7CXV/ltn9R/v+e+0Ywjj4AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:32 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3898']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:41 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_extra_info /><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_video_iframe
-      /><request_reviews /><request_cost_range /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><request_source_info
-      /><mime_text_type>html</mime_text_type></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['903']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1b63LbNhb+n6dAujPtj9oiKVG3hlXXtZ1sNmmS2s5ms384IAmKjEhCBkAr6uvs
-        m+yT7TkASZGSfMsm07TrjCYmDz6cO248pPfTxzwjV0zIlBc/fuP07G8IK0IepcX8x2/eXjw9nHzz
-        0+yRx65YoXzJqAgTXzBZZmrmyTKIeE7Twi8lE34q/YBGszWTnrW/yQvFeqm4H2Q8XMze+oeHV4tl
-        PF0cT5dvh6+Dw7ngceSoZ6vw1Zv3HwYslB8GJ++d0YdfF6/t9++Kk6v84kUijwZL/+Pby/HZy6fr
-        k3B4eBY58ejFZVy+f345P3oqX58Vq/UltS+c0WtX+Cf54OXz01/Xl+L0w+Vkmon+m+fFdHCyWM2z
-        957V0cmLUqloETLpU8H8K5ql0azgnrWPbrwy84BCffAZm52+86zNnWmImAxnp+Di9SphglUATfWC
-        dF4ukVvJZo5te1ab4IWpWhtOGS8iXhyWC1C3IZp2zeilbq8aDeswo1JWfwxeJYwqVKBFq9p1l4tu
-        u2EDkdNhNOx0bLskr0qKBVvXEiyI/4aIaVJB654NpcNvg9vDcpFGcj9bY0jV3qFtINqWpzRPs3UL
-        ZCy0NnKt2mlcKl/QYg48AgbXOiA+j2MmIKqB5FmpmC/pFQyTmTPoQeS2qV5cZhnokQdpwaLZsI+g
-        Ls1AwCa1FGnIZu64wWyIFagEu6kAhYYbTEPztGYbxoMpgraIFWjDeTDcoFryKkLD3G2hNhKXTISQ
-        /HTeGNwfetYuFVJ6x4E5/bita4ekAab/g88/yee7DtSULTW6NAPpqtAleTmO+to2xyDapAoA8b4m
-        bO4douZMbo9aC3N91Ow7RM1x7xK1NuqGqNl3jVr/mqhteQ/vt5Xo0gykq0CX5BXcl8A+Y9J/mNYe
-        prU/tM8fprWHaa0Sf1nSQuFuly8VHF1g06b35H5NnzmetUXZRvRvRQxuRbi3Ioa3Ika7CGvXPD1v
-        +2EpBJzPAFJfma3uPFjC7rVD2iBiGiouzAFjm7hBFWUeQHgm/VELVRE3qGVG4RCEvtsmtTAYbLnO
-        A55ZbTIcnAx19p9/t/tv6J61babiS18nxcOU+UlT5o7/rGs2BA8D6mFAPQyoTxlQ7VEU8rJQokoY
-        /bimTWia9ZOHt0WqWEReAN+I5xto9fxGpCoNfcGuUrbyK02qlNvb5EUUwmXCzYqouq+e7JQHxJmo
-        hByV81Iq0rcdSMoNwGBLFaJRkqnZYISCtqkbmGQhLyIJq/fYGbpDu4OuGw18Df/yPIpmKNSeOJMK
-        2dC9VPLJyHZ8TaZF5Ks0Zxp+aE8OncmFM/1hYP9g29/bzg8oaX+Hiu+2B8y9VFSoHZ/0HXDGEYQz
-        +5wuGTn90cC9s0vcvnMvl7iHfedTXFK5wDzK1fn46u3F8dnR8YvTM89qkSuIdsMvVKmErcjPvBQF
-        +06SV2COoOGCicd1J+Mvc51Gs9Hzp3VL85DUT4uYz77N1JMovfp2rp50+X5L8+WTvwymTySRqiwK
-        GBJkKXhUhjhZEx63xRLBFHSSJC0gavaEKE7OaZQx0WLzjmWZJIketSQQfMEKQrOMBPwjsIth/AKb
-        kItIkqgUCMoo5MKa0TYXCVwOeanggkpe9NCAQBALLXjUublIUkliOBOmV4woAfMPQQJMbKg9NipB
-        I5ZTsQAT1xlD8ipVB2RJVcIlgZgR87AzDWlGcjpPw17H7JhnGV9JcpxRQVtKftAuXJNY8JxQEmSM
-        LshxIlKpcirJKSgE2pyI3ongUjYdyWuxTGgBk9sBCBa8nCfQWyZpnjPtEPDRoVxQhdcryF4mMlRS
-        K8pRVyKXLFQ0LEEhEgJ9jTou0LLzFWMqZdjhBqe9zsBbgtAVFdHhKjVxh2xK5wWQjwpwTLEm76BV
-        S72A2Tpd8Cu5WLfMz8swOcz4FUylEgLKSL1EoHsTItPffsuQb5hAI58LukzWZF6CDwvFIFYJOOfa
-        bGz7H2JIwclMJgckS5eHMocG4HwA2SF0noHhGOUUkxZiuIlBTAW7wQ9d8ZC1IClMUoY2BRyMgIEL
-        nNJQuwHsgwiFKUiQZQg7BWksxSRLMW8KqrOwAI5VZUeiavrhtk6uAEYCU7JHXtY5rzu/ySh4G1hh
-        xr/TYyOHnIWgCh3uM76Gzq9oZV5VLzjAgcRS1FWtOMGYphg9DKpJa2AtwfkqW2PiBDjyrhCvPWJV
-        E8Ij7ZLExet3CYzWY1qQ5+QZ/0mjTMOj1gxyVKxxjiNrXkI4FuwxOZIk4xAGcJ/CUksrjpjYfEVg
-        CPdukgrZc8JvlIqXS7y4qCed7+rJBl0MAZTsse67rOH7ZVHVUu95EWZlxKLrpOrykUowx9Dcgt3g
-        vGecw1Dh5EXBV9ewgxGFQ+0x+QX8DLMocicqnSfK/C+vZX5eporCDEOeQk4cJ2kWwbbyGinnJSbH
-        B9xvQMxxkOtJDzOJQkqxHNYFyCTMmz1CmyUEF45qEcFxzDd1rDaxQuQsSilsnqje5cNmGaZWNdPU
-        HoyfBWQ9jJUw6YW449KNXlrA6gy64t5yCeMCVmyRzRKllvIHy9rf15KwcWSR1ZIK2zK+hM2YNR3A
-        L7TdILajvsviQWQP2SRmsRvQ8dieRrHtDlxGnUHY+7Ccw9q9VwGvoLCC4wwqwRwwV997uFzMPqt4
-        zdH7nX2w1wOyXC5h3pA+KqLLsF1KFyDr0nOH5lmdzPh60mTM4Ge7k3A0HMbjaeRQZjuuMw2nfbdv
-        T0ZOFDvDUTAZxHdIE9hXXJbs7klyb+FfIknurcT/X5IMGfxs2437w2BIaTCK3UE/jMZsNBlMAxhI
-        bj+a0GHsjIPbk0Rewq7n7jlyb9lfIkfurcTXkCORs/rorgbDMsij9GMvzHgZwe68UL2CqdtTBRx1
-        I4d9/mIfla/g+GFb38u1VCz3NxQ0JIM92R0ypELemiN3F3d7UnxBW++QDLuh/mPPGPEUfpTCQgvL
-        rzsehwN7EI0nQTh07HEY2uOhG8UTd0TDye35AIdRJPkxbNfvPG/cW4MvMW/cW4mvYd74M2QKnIAe
-        MuXPuMJU/vI10poO4RdMw8Cl00lMx8HQcQPXHbn2dEztyTgOgnEwdpwwpHdPHjgM3jV3PlWNL7Ac
-        /Y8afRVr1O+eT/0h/OzRMJqGo4j2w9Fo7AymcD8eUzdy3cFoOgqd4TQa3COfVCLufib6VEW+eEbd
-        W6OvIqP+BGuZWvGHpewzLmVSUVXKWaY3kx1SDSiDiCpq1fcKyzbtepIh1K3rJZxYUlTdN15qYNhS
-        ocolFnH8LJWqU6M63VOjuq52BfQXb9t0aw/vOeNYfQNrM6pSVUZsNnR6Q89qbj18Om0uD+2eg00N
-        wbM2/RMq/YJjYTeW2v8dAr5Fj/VtFjWvz1e3+lU3Ycpnpv7n9Ku33TpU/XrVHtw21cPnzH7EllQo
-        TBOsJWp99tErcCl0eaAFqykGgDZwkeOnFEb9HaqHbzuYrymOnTPiXryCwVKTPFP0lvWF9ob+xKS6
-        R7lbpArq01IlXOBnDuQCzAPZ3YYaF/BoPTumRcGVrhHmOdO1OVPGWBFWYK3scdNd4+vOrQJzyQ6I
-        M1YJecWvGL71gTXmYdOtVWpuU9q14aHjOONuh02JuKJmtJjPWNGg9H3dyEWK5aAMB7bVUDG4RvKw
-        15+SN780nTctHWyS5LmUM2fcn2KRfE/TBq4yNntb5KmUWCd43EJji4dFaF/ooiK+ydO+raHNxeZL
-        kPrrG3+Rm7cB99A9DI7OJJO9Zlrq0jwJxxOA01jh+x8UX4JiOU2zWVhKxXMmdCkvZPKvoJFgUnKY
-        c3v4Ise1PWueOj+bBxFNh+pLFHNjEgPaybl+cEH+xQRvoMbxrRsfS7rAoYjT+c3dOsiaBSsuy1Sk
-        97Zxu1/NLy3A9qIq//kx/Tj73nUhqQfEGYzHrtNvOOwi9/NYJrDl73Lp29dwMdiaT8bDirO9T4FN
-        c7eDYWLvk9YG1J1w3gEijSIxw9IXI+PhAflHim96pRQLpiEMciz/rbDqdq5gv6kOyM8si7Gy+vOF
-        0yfDp/9sZLT51TKqR1jm06M6f5oenda6i9JveIQzLMLBTKcLnpgduHwQXmTr3iOY5bBBMGKmMZoR
-        vWaZiiwt1oQqYLwEguJkqd+Egg5gYi7NmwRmwqsep5FVii9PMCzzh2BuVV3HQjHwh2TqNRrXysFQ
-        F2WIC0RUFfHQbIZm6D3Vkbmrd1jmm7emvHrGJQuwLHkEWuNM+lxioU/x4oCYr902RVb9uh9+MGc1
-        EuYQDtgt+IuCryp57bpoR6iFi28HD/O1MDORhr2ubnd6bXD4RhiumxFTMGJkZbCGvzFNpGoi2ARL
-        HWb1DsP9bGRVdPWhox9WRdeK+96C7A7fazisEqpQiCk+VxyvK03vMN3uvUpY4UN++Kk/5w2zdiV/
-        D4tOF/2BpB/xLQ6tqvw12XK3YvwmT7YEWTupqpPOjNN9xf/7ZOdWVbvFuZKiV4jzo5OXp2fn705f
-        vjyvQWbpMNd6bejaWMPMsmGum9estGhScSWaLXl+To7Im5dHx6cdn2w6eldpBLvQNBbGya07f3O8
-        65AThrX72QA3NvsattB4+FutVr01zBxlwMyRcBfS7WUOX7iFiqxnzt+Xp397lv62cLc6mgNVh7R7
-        krmh+Yau1RnnJkC3N2y3fJ3b9TGzOdRtGX+rVbucrpH0ueTslbJKI3CuXi330LvE+nTUnJK6X43/
-        F5UfhalyPgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3543']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:32 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/InvalidEventTests.test_get_details.yaml
+++ b/tests/interface_objects/cassettes/InvalidEventTests.test_get_details.yaml
@@ -1,79 +1,50 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PmludmFsaWQ8L2V2ZW50X3Rva2VuX2xpc3Q+PHJlcXVlc3RfdmlkZW9faWZyYW1l
+      IC8+PHJlcXVlc3RfbWVkaWE+c3F1YXJlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPmxh
+      bmRzY2FwZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X29uZTwvcmVxdWVz
+      dF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X3R3bzwvcmVxdWVzdF9tZWRpYT48cmVxdWVz
+      dF9tZWRpYT50cmlwbGV0X3RocmVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfZm91cjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X2ZpdmU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bWFycXVlZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9t
+      ZWRpYT5zZWF0aW5nX3BsYW48L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+c3VwcGxpZXI8
+      L3JlcXVlc3RfbWVkaWE+PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjxyZXF1ZXN0X3Jldmlld3MgLz48
+      cmVxdWVzdF9jdXN0b21fZmllbGRzIC8+PHVzZXJfaWQ+ZGVtbzwvdXNlcl9pZD48bWltZV90ZXh0
+      X3R5cGU+aHRtbDwvbWltZV90ZXh0X3R5cGU+PHJlcXVlc3RfbWV0YV9jb21wb25lbnRzIC8+PHJl
+      cXVlc3RfZXh0cmFfaW5mbyAvPjxyZXF1ZXN0X3NvdXJjZV9pbmZvIC8+PHJlcXVlc3RfY29zdF9y
+      YW5nZSAvPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['763']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA22QT2+CMByG7/sUhjvzz4RIUjFDpwmbiqDb9NK0pUi1FuyvIOzT77DTEq7vc3me
+        F82am+zVXIMo1NQaPg+sHlesSIU6T63DfmlPrJn/hHjNlcHAiWY51hwqaXwEFU2LGxEKV8A1FoAp
+        SX1VoH43QUy3pSkwlQW7+gzbtmtTuHxtLzI+a27Dgoaxtw1YNsnf3eaebLKV2SRREFF3KAftq6Dl
+        cn82Ab3TI3Mn88r5CCKSH5Io9vAcvj9PDfxAUi3c/agcjxQtafwId0H4Fp6a1bidX/N8RETmyZfU
+        yVqar52ds97IQRmM7SPq//NDqQBDFOOAiea4JlL8xXXtqN/10C8KwKxeXgEAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:14 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['274']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:17 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_extra_info /><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>invalid</event_token_list><request_video_iframe
-      /><request_reviews /><request_cost_range /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><request_source_info
-      /><mime_text_type>html</mime_text_type></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['907']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA22QTWuDMABA7/sVxbuzztVVSC1l1iEtsxVleAoxiVaNiUn8qP++54HX9y6PB47P
-        jm0mqnQt+MGw37fGhnIsSM2rg5Globk3jv4boBPlA9QUKfyAiuqRDT7QY0FEh2oOR00VrDUsEPEX
-        qoG1rgBWSz8IWDCBWz+Dpjm1fem1316f7eLCrJQoiT38zPj3ljcOxbpxgtx2m3sbb/M/Hkxdenno
-        k9PDZya/kmu4BHhnJsQu3YssxzyS1SnUccLnRaJtarvxp4JB51yj832R6tzIvcfUxy3inhO0c8Vy
-        YP1rAqTWA+KYaogUhRNiNfG5ANYaB9balhd8tZf/UwEAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['262']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:14 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/InvalidEventTests.test_get_performances.yaml
+++ b/tests/interface_objects/cassettes/InvalidEventTests.test_get_performances.yaml
@@ -1,78 +1,47 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PmludmFsaWQ8L2V2ZW50X3Rva2VuX2xpc3Q+PHJlcXVlc3RfbWVkaWE+c3F1YXJl
+      PC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPmxhbmRzY2FwZTwvcmVxdWVzdF9tZWRpYT48
+      cmVxdWVzdF9tZWRpYT50cmlwbGV0X29uZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50
+      cmlwbGV0X3R3bzwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X3RocmVlPC9y
+      ZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZm91cjwvcmVxdWVzdF9tZWRpYT48
+      cmVxdWVzdF9tZWRpYT50cmlwbGV0X2ZpdmU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+
+      bWFycXVlZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5zZWF0aW5nX3BsYW48L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+c3VwcGxpZXI8L3JlcXVlc3RfbWVkaWE+PHB1enpsZWQ+
+      eWVzPC9wdXp6bGVkPjxyZXF1ZXN0X2N1c3RvbV9maWVsZHMgLz48cmVxdWVzdF9jb3N0X3Jhbmdl
+      IC8+PHVzZXJfaWQ+ZGVtbzwvdXNlcl9pZD48L2V2ZW50X3NlYXJjaD4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['611']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA22QT2+CMByG7/sUhjvzz4RIUjFDpwmbiqDb9NK0pUi1FuyvIOzT77DTEq7vc3me
+        F82am+zVXIMo1NQaPg+sHlesSIU6T63DfmlPrJn/hHjNlcHAiWY51hwqaXwEFU2LGxEKV8A1FoAp
+        SX1VoH43QUy3pSkwlQW7+gzbtmtTuHxtLzI+a27Dgoaxtw1YNsnf3eaebLKV2SRREFF3KAftq6Dl
+        cn82Ab3TI3Mn88r5CCKSH5Io9vAcvj9PDfxAUi3c/agcjxQtafwId0H4Fp6a1bidX/N8RETmyZfU
+        yVqar52ds97IQRmM7SPq//NDqQBDFOOAiea4JlL8xXXtqN/10C8KwKxeXgEAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:14 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['274']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:17 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>invalid</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['782']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA22QTWuDMABA7/sVxbuzztVVSC1l1iEtsxVleAoxiVaNiUn8qP++54HX9y6PB47P
-        jm0mqnQt+MGw37fGhnIsSM2rg5Globk3jv4boBPlA9QUKfyAiuqRDT7QY0FEh2oOR00VrDUsEPEX
-        qoG1rgBWSz8IWDCBWz+Dpjm1fem1316f7eLCrJQoiT38zPj3ljcOxbpxgtx2m3sbb/M/Hkxdenno
-        k9PDZya/kmu4BHhnJsQu3YssxzyS1SnUccLnRaJtarvxp4JB51yj832R6tzIvcfUxy3inhO0c8Vy
-        YP1rAqTWA+KYaogUhRNiNfG5ANYaB9balhd8tZf/UwEAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['262']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:14 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/InvalidEventTests.test_get_valid_months.yaml
+++ b/tests/interface_objects/cassettes/InvalidEventTests.test_get_valid_months.yaml
@@ -1,78 +1,47 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PmludmFsaWQ8L2V2ZW50X3Rva2VuX2xpc3Q+PHJlcXVlc3RfbWVkaWE+c3F1YXJl
+      PC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPmxhbmRzY2FwZTwvcmVxdWVzdF9tZWRpYT48
+      cmVxdWVzdF9tZWRpYT50cmlwbGV0X29uZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50
+      cmlwbGV0X3R3bzwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X3RocmVlPC9y
+      ZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZm91cjwvcmVxdWVzdF9tZWRpYT48
+      cmVxdWVzdF9tZWRpYT50cmlwbGV0X2ZpdmU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+
+      bWFycXVlZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5zZWF0aW5nX3BsYW48L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+c3VwcGxpZXI8L3JlcXVlc3RfbWVkaWE+PHB1enpsZWQ+
+      eWVzPC9wdXp6bGVkPjxyZXF1ZXN0X2N1c3RvbV9maWVsZHMgLz48cmVxdWVzdF9jb3N0X3Jhbmdl
+      IC8+PHVzZXJfaWQ+ZGVtbzwvdXNlcl9pZD48L2V2ZW50X3NlYXJjaD4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['611']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA22QT2+CMByG7/sUhjvzz4RIUjFDpwmbiqDb9NK0pUi1FuyvIOzT77DTEq7vc3me
+        F82am+zVXIMo1NQaPg+sHlesSIU6T63DfmlPrJn/hHjNlcHAiWY51hwqaXwEFU2LGxEKV8A1FoAp
+        SX1VoH43QUy3pSkwlQW7+gzbtmtTuHxtLzI+a27Dgoaxtw1YNsnf3eaebLKV2SRREFF3KAftq6Dl
+        cn82Ab3TI3Mn88r5CCKSH5Io9vAcvj9PDfxAUi3c/agcjxQtafwId0H4Fp6a1bidX/N8RETmyZfU
+        yVqar52ds97IQRmM7SPq//NDqQBDFOOAiea4JlL8xXXtqN/10C8KwKxeXgEAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:15 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['274']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:17 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>invalid</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['782']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA22QTWuDMABA7/sVxbuzztVVSC1l1iEtsxVleAoxiVaNiUn8qP++54HX9y6PB47P
-        jm0mqnQt+MGw37fGhnIsSM2rg5Globk3jv4boBPlA9QUKfyAiuqRDT7QY0FEh2oOR00VrDUsEPEX
-        qoG1rgBWSz8IWDCBWz+Dpjm1fem1316f7eLCrJQoiT38zPj3ljcOxbpxgtx2m3sbb/M/Hkxdenno
-        k9PDZya/kmu4BHhnJsQu3YssxzyS1SnUccLnRaJtarvxp4JB51yj832R6tzIvcfUxy3inhO0c8Vy
-        YP1rAqTWA+KYaogUhRNiNfG5ANYaB9balhd8tZf/UwEAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['262']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:15 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/InvalidEventTests.test_property.yaml
+++ b/tests/interface_objects/cassettes/InvalidEventTests.test_property.yaml
@@ -1,79 +1,50 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PmludmFsaWQ8L2V2ZW50X3Rva2VuX2xpc3Q+PHJlcXVlc3RfdmlkZW9faWZyYW1l
+      IC8+PHJlcXVlc3RfbWVkaWE+c3F1YXJlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPmxh
+      bmRzY2FwZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X29uZTwvcmVxdWVz
+      dF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X3R3bzwvcmVxdWVzdF9tZWRpYT48cmVxdWVz
+      dF9tZWRpYT50cmlwbGV0X3RocmVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfZm91cjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X2ZpdmU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bWFycXVlZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9t
+      ZWRpYT5zZWF0aW5nX3BsYW48L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+c3VwcGxpZXI8
+      L3JlcXVlc3RfbWVkaWE+PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjxyZXF1ZXN0X3Jldmlld3MgLz48
+      cmVxdWVzdF9jdXN0b21fZmllbGRzIC8+PHVzZXJfaWQ+ZGVtbzwvdXNlcl9pZD48bWltZV90ZXh0
+      X3R5cGU+aHRtbDwvbWltZV90ZXh0X3R5cGU+PHJlcXVlc3RfbWV0YV9jb21wb25lbnRzIC8+PHJl
+      cXVlc3RfZXh0cmFfaW5mbyAvPjxyZXF1ZXN0X3NvdXJjZV9pbmZvIC8+PHJlcXVlc3RfY29zdF9y
+      YW5nZSAvPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['763']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA22QT2+CMByG7/sUhjvzz4RIUjFDpwmbiqDb9NK0pUi1FuyvIOzT77DTEq7vc3me
+        F82am+zVXIMo1NQaPg+sHlesSIU6T63DfmlPrJn/hHjNlcHAiWY51hwqaXwEFU2LGxEKV8A1FoAp
+        SX1VoH43QUy3pSkwlQW7+gzbtmtTuHxtLzI+a27Dgoaxtw1YNsnf3eaebLKV2SRREFF3KAftq6Dl
+        cn82Ab3TI3Mn88r5CCKSH5Io9vAcvj9PDfxAUi3c/agcjxQtafwId0H4Fp6a1bidX/N8RETmyZfU
+        yVqar52ds97IQRmM7SPq//NDqQBDFOOAiea4JlL8xXXtqN/10C8KwKxeXgEAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:15 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['274']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:18 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_extra_info /><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>invalid</event_token_list><request_video_iframe
-      /><request_reviews /><request_cost_range /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><request_source_info
-      /><mime_text_type>html</mime_text_type></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['907']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA22QTWuDMABA7/sVxbuzztVVSC1l1iEtsxVleAoxiVaNiUn8qP++54HX9y6PB47P
-        jm0mqnQt+MGw37fGhnIsSM2rg5Globk3jv4boBPlA9QUKfyAiuqRDT7QY0FEh2oOR00VrDUsEPEX
-        qoG1rgBWSz8IWDCBWz+Dpjm1fem1316f7eLCrJQoiT38zPj3ljcOxbpxgtx2m3sbb/M/Hkxdenno
-        k9PDZya/kmu4BHhnJsQu3YssxzyS1SnUccLnRaJtarvxp4JB51yj832R6tzIvcfUxy3inhO0c8Vy
-        YP1rAqTWA+KYaogUhRNiNfG5ANYaB9balhd8tZf/UwEAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['262']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:15 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/MakeReservationTests.test_bool_properties.yaml
+++ b/tests/interface_objects/cassettes/MakeReservationTests.test_bool_properties.yaml
@@ -1,628 +1,599 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:24 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:53 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:25 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:53 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:25 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:54 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGNyeXB0b19ibG9jaz5FMC0tRXhJNTJKUkNxLWdMRHN2eDR3blVa
+      elpTV1NZRHFxZXZKRkd2bDRwb0NpdkNxVVVmdlVMQVhnOWJwOVhnNi1jY0s1THRRSlN2Um1MZXZl
+      eGUxMzBpNXo1UWdFV3puMVdtRTJ5WHdnVnhkTm85U21KZmNlWHlZN0tNTnQ4enV5Vkp3OWFSWE9T
+      ajV5Rk5wLTB3QWR2MktCSHZwaDZjRnFST2NyejktNGxEaHV4MlhIYUFtMUY0U2JuZEoybXF3a1Jn
+      WjwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bm9fb2ZfdGlja2V0cz4xPC9u
+      b19vZl90aWNrZXRzPjxiYW5kX3Rva2VuPi0xLS1RMW16UTBaV0tTZWNaazl6NFdQN1pCSi1GazFR
+      bGpSTGVIODl4djlzQ1llOGJFZXYxM2hoRkhheXlfNllkVWJIQUd5d0VSNlNSeW5ZLUJlWGhUd3Ey
+      YWQtYzVoQXc4WmhLcEpubTNONjJLZnpNM3B5QnNtUC1Dd0NVSVktY2dzV3F2S1kxcS1CUUFfQ1N3
+      SmE4SFJjdGZ2WlFpSktYN3JGZGNGTHlwQzZjQ29DWGdPaF9vc3ZXY295UU1MWjd1SWlpYk9Sa1ly
+      NFV2dEl3el8xbWhvVzNQVVdmRGVnUzJzWkpzV0RpcU56bXJkZ243Tlg4cjlfZmFaRGhPSDdjOUpi
+      WjwvYmFuZF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkZXNwYXRjaF90b2tlbj5jXy0t
+      RnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJYaWgtWnkyeFNwU09EZEhh
+      SHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5OC1zaExzUlpJRW45TEJX
+      M1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tlbj48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['449']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS0HvDihIg7XFxZDKMgoBCj+Tv9Jf1kHg4Je
+        O4fKzLeqlauS2GfHCeLEOWcHJvPHxbYqEfADw3V+/0R8xj9VgKO6muEcfv+0EgdY89Mf7b8xmhGo
+        buhAyfUgYgaSD4LQgm0mCBXNtWXDkcIA+JIRSIqstR2Xqb62MCACDpon+0CW0DqgzW6YajHKDBoI
+        1DaLXis+68AHOSFFGdWAcca1XEdzHSw0mWoBZvaUOkntuTGfbMlBkP+V8WUfBohSALkx5XeQsfJ3
+        2fb+Xemh7YbJq5TMDNpUusPMbQyQp0eICYDsq7pkgjhdqYriUiBJ9HLebdodeXBW8J79abKjgtdO
+        s+3cCA9gwUn30ZUtC8B8o/2nCdlOq8UrVG9BTBLCz8OeHkIZuJvT+SvHgECrjFFaoaQoqPmp+AY0
+        VJRTkQHOkgd8NckRAscR8aWJ0WQIJF92DkACjpaPU2eiHv6rQgSwsgQeBLYC/AqJE3WmWlAydghV
+        yd3vAwDbVD1Z6hktaAFQUSoFbYJukI0a/ci+GTN6jP6zbU1rJ4viLZzImXccnbTbrOOElMKyo0nQ
+        sEFKx/AWhhMi0fqNwn/D8X/ixG/JSq8n5H6fY5CNA4iS40NUalCvTOX4Z8ajTtINCv/meNTw2nfF
+        o4b+/Jl45PtPe02WjvxK7Amd3pgVmGoJzilpGKYyhDo4V7pu6DvgH0GFR9vxZdVEKSSyS/E2MYtZ
+        9mxo7fpwcLMYt/4mWSjR3TZyJ8OkZ5TBnOHJUG9X0WTMztbFlHRdLMCc+7oYBAGs3uanU/LpaIcw
+        DNqWEd3d59CNgNqvDOXqbQxjD7QDw/YsgAKGnMPbvNSSs0IvAJaF3jSAD1tkP24RPU05vIxXX/g4
+        ADc5KLnNWDI0YIhiXiM+18hWnSCoBlO9owzq5ofsEcM/Ezg64VqdRIQ7zFQLZ7ocSI6b9IN9kKrN
+        A5B0U9QRUce5t9F8yNjyRfJDx0FHkeUNQaI9fEAZG3XdF7xnlHEA0FBGeCjfkDqkOZm+zys8J4e+
+        nGhoiXZDMkKyB9e3kzacvf4HlPHcAGbi2SOECi3yTPUO3SQCSTZM2JJpt/HP+F0jyjgT6G7aVffZ
+        dtLlnjAmQHmJ6KlzcEH5gnIycVeCb5xMty8Q+I5sVURErHSTRHa0SjEjq5/0UvCq478yMCixwnyt
+        Zac/YYXlhp1Mlky1ZMhJqfulrFnARzW8QakY3Gi5lOVXkIeIFt1wAzQkIMSv6JWtFkF/e68kPmrH
+        /2s6SfZ7rmulaZ7fHZ6wpCYsw05kOM280vArLZj4ZklKkyZ7O6yDz1FS5kBuCaTICAzFyhPtGcxY
+        RePKchB1p/yiuM6nFBDzsUQfyzP5f3Zwjc8UXplPmWoBZVZdt210nSFamY6VsWy9e46ofuxBV1Is
+        VzXbUwrDvHkNEtSBlVXalIXudWeTuhutBMPhuVlgkuo4UubOUbCgNrqQvd4RP9dbR77FLk5S5F35
+        2DT7K8FuGrQ+6jkreFUipdk5cUNLBc3x3pZ74tjXvL1lDYQmO5KPVmO6dq3RwWxQxHKCNa5DsS/W
+        pS0fen2bVcXTGIZDSu1btBoC1rBFZ4L7RmdPc7EAIHccWoK4PMCVt2GbEmsv+krUeANrsyX68/gw
+        P+v6ecguW+bUtg+z/uy9f9VDq7GmG5sWL0Flya3mZ3eh0YOr1j8tsV204eaDbp/g5pG55jcTjDxv
+        V9Pu+0ggllA4jKlOIOG0wq5rltPz9my0cFW18cZe6xam6ZFKBRNtAPvyXMPm516NdJeu4hIgNiPB
+        Hg1mKuQ9TtqO3ll8Rtgrj+pq/JEfnrjxmxWc1V7EwcF+KncGrLAJ3wMruA58F9DcdQ4243ptSvOD
+        3di3CfXisFAzzoPl5djvw+OkT485stsYyjVX0YQ3BXawXXLXLJ0vo1iyg1RSKj59HCtOS+e1pfhG
+        SuuqTaHqfUQYNfR99HUVF09ZGh8UD63+ABWMvaxC189vw09gwXLC5KrbbpL1EisHC5ZnySoI2mSJ
+        k0MlDhISKYhtxbWqZRipWIa2//uf8vwCL9AiGMFDXNCNAH8IS3JFQLLt7qViAo0U7wm6+0Dfh0rg
+        WiFqO4EcoTrPpO0ZRB8ftmI4qLdRrcR+HxYvk0a5019NxNILZaG/D7NvQA19+VUSzdRkXyuRcz34
+        yu7uQ+giHWyrOIadTKzVXY/jCx5zw8b727pPDh1BdLX94rR78whpEZIUy5HN96CGMm0VXTWcvcwI
+        +mw1WHuwhz2ObACbr8VU1xodD1YwkMddthlxTTpyur6+UehtxxjESmfKc9vOarzAj9aJXkP7PD5z
+        /MzpT8QemG0Wi94+gkGzZfqboOGdotp+PhiMdmezNbXOHe1AKFdlI7sxPFIm5UbWdGlSfJeXVq7W
+        s2EX7weqUbP2FuYd9dF4PN4u+ucBuSsFIdt1KQrJZbMcpez2iVQAKSfK1VyasgFKDSd7lJ4O9IWh
+        RE4Uz/MN1LOp2iO7sJTp6Fqiy/4BtOkn9t1QYmeXZ+m1/wcjk9WfJEeyYcmJwiFF/4Ax+SVHPhQ5
+        nQrPE8ikTiUlkdsseRHrCSpzkvSsPiCFsvryGU1woHEI3TDIbwgEuo6/NKR06ELZemKWMeY56KVQ
+        PwW4FNYXwXwMYbWo/D/dA0jiSz2gxw0n/a/0gJ5uWFoF3dLBj9Y/hup/MrPtKdcbqoPpZLVRjAO2
+        ssfieL2bAKTbI3vcXGMY2Y+3w51CBCJ+4PZCPzk6QG8miq0vunWjX9eIix7hsqGe4vCs26ap2dtA
+        wSSIBHl42I07kWVKFKcvWuxA1nbS25BerhoT1msK727Ei+PT6r0xmVDXQcvvXqh+h++1LrPNynwb
+        rsH1elI9aYdhX61l4gdqOTuYb61lovldtUx9by0/+/+rlu9BeVnL1JdqOZv3C2r5i3q+FFd9lv+a
+        oi+TnxMc+FPq2UT17GPxebJddlnWqznX/ZD2uzzRiHrWfOny5mEyn7iR8z7ZHvsX8chpR65Xj+Z2
+        NI15DzojxdKN6I2bDa2Q3bwfV+pKEt6l3tCGbOOkHK52d79Vh6fNsYOu9cLaP8lig641u9dQsE7u
+        uaY3LouDyHbZCF3FLd7t4cPl2TwbyKUn7bueQY5YZbicjI6NWcemPPYwmR2c4/xiYS3K655W5D6O
+        pyuBvtRngIhtasg1AqMJTD7e94Y0JvC0EPaImo3PZuTX+wH5I/3gu7SdrP/afvDs/69+cA/K9/eD
+        bN7P7wfUF7V91pl/rRcAx3D9impA4wqcn9IS6qglDEyKmxgcTte6Y0ne4wK7D4TgeMbttdUYGWK0
+        ah6W0LlsKa+3vhr+vjmCO6G31UdGf2SbMqV350rY6h54rTkX45ALdV912bXWXEN/esa242406ZHH
+        eG1uZ4Sxj5quxQn8pkZOehoei9KFvC75GPi7S3PhHWcCCXbXGqmfSJ2iRKsf8EJwUtXjEA99bo6j
+        b3TaOknfIPfUj1zdv0vuyV8s98/+/yrve1D+RHl/We7vj0H2W2VRkrprJD8/3H+x/GAp5dvTvz3/
+        D1lRoYe8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:25 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:54 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkaXNjb3VudF90b2tlbj5jMC0t
+      cWstOUJWS3l4MHlISTdZR1ZEMkluUlRvZGZRcVpHcDFfUXUyM0VIMjhZczVhbmtVdnpkMEV4TzE0
+      d2w3RW1GZnRDSDI3ZW1ONXkzQmxKamdsc0ZhS0JFOHZIODR2bkJyaFdiNFhBaUZ5YkFNTkhYQVVL
+      UTBqbHE0VnRtd0t3SE5PbkRMVENlT1dRUUNmdnRzODlrcldzN3BxdjVmUEZGSlp3azlNbHdBZGcx
+      YnpiV2FveXRqM2szb3ZsTVNrM05CTl9Vb2RDbXRCMERzY2k1bGZsLXBqaEpLS0tYUUR3RjJaPC9k
+      aXNjb3VudF90b2tlbj48cHV6emxlZD55ZXM8L3B1enpsZWQ+PGRlc3BhdGNoX3Rva2VuPmNfLS1G
+      eUpWRGY4RHlFRGhNWVU2Zllsa29BMUcxempMbnZkVndoN0tMSmticlhpaC1aeTJ4U3BTT0RkSGFI
+      emR5YUdqLXBySGQ0N0s3dmZDUkZYdU1FSnVValJLQnNHbldScW1IdDk4LXNoTHNSWklFbjlMQlcz
+      V1ZLczNQLS13Sm5RSE9fenB5WnV5VWlBLVk8L2Rlc3BhdGNoX3Rva2VuPjxjcnlwdG9fYmxvY2s+
+      TTMtLXBQNXQxM2dFYWM0a2FSQnpabTJob3ZVUmluTkhPc2syY0t2YlBualJsdGRKeDJDQ2owdzY5
+      ak45RVFxX3Zwek55a2tEVVJtOGk0aEpDblV0emJ2YjhBcUhJbGNlOEtmbWFDVEtyZHBmbGxGUjhF
+      SmFqbDdNVm9sSmdrNzMxU0wtN3pJVERUNl9YTnVwRG1FY1RxS3R1STNjRGw0Y3VlRWltVG5MMHJp
+      QWY0SHlSZXRIaklsUlRTZ3RVcFdFOF9FbVFEYnY3R2VWazlUclB5Z1B3aGh3SUVTOWtNbW1nT0RP
+      WUR6aHVsN1Y0N1c5Tl90YlNIVVB3b1FkNEZ6ZERxUy1adldIUEZCRDFIUHZrVk5XTC0yd1hVTUJZ
+      SlIxU3RSZ0szQXNfMDRiRVY1bG5DcGZFdlFvY2M3R0V6NmwtZGh2YzNzTGRGdERhUGQtUHdDNTJv
+      U29ibzFleWt2Um1KRk9jdE5wSF9YSllFME8xbVVwM0JkTmpOSXFIS0dsc3djQ3ZIdEZmTWFBRkVS
+      V3VZc2xzekZyb2U0SHpQZVdLNjVNNE5GWktybTFjeG5FdGRpd0ZTeGpERHRqTEQ0S0gyQjdJYTVv
+      YmRSR2J0QS1aPC9jcnlwdG9fYmxvY2s+PC9jcmVhdGVfb3JkZXI+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1148']
+      Content-Length: ['1008']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
+        H4sIAAAAAAAAA7VY2XLjuBV9z1ew+mHmIaG5aO9wOKW9ZVleJFmS/cLiAkm0SEICQC3+nfxJviyX
+        BChSsqbSmSSuLps491wA9+IuQBu/H8NA2iNCfRz99k27U79JKHKx50er3769Tnty/dvv5l8MlyCb
+        IQsTDxGLIBoHzDRo7Hg4tP3IiinAPrUc2zMjbCi3JYYbEwKzn/IvC5ZC5srZGsollDOWtsswMTVV
+        LXAEmLOiOHQQMet6tcASYM7aBraLqKkXOAIqcDBlFj2FDg6UIkyQQM1//qOon+M5CnrktGXYcgLs
+        bkzXkuWq7NCP+dNHMF4RJNOOcz9uPLXcZX09rB53k8dlnz1OnlvPTlUL1FPTd7a96Wr8Uhp674PP
+        jk9XnztGG97sx2uLWCffDwYrHZfr82iP3iZPM2cR9OkMP+/mnfmh5jgvGpr9mPW2sku0T//9hOy5
+        u5r1ds1P0pHfYKfF/Rn8XBneoMis6rL8flRlbRAd2/t5a9hYdtnboq82WAc1SbsfPcz6h9Wu8mPR
+        H9XR8TCddOo7/aU/6O3wptq+Xyx71n21/PBWZq1HN3Le41pVnSH/1B2w8eDw2Qg6u8FLadHc6c1h
+        975B1eWL3w3aeDhh6nTf7ez9Zs/W/U515I7eV/KijJv3R28dbYa91uKw9BalaIlaFW0zGNn68Zmw
+        oFtvfp68NVKX/rv9uWmMYxmTUml3Qp3RyDno88/jev/08sZG+DirnWrTYzir3J9au1Kz9XL/OGnY
+        4Xo/bTmd9kelNNdPVth2lg3NPtgf8vuQ6m5ra+nHwJ8ebH+kq4/DnX2oTiqzUT0s43c3Umn51WrY
+        nWnY1/36y3bufiw+P96qbzPWWw/cx2CNdtFC7i+I68z1Pn43lKLLuf9Nw0N0azN3bcGHa7ZxECCX
+        SUuCQ4mtEaRpFCNDuWTlSiFia+wVgDSR2k+tp4IOT67CkDJTu6tcMAD6L7eS5L/NbPPxdQrrF3iZ
+        IKey0xaZLp+/QEzhwvhsnE9dHEewQxeHjh8hzyw17pLSkA3PFG5rs/P6MIWJLsCck2686UE9kyiz
+        I88mXoHMzYqwhZcWhQpITc1QikMhY767QUVpBhgJbUt8F5mlSrLNfAzlk7hrm6yQWU4l52G+AdNA
+        4Gn4Y0P95Vvvzg0lH3FBus0uVPHTYY0IEgS+eddnoqQGOPJwJMcbcNYZ5PKU+pDKhVAoBzal4g/n
+        24RRoOSAEHI/glD6xQ63f5fa4NE42UpBbEAfSJsCn/aEYKZLKHEXeMHaoFO6kpI6LEOShiN4mdoZ
+        uZgs513P59mRi25Pys3JCBdgzkntaNkQrUwY2rlS4JYq+RaUzInJgRLh9vQQisBZnOq/Rj5DnjSE
+        Lgx9NKeKUyE+xBe04b2PDtYWETeJEd4gb4oML2nexI5WyEKRJ8bpZNN1/DdJo0yaoC1DSbuUdFWD
+        JppTODtmLgT2kiJmlqrJUtdoTqPIhVCCbCjX9FqlfMnOhJx+gp8w9DwzWVRtqJpgnnE4aVyvqpqV
+        wpCgkFohSumy2pBVbao1vpfU76r6V1X7nqx0W0HMe+0DPobMJ+yLVypsLY3s0//SH1W9XCupP+2P
+        ilr5j/xRgX9/xh/C/rTW8HBMCve42R52x4ZSgAUldcPIZtAJDlILxyRCv1LpEcwhNtQ9Ik27k2mm
+        yH3Gv33PrA56mQRGAg8g0LEJ09ksqRlFUDCgC6xNBZTlkK8rO+m6MpWj87oyQ5QpmX6qItTBQhZT
+        M/D35+kFlBF4Y1Kycdp/qB9uAySKeabHOxP/jrcUBQHslLILE7tfTYSv0Q+1iCs35lghbPEGGdjM
+        ZzH4vALtWW9UNa1UM5QzakA1X/FPWb3TVDjhShXutTlsKPlka5ta0JigHixpekG/AJJqmvQlaJ5Z
+        GRVDI7SPFomjCI6Cx42mgw1fUCOEqnuDd40aEUIeRMQW4g26QxqT6X5u4YIcE7AZRwVahnBCYgMm
+        YVKG+fa/oEZypefNs62NpfL00VDOUNYioOWyhG1tQlMVnfoaN+gap1V1yc1Jl7vCDApxCfR0cnSE
+        eIGYTKYrwBmH9+0jQySyA2kKRKmVBHLkSbkGz5/0HXWr4t8SGOn1jK81aXYeuuPJvPvwMDGUgkCQ
+        0uknthcgAjk8h1CkGU20MnEF+dOpD60szJ5iST0qDI2LY8pL7Bx50JW0/0cBbjS08s8XYO1rQ/qj
+        Spak1BbjQNwM09i4wpJEC/ww6e1pOBeG/6auaz/d59JI5LuTm+ozRLoAhIRae5/6TiCi9xrkrLwa
+        8sCGkidunzOhkkPG17y/zPnkNz+42l1JlZ5HhpJDXLpehyHckbQGb45FjK+Xp3Jyd7acxF5+vQf5
+        FVTkJGsoF0huWnImkDm7GNFzN4jwGUIev61fUwzeDgoeaA/G7Ydusu0rwQWVX+y2YI3k+sQN0KWC
+        8AZmdmBdPW2uQEG6epV8BS94hRfKLVhwr18r12hGu3y5XIM/XVnEs1e59b9L/wL2/DbImhIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:26 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1879']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:54 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order><crypto_block>E7--NuwIhns8SF9pSFmOCtayGoPi5orsAykdVtQtCufnKnVXd5ijHtnqR7hewEY9Siu9mKWZXgSi50wUnsm6QPTTn5Ap3rEh2y8qt7LQOigLgEgeiLH4ylijiJOz3cCcGHfmz-mr55XI7fNrF6K5mYhYQ3qn1nCceIO3_pGh-y2ODATK_1unwgfaRcvmf9rRBGVuoIht5KuL4JvyIf1HGwjOVpnEZgHPJm7kxU7hRzZCGSznxEZHloNsR7I2pTbq40t7v2mLo1javANm8iUGKktt-5o16BpnLLteyP0yqrtW48EZlb91SwCaca-PJX0S8BvzKCatNcVD_hETlolGxPekOoYcRxyhOS0oqh4PNL4fG5MfxXXjHxpdCbQvBrDibivFS6vhbjmFeBcQYWikaldIWXGQFooHSH2dWMs_BXrsAz6-j8VMn40F2LZish9H3g6jBjVkrnayZ4NMPTq5FtXcdK_5L7WFk2ASLauJCqJowO_bV8X2sPX_At8097h3QpXw1Kh0OkgxfUXvzDHbFI_bN0XSMiJ0al9y_p-VXab83-6hG9eHDURd6DtENaA6ZdPR1b2kCR_toknr_BpFKcDNzxpBDj9-GWfRRbpiCUM9rPYDDkijx5sFQiucuV4RNL_xRMwwjtm79e8Q_Ffs_Rbj0MXC_rEfuYOIlmhROtFCXJpXG4CNo46bV1NKHU8emAOPjTy5eN5yHKnfgvMsrKq0Ix6-yFmDNxXSz4pazVchj_p8eOwdiIe_aY0Ybh9RJBrav76RZUsxDdWqMKRqoWJyL_--Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>k0--5q_Eg4_-x1Nz1FPUkY_jXomw7H7E1_PjxiUKNYUK3emm0ERjusgvnWUYFQqZHjDGEekx61hC9iIriru1LpexlQdiFWf9oohhZR3m54tmVkLEMIItGP0eGhqQULniBgRbrSIgFusujEyS0Rw91TvO3pqX8rgNeFy0FDAL-H3GFetfBUfLnD1Zi-94KcFBeU0CKwDSXAHtxFWU5WZiFJ-wMeIriNlK_uoAMR58EAI8VqC-Z</discount_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></create_order>'
+    body: !!binary |
+      PHRyb2xsZXlfYWRkX29yZGVyPjxwdXp6bGVkPnllczwvcHV6emxlZD48dXNlcl9pZD5kZW1vPC91
+      c2VyX2lkPjxkZXNjcmliZV90cm9sbGV5IC8+PGNyeXB0b19ibG9jaz5jXy0tNi1ic2pXT2psUmdy
+      ZS1zRGJKUjlPQmNmOGhLNnhxU05mR3ROU1BCUGI2MWwweUFpYnBGVGdSUTNLZFpJekRpc2d6cXRz
+      OWRWSFVCcl95aWlsSWcybzQ4V252ZVlTT1ZiWGxHc1ZvUHFXRFd3N2JiUTFlVkhWRnAtY3Ixemla
+      eWVhV2NnVkZxQXpyRC1ZPC9jcnlwdG9fYmxvY2s+PG9yZGVyX3Rva2VuPjYyLS1aeDAtMUlueEN2
+      V0JLOWZFdFlYRzA5dERlQXJDR25MVkd3Z3E1SFhHTThleHdUU0Q4cTJRR0lGcW9rNkNKWGZGX0o2
+      NExZNHRCTmNuYlp1NzYwVmVpeUVJdFJJd3o5bERxSVEzWEFxMkFLRUo5czBmUWlFbENvS1N0MFR2
+      RUR2aUFGYTJpRDZNY01aZy1YNG9BSnhkaG5rS0ZCWHdmZFgzbmZlQjUxa0lNYTJ4UHJ0bEU4QXp5
+      ZGhlMGZpWmF6azlSdS1vcjMzcXllRE1NYncyV3p4aHZPUVl0TW94Vjd5N1R4bVY1SnlCcTNBQlFK
+      TlM5YW1odlRCYkRDajUzVzJ5X21DYmY5MWF3YWotWktzMmNCcF8yeGxpVHdhaU0yME5LcWF3NlM1
+      Vk04bTRvWmNuMHM0VV85YURUbUcyaThRcFdjalh6alk2WVZ0RmhJY05saGVxblgtR1hyY2JXMkdv
+      Wjwvb3JkZXJfdG9rZW4+PC90cm9sbGV5X2FkZF9vcmRlcj4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1384']
+      Content-Length: ['662']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61Y23arNhB971e456UPLQGM7eCzKF2O7cSJr8eX2M4LC4NsEwMiSPj2O/2TflkH
-        JAw47urpJQ8J2rMljUaaPVK0346eW9qjkDjY//WLfCd9KSHfwrbjb379Mps+CuqX3/QfNCtEJkUG
-        Dm0UGiEikUt1jUQrG3um4xsRAdghxsq09RMimnjbpFlRGMLwp+zLgLmQvlkFmliEMsbatCgOdVmS
-        chwOZiw/8lYo1NVyLcfiYMYKXNNCRC/nOBzKcTChBjl5K+yKeThEHNX/+D3fP8MzFPqFp4BiY+Vi
-        a6fPDEHY74J1fdesB7PqcCVsQry2Zfp0sAaj5buCLPKutJZy7f3bbigt535r7027WzJrrduLozVr
-        dk4fS7e36ODFYycc7pzm49ZS3pUK8YYtuTYvnxfl1+FUmPq78NR4f1EHctUZHdQP1HHnZ9I9P66X
-        4F3eJ41tJsU75OvtsiBUUadq7KMoaLxvvlmbRefQD6aovqh/bCZueSm5i6Bq4f1hJhNSeZ4vHxrC
-        eKYaG2XUi9Tn7nmDwrOhdFxJUfCz8NpvW+et1Gjuh/35Uq2co6qC5s11Y9NYlPeV+5O6eXMx7TkV
-        ggeDtUqXiO4WH294JAzkrdudvewOb/ZqLjUnR1SbnTyzbb9PFuH5MJSGRms4HlvzoHZ8RuOHD2Oz
-        O1bmUX359jIiw261idqCGTwaPeXQDOyPLpooo5qhfHtr7MevU3v89BBNzhNh0XkJXmsR7ftC1OvK
-        C9MJBpFKW8+NoTto9NWn1pM1Wi7HMJJihB0Htu5bf9h7c04P/frD1vJPvaemOnVmw6k5PE4n87ra
-        wXar1Yx6HyevLffnlve6mGxrxxfyGvlWxaOjxWhwdO+FN03Mh5/tha7ZiAQmtbYGfFh6E7susmhp
-        HWKvRLcI8tSPkCYWWVknD9EttnNAkkjN4cMw14clV65JqC7fVQsMgP6jK3H+m9TUB7MpzJ/jpYaM
-        Sk8B0i02fo6YwLn2ZXEOsXDkg4cW9laOj2y9XL+LpSFtXihsrZPprNUeTGGoApyxEtcnNLKRT0sh
-        yFyOypblYwOvDQISSHRZE/NNbqOOtUN5awpoMS0IHQvp5VrsZtYG/QytrRlukK4klkszc0DXEEQa
-        /pggwMzx9lwTsxYzJG62QcZPhy0KEScw51fOJgqMvelGiGloHtAsh3LBdbFvY8iEHYTyAjJ7MlAv
-        sXMjG9pyTUL4H8aHo2HS2IEcxu1Jl2nRzoaB6pCUCjZcUj+KUBxEiI2xQ6d0BjGJZArGpYhT054X
-        pDBexrsx5M6xye1h2UK4vYBllGQtj6bnuKccia1QzOYV06DF2xvyMCdBzwMXc9J/5jsU2aUuFGWo
-        qhmV70LowGmDqrx30MEIUGjFJ4aVy5smzY5reWj6G2Qg3+Ztvj/RLyVZpdtSI9pEhJbKkgwFNSMw
-        bkQtOORrgqiu1OKJrtGMRpAFBwcyo3IvVytVqcBOjYx+gh/PsyGhYVJJlVXOvOCwuVitSbKRwKZv
-        Q5p5KKELkirI6lSuf1Wkr5L0syR/jWe63YGPex0B1ibUDOmnmJRlCEYDEtf9P0NSk8s1pfLdIamU
-        5X8UkopQlv9NSHgIEulh5zHW8XGj2W2PNTEHc0oShr5JIZEOpQcchT76iZQGsJzQBBkMf0w7sXix
-        b8fWa8+PqQVaHHfhlONMSPIgZ4B7NCK66+wvdg6lBFZkxLSd1BLieIGLuDCn/ViVYd9RQJDrwlSE
-        Fnxsf/bxr3yP8e4sj4s3xt4gbLAi6JrUiQuPXk1K8KWpgRhv2Kcg3cmx6QJoYtZ/axID6g0k9pro
-        PtbEAhBrYVxukH0RQd7UPPNohJHvQ1jZ/stlOBqfUM0DzbzBu0Y1HyEbdjeAcxPBfTg+S4k/t3BO
-        jqDUwqMjR0sRRojXgEPP9KFUJu5/QrX4ps5qYlMelyrTgSZeoFTgoZLSmG3sPF3iBfga18gWJ/K4
-        ZsthT5giphE410BPBkdHODqI0Hi4HJxymGyAvTQ5EYq80hsK8YXKkiC5QPEbSqPVa48n83avN9HE
-        nIGT2AXFtF0UQlrN4SCRlMbLC78k/KtshNLipQ+lWB5yTa0Q7Uzx5sgGRbyPq8T/r4j3IPz/QBHv
-        PyniX6VonBsBxi6/uSWbfIXFGeM6Xlxtk3OZa/6d0N5/r9AmR4p5JzTqDTiyHOAWYuwd4qxcfgyv
-        QcbKFI6dUJAxfjt85V0ySPucwMXkjX+zjbu/U6TSqK+JGcSs263nwa1FritJAc9jbL4sJ+O7Lbz2
-        Yb3J7PECr6A8J55DLCDZ0uI9gbvLR4TIReF9fIGQzW7T1xSNSXwuAs3ncbPXjt2+MhSo7KoVwGpK
-        lhNaLip24NHA1HSNq6fHFchJV6+Gz2CBl3tB3II59/o1cY2mtOLL4hr8bl3hz1Lx1r9//gSe8Zbz
-        OxIAAA==
+        H4sIAAAAAAAAA7VY2XLqSBJ9n68g7sPMw4wsiZ07anWwGS+A2TG8KLQUIKONqhK2+J35k/6yTqkk
+        tMCNud0z7XDY0smTVZVZWZlZkn79sq3SGWFius4v38QH4VsJObprmM7+l2/LxSPX/Par/DeJYtey
+        UKCohqG42EBYwYj4FpUl4muGa6umo/gEYJMommrIjivx9yWSjgOPuopmufpR1hWOq3Ma+Vi/fViz
+        PUYc6Wkvs9ZbR981D6/1r9N8vBvQ8XzSmWh10RKCtql5j4v9bFp5NbbPl55J9pcTJS1j9bTsYCUw
+        Tet5X3arzbVzRpv520p7twZk5U5O6976s6FpUxGtnlaPHqdj8WJuA6Su9f3q8dS+4B63kfjc+qTQ
+        YM8lxNQsJAeISHwOuTqGukfkyPUKx1HltKPN4eZY/uQmY/OptqzOp4Y4OiCn2zMGtQDhz4G2Pguz
+        zVzbUkvd4O6upzoz1fQUNDY/4LF9IC+HdqX2YdSmi+eX2X4wtt6f943eevh+mXK1Chl0q4/meXS8
+        LH3zNH45dgJ62jp1vTzcfwUcev7s69MWVha2s3ndHmtvDj4/NbYNQ7QWRlM1zFdaGc0NI/CHh8eX
+        Dlcr94YeFygf/ZZm+ZfutPxWNTRjUz4tuu7r61PD7ArKhbaXA6WL/W6lhbTatvuiiFPRPVU3uvf+
+        Wf0Uh8qL3l8ZDc/ptBtH/VQdjQZ+q+NazY0uBo35YmXsyeSwmfc6fvujgrwGOl0Cd3z0a0652dOV
+        dr1RW5y1lepsyNtw2xla50V3Ig5O5TWtNN87Z63zPL+sZ+vlBW/JadhZdD/Gu7H4rin13mZbFyvT
+        WXnT2I1OC7wZzDa7yevmYz3ZzNr9CapNB8EXXZKn3mbzrgTTL6XpcX2s2YueJ3DcVuLzm3ndWxbw
+        uus7VBZTVhYO4wQZikmRrTi+rSEcMm/BZExZ0nzHCAOI/S/OcQdNmMT1sY4ANJCMvqhCEaHCVSMr
+        LWgYiOhy/4si7KhWaQFqpY6qg6VG6UY/4ib61KWqBUPamukgQ660HlJ+QVZUIVSuCg+1GzqhBSpM
+        6KlUP8jiDfsqymsQpFIPmzqSK7WbBaXCghJYd1DxHsnVW52rTNJ9jCENBukT8+he8yBB5KCUsVN1
+        6sK+C0KGE4MpKw6EZrmeYSXRcQU8S9URkcsZTgxlOOBFhQS25lp8FsYoRuXf/pPVT/EUlaUoxGQp
+        cTLb+W4YpDot7bBrl+gBQYVwfCTxeVaqZCN6cI0MELmm+9Z5y+gwd2VeIQii3c5D/+NSwqqjUlUe
+        Lxcwf4aXCFIqDTwk62z8DDGCM+9X40wSn8TCUUijP6EwW9u95XABA+XAlBMtvG1AFS0RqjqGio0M
+        mZnluIq7i6KZhGkh+xrLqAlHOCtNAKl4QDJnonAMMpHPp1Yi8HSY2TBS2dL7a0hp1zcmYEkFGojg
+        84Awigls8bpJ40NiuY7hOpx/BGddQSaPqMNIHgtjZUslJP7H+CqmUH4zQCxkfgRh6e+q7f271AWP
+        +uFSMmIJuo+oFWHDRoU8D4XuAi8oR0jO4Ux85LAECducmJeoXZHcYCmvOJ6hOjq6PygzJyHkwJQT
+        2dFRIVppbGivoMAs5dMl8IkTww3FsdujTcgCV3Gkv3SgXhmlV2gAoXtLqfGuYBPiC5q/s4k+FQ9B
+        rQgLVpTy7ookOHNIwaqzRwpUmvg9Gmxx8P9VEqEKzZEHJRISYKksiJAWUwpj+1SHwN4RROVKPZyq
+        iKY0gnQIJTgN1Ua5Uavm2YmQ0QP4sW3DkMNJhZYgxswrDjvtNuuCqEQwHFA4WjaK6JzQ4gRxIba+
+        V4TvgvBPQfweznRfIR636AP2Dicf0xuv1OihNFKD/6c/6uVqoyL8tD9qQu0P+aMGv3/GH7H9Ua5h
+        4Rgm7lm7+9qfSXwGjimRG0YqhUrwWepAs+Kgf5DSGMzBYS+DS4v+fJEoMp+xZ9OQ68+PiQTeYtyC
+        QHdlGE6lYc7IgjEDqsBB5kGZs9m8nBbNyxHOuc7LhW0Yn+hHKrE6WEh9Ilvm+Tp8DCUEVpj45D2q
+        P8S0vbAziZJ5oscqE3v2PYIsC1ZKaM7E/q2J8DR6ErI4f2eMPXIVViAtlZrUB5/XoDyXW3VRrDQk
+        /opKkM337JETHkQBdrhWh04lhSU+HeygEgUKE+SDHYmuhTkgzKZhXYLimaTR+FWy1S8F+44DW8Hi
+        RiyDDTeoZEPWvcMropKDoBc3kAfxBtUhisloPffwmOxjsNl1MrQEYYTQBhfbYRpmy79BpbBJY8Wz
+        K85K1cVY4q9QUiKg5NKQrRxtWYgrdRGXyMGNsuqOmRNNV8CkH1wNcneCn7oM5G4B0e39Xsa/J5Ci
+        9ozNNW/3hv3ZfN0fDucSnxHEpGj4uQodOIYzvIZQJAktLmVxC/Knj37hPpa7ieW2KU2xa2RAVRL/
+        igTcaonVn0/A4m1B+lEmC4+U57pW3BlGsVHAwoNmmXZY26Nwzrz+l7wu/nSdiyKRrY5rCxOI9BiI
+        JUQ5m5kPKUWQsdJsyAIbUl7cfa5ilRSSbs99/syHf9nGNR4qQmkygtv7FWLSw8G2oUcSW6w4ZjE2
+        X3qUw95Z0UJ7WXsP8gKU5YRz8DkkNS3cEzg5Jx+RazVw3CuEDNatFykSKwcZD3SfZ91hP1x2QZCj
+        ssbOA2tKuol1C+UVYm/cu+UXr/fsvXAruQVzvMwN5R4s3b/O39zj717gb27uP5tZ4mvvX5Mx+eTj
+        TvKpKP7OcPMJKYf/oe9N/PVDEv/Db7O/A9pPXdzdFQAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1828']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:26 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2085']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:55 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <trolley_add_order><describe_trolley /><user_id>whitelabel-testuser</user_id><order_token>E2--5eH5_vuupAjgQcgXHwMpTe9X9qgSl2Y0lXp5covwU1ss4IWYBA-RU8_g3PLu8IKzgerz_3Hl033oI-VMEczh0ACvOMWY84zu53eWCfAgAX2v47y8gZlotLi4soNNf8tYetkXqZoP-N1hlKUJkwZdbW0CSxe6UymaEdjSXrzwO0O_DORRcWp6xIeRBq_gkx4Wu9YZJPsOK5CeE-apF_L3wCpdqKeS3P6_3QZAvRVTdRGBuSzS-XHJpV6utMn-uLK1XaipNu8tDIAOlNAM8GDGcPYYRpF_3_rHi9pUQMOLZiyBM9BhcnyLGC8TiUOTaOxTSW98HodDDCuLqymE1MWcmVXSh6xJsVunc4mtPXPNxl7-Z</order_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsUDfEXxcUCHyqYlLXHoXFHrOkiCFhc3j34smOD16W2zX2VOT-TnkryAjJ8N15iPw8qeHlWzsKzFfY</crypto_block></trolley_add_order>'
+    body: !!binary |
+      PG1ha2VfcmVzZXJ2YXRpb24+PHNlbGZfcHJpbnRfbW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+
+      PGNyeXB0b19ibG9jaz5jXy0tNi1ic2pXT2psUmdyZS1zRGJKUjlPQmNmOGhLNnhxU05mR3ROU1BC
+      UGI2MWwweUFpYnBGVGdSUTNLZFpJekRpc2d6cXRzOWRWSFVCcl95aWlsSWcybzQ4V252ZVlTT1Zi
+      WGxHc1ZvUHFXRFd3N2JiUTFlVkhWRnAtY3IxemlaeWVhV2NnVkZxQXpyRC1ZPC9jcnlwdG9fYmxv
+      Y2s+PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjxkZXNjcmliZV90cm9sbGV5IC8+PHVzZXJfaWQ+ZGVt
+      bzwvdXNlcl9pZD48dHJvbGxleV90b2tlbj42My0tdF9xZnQ4TFlrMnctUE5pSDVVNFNRZDFNaGVu
+      Q0RkRzV5ZXJ3R2JXdjBSWVNiWnRsYVlyQ2ZEYW5SYWlwX2VOaWphblJBaHNKaEEzNWpkNVFUSUpS
+      Z0dObFhJZzdEV0xYelEtNTNzR0M0Rml2TWt6VXVpcU5Ka0J5dHFabjZjMkxneHktZUl3RWNROXJf
+      VG1uWUtaazVPbnJ2SDdaN2QxbFRkOGFkaUt0M01TZGR5dUxoRkpCLTUyRExwLXlfakU5Ymx1ekNR
+      Mk80ZGJkWTJxVENvS0tIN2lDMF96dEFVR19DcnVDMzllYjVaQ0pfMVExb3E0WWNwWHc0dzFMX0pj
+      RVZkN3BuQkE3a2NxNE1NR3U5Qm9sOFljMXk3U1RWZGdzUGhZU0RCdUFqM2VwN2VxenlvTmt1NW4y
+      OERjX0E2NzVUdmJWYW5Zc09MWkJMbHZUQ1AxR3EyV3QzOFhCdmJCSVN6V1JXVXpyWnNxTEJUQ2pO
+      Zk4xWGJfNkRZWjYxM1FSMlk3Zk1xVHJZR1JZZlBLWWpXUFlSQUVQZTVRR3l4dFVzSERZWVhfeVF4
+      XzhwLUVyYm1URHAwLS1aPC90cm9sbGV5X3Rva2VuPjwvbWFrZV9yZXNlcnZhdGlvbj4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['694']
+      Content-Length: ['791']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61YyZbiOBbd91fQualFN4HNTB6X6zBGkBAQASYYNj7GEth4DEsGzO/Un/SXtWzJ
-        I2R1ZnXmIgPdd5+GpzdZwh9XyyydoYd0x/79C//EfSlBW3WAbh9//7KSRuX2lz/EfwjYc0wTBrIC
-        gOx4AHqyB5FvYlFA/h44lqLbso8IrCN5rwAxgEioPBYJqhe42JH3pqMa4koul8+Ge+gY/Y67asz3
-        5aPnHACPny/q7G17qkEVnWqDLd88vRtzbru2B2dLmmhoNTgMN1d11X8JPrfmdPPibEYv3tzQ+yNN
-        rZ1qdWTNB3xzXb1tqh9zqSzZhhd0T9/aM76hv13an/DFXN/Q5DY6bIVKbk9CeErXQUjfm5AeJYck
-        1sCOAW2xWS+XdamGlY+2U61hua87DXgz24u1PaqCi2J9PtvX7jV4GV1ul+m5DgdtUJ4fpE7Dfx13
-        WvBtMzPQ+HX8MeeWo8PGOrsjvfF5Ac83/Tg4OtaQO43gDh28+lXvfszWvqoFL9bQ3pd372tzLUNi
-        JSmozdu93v6wQB/c+MOWDbDRpt3XRb87O/Dqdbp7vaKPPexIvU/34jacz8ZAA9Kwf3h2LP0KBsRQ
-        Jv/+8aENXv25Xquqp9bu1IDBYHDqtnby+HZsD/zF1Lm0x3Z9vXr+9N6Pi5GM3qA0WS6MUc/aYvXZ
-        qLfxoXY4ti4zs76a11cvcEXOic6b3vR96kp+Q7+1LEM78/K6Pmmure6u6jRWBuirE9ezTe+0rIE3
-        tf920s6X3nZX7WxXxjoYDYddaXRDw/Gnuw9UHQwnx8GmCYatjS55U74qvbQG0sUdztZcT/12la5b
-        ubpuapfn+rLz3us/j8G3YATWPe/sHSdL3ZSnr+f9rnXrgWALlU79E8tb6CxtY+bOvr2OVz17NBnM
-        p4FR3uh827QMeJPVzRyM7IVuBDO3vz+eaiCAg0bQHu93XvtdW3S0/UwbvzfLO6GSd5DEX2jkqI5v
-        Y5FPWVk49D0IZB1DS7Z9aw+9kHkPxnOKwt63QeiU9G9xjQdozESO76mQgACK8IplDBHmEo2stKAB
-        IFJFibBLywCRPZV20HOKihEpVsQOVkwyl7XXbQjEaucpXaggK6ogLNa4p8YdHeEClSzoKljVRP6O
-        nYjyGggq2PV0FYrV5t2GUmFBiZxOU7wjFGv3OolMUH3PI4k0SH9RUx73Lsk2OShlHBQVO+TCOS7D
-        YWDKYh7QrjYzrNgtEsA1FRUisZrhMCjDIVaUUWDtHbOShT3IUPE/f2b1UzxFRQHAvU52KKuao0fz
-        MyCVUIfRYGngW1ZQ6iseKA2oTKjkSImKbmN49BRMypIMFKxUUpGtWFAE4UypcoQlDBy4d4wIS4bp
-        r3TbUYyEk1BnoRvqh1Gm4tLBc6wSJkc4Q9uHoXaWlSpZEGsOyADRFffnvXlGh157ZkicOfLaPPR/
-        biUsv8Ry4mwlkfUzvFiQUiPjqHT+DDGxWfFwOmKppBDSaRTHFHrWpbQaDGcSmSoHp6xo60vsA2jj
-        Erl2mKHSY9mO7ByiqERhXssOmQzrqgGz0hgQioGeie1COGciuJKeEhJLh6nZgwrd+HBNcnIyooJo
-        m0PSSgUXDXqQEVga1I++K58V04c0urOAoOqYpQLTsYFjl32DmDIBqTyaaBrJmZBOrZoKQuwP5RPX
-        UHC4gQzG5HEgZuV0GtKcRZ0anS7qefJQaERiG9kgNYetUIksGYNhJ8iosWaC5OZLeQ+mNHSAHk9L
-        D8LkOSylRGcZKZZuBhkSPWElXbcSGy28Xo+ZOTJ6FkjEkf7KJuUXlCakMSZNbUplt+DpxNtIU3zW
-        4UV2IamAYf2NEvlDkUAiEMqeYh+hDG3Axux+/H+X+DbWSl3/6JMqW+V4kupTAuX6WCVOfkCQFMhm
-        uFARTWkIqsRxSGTUW3yj3uBy7FhI6QH5Z1mABDRZlGvzbcZMcHK5TrvJ8XIEKzYgYUZyb0gvc+0y
-        35b4ztca95Xj/sXxX8OVHiuweYsWoGOEFQ/f2aTKE2N0SeCav9IkTb7arNV/2CT1Kv9TJqmXq/zf
-        MQkzQZR6qD+GeXzR7U+GC6GSgRklMsOrgkkgXUo90oPZ8DdUmpHjeApJg94/YyVqL/pbB2JzPIol
-        ZMRwk3i5kyaSLMgYZHvYR6KpnxM5g2ICLTKVeBzVEqRbbtgtRYk51qNVhv72XQRNkyyFcG6Pw/s9
-        fm/vIT5ZZfHKg7mP0JFpETRJkxEWHrERleBkKJBkfKQ/y9wTH4oSQKik+pqCZFJvSGAfkGiTPjgH
-        hLkwLDcQJEmQDQVLucqeb9vErPT++SpxjTtUsEjOfMArooINyTcCgC7xG590aqEvRft5hDOyTzus
-        DC1GKCE8g+NZiq2y7+A7VAh7SFoT+/yiVJdmQiWB4gRPKikO2bJhiRwrwEVcQJoTpccDPQ59Qchj
-        wnc+WXLfKn/9kZL7OokaKNahdAfT4WK5Hk6nS6GSETASbVAU0ut7JKzWxJFQTGPlhTUJfysaC597
-        uQ+9nLXTjLeGgGTEVlglfn1GbJHE/xMZsXWXEb8XomFsuI5jss4tuuQCFkaMqVthtY38MjP8X4m2
-        9aOJNnIpurtyt9MlLssAJkHyWc+8/hRBykozHPVQksZYd/jBVFJIuA/gfPCG/9OLaz3VuNLbq1BJ
-        ISrVNMsiXQvfqUUFPIvR9dKYDHtbeR+eN1o9PGABynLCNSo5JD1aeCekd/n0IUoyvO0kEAS0my5S
-        BJriMxbojxf96TDcdkGQo9JWyyWnKam6p5owr8Cs8eg1ofiMQMeFr4Z7MMfLfEE8goXHzwZ37wUP
-        HwruXgh+NK+wz9JfnPoq8bNR/AjFHjLuHqdy+E+9ZFWSJ6rKd5+P/wu8uhIsgBYAAA==
+        H4sIAAAAAAAAA7VZ2ZajyBF991fo9IP9YNOAEEK0GeZoLa1IpV164SSQkpDYRIIE+h3/ib/MySbQ
+        Up6esadPnyryxo1cIiMjIrOEXwPTKF2gi3Tb+uUb/Z36VoKWamu6tf/l22LeIWrffhX/IpjgBGUX
+        IuhegIep0bdveKKAfEWzTaBbso+Fso5kBWiiZQvke4mguqHj2bJi2OpJPLEEcYGnxbDjeR+8yVLX
+        WZ9Vxgx9pfqHq+H6tzm/lulGlduy3fPYOM7GsxUKzHOf5xrXMX0cjyERXkFvaTfXi1slaA+cpocM
+        /dg3rzd2Ru31Xq1tnvG0ZbSBg35vVmsRV9737ep44k2ZTcirrda25ZjXVq3GKQOZGpkNyQlrA/lw
+        6LY7vemna5+bt3Pb0k/+lhnUjO7m6BpTwmh2Druytzyx3XYTQoMajeaMpRvhcGrWtp1P56o4zLUz
+        VBatD7pe3Q6aSoMus6e9wlVui63UqNSmhHuttxRmQHQCfxbqe35UPg17E8nv6Ve3TU+WXa41YjTe
+        q+0rGruvLhpSWzmvQoIAQdUKmB3fQQGoyEa3oROgvVOOvsRK9JKrzz7mDru5dD8mkJ6GkKoMuF61
+        Tqm1feMANW9U5i6gqq3p2+nDMDcDUw+NYIgnNTmeZm2GDQyG1kCj3hoeZWY018YnymT6ITVnP4a9
+        QXPMQs1Bx7qysrf1q3JQTsPww1xcG0gCbLnW6JvHHu/uB2BS+WBWE2V76W8DQ/kkYLgph1OzOSFu
+        /BXyK6LXnl6mNyDTNOsbMkV9hhCqZ/di7ff+pNM7Mg2jP1TQoS81uPbx0hkOzeHOm7FbHRinYctZ
+        GyfQD49cpbOoNXYQQG7WDZgR+xms0P52OrCDjjvhpvvrqTJuDPZ1+TpcgnN3DkC9prnzs0GPCJpq
+        Ty5Dgq5sVrcj1atsZ6xMEFuBfPBVwXOBhYAau7+uiXOKoggq+sFVBzWi1ak3BfKJI5i65XsQyQbc
+        eXJybLAvQpFmv2NNgfxKjgezDQOGsmefoCVWKwTRG80nUyUYudfWprY7d0b+WHKrfJXtmuxxO5d2
+        AT1qr93l2plftaBTbZV7zAl9esE06Mgb0KGkgd9cr4ftc1cab8D5uO7tx4jl5geX63K1D7rP8uxk
+        dhusHL8l78pDRSvTodqcno16d8oMFv0OwetjJE3R7FTXt50WCur+Uh8sWMB0ljv+NB1JaAsrujVb
+        H7UR2/xk6aF6NHa6CjprbmFsN/RYovnepS19sty6afsXZiD10WV23B1DVurum73VvmFc7L60HfQr
+        g3LjxPc54mN4WNuL0YxDjlHdScfWmt2Ul+suvNm7jn84eQHb0pametrN3DLDlY1LbdO4tbrsTLIN
+        VOUu2qhKVNp9fb+a6xVdbwTh6Vwe6GF1SXCIoIMP6bwuD9b7Bbg2lwSgPmoXotE71eybel5a3M2C
+        nQ8H0caof92OP8vDkYuubF+2THei1bvlz8FxwfgdnWjWFB0tD2rvQJ+b5Sl77jXqdJtd8vgQNWuS
+        tGt7zsQqrwCUKq3wyNd4RZE0GFSC7adMq/srY/JVdQ3cbbVnOR+jzafZbvUmqCvX2/PQ85adS7hp
+        nhuRbz46yN1fbFfDwVa1fcsT6ZxVhDOuKCi+pRkw+/2s+wbNmMj2XRViUIMiDDwZu7BH3TWK0icN
+        DSJVbAcedC1glOZYrdQAKl6BVnrRj7mZvmd7wMBdmopuQU1k+O85/0n2rII8sUJ9Z1/oyHui4gEd
+        4KkHkX5h30WPGggCz3F1FYoM+zKhXPikhFd3AO4eipVXnbtMUH3Xxak4zL8Si+4VB0emByhn7HDs
+        sV2RjmLLM5izLN9UoCvWytUCKwVzlmMAFSKxXOCkUIGDrSij0FRsgyzCLkxR8d//KurneI6KQuxi
+        opAZOdn5ZuSkqlfaubZZ8g4QVymWDwXykZUrmdA72FoBiE3THDfGBZ3EXIUmdoJ4tx+h/3EqUekD
+        PCBKizkev8DLBDnVCx0oqkn/BWIMF9r3xekoPYlPRyH3/oySrLXeWgznuKMHMOfEE69ruJQrIQ9Y
+        GnC1AjlZlmXL9i72ZhSFhWIzlXk6PsJFaQYIzwekcCbSHnCWHI/LFC+QUb7UNTyoB3QjcjLbiHJo
+        LEu/hZ1vxB+pStYUcHWJU6eHe/agJl90eI1r0Dew4NrXpAeBTD/jqeAYFiTmISPAAS7AhwZ/k8U5
+        kemsn85w4diS+RZB7Cb4F3AhSOzeXglk3koESUTEFXh4PUAXpoTE8qrupSfcsC3Ntgj/hE1xBxN5
+        TB3G8lSYKhsAofRXwgeuhzAlB1Jh4gRYWPorMJ1/lprYHfxoKgVxZOG4mE+6DSGKrVuAIitiK8gn
+        nFmikcjYWBkSXRRSXqZ2Rx46y3nP/WnAUuH7TpPlZIQHMOfE62gAfNS8dKGtJ4VkpWQ+BTIzYrSh
+        bmr2eBOKwF0c6y8sHTtbaYBvUPj+k1PTXXF1fDiwV0bOKDsQJ7oo28bx+q1IwAEDX72AtYcyTpNp
+        O+5sfvD/UaJxCp1Bx4NR9C6VKRrH9JySsH1Pxadyh6AnMtVoqGc0pyGoYlfCR7nClTm28sjOhAk9
+        xP9MU4tOKF2leIpOmXcc77Rdq1K0HMM4uuC4YMKYTlA8QdFzmv/BUD8o6u8U/SMa6b1C2u+zDZI2
+        Dluu92IV1juURiD8f9qjWq5wDPXT9mAp9nfZg8X//4g90vXHsSZxxyjrTOvNQXsqkAU4pcRmGAEP
+        p7FrqYErLQv+DZUkvBw3KsTc0rw9m2eKic2Sbxwoq71OJonCZvJlYEe3Rdwd8KKYUQRTBk5hB5HE
+        yoSZjEso8bgEIqz7uERUQ5KZfqySquMVej4SDf1y7z6FMkKSVcmsHSdPpJtOVFbFmSjTS9Jq8u07
+        COLsYejIe1hi+3WJ+GvUpYo4+aaPPbTlJLsbwNM9H9ucxbVFma/SNMMJ5B0VcDTfJ58E9Z2m8A6z
+        VVxm5bBA5p0dAJJxVsXxYIfipPYARNE0ykk482dhNG0KJghk17csvBWJ39Dl6Mb5jEZ31He8Z1Sw
+        IIwyIc6MUXaIfTKezzs8Jftu/FpUoGVIQojWYLtmFIaT6b+gQlRhJsmzSU9LlbkkkHcoSxE45XoR
+        Wz6ZIpWWGc+4gA52HFV3yXLi4Z4w4Yt7zcOF5qduMg9XmPj9613EfycQ4toyGWtWbw3b09mqPRzO
+        BLIgSElx9zOArw8uPsMr7Iooo6WpLC1B/vDRx6nMzG4GOL4Xm8LDNuUhdgU1nJXoPyMA8zxd+fkA
+        TL8mpK8iWXSkHNs20rI29o0nLDpohm5GuT0rLbPmb8R1+qfzXOyJyeyIOjXBnp4CqQThEhbpipF6
+        7zOYsPJomDg2Dnlp9blMVXJIeD33j2c++plsHPedoUqTkUDmUCI9HEwT10g0nyTHIpaMlx/lqPCX
+        lWi9yd0Ey5+gIicag3xA8qXFFbsLzz5E92xg2XcIakml/kwRknRQsECzN20O29G0nwQP1KSwc/Bq
+        SqruqgZ8VEit8e6J4vltImk/XalewQde4Xr1Dhbev0W8PEK8fX14eXb42ciS3tn/nIhJZi9Tf+TN
+        NXvzSh9WXt7CHvDf9XBG3l/Odvg6iDNVLEVkls1AaMblFr5FF9NZERaAquJqHSjRDDAQXS5iPPqZ
+        1CfAhAG+DdzbiSi5pJkQ7yWwSu3AwRdblNJSo+UdFbszQXQDtr/ocfQg/Y2O8MFy1fiJ4Iu+ngj/
+        tTsctcAXHS1z0UMX5KvxkO84Nr4dyopuREWnDDQtskz6J6gvhPF+IRniG6fxoPEOT8lgH22iC3cw
+        erWCBfqzJCqy3v+57D/8qA2BbxsAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2158']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:26 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2872']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:55 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <make_reservation><describe_trolley /><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><trolley_token>64--iT3taV8o23t_Cio5ezl8RWnF2dwamqGnxAxyHFwzwLv4eD8d-OfT95uMI97ePXNksIMIVO0SFfXmvpFi5qwdGzigDgomE0jFeZsfr4xiAVNWuchyHmEnb-ZQWlW_eYj3Ty3O8BBbfRsV0IVn_kdXhLAMRCANf1cxLZMxsVbe9TBqpwp5oq5DhdTECfGomixdD6W2l1QVVhDMuOi32cj7Zj5eyDDjA7Z_Izg8DuRLow8In4WUGqrQgRF_sPeTKSRkFBmYtcGk48tf3fg7wNl4UO4UHeUT95svXBLQLpTu5iz7mkhv1_W4K6WmAZ2o5UkdCcKprnlrjS3dPcCPjhvwBYZ29YUkWyFEEATFzsEIqpbycidEKgDX6dE7XiTrL12TH7DTwpENW0BcJxTxY_2W6hwG4S9QBCGIdJyFdWBrvrgKSil_LMvbZ7zBdyYea94qt_YeoSnkNpNJMIUBnFKDOLyk-Xi18lmkez_cXOdFnRikyNpCbgj3dyeD5y8IbZr8QhR9hbNhIQ6-Z</trolley_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsUDfEXxcUCHyqYlLXHoXFHrOkiCFhc3j34smOD16W2zX2VOT-TnkryAjJ8N15iPw8qeHlWzsKzFfY</crypto_block></make_reservation>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['895']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61ZybaqSBad11dYb1KDKp6gAvoWaS4b7MUOm8uEFUCoKJ0Enf5O/Ul9WQWNgs3L
-        yszKO7iX2GefQ8QhThNxuV8j0ygF0EW6bf3yjfpOfitBS7U13Tr88m0t9oj6t1+bf+NMcIayCxF0
-        A+BhavzsG16TQ76i2SbQLdnHQllHsgK05hUirvxZxKnu1fFsWTFs9dw8MwTBbCa1s8W3r8RKBxt+
-        K1Lr/aC+Gmm7cUMw9UVkL8Il0ub9L6MuddZdml71I/TVNuYLYQhnPX9wRhI7sC3B3O9bbqBrk3r/
-        BoSLUPGNKdVZTmlJ7A29RRveqkhRjrbLooiJxu2xNYl2rZbckkhTbHn14SAaDVoscxSAVWOH21av
-        PT+PVHF9Zand7RautvJ+2+7saI/uCrUwXFYmFgHHfh+xo8Xs/GXTVjUi/RF1+arXAjZCpLQ5a1V2
-        JGyqiyovzMkBCC2CpPj9QWKOPHG199PhqjvR8UuVAExCcjCTt4dOeySqw3bQEhZoedP6ZiD1h9Vd
-        tb7bTYj5PhyhxZQNem1zNWgfJdf0G8swaqDjHpJ+TRpUR3ovMCqHyfhsR5PxQNSE6rRuRaMNalxt
-        6cjTDPBb1DbQ3fGUoO1wy3Yvu+5mEyC7YlRdujeGO3u6WbKHy0Dv26f5aS5rmq2tgst8ZVUMcRPc
-        dGPk+GNvHtZMsRrW+vSK3u0GR7LT6+nbtbmdiwienNu5YlESnG0Du+40HO1yDZB0dm6bHrULRRN8
-        qcKmu1SdRZ10WrW9LkosMyMQrGl9JIWsSc9swqnAE13rna1dDbgt2B6IIjVst9TxsT2grdkERqrl
-        t5xRNKvVrI1LeOGo32LXkzVBCwIf0VX/dGBvJyGUD/vd1puMo5PYV8OLHvqXlU+fGUW4ociqHYiN
-        HQ4PDlGtR0fhpNx4hugw7bVZiepHXll68rlfXV/btBAusd8nR+SPA+9q75Sq2BhL0BcrTuW63K6n
-        webArkI66nb3vf1sURlBIthflyxDSFz5af9zngssBNQkpnStKZEkSZDxryrLLokBU2e48guHM3XL
-        9yCSDbj35DQWcVzCJkN+x5pc+Wdy/DLbMOBV9uwztJo8TRDtPg/ZqCb2mJty0gQBhTTpLjYNQM52
-        vCVcOkTbn+gLfXiW9sFw3ZaP4rnRGSEbVnqeRc5CfsFU6vKybc3mB82UThfGud6Wl5pKLyd6R8VW
-        iCGP6lVDO1Ed3691q33RN5Y2IuZ11IOEEKzn/JhuWH5ID12dHhGMe+rYHvT4K9wdrrLrzBZqq7U+
-        XCZtb9VdDjpHSaVOgTMYC9e1Mr9AFkyE0d69Lo6a0tAX1rTqTniguDo7Jy9OcHRc6TCYdhTS8Fy0
-        xrYZad1SwDJqUC1CQ+PKYY1aZ5+fzmfswZrO4Z6SBp2REvCzsTs3LTiUBBQJ0fbSGMxvuyOCjjRq
-        8Ld2sK4t3fpAbqmL1Xyuh2162bJYahtuB5sjXoDQ3/C9W4Psui6qLWAbzRoOq50dSboNrtWteSWc
-        zYzdL8lrY+NNjmLYWIvKdB0tzZm0ulVEIIc7ecQyu17QHwiD0SHcgMt2Xj9Zvd4F2cbK+PqaTX1N
-        c3vaEEyBEsx60wDRtCJS4xO6kQbbIVZfxnId2Pvzmt2xTHsgXNrkilj41OzSZlc3uNqRdl8KFpKp
-        7vhGZauMwNkVeF2k1Mvo3NneYARqumbvu23XavGTylTajr5ms6lGO7xPnU7Ml+zJtQqI3I41Ai1F
-        8UFFE7b+eb2kuuveypiozpY0q/Hef96Aj/1ouxouEKrtW16TyllF+M5tcopvaQa8/33V/YDemcj2
-        XRViUINNGHkyDhGPfGgUpS8aGkRqU8Ts0uqKPGiWJOjar4oJ6a7o2R4wsC1T0S2oNSuN7/mLXmSv
-        KshrVsnv9BsdeS9U/EIHeOqxSb2xH6JnDQSB57i6CpsV5m1CufBFCa/uCNwDbFbfdR4yTvVdFzcO
-        1/wpdeVBcXDKe4Jyxh4nNdttUnHSegVzluWbCnSb9QpTYGVgznIMoELUrBQ4GVTgYC/K6GoqtlEu
-        wi7M0OZ//l3Uz/EcbXIaVHQ8Q1k92npiPwNySbphjrDU9U3zWuoAVyt1UxlXfiI9VHTLgwc37a00
-        4IFyLrKACZtabClXTrAHw7s6b4wEewzzp3zaSYzERtLNkk6oE0eZ6pX2rm2WPLyEAFo+jLWLrFzJ
-        hN7R1gpA8ok7s/asoJN+9sIQb+Zk1z5D/+dU4n4Te64prEX8/gLvLsipiXPU1H6B+PDZ6+J0lKWS
-        l5DOo/hOSde6EtddXhCxqSc4ZyVTX3m+Bi2vhD87LFDTZVm2bO+TqERxXisOM5mnq2dYlN4B7jXQ
-        C7GdWcBtxFe3QmLVuKHQNfxSD+hGHCy2ETcZiSx75va+kTxkKvchh1t63Ft42LIHNTnQYdi0cGL8
-        AHOuHaYWuHL2mEwFJ+EodU45BhyAfWG7+LlcnFM5m/VLLiqkn3L+iSDeJvgPcCFIvc5vuXI+SgWJ
-        j3l87rmGR+jCjJDlcP3gO3IADB+mqakIcKruZXnMsC3Ntgj/jB31AFN5YmiSyDNhalo1AELZn5SP
-        9zXw4gkUsEx+zyJFeWoGOzg5V6XmksPWMxT7FvtGPuOCmb2hnHjxDsbntox613wgT/Zy3geTZ11D
-        n82mC8nkT1hOSdbSA6ZuXAukdIXl/L3lu9Piz+tmbk6cXgQe4kR/bel465XG+BSLj6A5NfsKro5D
-        Be/ReGvKDsTlO24ekir0UcTh9IGPv8A6QBlaWjbOvo//rxJV946lln/wcYuAIwTXqZyQcn1PxRG6
-        RxBXdyZ+0Sua0xBU8cbBYV1jKbpGk0/suzClX/GPaWpJtDJknapnzAeOP65dZ0hKTmBgaThH4MIR
-        0wmyTlB1kWr8qJI/SPKfJPUjftNnhczuqwfSMfKA6735pEJhZ7Rw1jH+SpcwVIWp1n63S2oV6g+5
-        pEZUqD/jkswFSepJ92NchJatzphfcuUCnFESN0yBhwMpLLVxA2nBf6CSgJfjApzD3b/flVJ/pc84
-        ZzLD3l0SZ9D0ycC73M4TSRHMGHh6no+ahh485Bl0J6QVsnwfJ4UQ6aYTt3pJVbnrpSUyffYdBHEl
-        MHTkPc2Rf5/jz+Ye4+N1ES9/sH2AtpxWcAN3SHHVbNJJ//AYcjgZH9JHgvxOxaIHwJVz/SNAMi6W
-        OLD3KKlVT0CcC+NSA7VHEsyGnAki2fUtC7s1/f5UJT5pv6Lx2fwT7xXlLAjjAocLnufjNjPeS8l8
-        PuEZ2U/bwwLtjqSEeA22awIL1/lk+m8oFzfAaU3sUMtSTRS48gO6J3hcSb2YLZ/NJpl1D684h452
-        kh736XLS+75njPvJeevpoPXbJ6yno1XS/WXtVas74ZerLT+ZrLhyQZCR0u4K4IOKi8NqizcSutOy
-        8pI1CX8qGnFpMe/nj7iBKgy5J2/nGW8LNZwR2bhK/PUZkcWJ/w9kRPYtI/4sROPYcGzbyNrO5CO/
-        YHHEGLoZV9t763cf/q9Ey/7eRJtsqXR2RKvRwls2AzIJwi0m0hUj24avYMrKM1y6Q3Eay7rDTaaS
-        Q9x7AD8Hb/w7/XDs9ypZmk+5cg6l0uPRNHHXQjWqSQEvYun78piMG3NZidebvD1e4AtU5MTvKD8h
-        +dKSjtqFFx+iR4a37AcEtbSTfqVwaYoveKAzXHYmfDztF8ETNW21HLyakqq7qgGfFTJvfLoKeb0D
-        SccvR5538IlXOP58grnPdx5vlx0fbznerjd+b17JztR/ceor3++8/sxt8f02Lbu5ebtle8L/0JVc
-        +XEnt8fnNFxrEikq3+sRuJpJ4wNcrViQijAHVBU6HlDiGWAg7vMTPP6dNhsmiM+S2CU5lEqztF2U
-        Zu7KTTwbwv514/FPbb0QftMczi/gJ4Y2uejJRPl9tch3HNv1kKzoRtyzyUDT8OEZ3f+F9hNp4mEk
-        Q3xGMx7gvTF4xTMyOMRud+EexhdZsEB/lcSNzef/9/0XWg/ibjAcAAA=
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3005']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:26 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/MakeReservationTests.test_get_details.yaml
+++ b/tests/interface_objects/cassettes/MakeReservationTests.test_get_details.yaml
@@ -1,731 +1,667 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:27 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:55 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:27 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:57 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:27 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:58 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGNyeXB0b19ibG9jaz5FMC0tRXhJNTJKUkNxLWdMRHN2eDR3blVa
+      elpTV1NZRHFxZXZKRkd2bDRwb0NpdkNxVVVmdlVMQVhnOWJwOVhnNi1jY0s1THRRSlN2Um1MZXZl
+      eGUxMzBpNXo1UWdFV3puMVdtRTJ5WHdnVnhkTm85U21KZmNlWHlZN0tNTnQ4enV5Vkp3OWFSWE9T
+      ajV5Rk5wLTB3QWR2MktCSHZwaDZjRnFST2NyejktNGxEaHV4MlhIYUFtMUY0U2JuZEoybXF3a1Jn
+      WjwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bm9fb2ZfdGlja2V0cz4xPC9u
+      b19vZl90aWNrZXRzPjxiYW5kX3Rva2VuPi0xLS1RMW16UTBaV0tTZWNaazl6NFdQN1pCSi1GazFR
+      bGpSTGVIODl4djlzQ1llOGJFZXYxM2hoRkhheXlfNllkVWJIQUd5d0VSNlNSeW5ZLUJlWGhUd3Ey
+      YWQtYzVoQXc4WmhLcEpubTNONjJLZnpNM3B5QnNtUC1Dd0NVSVktY2dzV3F2S1kxcS1CUUFfQ1N3
+      SmE4SFJjdGZ2WlFpSktYN3JGZGNGTHlwQzZjQ29DWGdPaF9vc3ZXY295UU1MWjd1SWlpYk9Sa1ly
+      NFV2dEl3el8xbWhvVzNQVVdmRGVnUzJzWkpzV0RpcU56bXJkZ243Tlg4cjlfZmFaRGhPSDdjOUpi
+      WjwvYmFuZF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkZXNwYXRjaF90b2tlbj5jXy0t
+      RnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJYaWgtWnkyeFNwU09EZEhh
+      SHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5OC1zaExzUlpJRW45TEJX
+      M1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tlbj48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['449']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS0HvDihIg7XFxZDKMgoBCj+Tv9Jf1kHg4Je
+        O4fKzLeqlauS2GfHCeLEOWcHJvPHxbYqEfADw3V+/0R8xj9VgKO6muEcfv+0EgdY89Mf7b8xmhGo
+        buhAyfUgYgaSD4LQgm0mCBXNtWXDkcIA+JIRSIqstR2Xqb62MCACDpon+0CW0DqgzW6YajHKDBoI
+        1DaLXis+68AHOSFFGdWAcca1XEdzHSw0mWoBZvaUOkntuTGfbMlBkP+V8WUfBohSALkx5XeQsfJ3
+        2fb+Xemh7YbJq5TMDNpUusPMbQyQp0eICYDsq7pkgjhdqYriUiBJ9HLebdodeXBW8J79abKjgtdO
+        s+3cCA9gwUn30ZUtC8B8o/2nCdlOq8UrVG9BTBLCz8OeHkIZuJvT+SvHgECrjFFaoaQoqPmp+AY0
+        VJRTkQHOkgd8NckRAscR8aWJ0WQIJF92DkACjpaPU2eiHv6rQgSwsgQeBLYC/AqJE3WmWlAydghV
+        yd3vAwDbVD1Z6hktaAFQUSoFbYJukI0a/ci+GTN6jP6zbU1rJ4viLZzImXccnbTbrOOElMKyo0nQ
+        sEFKx/AWhhMi0fqNwn/D8X/ixG/JSq8n5H6fY5CNA4iS40NUalCvTOX4Z8ajTtINCv/meNTw2nfF
+        o4b+/Jl45PtPe02WjvxK7Amd3pgVmGoJzilpGKYyhDo4V7pu6DvgH0GFR9vxZdVEKSSyS/E2MYtZ
+        9mxo7fpwcLMYt/4mWSjR3TZyJ8OkZ5TBnOHJUG9X0WTMztbFlHRdLMCc+7oYBAGs3uanU/LpaIcw
+        DNqWEd3d59CNgNqvDOXqbQxjD7QDw/YsgAKGnMPbvNSSs0IvAJaF3jSAD1tkP24RPU05vIxXX/g4
+        ADc5KLnNWDI0YIhiXiM+18hWnSCoBlO9owzq5ofsEcM/Ezg64VqdRIQ7zFQLZ7ocSI6b9IN9kKrN
+        A5B0U9QRUce5t9F8yNjyRfJDx0FHkeUNQaI9fEAZG3XdF7xnlHEA0FBGeCjfkDqkOZm+zys8J4e+
+        nGhoiXZDMkKyB9e3kzacvf4HlPHcAGbi2SOECi3yTPUO3SQCSTZM2JJpt/HP+F0jyjgT6G7aVffZ
+        dtLlnjAmQHmJ6KlzcEH5gnIycVeCb5xMty8Q+I5sVURErHSTRHa0SjEjq5/0UvCq478yMCixwnyt
+        Zac/YYXlhp1Mlky1ZMhJqfulrFnARzW8QakY3Gi5lOVXkIeIFt1wAzQkIMSv6JWtFkF/e68kPmrH
+        /2s6SfZ7rmulaZ7fHZ6wpCYsw05kOM280vArLZj4ZklKkyZ7O6yDz1FS5kBuCaTICAzFyhPtGcxY
+        RePKchB1p/yiuM6nFBDzsUQfyzP5f3Zwjc8UXplPmWoBZVZdt210nSFamY6VsWy9e46ofuxBV1Is
+        VzXbUwrDvHkNEtSBlVXalIXudWeTuhutBMPhuVlgkuo4UubOUbCgNrqQvd4RP9dbR77FLk5S5F35
+        2DT7K8FuGrQ+6jkreFUipdk5cUNLBc3x3pZ74tjXvL1lDYQmO5KPVmO6dq3RwWxQxHKCNa5DsS/W
+        pS0fen2bVcXTGIZDSu1btBoC1rBFZ4L7RmdPc7EAIHccWoK4PMCVt2GbEmsv+krUeANrsyX68/gw
+        P+v6ecguW+bUtg+z/uy9f9VDq7GmG5sWL0Flya3mZ3eh0YOr1j8tsV204eaDbp/g5pG55jcTjDxv
+        V9Pu+0ggllA4jKlOIOG0wq5rltPz9my0cFW18cZe6xam6ZFKBRNtAPvyXMPm516NdJeu4hIgNiPB
+        Hg1mKuQ9TtqO3ll8Rtgrj+pq/JEfnrjxmxWc1V7EwcF+KncGrLAJ3wMruA58F9DcdQ4243ptSvOD
+        3di3CfXisFAzzoPl5djvw+OkT485stsYyjVX0YQ3BXawXXLXLJ0vo1iyg1RSKj59HCtOS+e1pfhG
+        SuuqTaHqfUQYNfR99HUVF09ZGh8UD63+ABWMvaxC189vw09gwXLC5KrbbpL1EisHC5ZnySoI2mSJ
+        k0MlDhISKYhtxbWqZRipWIa2//uf8vwCL9AiGMFDXNCNAH8IS3JFQLLt7qViAo0U7wm6+0Dfh0rg
+        WiFqO4EcoTrPpO0ZRB8ftmI4qLdRrcR+HxYvk0a5019NxNILZaG/D7NvQA19+VUSzdRkXyuRcz34
+        yu7uQ+giHWyrOIadTKzVXY/jCx5zw8b727pPDh1BdLX94rR78whpEZIUy5HN96CGMm0VXTWcvcwI
+        +mw1WHuwhz2ObACbr8VU1xodD1YwkMddthlxTTpyur6+UehtxxjESmfKc9vOarzAj9aJXkP7PD5z
+        /MzpT8QemG0Wi94+gkGzZfqboOGdotp+PhiMdmezNbXOHe1AKFdlI7sxPFIm5UbWdGlSfJeXVq7W
+        s2EX7weqUbP2FuYd9dF4PN4u+ucBuSsFIdt1KQrJZbMcpez2iVQAKSfK1VyasgFKDSd7lJ4O9IWh
+        RE4Uz/MN1LOp2iO7sJTp6Fqiy/4BtOkn9t1QYmeXZ+m1/wcjk9WfJEeyYcmJwiFF/4Ax+SVHPhQ5
+        nQrPE8ikTiUlkdsseRHrCSpzkvSsPiCFsvryGU1woHEI3TDIbwgEuo6/NKR06ELZemKWMeY56KVQ
+        PwW4FNYXwXwMYbWo/D/dA0jiSz2gxw0n/a/0gJ5uWFoF3dLBj9Y/hup/MrPtKdcbqoPpZLVRjAO2
+        ssfieL2bAKTbI3vcXGMY2Y+3w51CBCJ+4PZCPzk6QG8miq0vunWjX9eIix7hsqGe4vCs26ap2dtA
+        wSSIBHl42I07kWVKFKcvWuxA1nbS25BerhoT1msK727Ei+PT6r0xmVDXQcvvXqh+h++1LrPNynwb
+        rsH1elI9aYdhX61l4gdqOTuYb61lovldtUx9by0/+/+rlu9BeVnL1JdqOZv3C2r5i3q+FFd9lv+a
+        oi+TnxMc+FPq2UT17GPxebJddlnWqznX/ZD2uzzRiHrWfOny5mEyn7iR8z7ZHvsX8chpR65Xj+Z2
+        NI15DzojxdKN6I2bDa2Q3bwfV+pKEt6l3tCGbOOkHK52d79Vh6fNsYOu9cLaP8lig641u9dQsE7u
+        uaY3LouDyHbZCF3FLd7t4cPl2TwbyKUn7bueQY5YZbicjI6NWcemPPYwmR2c4/xiYS3K655W5D6O
+        pyuBvtRngIhtasg1AqMJTD7e94Y0JvC0EPaImo3PZuTX+wH5I/3gu7SdrP/afvDs/69+cA/K9/eD
+        bN7P7wfUF7V91pl/rRcAx3D9impA4wqcn9IS6qglDEyKmxgcTte6Y0ne4wK7D4TgeMbttdUYGWK0
+        ah6W0LlsKa+3vhr+vjmCO6G31UdGf2SbMqV350rY6h54rTkX45ALdV912bXWXEN/esa242406ZHH
+        eG1uZ4Sxj5quxQn8pkZOehoei9KFvC75GPi7S3PhHWcCCXbXGqmfSJ2iRKsf8EJwUtXjEA99bo6j
+        b3TaOknfIPfUj1zdv0vuyV8s98/+/yrve1D+RHl/We7vj0H2W2VRkrprJD8/3H+x/GAp5dvTvz3/
+        D1lRoYe8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:28 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:59 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkaXNjb3VudF90b2tlbj5jMC0t
+      cWstOUJWS3l4MHlISTdZR1ZEMkluUlRvZGZRcVpHcDFfUXUyM0VIMjhZczVhbmtVdnpkMEV4TzE0
+      d2w3RW1GZnRDSDI3ZW1ONXkzQmxKamdsc0ZhS0JFOHZIODR2bkJyaFdiNFhBaUZ5YkFNTkhYQVVL
+      UTBqbHE0VnRtd0t3SE5PbkRMVENlT1dRUUNmdnRzODlrcldzN3BxdjVmUEZGSlp3azlNbHdBZGcx
+      YnpiV2FveXRqM2szb3ZsTVNrM05CTl9Vb2RDbXRCMERzY2k1bGZsLXBqaEpLS0tYUUR3RjJaPC9k
+      aXNjb3VudF90b2tlbj48cHV6emxlZD55ZXM8L3B1enpsZWQ+PGRlc3BhdGNoX3Rva2VuPmNfLS1G
+      eUpWRGY4RHlFRGhNWVU2Zllsa29BMUcxempMbnZkVndoN0tMSmticlhpaC1aeTJ4U3BTT0RkSGFI
+      emR5YUdqLXBySGQ0N0s3dmZDUkZYdU1FSnVValJLQnNHbldScW1IdDk4LXNoTHNSWklFbjlMQlcz
+      V1ZLczNQLS13Sm5RSE9fenB5WnV5VWlBLVk8L2Rlc3BhdGNoX3Rva2VuPjxjcnlwdG9fYmxvY2s+
+      TTMtLXBQNXQxM2dFYWM0a2FSQnpabTJob3ZVUmluTkhPc2syY0t2YlBualJsdGRKeDJDQ2owdzY5
+      ak45RVFxX3Zwek55a2tEVVJtOGk0aEpDblV0emJ2YjhBcUhJbGNlOEtmbWFDVEtyZHBmbGxGUjhF
+      SmFqbDdNVm9sSmdrNzMxU0wtN3pJVERUNl9YTnVwRG1FY1RxS3R1STNjRGw0Y3VlRWltVG5MMHJp
+      QWY0SHlSZXRIaklsUlRTZ3RVcFdFOF9FbVFEYnY3R2VWazlUclB5Z1B3aGh3SUVTOWtNbW1nT0RP
+      WUR6aHVsN1Y0N1c5Tl90YlNIVVB3b1FkNEZ6ZERxUy1adldIUEZCRDFIUHZrVk5XTC0yd1hVTUJZ
+      SlIxU3RSZ0szQXNfMDRiRVY1bG5DcGZFdlFvY2M3R0V6NmwtZGh2YzNzTGRGdERhUGQtUHdDNTJv
+      U29ibzFleWt2Um1KRk9jdE5wSF9YSllFME8xbVVwM0JkTmpOSXFIS0dsc3djQ3ZIdEZmTWFBRkVS
+      V3VZc2xzekZyb2U0SHpQZVdLNjVNNE5GWktybTFjeG5FdGRpd0ZTeGpERHRqTEQ0S0gyQjdJYTVv
+      YmRSR2J0QS1aPC9jcnlwdG9fYmxvY2s+PC9jcmVhdGVfb3JkZXI+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1148']
+      Content-Length: ['1008']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
+        H4sIAAAAAAAAA7VY2XLjuBV9z1ew+mHmIaG5aO9wOKW9ZVleJFmS/cLiAkm0SEICQC3+nfxJviyX
+        BChSsqbSmSSuLps491wA9+IuQBu/H8NA2iNCfRz99k27U79JKHKx50er3769Tnty/dvv5l8MlyCb
+        IQsTDxGLIBoHzDRo7Hg4tP3IiinAPrUc2zMjbCi3JYYbEwKzn/IvC5ZC5srZGsollDOWtsswMTVV
+        LXAEmLOiOHQQMet6tcASYM7aBraLqKkXOAIqcDBlFj2FDg6UIkyQQM1//qOon+M5CnrktGXYcgLs
+        bkzXkuWq7NCP+dNHMF4RJNOOcz9uPLXcZX09rB53k8dlnz1OnlvPTlUL1FPTd7a96Wr8Uhp674PP
+        jk9XnztGG97sx2uLWCffDwYrHZfr82iP3iZPM2cR9OkMP+/mnfmh5jgvGpr9mPW2sku0T//9hOy5
+        u5r1ds1P0pHfYKfF/Rn8XBneoMis6rL8flRlbRAd2/t5a9hYdtnboq82WAc1SbsfPcz6h9Wu8mPR
+        H9XR8TCddOo7/aU/6O3wptq+Xyx71n21/PBWZq1HN3Le41pVnSH/1B2w8eDw2Qg6u8FLadHc6c1h
+        975B1eWL3w3aeDhh6nTf7ez9Zs/W/U515I7eV/KijJv3R28dbYa91uKw9BalaIlaFW0zGNn68Zmw
+        oFtvfp68NVKX/rv9uWmMYxmTUml3Qp3RyDno88/jev/08sZG+DirnWrTYzir3J9au1Kz9XL/OGnY
+        4Xo/bTmd9kelNNdPVth2lg3NPtgf8vuQ6m5ra+nHwJ8ebH+kq4/DnX2oTiqzUT0s43c3Umn51WrY
+        nWnY1/36y3bufiw+P96qbzPWWw/cx2CNdtFC7i+I68z1Pn43lKLLuf9Nw0N0azN3bcGHa7ZxECCX
+        SUuCQ4mtEaRpFCNDuWTlSiFia+wVgDSR2k+tp4IOT67CkDJTu6tcMAD6L7eS5L/NbPPxdQrrF3iZ
+        IKey0xaZLp+/QEzhwvhsnE9dHEewQxeHjh8hzyw17pLSkA3PFG5rs/P6MIWJLsCck2686UE9kyiz
+        I88mXoHMzYqwhZcWhQpITc1QikMhY767QUVpBhgJbUt8F5mlSrLNfAzlk7hrm6yQWU4l52G+AdNA
+        4Gn4Y0P95Vvvzg0lH3FBus0uVPHTYY0IEgS+eddnoqQGOPJwJMcbcNYZ5PKU+pDKhVAoBzal4g/n
+        24RRoOSAEHI/glD6xQ63f5fa4NE42UpBbEAfSJsCn/aEYKZLKHEXeMHaoFO6kpI6LEOShiN4mdoZ
+        uZgs513P59mRi25Pys3JCBdgzkntaNkQrUwY2rlS4JYq+RaUzInJgRLh9vQQisBZnOq/Rj5DnjSE
+        Lgx9NKeKUyE+xBe04b2PDtYWETeJEd4gb4oML2nexI5WyEKRJ8bpZNN1/DdJo0yaoC1DSbuUdFWD
+        JppTODtmLgT2kiJmlqrJUtdoTqPIhVCCbCjX9FqlfMnOhJx+gp8w9DwzWVRtqJpgnnE4aVyvqpqV
+        wpCgkFohSumy2pBVbao1vpfU76r6V1X7nqx0W0HMe+0DPobMJ+yLVypsLY3s0//SH1W9XCupP+2P
+        ilr5j/xRgX9/xh/C/rTW8HBMCve42R52x4ZSgAUldcPIZtAJDlILxyRCv1LpEcwhNtQ9Ik27k2mm
+        yH3Gv33PrA56mQRGAg8g0LEJ09ksqRlFUDCgC6xNBZTlkK8rO+m6MpWj87oyQ5QpmX6qItTBQhZT
+        M/D35+kFlBF4Y1Kycdp/qB9uAySKeabHOxP/jrcUBQHslLILE7tfTYSv0Q+1iCs35lghbPEGGdjM
+        ZzH4vALtWW9UNa1UM5QzakA1X/FPWb3TVDjhShXutTlsKPlka5ta0JigHixpekG/AJJqmvQlaJ5Z
+        GRVDI7SPFomjCI6Cx42mgw1fUCOEqnuDd40aEUIeRMQW4g26QxqT6X5u4YIcE7AZRwVahnBCYgMm
+        YVKG+fa/oEZypefNs62NpfL00VDOUNYioOWyhG1tQlMVnfoaN+gap1V1yc1Jl7vCDApxCfR0cnSE
+        eIGYTKYrwBmH9+0jQySyA2kKRKmVBHLkSbkGz5/0HXWr4t8SGOn1jK81aXYeuuPJvPvwMDGUgkCQ
+        0uknthcgAjk8h1CkGU20MnEF+dOpD60szJ5iST0qDI2LY8pL7Bx50JW0/0cBbjS08s8XYO1rQ/qj
+        Spak1BbjQNwM09i4wpJEC/ww6e1pOBeG/6auaz/d59JI5LuTm+ozRLoAhIRae5/6TiCi9xrkrLwa
+        8sCGkidunzOhkkPG17y/zPnkNz+42l1JlZ5HhpJDXLpehyHckbQGb45FjK+Xp3Jyd7acxF5+vQf5
+        FVTkJGsoF0huWnImkDm7GNFzN4jwGUIev61fUwzeDgoeaA/G7Ydusu0rwQWVX+y2YI3k+sQN0KWC
+        8AZmdmBdPW2uQEG6epV8BS94hRfKLVhwr18r12hGu3y5XIM/XVnEs1e59b9L/wL2/DbImhIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:28 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1879']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:00 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order><crypto_block>E7--NuwIhns8SF9pSFmOCtayGoPi5orsAykdVtQtCufnKnVXd5ijHtnqR7hewEY9Siu9mKWZXgSi50wUnsm6QPTTn5Ap3rEh2y8qt7LQOigLgEgeiLH4ylijiJOz3cCcGHfmz-mr55XI7fNrF6K5mYhYQ3qn1nCceIO3_pGh-y2ODATK_1unwgfaRcvmf9rRBGVuoIht5KuL4JvyIf1HGwjOVpnEZgHPJm7kxU7hRzZCGSznxEZHloNsR7I2pTbq40t7v2mLo1javANm8iUGKktt-5o16BpnLLteyP0yqrtW48EZlb91SwCaca-PJX0S8BvzKCatNcVD_hETlolGxPekOoYcRxyhOS0oqh4PNL4fG5MfxXXjHxpdCbQvBrDibivFS6vhbjmFeBcQYWikaldIWXGQFooHSH2dWMs_BXrsAz6-j8VMn40F2LZish9H3g6jBjVkrnayZ4NMPTq5FtXcdK_5L7WFk2ASLauJCqJowO_bV8X2sPX_At8097h3QpXw1Kh0OkgxfUXvzDHbFI_bN0XSMiJ0al9y_p-VXab83-6hG9eHDURd6DtENaA6ZdPR1b2kCR_toknr_BpFKcDNzxpBDj9-GWfRRbpiCUM9rPYDDkijx5sFQiucuV4RNL_xRMwwjtm79e8Q_Ffs_Rbj0MXC_rEfuYOIlmhROtFCXJpXG4CNo46bV1NKHU8emAOPjTy5eN5yHKnfgvMsrKq0Ix6-yFmDNxXSz4pazVchj_p8eOwdiIe_aY0Ybh9RJBrav76RZUsxDdWqMKRqoWJyL_--Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>k0--5q_Eg4_-x1Nz1FPUkY_jXomw7H7E1_PjxiUKNYUK3emm0ERjusgvnWUYFQqZHjDGEekx61hC9iIriru1LpexlQdiFWf9oohhZR3m54tmVkLEMIItGP0eGhqQULniBgRbrSIgFusujEyS0Rw91TvO3pqX8rgNeFy0FDAL-H3GFetfBUfLnD1Zi-94KcFBeU0CKwDSXAHtxFWU5WZiFJ-wMeIriNlK_uoAMR58EAI8VqC-Z</discount_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></create_order>'
+    body: !!binary |
+      PHRyb2xsZXlfYWRkX29yZGVyPjxwdXp6bGVkPnllczwvcHV6emxlZD48dXNlcl9pZD5kZW1vPC91
+      c2VyX2lkPjxkZXNjcmliZV90cm9sbGV5IC8+PGNyeXB0b19ibG9jaz5jXy0tNi1ic2pXT2psUmdy
+      ZS1zRGJKUjlPQmNmOGhLNnhxU05mR3ROU1BCUGI2MWwweUFpYnBGVGdSUTNLZFpJekRpc2d6cXRz
+      OWRWSFVCcl95aWlsSWcybzQ4V252ZVlTT1ZiWGxHc1ZvUHFXRFd3N2JiUTFlVkhWRnAtY3Ixemla
+      eWVhV2NnVkZxQXpyRC1ZPC9jcnlwdG9fYmxvY2s+PG9yZGVyX3Rva2VuPjYyLS1aeDAtMUlueEN2
+      V0JLOWZFdFlYRzA5dERlQXJDR25MVkd3Z3E1SFhHTThleHdUU0Q4cTJRR0lGcW9rNkNKWGZGX0o2
+      NExZNHRCTmNuYlp1NzYwVmVpeUVJdFJJd3o5bERxSVEzWEFxMkFLRUo5czBmUWlFbENvS1N0MFR2
+      RUR2aUFGYTJpRDZNY01aZy1YNG9BSnhkaG5rS0ZCWHdmZFgzbmZlQjUxa0lNYTJ4UHJ0bEU4QXp5
+      ZGhlMGZpWmF6azlSdS1vcjMzcXllRE1NYncyV3p4aHZPUVl0TW94Vjd5N1R4bVY1SnlCcTNBQlFK
+      TlM5YW1odlRCYkRDajUzVzJ5X21DYmY5MWF3YWotWktzMmNCcF8yeGxpVHdhaU0yME5LcWF3NlM1
+      Vk04bTRvWmNuMHM0VV85YURUbUcyaThRcFdjalh6alk2WVZ0RmhJY05saGVxblgtR1hyY2JXMkdv
+      Wjwvb3JkZXJfdG9rZW4+PC90cm9sbGV5X2FkZF9vcmRlcj4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1384']
+      Content-Length: ['662']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61Y23arNhB971e456UPLQGM7eCzKF2O7cSJr8eX2M4LC4NsEwMiSPj2O/2TflkH
-        JAw47urpJQ8J2rMljUaaPVK0346eW9qjkDjY//WLfCd9KSHfwrbjb379Mps+CuqX3/QfNCtEJkUG
-        Dm0UGiEikUt1jUQrG3um4xsRAdghxsq09RMimnjbpFlRGMLwp+zLgLmQvlkFmliEMsbatCgOdVmS
-        chwOZiw/8lYo1NVyLcfiYMYKXNNCRC/nOBzKcTChBjl5K+yKeThEHNX/+D3fP8MzFPqFp4BiY+Vi
-        a6fPDEHY74J1fdesB7PqcCVsQry2Zfp0sAaj5buCLPKutJZy7f3bbigt535r7027WzJrrduLozVr
-        dk4fS7e36ODFYycc7pzm49ZS3pUK8YYtuTYvnxfl1+FUmPq78NR4f1EHctUZHdQP1HHnZ9I9P66X
-        4F3eJ41tJsU75OvtsiBUUadq7KMoaLxvvlmbRefQD6aovqh/bCZueSm5i6Bq4f1hJhNSeZ4vHxrC
-        eKYaG2XUi9Tn7nmDwrOhdFxJUfCz8NpvW+et1Gjuh/35Uq2co6qC5s11Y9NYlPeV+5O6eXMx7TkV
-        ggeDtUqXiO4WH294JAzkrdudvewOb/ZqLjUnR1SbnTyzbb9PFuH5MJSGRms4HlvzoHZ8RuOHD2Oz
-        O1bmUX359jIiw261idqCGTwaPeXQDOyPLpooo5qhfHtr7MevU3v89BBNzhNh0XkJXmsR7ftC1OvK
-        C9MJBpFKW8+NoTto9NWn1pM1Wi7HMJJihB0Htu5bf9h7c04P/frD1vJPvaemOnVmw6k5PE4n87ra
-        wXar1Yx6HyevLffnlve6mGxrxxfyGvlWxaOjxWhwdO+FN03Mh5/tha7ZiAQmtbYGfFh6E7susmhp
-        HWKvRLcI8tSPkCYWWVknD9EttnNAkkjN4cMw14clV65JqC7fVQsMgP6jK3H+m9TUB7MpzJ/jpYaM
-        Sk8B0i02fo6YwLn2ZXEOsXDkg4cW9laOj2y9XL+LpSFtXihsrZPprNUeTGGoApyxEtcnNLKRT0sh
-        yFyOypblYwOvDQISSHRZE/NNbqOOtUN5awpoMS0IHQvp5VrsZtYG/QytrRlukK4klkszc0DXEEQa
-        /pggwMzx9lwTsxYzJG62QcZPhy0KEScw51fOJgqMvelGiGloHtAsh3LBdbFvY8iEHYTyAjJ7MlAv
-        sXMjG9pyTUL4H8aHo2HS2IEcxu1Jl2nRzoaB6pCUCjZcUj+KUBxEiI2xQ6d0BjGJZArGpYhT054X
-        pDBexrsx5M6xye1h2UK4vYBllGQtj6bnuKccia1QzOYV06DF2xvyMCdBzwMXc9J/5jsU2aUuFGWo
-        qhmV70LowGmDqrx30MEIUGjFJ4aVy5smzY5reWj6G2Qg3+Ztvj/RLyVZpdtSI9pEhJbKkgwFNSMw
-        bkQtOORrgqiu1OKJrtGMRpAFBwcyo3IvVytVqcBOjYx+gh/PsyGhYVJJlVXOvOCwuVitSbKRwKZv
-        Q5p5KKELkirI6lSuf1Wkr5L0syR/jWe63YGPex0B1ibUDOmnmJRlCEYDEtf9P0NSk8s1pfLdIamU
-        5X8UkopQlv9NSHgIEulh5zHW8XGj2W2PNTEHc0oShr5JIZEOpQcchT76iZQGsJzQBBkMf0w7sXix
-        b8fWa8+PqQVaHHfhlONMSPIgZ4B7NCK66+wvdg6lBFZkxLSd1BLieIGLuDCn/ViVYd9RQJDrwlSE
-        Fnxsf/bxr3yP8e4sj4s3xt4gbLAi6JrUiQuPXk1K8KWpgRhv2Kcg3cmx6QJoYtZ/axID6g0k9pro
-        PtbEAhBrYVxukH0RQd7UPPNohJHvQ1jZ/stlOBqfUM0DzbzBu0Y1HyEbdjeAcxPBfTg+S4k/t3BO
-        jqDUwqMjR0sRRojXgEPP9KFUJu5/QrX4ps5qYlMelyrTgSZeoFTgoZLSmG3sPF3iBfga18gWJ/K4
-        ZsthT5giphE410BPBkdHODqI0Hi4HJxymGyAvTQ5EYq80hsK8YXKkiC5QPEbSqPVa48n83avN9HE
-        nIGT2AXFtF0UQlrN4SCRlMbLC78k/KtshNLipQ+lWB5yTa0Q7Uzx5sgGRbyPq8T/r4j3IPz/QBHv
-        PyniX6VonBsBxi6/uSWbfIXFGeM6Xlxtk3OZa/6d0N5/r9AmR4p5JzTqDTiyHOAWYuwd4qxcfgyv
-        QcbKFI6dUJAxfjt85V0ySPucwMXkjX+zjbu/U6TSqK+JGcSs263nwa1FritJAc9jbL4sJ+O7Lbz2
-        Yb3J7PECr6A8J55DLCDZ0uI9gbvLR4TIReF9fIGQzW7T1xSNSXwuAs3ncbPXjt2+MhSo7KoVwGpK
-        lhNaLip24NHA1HSNq6fHFchJV6+Gz2CBl3tB3II59/o1cY2mtOLL4hr8bl3hz1Lx1r9//gSe8Zbz
-        OxIAAA==
+        H4sIAAAAAAAAA7VY2XLqSBJ9n68g7sPMw4wsiZ07anWwGS+A2TG8KLQUIKONqhK2+J35k/6yTqkk
+        tMCNud0z7XDY0smTVZVZWZlZkn79sq3SGWFius4v38QH4VsJObprmM7+l2/LxSPX/Par/DeJYtey
+        UKCohqG42EBYwYj4FpUl4muGa6umo/gEYJMommrIjivx9yWSjgOPuopmufpR1hWOq3Ma+Vi/fViz
+        PUYc6Wkvs9ZbR981D6/1r9N8vBvQ8XzSmWh10RKCtql5j4v9bFp5NbbPl55J9pcTJS1j9bTsYCUw
+        Tet5X3arzbVzRpv520p7twZk5U5O6976s6FpUxGtnlaPHqdj8WJuA6Su9f3q8dS+4B63kfjc+qTQ
+        YM8lxNQsJAeISHwOuTqGukfkyPUKx1HltKPN4eZY/uQmY/OptqzOp4Y4OiCn2zMGtQDhz4G2Pguz
+        zVzbUkvd4O6upzoz1fQUNDY/4LF9IC+HdqX2YdSmi+eX2X4wtt6f943eevh+mXK1Chl0q4/meXS8
+        LH3zNH45dgJ62jp1vTzcfwUcev7s69MWVha2s3ndHmtvDj4/NbYNQ7QWRlM1zFdaGc0NI/CHh8eX
+        Dlcr94YeFygf/ZZm+ZfutPxWNTRjUz4tuu7r61PD7ArKhbaXA6WL/W6lhbTatvuiiFPRPVU3uvf+
+        Wf0Uh8qL3l8ZDc/ptBtH/VQdjQZ+q+NazY0uBo35YmXsyeSwmfc6fvujgrwGOl0Cd3z0a0652dOV
+        dr1RW5y1lepsyNtw2xla50V3Ig5O5TWtNN87Z63zPL+sZ+vlBW/JadhZdD/Gu7H4rin13mZbFyvT
+        WXnT2I1OC7wZzDa7yevmYz3ZzNr9CapNB8EXXZKn3mbzrgTTL6XpcX2s2YueJ3DcVuLzm3ndWxbw
+        uus7VBZTVhYO4wQZikmRrTi+rSEcMm/BZExZ0nzHCAOI/S/OcQdNmMT1sY4ANJCMvqhCEaHCVSMr
+        LWgYiOhy/4si7KhWaQFqpY6qg6VG6UY/4ib61KWqBUPamukgQ660HlJ+QVZUIVSuCg+1GzqhBSpM
+        6KlUP8jiDfsqymsQpFIPmzqSK7WbBaXCghJYd1DxHsnVW52rTNJ9jCENBukT8+he8yBB5KCUsVN1
+        6sK+C0KGE4MpKw6EZrmeYSXRcQU8S9URkcsZTgxlOOBFhQS25lp8FsYoRuXf/pPVT/EUlaUoxGQp
+        cTLb+W4YpDot7bBrl+gBQYVwfCTxeVaqZCN6cI0MELmm+9Z5y+gwd2VeIQii3c5D/+NSwqqjUlUe
+        Lxcwf4aXCFIqDTwk62z8DDGCM+9X40wSn8TCUUijP6EwW9u95XABA+XAlBMtvG1AFS0RqjqGio0M
+        mZnluIq7i6KZhGkh+xrLqAlHOCtNAKl4QDJnonAMMpHPp1Yi8HSY2TBS2dL7a0hp1zcmYEkFGojg
+        84Awigls8bpJ40NiuY7hOpx/BGddQSaPqMNIHgtjZUslJP7H+CqmUH4zQCxkfgRh6e+q7f271AWP
+        +uFSMmIJuo+oFWHDRoU8D4XuAi8oR0jO4Ux85LAECducmJeoXZHcYCmvOJ6hOjq6PygzJyHkwJQT
+        2dFRIVppbGivoMAs5dMl8IkTww3FsdujTcgCV3Gkv3SgXhmlV2gAoXtLqfGuYBPiC5q/s4k+FQ9B
+        rQgLVpTy7ookOHNIwaqzRwpUmvg9Gmxx8P9VEqEKzZEHJRISYKksiJAWUwpj+1SHwN4RROVKPZyq
+        iKY0gnQIJTgN1Ua5Uavm2YmQ0QP4sW3DkMNJhZYgxswrDjvtNuuCqEQwHFA4WjaK6JzQ4gRxIba+
+        V4TvgvBPQfweznRfIR636AP2Dicf0xuv1OihNFKD/6c/6uVqoyL8tD9qQu0P+aMGv3/GH7H9Ua5h
+        4Rgm7lm7+9qfSXwGjimRG0YqhUrwWepAs+Kgf5DSGMzBYS+DS4v+fJEoMp+xZ9OQ68+PiQTeYtyC
+        QHdlGE6lYc7IgjEDqsBB5kGZs9m8nBbNyxHOuc7LhW0Yn+hHKrE6WEh9Ilvm+Tp8DCUEVpj45D2q
+        P8S0vbAziZJ5oscqE3v2PYIsC1ZKaM7E/q2J8DR6ErI4f2eMPXIVViAtlZrUB5/XoDyXW3VRrDQk
+        /opKkM337JETHkQBdrhWh04lhSU+HeygEgUKE+SDHYmuhTkgzKZhXYLimaTR+FWy1S8F+44DW8Hi
+        RiyDDTeoZEPWvcMropKDoBc3kAfxBtUhisloPffwmOxjsNl1MrQEYYTQBhfbYRpmy79BpbBJY8Wz
+        K85K1cVY4q9QUiKg5NKQrRxtWYgrdRGXyMGNsuqOmRNNV8CkH1wNcneCn7oM5G4B0e39Xsa/J5Ci
+        9ozNNW/3hv3ZfN0fDucSnxHEpGj4uQodOIYzvIZQJAktLmVxC/Knj37hPpa7ieW2KU2xa2RAVRL/
+        igTcaonVn0/A4m1B+lEmC4+U57pW3BlGsVHAwoNmmXZY26Nwzrz+l7wu/nSdiyKRrY5rCxOI9BiI
+        JUQ5m5kPKUWQsdJsyAIbUl7cfa5ilRSSbs99/syHf9nGNR4qQmkygtv7FWLSw8G2oUcSW6w4ZjE2
+        X3qUw95Z0UJ7WXsP8gKU5YRz8DkkNS3cEzg5Jx+RazVw3CuEDNatFykSKwcZD3SfZ91hP1x2QZCj
+        ssbOA2tKuol1C+UVYm/cu+UXr/fsvXAruQVzvMwN5R4s3b/O39zj717gb27uP5tZ4mvvX5Mx+eTj
+        TvKpKP7OcPMJKYf/oe9N/PVDEv/Db7O/A9pPXdzdFQAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1828']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:29 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2085']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:01 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <trolley_add_order><describe_trolley /><user_id>whitelabel-testuser</user_id><order_token>E2--5eH5_vuupAjgQcgXHwMpTe9X9qgSl2Y0lXp5covwU1ss4IWYBA-RU8_g3PLu8IKzgerz_3Hl033oI-VMEczh0ACvOMWY84zu53eWCfAgAX2v47y8gZlotLi4soNNf8tYetkXqZoP-N1hlKUJkwZdbW0CSxe6UymaEdjSXrzwO0O_DORRcWp6xIeRBq_gkx4Wu9YZJPsOK5CeE-apF_L3wCpdqKeS3P6_3QZAvRVTdRGBuSzS-XHJpV6utMn-uLK1XaipNu8tDIAOlNAM8GDGcPYYRpF_3_rHi9pUQMOLZiyBM9BhcnyLGC8TiUOTaOxTSW98HodDDCuLqymE1MWcmVXSh6xJsVunc4mtPXPNxl7-Z</order_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsUDfEXxcUCHyqYlLXHoXFHrOkiCFhc3j34smOD16W2zX2VOT-TnkryAjJ8N15iPw8qeHlWzsKzFfY</crypto_block></trolley_add_order>'
+    body: !!binary |
+      PG1ha2VfcmVzZXJ2YXRpb24+PHNlbGZfcHJpbnRfbW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+
+      PGNyeXB0b19ibG9jaz5jXy0tNi1ic2pXT2psUmdyZS1zRGJKUjlPQmNmOGhLNnhxU05mR3ROU1BC
+      UGI2MWwweUFpYnBGVGdSUTNLZFpJekRpc2d6cXRzOWRWSFVCcl95aWlsSWcybzQ4V252ZVlTT1Zi
+      WGxHc1ZvUHFXRFd3N2JiUTFlVkhWRnAtY3IxemlaeWVhV2NnVkZxQXpyRC1ZPC9jcnlwdG9fYmxv
+      Y2s+PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjxkZXNjcmliZV90cm9sbGV5IC8+PHVzZXJfaWQ+ZGVt
+      bzwvdXNlcl9pZD48dHJvbGxleV90b2tlbj42My0tdF9xZnQ4TFlrMnctUE5pSDVVNFNRZDFNaGVu
+      Q0RkRzV5ZXJ3R2JXdjBSWVNiWnRsYVlyQ2ZEYW5SYWlwX2VOaWphblJBaHNKaEEzNWpkNVFUSUpS
+      Z0dObFhJZzdEV0xYelEtNTNzR0M0Rml2TWt6VXVpcU5Ka0J5dHFabjZjMkxneHktZUl3RWNROXJf
+      VG1uWUtaazVPbnJ2SDdaN2QxbFRkOGFkaUt0M01TZGR5dUxoRkpCLTUyRExwLXlfakU5Ymx1ekNR
+      Mk80ZGJkWTJxVENvS0tIN2lDMF96dEFVR19DcnVDMzllYjVaQ0pfMVExb3E0WWNwWHc0dzFMX0pj
+      RVZkN3BuQkE3a2NxNE1NR3U5Qm9sOFljMXk3U1RWZGdzUGhZU0RCdUFqM2VwN2VxenlvTmt1NW4y
+      OERjX0E2NzVUdmJWYW5Zc09MWkJMbHZUQ1AxR3EyV3QzOFhCdmJCSVN6V1JXVXpyWnNxTEJUQ2pO
+      Zk4xWGJfNkRZWjYxM1FSMlk3Zk1xVHJZR1JZZlBLWWpXUFlSQUVQZTVRR3l4dFVzSERZWVhfeVF4
+      XzhwLUVyYm1URHAwLS1aPC90cm9sbGV5X3Rva2VuPjwvbWFrZV9yZXNlcnZhdGlvbj4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['694']
+      Content-Length: ['791']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61YyZbiOBbd91fQualFN4HNTB6X6zBGkBAQASYYNj7GEth4DEsGzO/Un/SXtWzJ
-        I2R1ZnXmIgPdd5+GpzdZwh9XyyydoYd0x/79C//EfSlBW3WAbh9//7KSRuX2lz/EfwjYc0wTBrIC
-        gOx4AHqyB5FvYlFA/h44lqLbso8IrCN5rwAxgEioPBYJqhe42JH3pqMa4koul8+Ge+gY/Y67asz3
-        5aPnHACPny/q7G17qkEVnWqDLd88vRtzbru2B2dLmmhoNTgMN1d11X8JPrfmdPPibEYv3tzQ+yNN
-        rZ1qdWTNB3xzXb1tqh9zqSzZhhd0T9/aM76hv13an/DFXN/Q5DY6bIVKbk9CeErXQUjfm5AeJYck
-        1sCOAW2xWS+XdamGlY+2U61hua87DXgz24u1PaqCi2J9PtvX7jV4GV1ul+m5DgdtUJ4fpE7Dfx13
-        WvBtMzPQ+HX8MeeWo8PGOrsjvfF5Ac83/Tg4OtaQO43gDh28+lXvfszWvqoFL9bQ3pd372tzLUNi
-        JSmozdu93v6wQB/c+MOWDbDRpt3XRb87O/Dqdbp7vaKPPexIvU/34jacz8ZAA9Kwf3h2LP0KBsRQ
-        Jv/+8aENXv25Xquqp9bu1IDBYHDqtnby+HZsD/zF1Lm0x3Z9vXr+9N6Pi5GM3qA0WS6MUc/aYvXZ
-        qLfxoXY4ti4zs76a11cvcEXOic6b3vR96kp+Q7+1LEM78/K6Pmmure6u6jRWBuirE9ezTe+0rIE3
-        tf920s6X3nZX7WxXxjoYDYddaXRDw/Gnuw9UHQwnx8GmCYatjS55U74qvbQG0sUdztZcT/12la5b
-        ubpuapfn+rLz3us/j8G3YATWPe/sHSdL3ZSnr+f9rnXrgWALlU79E8tb6CxtY+bOvr2OVz17NBnM
-        p4FR3uh827QMeJPVzRyM7IVuBDO3vz+eaiCAg0bQHu93XvtdW3S0/UwbvzfLO6GSd5DEX2jkqI5v
-        Y5FPWVk49D0IZB1DS7Z9aw+9kHkPxnOKwt63QeiU9G9xjQdozESO76mQgACK8IplDBHmEo2stKAB
-        IFJFibBLywCRPZV20HOKihEpVsQOVkwyl7XXbQjEaucpXaggK6ogLNa4p8YdHeEClSzoKljVRP6O
-        nYjyGggq2PV0FYrV5t2GUmFBiZxOU7wjFGv3OolMUH3PI4k0SH9RUx73Lsk2OShlHBQVO+TCOS7D
-        YWDKYh7QrjYzrNgtEsA1FRUisZrhMCjDIVaUUWDtHbOShT3IUPE/f2b1UzxFRQHAvU52KKuao0fz
-        MyCVUIfRYGngW1ZQ6iseKA2oTKjkSImKbmN49BRMypIMFKxUUpGtWFAE4UypcoQlDBy4d4wIS4bp
-        r3TbUYyEk1BnoRvqh1Gm4tLBc6wSJkc4Q9uHoXaWlSpZEGsOyADRFffnvXlGh157ZkicOfLaPPR/
-        biUsv8Ry4mwlkfUzvFiQUiPjqHT+DDGxWfFwOmKppBDSaRTHFHrWpbQaDGcSmSoHp6xo60vsA2jj
-        Erl2mKHSY9mO7ByiqERhXssOmQzrqgGz0hgQioGeie1COGciuJKeEhJLh6nZgwrd+HBNcnIyooJo
-        m0PSSgUXDXqQEVga1I++K58V04c0urOAoOqYpQLTsYFjl32DmDIBqTyaaBrJmZBOrZoKQuwP5RPX
-        UHC4gQzG5HEgZuV0GtKcRZ0anS7qefJQaERiG9kgNYetUIksGYNhJ8iosWaC5OZLeQ+mNHSAHk9L
-        D8LkOSylRGcZKZZuBhkSPWElXbcSGy28Xo+ZOTJ6FkjEkf7KJuUXlCakMSZNbUplt+DpxNtIU3zW
-        4UV2IamAYf2NEvlDkUAiEMqeYh+hDG3Axux+/H+X+DbWSl3/6JMqW+V4kupTAuX6WCVOfkCQFMhm
-        uFARTWkIqsRxSGTUW3yj3uBy7FhI6QH5Z1mABDRZlGvzbcZMcHK5TrvJ8XIEKzYgYUZyb0gvc+0y
-        35b4ztca95Xj/sXxX8OVHiuweYsWoGOEFQ/f2aTKE2N0SeCav9IkTb7arNV/2CT1Kv9TJqmXq/zf
-        MQkzQZR6qD+GeXzR7U+GC6GSgRklMsOrgkkgXUo90oPZ8DdUmpHjeApJg94/YyVqL/pbB2JzPIol
-        ZMRwk3i5kyaSLMgYZHvYR6KpnxM5g2ICLTKVeBzVEqRbbtgtRYk51qNVhv72XQRNkyyFcG6Pw/s9
-        fm/vIT5ZZfHKg7mP0JFpETRJkxEWHrERleBkKJBkfKQ/y9wTH4oSQKik+pqCZFJvSGAfkGiTPjgH
-        hLkwLDcQJEmQDQVLucqeb9vErPT++SpxjTtUsEjOfMArooINyTcCgC7xG590aqEvRft5hDOyTzus
-        DC1GKCE8g+NZiq2y7+A7VAh7SFoT+/yiVJdmQiWB4gRPKikO2bJhiRwrwEVcQJoTpccDPQ59Qchj
-        wnc+WXLfKn/9kZL7OokaKNahdAfT4WK5Hk6nS6GSETASbVAU0ut7JKzWxJFQTGPlhTUJfysaC597
-        uQ+9nLXTjLeGgGTEVlglfn1GbJHE/xMZsXWXEb8XomFsuI5jss4tuuQCFkaMqVthtY38MjP8X4m2
-        9aOJNnIpurtyt9MlLssAJkHyWc+8/hRBykozHPVQksZYd/jBVFJIuA/gfPCG/9OLaz3VuNLbq1BJ
-        ISrVNMsiXQvfqUUFPIvR9dKYDHtbeR+eN1o9PGABynLCNSo5JD1aeCekd/n0IUoyvO0kEAS0my5S
-        BJriMxbojxf96TDcdkGQo9JWyyWnKam6p5owr8Cs8eg1ofiMQMeFr4Z7MMfLfEE8goXHzwZ37wUP
-        HwruXgh+NK+wz9JfnPoq8bNR/AjFHjLuHqdy+E+9ZFWSJ6rKd5+P/wu8uhIsgBYAAA==
+        H4sIAAAAAAAAA7VZ2ZaqShJ9769wnYfuh24OoKLlaS53OWvhgIrjCyuFRFAmIVH0d/pP+ss6mQTR
+        6nvu7b5nnVVF7tiRQ2RkRGQW+2tgGqULdD3dtn75Rn+nvpWgJduKbh1++bYUe8THt1+5v7AmOEHJ
+        hR50LwBhavjtG4hjPX+v2CbQLcnHQkn3pD1QOMtmyfcSVnZvDrKlvWHLJ+7EEMQFnpajHkL9Rn9S
+        U2+f5rHRRLebL4zd4aF3svZQGk2qCmAmYnuyV4a05fOTsbuYXDqyXz3b3eV6ZSn2uU4FZbd87GjS
+        1a72UaWqNr2eI0lKbdhThavFDC3Qmt43HcGbdxq6dgpux0+8QNovDxh4+VCbjHNzhVmNabY6/Val
+        eaLvlti6t+5L5jhxL1NBbDWA6x9Q3+Tvm03Hp9VWe/lpH+1bc/TB8L5GLL0WVWu4MrMTZ+ruNHA1
+        c6zD1vy4Lw/ni6FMz7tCr8vzlqkKLafOW9XqZD85tGHzQ+A1/dJDs7Z07NUbUCt/+Ki8syvz0bbS
+        d5TAlnh02az9Na9MwbjPb2GnF4whc2peF/1e3234mo9GB3HXq1eni6ura6tanQ4s0L/OlkT/eKss
+        VyN/wsiq4l9XElidu3Z9FXTKu9vsfD9sgkAToHsV6t5WOasja9RC1KUpBNPuiRC2beYYzEX+Vp1A
+        VRe6/G6zue+ondLzBou7LGw3iBqow3FjLjjGRLrOT/dOZfRRQUwATq6oibXzeFo+2pOjRiGBno3W
+        MiofrjVa7FWIlStsTGHU4hWnc9Lax8NiTvPl3RbIp9pKadV8MHbrLjWtz5DTHS+nirqxrgeqwVdq
+        p/vHkW5Qgk0cvIp5mUufsN6u8Ke7Ddstmfe2M8nef86C/pyf8d39eOrMaeLT0Yd6WZtYc6K8MC78
+        5jSkaou9eB110Gq45hlxBCSC2LHkk6+yyAWWB+TI/XWFEymKIqjwR73GfxC9boVhyQKHNXXLR9CT
+        DKgiKT42+AhBjma+Y02W/EqOB7MNA94kZJ+gxdWqBOHtAd2GBBoulCNfNT6uuAMluBPL/WRQ1521
+        tjuh+tIKBPU6plujnvLBq4Ew2F1mri2dx3qVuo7Wh4q0Gt5njeOSPp9m6vR61g+tZW+kK9axYU7W
+        n6NOcHanvSOzQ3LjYNSvNrxPll144mtCa7tcBtOp5h/7onYQL6BTawd6FbQGnfp2G7Trsj+l+oax
+        Qbf9iNCFOTBHSsf6PK63dd87W5aw9wzmdm/uque+cjD7/YOo7MSaPYezS5uwevTwtKkMjtA2LFCb
+        di5No8ZQ06t36DNTnuEHC2JJLOn5sH0ZrGtqY9A+1pn7Qg6aS1T2P+uXi3JbNBRauZQpHorE3Zvs
+        qpfuwUQALlvCh3elg6V72PTFrqPQ3cmMb3sX01mItcVswaAgaPqTM3FXGexOPAP0s3eE4+a2t9c3
+        a3qtduvlYNnTHH/fuvbNyqSr+Pz+dDSbdE+oBJ65ocFGaWnnUbMyQWVPmspSw+4Rl07LYOqr1flW
+        5Tez+QZsqzI9rStb9bMyud5mR9Fk7raCBtNZuW65g1OXvxGSXLHWxKGy4YE0DYIlUC7TVW02bRsW
+        f6JC33x2kIe/2K6Cg61s+xbi6IyVh1Mux+59SzFg+ruo+wZNmZ7tuzLEoAI5GCAJuzCiHhp5aUFD
+        gZ7MdQMEXQsYJRGrlVr4nENLKb3oR9xUH9kIGLhLc69bUOEqje8ZvyArqniIq1LfmRe6hwpUPKAD
+        kKxx9Av7IXrW8CBAjqvLkKswLxPKhAUlvDoNuAfIVV91HjJW9l0Xp+Jb9hVb9LB3cGR6gjKGimOP
+        7XJ0GFuKYMayfHMPXe6jXMuxEjBjOQaQoceVc5wEynGwFSXvZu5tg8zDLkxQ7t//yutneIZybORi
+        HJsaOd75duikMiqprm2WkAZxlWL5kCWfWZmSCZFmKzkgMk172prmdGJz5ZrYCaLdfob+x6mEpQ9A
+        gJssRTx+jpcKMiq6OZCT4/5zxAjOtR+L073kJBaOQub9KSVea7OzHIm4oycw40QTbyq4lCt5CFgK
+        cJUcOV6WZUu2GnmzF4aFfDORIR0f4bw0BdjiAcmdiaQHnCX7Ak3VWTLMl7qCB0VAN0Ins40wh0ay
+        5JtVfSP6SFTSJourS5w6Ee4ZQUW66PAa1aBvYNa1r3EPLJl8RlPBMSyIzUOGgANcgA8N/ibzcyKT
+        WRfOcO7YktkWQewm+BdwIYjt3l2zZNaKBXFExBX47apBFyaE2PKyjpITbti4xLUI/4RN8QBjeUQd
+        RfJEmCgbwPOSXzEfuMjDlAxIhLETYGHpr8B0/llqY3fww6nkxKGFo2I+7vYGvci6OSi0IraCdMKZ
+        JRyJjIyVIuFFIeGlag/kqbOMV+xPAZYM33caLyclPIEZJ1pHC+CjhpKFdgoK8UrJbApkasRwQ93E
+        7NEm5IGHONJfWjp2thKPb1D4/pNRk11xdXw4sFeGzig5ECe6MNtG8fqtiMUBA1+9gHWAEk6TSTvq
+        TNT8f5RonEIX0EEwjN6lMkXjmJ5RYraPZHwqVQ8irlILhyqiGc2DMnYlfJSr9XKdqT6zU2FMv+F/
+        pqkoXDgo1aDohPnA8U7bHzWKliIYRxccF0wY0QmqQVC0SDd+VKgfFPV3iv4RjvReIem3aIO4jcOW
+        i16swiCtNAa3/6c9auVqvUL9tD0Yivld9mDw/z9ij2T9UayJ3THMOvNmm+/OWTIHJ5TIDGOAcBq7
+        llq40rLg37zSBC/HDQsxtyR2F2KqGNss/saBEt+kU0kYNuMvAzu6zeHuAApjRh5MGDiFaRyJlQkz
+        HpfYR+MSHmE9xiXCGpJM9SOVRB2vEPkeZ+iXR/cJlBLirEqm7Sh5errphGVVlIlSvTitxt++40Gc
+        PQzdQ09L7L4uEX+NB1QeJ9/0cYC2FGd3AyAd+djmDK4tyo0aTVdwsnqgLI7mh/iToL7TFN5hpobL
+        rAxmyawzDXgSzqo4HqhelNSegDCahjkJZ/40jCZN1gSB5PqWhbci9hu6HN44i2h4R33HK6KsBWGY
+        CXFmDLND5JPRfN7hCdl3o9eiHC1FYkK4Bts1wzAcT/8FZcMKM06ebXpeqooTlnxAaYrAKReFbOlk
+        clRSZhRx1tPsKKqq8XKi4QoY+8W95ulC81M3macrTPT+9S7ivxOwUW0Zj7Vodkbd+WLdHY0WLJkT
+        JKSo+wXA1wcXn+E1dkUvpSWpLClB/vDRx6nMTG8GOL7nm+zTNmUhdg0VnJXoPyMANxp09ecDMP2a
+        kL6KZOGRcmzbSMrayDcKWHjQDN0Mc3taWqbN34jr9E/nucgT49kRTQoXqCmQSDxcwnr63ki8twjG
+        rCwaxo6NQ15Sfa4SlQxiX8/985kPf8YbV/9eoUrCmCUzKJZqmmniGoluxMkxj8XjZUc5LPylfbje
+        +G6C5QUozwnHIJ+QbGlRxe7Csw+9Rzaw7AcElbhSL1LYOB3kLNAeztujbjjtguCJGhd2Dl5NSdZd
+        2YDPCok13j1RFN8m4nbhSvUKPvFy16t3MPv+LeLlEeLt68PLs8PPRpbkzv7nREwyfZn6I2+u6ZtX
+        8rDy8hb2hP+uhzPy8XKm4usgzlSR1CPTbAZuZlRu4Vt0Pp3lYRbIMq7WwT6cAQbCy0WEhz/j+gSY
+        MMC3gUc7FsWXNBPivQRWqRs4+GLrJbTEaFlH+e5MEN6A7S96HD9Jf6MjfLBcOXoi+KKvAuG/doej
+        Fviio1UmeuqCfDWe5zuOjW+H0l43wqJTAooSWib5E9QXwmi/PAniG6fxpPEOT8jgEG6iC1UYvlrB
+        HL0oCYus938u+w9qodUvbxsAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2158']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:29 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2869']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:01 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <make_reservation><describe_trolley /><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><trolley_token>64--iT3taV8o23t_Cio5ezl8RWnF2dwamqGnxAxyHFwzwLv4eD8d-OfT95uMI97ePXNksIMIVO0SFfXmvpFi5qwdGzigDgomE0jFeZsfr4xiAVNWuchyHmEnb-ZQWlW_eYj3Ty3O8BBbfRsV0IVn_kdXhLAMRCANf1cxLZMxsVbe9TBqpwp5oq5DhdTECfGomixdD6W2l1QVVhDMuOi32cj7Zj5eyDDjA7Z_Izg8DuRLow8In4WUGqrQgRF_sPeTKSRkFBmYtcGk48tf3fg7wNl4UO4UHeUT95svXBLQLpTu5iz7mkhv1_W4K6WmAZ2o5UkdCcKprnlrjS3dPcCPjhvwBYZ29YUkWyFEEATFzsEIqpbycidEKgDX6dE7XiTrL12TH7DTwpENW0BcJxTxY_2W6hwG4S9QBCGIdJyFdWBrvrgKSil_LMvbZ7zBdyYea94qt_YeoSnkNpNJMIUBnFKDOLyk-Xi18lmkez_cXOdFnRikyNpCbgj3dyeD5y8IbZr8QhR9hbNhIQ6-Z</trolley_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsUDfEXxcUCHyqYlLXHoXFHrOkiCFhc3j34smOD16W2zX2VOT-TnkryAjJ8N15iPw8qeHlWzsKzFfY</crypto_block></make_reservation>'
+    body: !!binary |
+      PHRyYW5zYWN0aW9uX2luZm8+PHVzZXJfcGFzc3dkPmRlbW9wYXNzPC91c2VyX3Bhc3N3ZD48ZGVz
+      Y3JpYmVfdHJvbGxleSAvPjxwdXp6bGVkPnllczwvcHV6emxlZD48ZGVzY3JpYmVfY3VzdG9tZXIg
+      Lz48ZGVzY3JpYmVfZXh0ZXJuYWxfc2FsZV9wYWdlIC8+PHVzZXJfaWQ+ZGVtbzwvdXNlcl9pZD48
+      dHJhbnNhY3Rpb25faWQ+VDAwMC0wMDAwLTc2SzgtRkUzNTwvdHJhbnNhY3Rpb25faWQ+PC90cmFu
+      c2FjdGlvbl9pbmZvPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['895']
+      Content-Length: ['241']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61ZybaqSBad11dYb1KDKp50Ir5Fmsu+xRbbCSuAEFA6IVDxd+pP6ssqaBTU+7Iy
-        s/IO7o3YZ59oDnGaiCv8erOt0gX6gek6v3yjvpPfStBRXc109F++raQuwX/7tf43wQYnKPswgP4F
-        IEyN26GF6kIQKpprA9ORQyyUzUBWgFaPYCCUvxYJqh95yJUVy1VP9YAjiHsPMuN2fyZxU27JG1G7
-        ubha5oltgbG0O4gq2TkYl43vSdFMmW3P/a63PmPRsXslDGpZGTTDarfNV697C6yYYbRy+ooodw7D
-        +/lMDbx5MKg252BOHquB2RyFfcee9LeieNu19MrtNlttRX2qq3LNb4edoEns9Wk4P0sbMjw00Ga6
-        2Db5TXvcWS4O3GVrHh13TOxbNrLlzpQ+XjiqD5mNbawvMgd2K2MQhkNuIYXHsbe7B2OKZk883b+p
-        1ZO6aRKTwwoo+j3yyUvPmk7kC6H2KQ6dqON82ziOuJvZ7oqGTlMW4++pymLvr9Ddnunu5Ir01cGX
-        JgzdMnoduWHat6VzDHYX1FGPQ/fCdyrnjTmqIHUdGlVKNCOme/Ubtsn1xfnJHzK3A0d1bpfAXIyX
-        o4ZIX7zr6j5f2bM+Lc8CSbWqPdAbbSZDxrBa5JI3r0o4bJpXcj0kyP70ctZa2OqEtwbhwVYGbHN1
-        2w8Yd7Qf+qo4qW5bXbOyqbUH4nbvINSfm+wZydfd8nzqRcvVdNxcuLOw03Xas204FrmVZvT0m1MJ
-        WFFpLYltRNNweF6z07mhOCQjh9E9Mkn+tt5s++LRb+5WzdlwpFzmMhrS7GbePNToedePbv55Rg3o
-        0A1P5IzvgSM+App8nCkseelWe8NIP3a7675iLBxLIyab3YXbSJ5crRAbWt/QFc7ZNaIR2Bi3Cj9a
-        KlTY7Muuumg1rtN7uzaUxCVzPDBu32q224cWOznzit5i51PbOQ9nRkUV3WtVBJzfu7rX/ViT3Olm
-        rUmBylf2drO7UaaQoZqw04YmJrg8XM+jczAaSXOSIPZC+cUXBOQDJwBq4l+mVt+TJEmQ8S+mWl0Q
-        A7LBC+U3jmCbTohgIFvwgOTUL7GPwjpHfseaQvlncjyZa1kwkpF7gk69U8F+eNJ344g7+d2BPVDF
-        rXMSNX9kU1xvqx+12863Qmt+JXR6ZvS7+9Nlacxcw51YQUPbSnb/3qw19g3JPQYVvWJB9qoearZN
-        nHph35Po/snu8vvxrmnTFxewzG7LVw6Rq7H6Srn2xlOWq6qcNehejJHYmJw6tx1A1YnJqrUbaEnd
-        XXd3Egdsf1kdLUF06BFnEdHDmcsoXWBNalNaXa8UaqDq8sGzzmyPjzb0sSndycpovRzN7dbsqEvi
-        GBwr93AxWAC31gpPtMwNT9PaSB3YIzKcb1iab3dWYHpUWubOa7K9/rxqS9NRtKZ3HucYjrkfHAPW
-        vF30sW1AwkOOM95N2N7EbrtgPKotdwOemUihe2elYzXaDtt3cPd2ZqsbXFR4qN2GIb/tnmitqhDW
-        DR+P1vmAhozHbgd7rzJvO+x4fWOmcx9ba4IsZdRrSD4yZvp6ojSOnNirUQ13GG36g/6wRlpnMBnv
-        ie20YZ/vtCfuhlOCGiMaitP7snG2J+2htLz3nOtwByb83Zvog6sKr+RpIHbVJmI21HAcHYjQoFy9
-        uqfDqnZ2bnRblliN2VqWtD8ziwWv7m8r6ur2qPtl3VWIzvo4l7cdT5nMl/q4O9Xc23Xti8x9qK/Y
-        wTrczvQtby5b5pytVJvmbOQMRrv9vLrtyavu0hqr3oa0mfjsvx7A53l0fQ0nC9UNHVSnclYRfnDr
-        ghI6mgUff991v0AfzMANfRViUIN1eEMydhFEPjWK0jcNDQZqXcLs0jIKELRLe+i774oJ6aGIXAQs
-        PJatmA7U6nTtez7Rm+xdJUB1hvxe+aAH6I2KJ/QAUo069cF+il41AgiQ55sqrNPcx4Jy4ZsS3p0B
-        fB3WmU+dp0xQQ9/HRUSUt1JT6oqHQ94LlDMOOKi5fp2Kg9Y7mLOc0FagX+dprsDKwJzlWUCFQZ0u
-        cDKowMFWlIPIVlyrXIR9mKH1//y7qJ/jOVoXNKiYeIWyarhmMn4G5JL0wBiw1A5tOyq1gK+V2qlM
-        KL+Qniqmg6Dup3WWBhAo5yIH2LCuxSPlygn2ZKDI+2Ak2LObt/JlJz4SD5IelnRBrdjLVFQ6+K5d
-        QngLF+iEMNYusnIlGyLD1QpA8olb0+a0oJN+9kIXH+bk1L5C/+dS4toTW64+WUl4/gLvIcipiXHU
-        dPwC8Wmz982ZQRZK3lw69+IHJd3rUlq1OxMJD/UC56xk6UsUatBBJfzZYYGabstxZfeQeGUQx7Vi
-        N5MhUz3BovQBCO+OXvDtbARcRox2VA17S1xQmBqeFAHTip3FteIiI5FlbeEQWkkjU3l0BVze49oC
-        4ZER1OSLCa91BwfGL2DBd6/pCEI5ayZLwUH4lhqnHAMewLZwfdwuF9dUzlb9FosK4aecfyKIjwn+
-        A3wIUqt3NkI576WCxMYdfAeKrgb0YUbIYriph558AVYI09BUBATVRFkcs1xHcx0iPGFDPcFUngw0
-        TuSZMB1atUAQZH9SPj7XAMULKGCZ/BFFivJ0GGzg5I6VDpdcvF6h2LbYNvIJJ8xshnJixQcY3+Ey
-        6kPzibyMl/O+GPJkasHXw6YbyeQvWE5J9tIFtmlFBVK6w3I+b/lhtPjz+pmZE6MXgac40V85Jj56
-        pRG+0eLraE7NvoJvYlfBZzQ+mrIHcfqOi4ckC30pEnD4wFdh4OhQho6W9bPvE/6rRPHIKDVCPcQl
-        Ak1SOE/lhJQbIhV76CGAOLtz8UTvaE4LoIoPDnZrtkpV2Ar5wn4IU3qEf2xbw9EIT0ryFJ8xnzj+
-        uC7PkZScwMDRcIzAiSOmEyRPULxE1X4w5A+S/CdJ/Yhn+lohG/fdAmk/QMBHHzahKWyMBo461l9p
-        Eo6iOYb93SZhaeoPmYQlaOrPmCQzQRJ60vMYJ6FFozXqLIRyAc4oiRlEgLAjXUtNXEA68B9BaYK3
-        4wMcw/2/P5RSe6VtHDO5QfchiSNo2rLwKXfzQFIEMwZeHgqDumVenvIMehDSDFl+9JNEGJi2F5d6
-        SVZ56KUpMm2HXgBxJrDMAL2ssfO5xp+tPcZHqyJe/mJsHbpymsEtXCHFWbNeSeqHZ1fAwVhPmwT5
-        nYpFT0Ao5/oGCGScLLFjH4IkV70AcSyMUw3UnkEw6wo2uMl+6DjYrOn3p+j4pv2Oxnfzr3jvqOBA
-        GCc4nPBQiMvM+Cwl6/kKz8hhWh4WaA8kJcR7cH0bODjPJ8v/QIW4AE5zYotalFhpIpSf0CPA40yK
-        YrZ8sutkVj2840JguEl4PKTbSd/+XjHhJ/etl4vWb9+wXq5WSfWXlVeN9rizWG464/FSKBcEGSmt
-        rgC+qPjYrTb4IAUPWpZesiLhT3kjTi324/6Bw0uxK7xYO494G6jhiFiNs8RfHxGrOPD/gYhY/YiI
-        P3PR2Dc817WysjP5yG9Y7DGWacfZ9lH6Pbr/K9BWf2+gTY5UujqiUWvgI5sBmSTAJWZgKlZ2DN/B
-        lJVHuPSE4jCWVYfrTCWHhE8HfnXe+Hf64arfGbI0E4VyDqVSw7BtXLVQNSZJ4EUsnS/3ybgwl5V4
-        v8ns8QbfoCInnqP8guRbSypqH55DGDwjvOM+IaillfQ7RUhDfMECrcGiNe7Ey34TvFDTUsvDuymp
-        pq9a8FUhs8ZXTyHvbyBp/+3K8wm+8ArXn69g4es3j4/Hji9fOT6eN35vXMnu1H9x6Cs/3rz+zGvx
-        4zUte7n5eGV7wf/Qk1z5+SZ3wPc0nGsSaVB+5CMQ2UnhA3ytmJCKsABUFXoIKPEKMBDX+Qke/06L
-        DRvEd0lskhxKpVnYLkozc+VDvA6E7evH/Z+O9Ub4zeFwfAE/GWidi16GKH/uNgg9z/VRICumFdds
-        MtA0fHkOHv9O+4k0sXAgQ3xHs57gozB4xzMy0GOz+/AA44csWKC/S+LC5uv//f0XYZENVDwcAAA=
+        H4sIAAAAAAAAA7VY23LbNhB971dw/NA+tDRJ2ZIsF2HGF6XNxE4ytlzP9IUDkZDEMQmoAGhb39M/
+        6Zd1cSEJUnTqpo0fLOLsWVwWi90F0NvnsvAeCRc5o28OosPwwCM0ZVlO128O7hbv/JODt/F3SHJM
+        BU4lsJKcrljCiagKGSNRLTNW4pwmlSA8yUWyxFlMGQqGJYg8S8IpLhKBC5Js8ZoEMSowXVfwmRS5
+        kDGhKOgiqMxpJYlICrKSCcwBhif8kcTR+DBEwUtSVDJKdquCPSXpBlNKigSWRuKMlDDBF4SIg1SS
+        RORSTc32BfNnJ5MwSjIMMkyzROYliUdhNPHDsR8eL6LpaXhyGka/o+DLOk2Xyi4xWuL0gYBszVm1
+        1VMDC1sbZWSZSyNBQZeIUgYsaqUw0YysMGwJLKKiku/MYqoHFAwKkNqP0VLvlP2EecGQFMMUL2EW
+        VMCmqw337mCealG1FAkJCyrV4BkRKc+3kvFAwbuCxKv8mWS+xEsBPqAR5SSJ+dT/Mx+vVr6dlnaU
+        xCU2TfBBMJVg/ppQwvPUUrt0ZUQY2/hYZre2brVbYWzturFaRCViS8hQMCAEBVYUZAe7VNFMDWl+
+        E8YzGEFbNI5ga/bRmilYxVNijA6+n4CfyrDRcKU9DWXaeG5Pi7cANe/ceIC3p6+5tb5kEitfLpc5
+        JVl8NDts+T1ZXwWO2nF4ON6jC9mjwoBbLNNNHO2xG1FXQxAst7CJJD4a702oFfaUYHUbzNckPt7X
+        aWQorTiHqLVrv4xF10s4Nl2oZaxgqxmPozB0OBZsWbQql+A5J6OJw7Jgy9oWOCUiHjkcCzkcsGIi
+        duWSFYELc2LR+K8/Xf0Wb9EYaRdTh90Y2ez8hXLSVHorzkpPbggEdFoRdfJdVqtUErlhmQNo01x8
+        Ov/k6BhzOU1wAr3bXeg/TkVlCSxx/PFuAeM7vFrQUuVuS+LU9O8QNey0m8Xlwp7E3lFovb+mmLWe
+        Xd5dLaCjDthy9MTPMghZHkQHmmGeOWSzLMoSttLeLFRYcJtWJnM4wq60BlD/gDhnwvYAAe2Xz1E4
+        hYidqRYMKnFeKCdjhQp3Wma/0aoq9IdVqZsq8EPMk9CzJFnymJOnOgn0YcQhN+oeII6aTz0ViGHP
+        xjwq6JMthjyhE0Dgzimws+6dYefYBu0WEXAT+MGQZIzd5/coaFtGYCIiFCu7pw3hxBKM5dNc2hNe
+        MJox6qvM14JGrqlXWm6FVrnAQtgfw8dcQvpyACs0TgBC73tcbn/2LsAdKjUVR6wsrOse0+2OCG1d
+        B1JWBCskD5BZ1EiBNlaNqLRmebVag3Q6a3n9/jJMUzLcqa2ALKEDthy9jnMMR03ahV72FMxKg3YK
+        QW3EfvnRLTvqlta/o1BjZd4HSPRQKrZUuys8h8MBXqmcMdkSSHQq2+p4PShCus6CLA5lI6RJ29ad
+        LTbVT14EKfSWbKF0gejtqdINXLChGHYlUziVK0FkfDRRQ/XRliYIlGAZHOXj6Wg6Pu6ya6Gh7+Cv
+        LLNM14vhLIwss8HRl8rLmR9Gi2h2ehSehuGPYXSqRnqhtgwGbWDaELa43LPKWG68a7z7P+0xGR1P
+        j8JX22Mcjv+VPaDcHn+NPez6dawx7qiyzs3ZxYf5DQoc2FK0Ga6xhDT25J1DpUXJD8L7CMvhqhDj
+        3mJ+u6gVjc3MNwTKyft3tUSFTfNVgKOzGLrDUsUMF7QMSGGbOABlvzTj+ks9ri982ozrqxoyqPW1
+        ilW3ZWuRPzbd15WsbZmsGtRtnTxFXm5VWaUzUa1n0qr5rraCQPYwVzFnifP9JcLX9a+hiwcDfawJ
+        S0x2L+CKISuw+Rhqi9FsEkVHU3X7syiCaL42n354GIWww+MJlFktjIK2sw0WCWRViAcroZNaB1DR
+        VOUkyPx1GLVNVOLnhFeUwlYYv4lG6lrZR9U1dIjXRxElRGVCyIwqO2if1PMZwi25Mpcth1YjhqDW
+        wHipwrCZ/h6KVIVpkudFdOMdLz6ioIHqFAEpVyp28lDGoS0z+jgSG6aj6sosRw/Xw9AL95rOheZV
+        N5nOFUZf3IYi/pAA6drSjHV7dnk1v7m9n19d3aLAEViS7v4Ww/WBwxm+B1cUNc2mMluCfPXRh1RW
+        1jcDiO9uE3W2qQ2x9ySDrBR9iwA8m0XHrw/A0X5CeimSqSO1ZaywZa32jR6mDlqRlyq316Vl3fyH
+        uB69Os9pTzSz889CKFBrwEoElLAiXxbWe/ugYbXR0Dg2hDxbff5mVVoIqXHNxkwPj0Lv8zUKWshI
+        N5uyhBoompnk52Kmv/aoqsI+War1mLsHyHuQy1FjBB2knbquyDn5oyKiifaUNZB62RiiIBPunRVe
+        vL+5uJqrafcEHaop3LawGi/NeVqQroK1xtATRP/twbR7V6Z9sMNzrk9DMBp+a9h7ZBh8Xdh7Vnht
+        5LB38m8TEYP65anzBJvFC3AxP1T/ppMPJ/67+dG4+4SlzoJ9vkrsw0nzXjWIN+ze49YQ3KBxb1Dn
+        bfhvx3Vat1wWAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3020']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:29 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1892']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:01 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['108']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:29 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <transaction_info><describe_external_sale_page /><describe_trolley /><user_id>whitelabel-testuser</user_id><describe_customer
-      /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><transaction_id>Z000-0000-377R-I0A8</transaction_id></transaction_info>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['412']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61YzXLbNhC+9ylYX3poZZKSrR8PwozjKDMeO07HlutpLhyIhCSOSYAFQNt6nr5J
-        n6yLH5IgRadJGh8s4NsPwGK52F0AvX0pcu+JcJEx+uYoPA6OPEITlmZ0++bofvVhND96G/2EJMdU
-        4EQCK87ohsWciCqXERLVOmUFzmhcCcLjTMRrnEZ7IpA/LELkRRJOcR4LnJO4xFviRyjHdFtBM84z
-        ISNCkd9FUJHRShIR52QjY1AC1if8iUSni+PFfGL/kP8aDRWMkv0mZ89xssOUkjyGTZLoeZdJkuM1
-        yUcwTCpFYZJhLuKkYJLEAob4qqenhn2x+TQI4xSDDNM0lllBonEQTkfByWgcrMLwLFycjRefkf/l
-        Mc2USo0IrXHySEC25awqIymekd+FUMKoJFSaLqiUkg2GrwLqVlTyvVG7ekT+oACWg69AMay8gr17
-        D8oW3rUyhnevDdESkJCgaqEWS4lIeFZKxn0F73MSlRUn8L11W3lErJu+bff6anPQND6RDn+BWtha
-        zJjEdUOlUSUiS0iRPyCEASzPyR6MWdFUaWd+Y8ZTWEGbIwrBrodozRSs4gkxFgPXjZWSQTPClfZG
-        KDsZw97tBdjO+0w46w/UpHqgZBIrXyvWGSVpNF4ctwv1ZP0hcEQmwfHpAV3IHhUWLLFMdlF4wG5E
-        3RGCYFnyLAGfnh4o1Ap7g2B3O8y3JJocjmlkKKk4h3Czb1vGlNt1ifwu1DI28I0Zj8IgcDgWbFm0
-        KtbgMvPx1GFZsGWVOU6IiMYOx0IOB6wYi32xZrnvwpxYNPrnb3d8i7dohLRvqSNqjGy+/IXyzkR6
-        G84KT+4IRGJaEXVeXVY7qCByx1IH0Ka5+PTukzPGmMvpghPor92F/qcqKrpjiaOb+xWs7/BqQUuV
-        +5JEiZnfIWrY6Teby4Q9gr2j0Hp/TTF7vVvdv1/erGCqDtyytOp3skohfnkcAplDNduiLGYb7c1C
-        xQO3a2Uyg9DrSmsA9Q+IcybsDBDJrv4MF+BlKqZlKSwqcZYrJ2O5inNaZttoU+W6YYfUXQQJFIKd
-        hJklSeOnjDxHFALKAIw45C49AwRQ09SqQPB6McZRsZiUGGyhw7jv6uRbrXtn2Dm2fvuJCLgJ/GBI
-        Fcbqywfktz0j0DZeQpWxf94RlSpaFK2zbVXGTziviDnSLoCSTNrznzOaMjpS2awFjVxPdK3lVmim
-        TnIshP0xfPBrLJUCDmblJlx35WYaMLCuYsx0urTpQsq2YJv4ERKNXcHXVqxBlfcstR7ZIJ35Wt7A
-        lI9ZKoanNRux8g7WUvRePuAiy/cOyezQb9f1a6P1S4hu6VD39Ph7Cik89a6gZoSCr6Xar8AzOCrg
-        o8o145JA2lNJV0fvQRHSVREkcyj+oNixfft9qt+8cC533nm1rSC1qjIL3LEhGG4lEzihG0EgK07V
-        Qn20pQkCRVQKx/pkFp6enAYddi009D38FUWa6toumIdzy2xw9KVScD4K5yuoAyfBWRD8GoRnaqVX
-        6kB/0AKmD5UNlwc2GYdgjHOIOvmPNMk0HE8nJ19tkpNx+E0mgeo4/B6TWBPo0GP8USWh2/OLq+Ut
-        8h3YUrQZPmIJB+nZeweFFyW/CO8GtsNVPc1/rgcZe5k2xMzp5YdaoiKoaeXg5awNJC5oGbb2zLOn
-        Rl6Xo7ZnMqRf93UiFFlRqhJJZ5V6nEmRpl2VgkAmMNchR8floY6v6a7wq3sX9wfm3hIWmwyeY5mp
-        rBmd6vqh6SIIxlvTHAXHoRI1APLb8TssYkiWcLA3QueqDqBioUo1JG2CoO2iAr/EvKIUzGq+fzgG
-        1zhA1a1wiNdHESVEJThIeBKuKtq3tD5DuCVXkBvhJuHQasQQ1B4YLzCFPK/VP0CRKhxNTrwIb72T
-        1Q3yG6gO8JBJpWLHj0UU2OqhjyOxYzo8bsx2zO26i6FX7imdC8qXbyadK4mu/mx5df7+enl797C8
-        vr5DviOwJFNdYSjwORyrB3AkUdNserFFwnedRkgtRV23Q3hxu6hj7TbiPZAUIuJMZYkfHxFnEPi/
-        ISLODiLia0dUnY2SsdyWnfoj9zB1YvKsUNm2Lv3q7n8F2tnXBlrtUka70fniHFzWAlYioMQU2Tq3
-        btgHDauNcMZDIYzZ6vAPO6SFkFrXfJjZ8STwfv8IV/kGMtLdriigKgkXE52gXczM1545VXjHa7Uf
-        PbvaQA9yOWoNv4O0quuKmZO/KiKaCE5ZA6knhyEKMiHc2eHF5e3F9VKp3RN0qKaUKmE3XpLxJCfd
-        AdYaQ08E/bcB0+9daQ7BDs+53gzBaPgt4OARYPD2f3Dt/9q4Ye/MPzi0+fVbUOdRM40+g2+NAvVv
-        Mpvdji6D83n3UUkdAvugFNsXjeYFaRBv2L3npiG4QaPeos5r67+SfQyGrhUAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1813']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:29 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/MakeReservationTests.test_reservation_is_reservation.yaml
+++ b/tests/interface_objects/cassettes/MakeReservationTests.test_reservation_is_reservation.yaml
@@ -1,628 +1,599 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:30 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:02 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:30 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:02 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:30 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:03 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGNyeXB0b19ibG9jaz5FMC0tRXhJNTJKUkNxLWdMRHN2eDR3blVa
+      elpTV1NZRHFxZXZKRkd2bDRwb0NpdkNxVVVmdlVMQVhnOWJwOVhnNi1jY0s1THRRSlN2Um1MZXZl
+      eGUxMzBpNXo1UWdFV3puMVdtRTJ5WHdnVnhkTm85U21KZmNlWHlZN0tNTnQ4enV5Vkp3OWFSWE9T
+      ajV5Rk5wLTB3QWR2MktCSHZwaDZjRnFST2NyejktNGxEaHV4MlhIYUFtMUY0U2JuZEoybXF3a1Jn
+      WjwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bm9fb2ZfdGlja2V0cz4xPC9u
+      b19vZl90aWNrZXRzPjxiYW5kX3Rva2VuPi0xLS1RMW16UTBaV0tTZWNaazl6NFdQN1pCSi1GazFR
+      bGpSTGVIODl4djlzQ1llOGJFZXYxM2hoRkhheXlfNllkVWJIQUd5d0VSNlNSeW5ZLUJlWGhUd3Ey
+      YWQtYzVoQXc4WmhLcEpubTNONjJLZnpNM3B5QnNtUC1Dd0NVSVktY2dzV3F2S1kxcS1CUUFfQ1N3
+      SmE4SFJjdGZ2WlFpSktYN3JGZGNGTHlwQzZjQ29DWGdPaF9vc3ZXY295UU1MWjd1SWlpYk9Sa1ly
+      NFV2dEl3el8xbWhvVzNQVVdmRGVnUzJzWkpzV0RpcU56bXJkZ243Tlg4cjlfZmFaRGhPSDdjOUpi
+      WjwvYmFuZF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkZXNwYXRjaF90b2tlbj5jXy0t
+      RnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJYaWgtWnkyeFNwU09EZEhh
+      SHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5OC1zaExzUlpJRW45TEJX
+      M1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tlbj48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['449']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS0HvDihIg7XFxZDKMgoBCj+Tv9Jf1kHg4Je
+        O4fKzLeqlauS2GfHCeLEOWcHJvPHxbYqEfADw3V+/0R8xj9VgKO6muEcfv+0EgdY89Mf7b8xmhGo
+        buhAyfUgYgaSD4LQgm0mCBXNtWXDkcIA+JIRSIqstR2Xqb62MCACDpon+0CW0DqgzW6YajHKDBoI
+        1DaLXis+68AHOSFFGdWAcca1XEdzHSw0mWoBZvaUOkntuTGfbMlBkP+V8WUfBohSALkx5XeQsfJ3
+        2fb+Xemh7YbJq5TMDNpUusPMbQyQp0eICYDsq7pkgjhdqYriUiBJ9HLebdodeXBW8J79abKjgtdO
+        s+3cCA9gwUn30ZUtC8B8o/2nCdlOq8UrVG9BTBLCz8OeHkIZuJvT+SvHgECrjFFaoaQoqPmp+AY0
+        VJRTkQHOkgd8NckRAscR8aWJ0WQIJF92DkACjpaPU2eiHv6rQgSwsgQeBLYC/AqJE3WmWlAydghV
+        yd3vAwDbVD1Z6hktaAFQUSoFbYJukI0a/ci+GTN6jP6zbU1rJ4viLZzImXccnbTbrOOElMKyo0nQ
+        sEFKx/AWhhMi0fqNwn/D8X/ixG/JSq8n5H6fY5CNA4iS40NUalCvTOX4Z8ajTtINCv/meNTw2nfF
+        o4b+/Jl45PtPe02WjvxK7Amd3pgVmGoJzilpGKYyhDo4V7pu6DvgH0GFR9vxZdVEKSSyS/E2MYtZ
+        9mxo7fpwcLMYt/4mWSjR3TZyJ8OkZ5TBnOHJUG9X0WTMztbFlHRdLMCc+7oYBAGs3uanU/LpaIcw
+        DNqWEd3d59CNgNqvDOXqbQxjD7QDw/YsgAKGnMPbvNSSs0IvAJaF3jSAD1tkP24RPU05vIxXX/g4
+        ADc5KLnNWDI0YIhiXiM+18hWnSCoBlO9owzq5ofsEcM/Ezg64VqdRIQ7zFQLZ7ocSI6b9IN9kKrN
+        A5B0U9QRUce5t9F8yNjyRfJDx0FHkeUNQaI9fEAZG3XdF7xnlHEA0FBGeCjfkDqkOZm+zys8J4e+
+        nGhoiXZDMkKyB9e3kzacvf4HlPHcAGbi2SOECi3yTPUO3SQCSTZM2JJpt/HP+F0jyjgT6G7aVffZ
+        dtLlnjAmQHmJ6KlzcEH5gnIycVeCb5xMty8Q+I5sVURErHSTRHa0SjEjq5/0UvCq478yMCixwnyt
+        Zac/YYXlhp1Mlky1ZMhJqfulrFnARzW8QakY3Gi5lOVXkIeIFt1wAzQkIMSv6JWtFkF/e68kPmrH
+        /2s6SfZ7rmulaZ7fHZ6wpCYsw05kOM280vArLZj4ZklKkyZ7O6yDz1FS5kBuCaTICAzFyhPtGcxY
+        RePKchB1p/yiuM6nFBDzsUQfyzP5f3Zwjc8UXplPmWoBZVZdt210nSFamY6VsWy9e46ofuxBV1Is
+        VzXbUwrDvHkNEtSBlVXalIXudWeTuhutBMPhuVlgkuo4UubOUbCgNrqQvd4RP9dbR77FLk5S5F35
+        2DT7K8FuGrQ+6jkreFUipdk5cUNLBc3x3pZ74tjXvL1lDYQmO5KPVmO6dq3RwWxQxHKCNa5DsS/W
+        pS0fen2bVcXTGIZDSu1btBoC1rBFZ4L7RmdPc7EAIHccWoK4PMCVt2GbEmsv+krUeANrsyX68/gw
+        P+v6ecguW+bUtg+z/uy9f9VDq7GmG5sWL0Flya3mZ3eh0YOr1j8tsV204eaDbp/g5pG55jcTjDxv
+        V9Pu+0ggllA4jKlOIOG0wq5rltPz9my0cFW18cZe6xam6ZFKBRNtAPvyXMPm516NdJeu4hIgNiPB
+        Hg1mKuQ9TtqO3ll8Rtgrj+pq/JEfnrjxmxWc1V7EwcF+KncGrLAJ3wMruA58F9DcdQ4243ptSvOD
+        3di3CfXisFAzzoPl5djvw+OkT485stsYyjVX0YQ3BXawXXLXLJ0vo1iyg1RSKj59HCtOS+e1pfhG
+        SuuqTaHqfUQYNfR99HUVF09ZGh8UD63+ABWMvaxC189vw09gwXLC5KrbbpL1EisHC5ZnySoI2mSJ
+        k0MlDhISKYhtxbWqZRipWIa2//uf8vwCL9AiGMFDXNCNAH8IS3JFQLLt7qViAo0U7wm6+0Dfh0rg
+        WiFqO4EcoTrPpO0ZRB8ftmI4qLdRrcR+HxYvk0a5019NxNILZaG/D7NvQA19+VUSzdRkXyuRcz34
+        yu7uQ+giHWyrOIadTKzVXY/jCx5zw8b727pPDh1BdLX94rR78whpEZIUy5HN96CGMm0VXTWcvcwI
+        +mw1WHuwhz2ObACbr8VU1xodD1YwkMddthlxTTpyur6+UehtxxjESmfKc9vOarzAj9aJXkP7PD5z
+        /MzpT8QemG0Wi94+gkGzZfqboOGdotp+PhiMdmezNbXOHe1AKFdlI7sxPFIm5UbWdGlSfJeXVq7W
+        s2EX7weqUbP2FuYd9dF4PN4u+ucBuSsFIdt1KQrJZbMcpez2iVQAKSfK1VyasgFKDSd7lJ4O9IWh
+        RE4Uz/MN1LOp2iO7sJTp6Fqiy/4BtOkn9t1QYmeXZ+m1/wcjk9WfJEeyYcmJwiFF/4Ax+SVHPhQ5
+        nQrPE8ikTiUlkdsseRHrCSpzkvSsPiCFsvryGU1woHEI3TDIbwgEuo6/NKR06ELZemKWMeY56KVQ
+        PwW4FNYXwXwMYbWo/D/dA0jiSz2gxw0n/a/0gJ5uWFoF3dLBj9Y/hup/MrPtKdcbqoPpZLVRjAO2
+        ssfieL2bAKTbI3vcXGMY2Y+3w51CBCJ+4PZCPzk6QG8miq0vunWjX9eIix7hsqGe4vCs26ap2dtA
+        wSSIBHl42I07kWVKFKcvWuxA1nbS25BerhoT1msK727Ei+PT6r0xmVDXQcvvXqh+h++1LrPNynwb
+        rsH1elI9aYdhX61l4gdqOTuYb61lovldtUx9by0/+/+rlu9BeVnL1JdqOZv3C2r5i3q+FFd9lv+a
+        oi+TnxMc+FPq2UT17GPxebJddlnWqznX/ZD2uzzRiHrWfOny5mEyn7iR8z7ZHvsX8chpR65Xj+Z2
+        NI15DzojxdKN6I2bDa2Q3bwfV+pKEt6l3tCGbOOkHK52d79Vh6fNsYOu9cLaP8lig641u9dQsE7u
+        uaY3LouDyHbZCF3FLd7t4cPl2TwbyKUn7bueQY5YZbicjI6NWcemPPYwmR2c4/xiYS3K655W5D6O
+        pyuBvtRngIhtasg1AqMJTD7e94Y0JvC0EPaImo3PZuTX+wH5I/3gu7SdrP/afvDs/69+cA/K9/eD
+        bN7P7wfUF7V91pl/rRcAx3D9impA4wqcn9IS6qglDEyKmxgcTte6Y0ne4wK7D4TgeMbttdUYGWK0
+        ah6W0LlsKa+3vhr+vjmCO6G31UdGf2SbMqV350rY6h54rTkX45ALdV912bXWXEN/esa242406ZHH
+        eG1uZ4Sxj5quxQn8pkZOehoei9KFvC75GPi7S3PhHWcCCXbXGqmfSJ2iRKsf8EJwUtXjEA99bo6j
+        b3TaOknfIPfUj1zdv0vuyV8s98/+/yrve1D+RHl/We7vj0H2W2VRkrprJD8/3H+x/GAp5dvTvz3/
+        D1lRoYe8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:31 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:04 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkaXNjb3VudF90b2tlbj5jMC0t
+      cWstOUJWS3l4MHlISTdZR1ZEMkluUlRvZGZRcVpHcDFfUXUyM0VIMjhZczVhbmtVdnpkMEV4TzE0
+      d2w3RW1GZnRDSDI3ZW1ONXkzQmxKamdsc0ZhS0JFOHZIODR2bkJyaFdiNFhBaUZ5YkFNTkhYQVVL
+      UTBqbHE0VnRtd0t3SE5PbkRMVENlT1dRUUNmdnRzODlrcldzN3BxdjVmUEZGSlp3azlNbHdBZGcx
+      YnpiV2FveXRqM2szb3ZsTVNrM05CTl9Vb2RDbXRCMERzY2k1bGZsLXBqaEpLS0tYUUR3RjJaPC9k
+      aXNjb3VudF90b2tlbj48cHV6emxlZD55ZXM8L3B1enpsZWQ+PGRlc3BhdGNoX3Rva2VuPmNfLS1G
+      eUpWRGY4RHlFRGhNWVU2Zllsa29BMUcxempMbnZkVndoN0tMSmticlhpaC1aeTJ4U3BTT0RkSGFI
+      emR5YUdqLXBySGQ0N0s3dmZDUkZYdU1FSnVValJLQnNHbldScW1IdDk4LXNoTHNSWklFbjlMQlcz
+      V1ZLczNQLS13Sm5RSE9fenB5WnV5VWlBLVk8L2Rlc3BhdGNoX3Rva2VuPjxjcnlwdG9fYmxvY2s+
+      TTMtLXBQNXQxM2dFYWM0a2FSQnpabTJob3ZVUmluTkhPc2syY0t2YlBualJsdGRKeDJDQ2owdzY5
+      ak45RVFxX3Zwek55a2tEVVJtOGk0aEpDblV0emJ2YjhBcUhJbGNlOEtmbWFDVEtyZHBmbGxGUjhF
+      SmFqbDdNVm9sSmdrNzMxU0wtN3pJVERUNl9YTnVwRG1FY1RxS3R1STNjRGw0Y3VlRWltVG5MMHJp
+      QWY0SHlSZXRIaklsUlRTZ3RVcFdFOF9FbVFEYnY3R2VWazlUclB5Z1B3aGh3SUVTOWtNbW1nT0RP
+      WUR6aHVsN1Y0N1c5Tl90YlNIVVB3b1FkNEZ6ZERxUy1adldIUEZCRDFIUHZrVk5XTC0yd1hVTUJZ
+      SlIxU3RSZ0szQXNfMDRiRVY1bG5DcGZFdlFvY2M3R0V6NmwtZGh2YzNzTGRGdERhUGQtUHdDNTJv
+      U29ibzFleWt2Um1KRk9jdE5wSF9YSllFME8xbVVwM0JkTmpOSXFIS0dsc3djQ3ZIdEZmTWFBRkVS
+      V3VZc2xzekZyb2U0SHpQZVdLNjVNNE5GWktybTFjeG5FdGRpd0ZTeGpERHRqTEQ0S0gyQjdJYTVv
+      YmRSR2J0QS1aPC9jcnlwdG9fYmxvY2s+PC9jcmVhdGVfb3JkZXI+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1148']
+      Content-Length: ['1008']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
+        H4sIAAAAAAAAA7VY2XLjuBV9z1ew+mHmIaG5aO9wOKW9ZVleJFmS/cLiAkm0SEICQC3+nfxJviyX
+        BChSsqbSmSSuLps491wA9+IuQBu/H8NA2iNCfRz99k27U79JKHKx50er3769Tnty/dvv5l8MlyCb
+        IQsTDxGLIBoHzDRo7Hg4tP3IiinAPrUc2zMjbCi3JYYbEwKzn/IvC5ZC5srZGsollDOWtsswMTVV
+        LXAEmLOiOHQQMet6tcASYM7aBraLqKkXOAIqcDBlFj2FDg6UIkyQQM1//qOon+M5CnrktGXYcgLs
+        bkzXkuWq7NCP+dNHMF4RJNOOcz9uPLXcZX09rB53k8dlnz1OnlvPTlUL1FPTd7a96Wr8Uhp674PP
+        jk9XnztGG97sx2uLWCffDwYrHZfr82iP3iZPM2cR9OkMP+/mnfmh5jgvGpr9mPW2sku0T//9hOy5
+        u5r1ds1P0pHfYKfF/Rn8XBneoMis6rL8flRlbRAd2/t5a9hYdtnboq82WAc1SbsfPcz6h9Wu8mPR
+        H9XR8TCddOo7/aU/6O3wptq+Xyx71n21/PBWZq1HN3Le41pVnSH/1B2w8eDw2Qg6u8FLadHc6c1h
+        975B1eWL3w3aeDhh6nTf7ez9Zs/W/U515I7eV/KijJv3R28dbYa91uKw9BalaIlaFW0zGNn68Zmw
+        oFtvfp68NVKX/rv9uWmMYxmTUml3Qp3RyDno88/jev/08sZG+DirnWrTYzir3J9au1Kz9XL/OGnY
+        4Xo/bTmd9kelNNdPVth2lg3NPtgf8vuQ6m5ra+nHwJ8ebH+kq4/DnX2oTiqzUT0s43c3Umn51WrY
+        nWnY1/36y3bufiw+P96qbzPWWw/cx2CNdtFC7i+I68z1Pn43lKLLuf9Nw0N0azN3bcGHa7ZxECCX
+        SUuCQ4mtEaRpFCNDuWTlSiFia+wVgDSR2k+tp4IOT67CkDJTu6tcMAD6L7eS5L/NbPPxdQrrF3iZ
+        IKey0xaZLp+/QEzhwvhsnE9dHEewQxeHjh8hzyw17pLSkA3PFG5rs/P6MIWJLsCck2686UE9kyiz
+        I88mXoHMzYqwhZcWhQpITc1QikMhY767QUVpBhgJbUt8F5mlSrLNfAzlk7hrm6yQWU4l52G+AdNA
+        4Gn4Y0P95Vvvzg0lH3FBus0uVPHTYY0IEgS+eddnoqQGOPJwJMcbcNYZ5PKU+pDKhVAoBzal4g/n
+        24RRoOSAEHI/glD6xQ63f5fa4NE42UpBbEAfSJsCn/aEYKZLKHEXeMHaoFO6kpI6LEOShiN4mdoZ
+        uZgs513P59mRi25Pys3JCBdgzkntaNkQrUwY2rlS4JYq+RaUzInJgRLh9vQQisBZnOq/Rj5DnjSE
+        Lgx9NKeKUyE+xBe04b2PDtYWETeJEd4gb4oML2nexI5WyEKRJ8bpZNN1/DdJo0yaoC1DSbuUdFWD
+        JppTODtmLgT2kiJmlqrJUtdoTqPIhVCCbCjX9FqlfMnOhJx+gp8w9DwzWVRtqJpgnnE4aVyvqpqV
+        wpCgkFohSumy2pBVbao1vpfU76r6V1X7nqx0W0HMe+0DPobMJ+yLVypsLY3s0//SH1W9XCupP+2P
+        ilr5j/xRgX9/xh/C/rTW8HBMCve42R52x4ZSgAUldcPIZtAJDlILxyRCv1LpEcwhNtQ9Ik27k2mm
+        yH3Gv33PrA56mQRGAg8g0LEJ09ksqRlFUDCgC6xNBZTlkK8rO+m6MpWj87oyQ5QpmX6qItTBQhZT
+        M/D35+kFlBF4Y1Kycdp/qB9uAySKeabHOxP/jrcUBQHslLILE7tfTYSv0Q+1iCs35lghbPEGGdjM
+        ZzH4vALtWW9UNa1UM5QzakA1X/FPWb3TVDjhShXutTlsKPlka5ta0JigHixpekG/AJJqmvQlaJ5Z
+        GRVDI7SPFomjCI6Cx42mgw1fUCOEqnuDd40aEUIeRMQW4g26QxqT6X5u4YIcE7AZRwVahnBCYgMm
+        YVKG+fa/oEZypefNs62NpfL00VDOUNYioOWyhG1tQlMVnfoaN+gap1V1yc1Jl7vCDApxCfR0cnSE
+        eIGYTKYrwBmH9+0jQySyA2kKRKmVBHLkSbkGz5/0HXWr4t8SGOn1jK81aXYeuuPJvPvwMDGUgkCQ
+        0uknthcgAjk8h1CkGU20MnEF+dOpD60szJ5iST0qDI2LY8pL7Bx50JW0/0cBbjS08s8XYO1rQ/qj
+        Spak1BbjQNwM09i4wpJEC/ww6e1pOBeG/6auaz/d59JI5LuTm+ozRLoAhIRae5/6TiCi9xrkrLwa
+        8sCGkidunzOhkkPG17y/zPnkNz+42l1JlZ5HhpJDXLpehyHckbQGb45FjK+Xp3Jyd7acxF5+vQf5
+        FVTkJGsoF0huWnImkDm7GNFzN4jwGUIev61fUwzeDgoeaA/G7Ydusu0rwQWVX+y2YI3k+sQN0KWC
+        8AZmdmBdPW2uQEG6epV8BS94hRfKLVhwr18r12hGu3y5XIM/XVnEs1e59b9L/wL2/DbImhIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:31 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1879']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:04 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order><crypto_block>E7--NuwIhns8SF9pSFmOCtayGoPi5orsAykdVtQtCufnKnVXd5ijHtnqR7hewEY9Siu9mKWZXgSi50wUnsm6QPTTn5Ap3rEh2y8qt7LQOigLgEgeiLH4ylijiJOz3cCcGHfmz-mr55XI7fNrF6K5mYhYQ3qn1nCceIO3_pGh-y2ODATK_1unwgfaRcvmf9rRBGVuoIht5KuL4JvyIf1HGwjOVpnEZgHPJm7kxU7hRzZCGSznxEZHloNsR7I2pTbq40t7v2mLo1javANm8iUGKktt-5o16BpnLLteyP0yqrtW48EZlb91SwCaca-PJX0S8BvzKCatNcVD_hETlolGxPekOoYcRxyhOS0oqh4PNL4fG5MfxXXjHxpdCbQvBrDibivFS6vhbjmFeBcQYWikaldIWXGQFooHSH2dWMs_BXrsAz6-j8VMn40F2LZish9H3g6jBjVkrnayZ4NMPTq5FtXcdK_5L7WFk2ASLauJCqJowO_bV8X2sPX_At8097h3QpXw1Kh0OkgxfUXvzDHbFI_bN0XSMiJ0al9y_p-VXab83-6hG9eHDURd6DtENaA6ZdPR1b2kCR_toknr_BpFKcDNzxpBDj9-GWfRRbpiCUM9rPYDDkijx5sFQiucuV4RNL_xRMwwjtm79e8Q_Ffs_Rbj0MXC_rEfuYOIlmhROtFCXJpXG4CNo46bV1NKHU8emAOPjTy5eN5yHKnfgvMsrKq0Ix6-yFmDNxXSz4pazVchj_p8eOwdiIe_aY0Ybh9RJBrav76RZUsxDdWqMKRqoWJyL_--Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>k0--5q_Eg4_-x1Nz1FPUkY_jXomw7H7E1_PjxiUKNYUK3emm0ERjusgvnWUYFQqZHjDGEekx61hC9iIriru1LpexlQdiFWf9oohhZR3m54tmVkLEMIItGP0eGhqQULniBgRbrSIgFusujEyS0Rw91TvO3pqX8rgNeFy0FDAL-H3GFetfBUfLnD1Zi-94KcFBeU0CKwDSXAHtxFWU5WZiFJ-wMeIriNlK_uoAMR58EAI8VqC-Z</discount_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></create_order>'
+    body: !!binary |
+      PHRyb2xsZXlfYWRkX29yZGVyPjxwdXp6bGVkPnllczwvcHV6emxlZD48dXNlcl9pZD5kZW1vPC91
+      c2VyX2lkPjxkZXNjcmliZV90cm9sbGV5IC8+PGNyeXB0b19ibG9jaz5jXy0tNi1ic2pXT2psUmdy
+      ZS1zRGJKUjlPQmNmOGhLNnhxU05mR3ROU1BCUGI2MWwweUFpYnBGVGdSUTNLZFpJekRpc2d6cXRz
+      OWRWSFVCcl95aWlsSWcybzQ4V252ZVlTT1ZiWGxHc1ZvUHFXRFd3N2JiUTFlVkhWRnAtY3Ixemla
+      eWVhV2NnVkZxQXpyRC1ZPC9jcnlwdG9fYmxvY2s+PG9yZGVyX3Rva2VuPjYyLS1aeDAtMUlueEN2
+      V0JLOWZFdFlYRzA5dERlQXJDR25MVkd3Z3E1SFhHTThleHdUU0Q4cTJRR0lGcW9rNkNKWGZGX0o2
+      NExZNHRCTmNuYlp1NzYwVmVpeUVJdFJJd3o5bERxSVEzWEFxMkFLRUo5czBmUWlFbENvS1N0MFR2
+      RUR2aUFGYTJpRDZNY01aZy1YNG9BSnhkaG5rS0ZCWHdmZFgzbmZlQjUxa0lNYTJ4UHJ0bEU4QXp5
+      ZGhlMGZpWmF6azlSdS1vcjMzcXllRE1NYncyV3p4aHZPUVl0TW94Vjd5N1R4bVY1SnlCcTNBQlFK
+      TlM5YW1odlRCYkRDajUzVzJ5X21DYmY5MWF3YWotWktzMmNCcF8yeGxpVHdhaU0yME5LcWF3NlM1
+      Vk04bTRvWmNuMHM0VV85YURUbUcyaThRcFdjalh6alk2WVZ0RmhJY05saGVxblgtR1hyY2JXMkdv
+      Wjwvb3JkZXJfdG9rZW4+PC90cm9sbGV5X2FkZF9vcmRlcj4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1384']
+      Content-Length: ['662']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61Y23arNhB971e456UPLQGM7eCzKF2O7cSJr8eX2M4LC4NsEwMiSPj2O/2TflkH
-        JAw47urpJQ8J2rMljUaaPVK0346eW9qjkDjY//WLfCd9KSHfwrbjb379Mps+CuqX3/QfNCtEJkUG
-        Dm0UGiEikUt1jUQrG3um4xsRAdghxsq09RMimnjbpFlRGMLwp+zLgLmQvlkFmliEMsbatCgOdVmS
-        chwOZiw/8lYo1NVyLcfiYMYKXNNCRC/nOBzKcTChBjl5K+yKeThEHNX/+D3fP8MzFPqFp4BiY+Vi
-        a6fPDEHY74J1fdesB7PqcCVsQry2Zfp0sAaj5buCLPKutJZy7f3bbigt535r7027WzJrrduLozVr
-        dk4fS7e36ODFYycc7pzm49ZS3pUK8YYtuTYvnxfl1+FUmPq78NR4f1EHctUZHdQP1HHnZ9I9P66X
-        4F3eJ41tJsU75OvtsiBUUadq7KMoaLxvvlmbRefQD6aovqh/bCZueSm5i6Bq4f1hJhNSeZ4vHxrC
-        eKYaG2XUi9Tn7nmDwrOhdFxJUfCz8NpvW+et1Gjuh/35Uq2co6qC5s11Y9NYlPeV+5O6eXMx7TkV
-        ggeDtUqXiO4WH294JAzkrdudvewOb/ZqLjUnR1SbnTyzbb9PFuH5MJSGRms4HlvzoHZ8RuOHD2Oz
-        O1bmUX359jIiw261idqCGTwaPeXQDOyPLpooo5qhfHtr7MevU3v89BBNzhNh0XkJXmsR7ftC1OvK
-        C9MJBpFKW8+NoTto9NWn1pM1Wi7HMJJihB0Htu5bf9h7c04P/frD1vJPvaemOnVmw6k5PE4n87ra
-        wXar1Yx6HyevLffnlve6mGxrxxfyGvlWxaOjxWhwdO+FN03Mh5/tha7ZiAQmtbYGfFh6E7susmhp
-        HWKvRLcI8tSPkCYWWVknD9EttnNAkkjN4cMw14clV65JqC7fVQsMgP6jK3H+m9TUB7MpzJ/jpYaM
-        Sk8B0i02fo6YwLn2ZXEOsXDkg4cW9laOj2y9XL+LpSFtXihsrZPprNUeTGGoApyxEtcnNLKRT0sh
-        yFyOypblYwOvDQISSHRZE/NNbqOOtUN5awpoMS0IHQvp5VrsZtYG/QytrRlukK4klkszc0DXEEQa
-        /pggwMzx9lwTsxYzJG62QcZPhy0KEScw51fOJgqMvelGiGloHtAsh3LBdbFvY8iEHYTyAjJ7MlAv
-        sXMjG9pyTUL4H8aHo2HS2IEcxu1Jl2nRzoaB6pCUCjZcUj+KUBxEiI2xQ6d0BjGJZArGpYhT054X
-        pDBexrsx5M6xye1h2UK4vYBllGQtj6bnuKccia1QzOYV06DF2xvyMCdBzwMXc9J/5jsU2aUuFGWo
-        qhmV70LowGmDqrx30MEIUGjFJ4aVy5smzY5reWj6G2Qg3+Ztvj/RLyVZpdtSI9pEhJbKkgwFNSMw
-        bkQtOORrgqiu1OKJrtGMRpAFBwcyo3IvVytVqcBOjYx+gh/PsyGhYVJJlVXOvOCwuVitSbKRwKZv
-        Q5p5KKELkirI6lSuf1Wkr5L0syR/jWe63YGPex0B1ibUDOmnmJRlCEYDEtf9P0NSk8s1pfLdIamU
-        5X8UkopQlv9NSHgIEulh5zHW8XGj2W2PNTEHc0oShr5JIZEOpQcchT76iZQGsJzQBBkMf0w7sXix
-        b8fWa8+PqQVaHHfhlONMSPIgZ4B7NCK66+wvdg6lBFZkxLSd1BLieIGLuDCn/ViVYd9RQJDrwlSE
-        Fnxsf/bxr3yP8e4sj4s3xt4gbLAi6JrUiQuPXk1K8KWpgRhv2Kcg3cmx6QJoYtZ/axID6g0k9pro
-        PtbEAhBrYVxukH0RQd7UPPNohJHvQ1jZ/stlOBqfUM0DzbzBu0Y1HyEbdjeAcxPBfTg+S4k/t3BO
-        jqDUwqMjR0sRRojXgEPP9KFUJu5/QrX4ps5qYlMelyrTgSZeoFTgoZLSmG3sPF3iBfga18gWJ/K4
-        ZsthT5giphE410BPBkdHODqI0Hi4HJxymGyAvTQ5EYq80hsK8YXKkiC5QPEbSqPVa48n83avN9HE
-        nIGT2AXFtF0UQlrN4SCRlMbLC78k/KtshNLipQ+lWB5yTa0Q7Uzx5sgGRbyPq8T/r4j3IPz/QBHv
-        PyniX6VonBsBxi6/uSWbfIXFGeM6Xlxtk3OZa/6d0N5/r9AmR4p5JzTqDTiyHOAWYuwd4qxcfgyv
-        QcbKFI6dUJAxfjt85V0ySPucwMXkjX+zjbu/U6TSqK+JGcSs263nwa1FritJAc9jbL4sJ+O7Lbz2
-        Yb3J7PECr6A8J55DLCDZ0uI9gbvLR4TIReF9fIGQzW7T1xSNSXwuAs3ncbPXjt2+MhSo7KoVwGpK
-        lhNaLip24NHA1HSNq6fHFchJV6+Gz2CBl3tB3II59/o1cY2mtOLL4hr8bl3hz1Lx1r9//gSe8Zbz
-        OxIAAA==
+        H4sIAAAAAAAAA7VY2XLqSBJ9n68g7sPMw4wsiZ07anWwGS+A2TG8KLQUIKONqhK2+J35k/6yTqkk
+        tMCNud0z7XDY0smTVZVZWZlZkn79sq3SGWFius4v38QH4VsJObprmM7+l2/LxSPX/Par/DeJYtey
+        UKCohqG42EBYwYj4FpUl4muGa6umo/gEYJMommrIjivx9yWSjgOPuopmufpR1hWOq3Ma+Vi/fViz
+        PUYc6Wkvs9ZbR981D6/1r9N8vBvQ8XzSmWh10RKCtql5j4v9bFp5NbbPl55J9pcTJS1j9bTsYCUw
+        Tet5X3arzbVzRpv520p7twZk5U5O6976s6FpUxGtnlaPHqdj8WJuA6Su9f3q8dS+4B63kfjc+qTQ
+        YM8lxNQsJAeISHwOuTqGukfkyPUKx1HltKPN4eZY/uQmY/OptqzOp4Y4OiCn2zMGtQDhz4G2Pguz
+        zVzbUkvd4O6upzoz1fQUNDY/4LF9IC+HdqX2YdSmi+eX2X4wtt6f943eevh+mXK1Chl0q4/meXS8
+        LH3zNH45dgJ62jp1vTzcfwUcev7s69MWVha2s3ndHmtvDj4/NbYNQ7QWRlM1zFdaGc0NI/CHh8eX
+        Dlcr94YeFygf/ZZm+ZfutPxWNTRjUz4tuu7r61PD7ArKhbaXA6WL/W6lhbTatvuiiFPRPVU3uvf+
+        Wf0Uh8qL3l8ZDc/ptBtH/VQdjQZ+q+NazY0uBo35YmXsyeSwmfc6fvujgrwGOl0Cd3z0a0652dOV
+        dr1RW5y1lepsyNtw2xla50V3Ig5O5TWtNN87Z63zPL+sZ+vlBW/JadhZdD/Gu7H4rin13mZbFyvT
+        WXnT2I1OC7wZzDa7yevmYz3ZzNr9CapNB8EXXZKn3mbzrgTTL6XpcX2s2YueJ3DcVuLzm3ndWxbw
+        uus7VBZTVhYO4wQZikmRrTi+rSEcMm/BZExZ0nzHCAOI/S/OcQdNmMT1sY4ANJCMvqhCEaHCVSMr
+        LWgYiOhy/4si7KhWaQFqpY6qg6VG6UY/4ib61KWqBUPamukgQ660HlJ+QVZUIVSuCg+1GzqhBSpM
+        6KlUP8jiDfsqymsQpFIPmzqSK7WbBaXCghJYd1DxHsnVW52rTNJ9jCENBukT8+he8yBB5KCUsVN1
+        6sK+C0KGE4MpKw6EZrmeYSXRcQU8S9URkcsZTgxlOOBFhQS25lp8FsYoRuXf/pPVT/EUlaUoxGQp
+        cTLb+W4YpDot7bBrl+gBQYVwfCTxeVaqZCN6cI0MELmm+9Z5y+gwd2VeIQii3c5D/+NSwqqjUlUe
+        Lxcwf4aXCFIqDTwk62z8DDGCM+9X40wSn8TCUUijP6EwW9u95XABA+XAlBMtvG1AFS0RqjqGio0M
+        mZnluIq7i6KZhGkh+xrLqAlHOCtNAKl4QDJnonAMMpHPp1Yi8HSY2TBS2dL7a0hp1zcmYEkFGojg
+        84Awigls8bpJ40NiuY7hOpx/BGddQSaPqMNIHgtjZUslJP7H+CqmUH4zQCxkfgRh6e+q7f271AWP
+        +uFSMmIJuo+oFWHDRoU8D4XuAi8oR0jO4Ux85LAECducmJeoXZHcYCmvOJ6hOjq6PygzJyHkwJQT
+        2dFRIVppbGivoMAs5dMl8IkTww3FsdujTcgCV3Gkv3SgXhmlV2gAoXtLqfGuYBPiC5q/s4k+FQ9B
+        rQgLVpTy7ookOHNIwaqzRwpUmvg9Gmxx8P9VEqEKzZEHJRISYKksiJAWUwpj+1SHwN4RROVKPZyq
+        iKY0gnQIJTgN1Ua5Uavm2YmQ0QP4sW3DkMNJhZYgxswrDjvtNuuCqEQwHFA4WjaK6JzQ4gRxIba+
+        V4TvgvBPQfweznRfIR636AP2Dicf0xuv1OihNFKD/6c/6uVqoyL8tD9qQu0P+aMGv3/GH7H9Ua5h
+        4Rgm7lm7+9qfSXwGjimRG0YqhUrwWepAs+Kgf5DSGMzBYS+DS4v+fJEoMp+xZ9OQ68+PiQTeYtyC
+        QHdlGE6lYc7IgjEDqsBB5kGZs9m8nBbNyxHOuc7LhW0Yn+hHKrE6WEh9Ilvm+Tp8DCUEVpj45D2q
+        P8S0vbAziZJ5oscqE3v2PYIsC1ZKaM7E/q2J8DR6ErI4f2eMPXIVViAtlZrUB5/XoDyXW3VRrDQk
+        /opKkM337JETHkQBdrhWh04lhSU+HeygEgUKE+SDHYmuhTkgzKZhXYLimaTR+FWy1S8F+44DW8Hi
+        RiyDDTeoZEPWvcMropKDoBc3kAfxBtUhisloPffwmOxjsNl1MrQEYYTQBhfbYRpmy79BpbBJY8Wz
+        K85K1cVY4q9QUiKg5NKQrRxtWYgrdRGXyMGNsuqOmRNNV8CkH1wNcneCn7oM5G4B0e39Xsa/J5Ci
+        9ozNNW/3hv3ZfN0fDucSnxHEpGj4uQodOIYzvIZQJAktLmVxC/Knj37hPpa7ieW2KU2xa2RAVRL/
+        igTcaonVn0/A4m1B+lEmC4+U57pW3BlGsVHAwoNmmXZY26Nwzrz+l7wu/nSdiyKRrY5rCxOI9BiI
+        JUQ5m5kPKUWQsdJsyAIbUl7cfa5ilRSSbs99/syHf9nGNR4qQmkygtv7FWLSw8G2oUcSW6w4ZjE2
+        X3qUw95Z0UJ7WXsP8gKU5YRz8DkkNS3cEzg5Jx+RazVw3CuEDNatFykSKwcZD3SfZ91hP1x2QZCj
+        ssbOA2tKuol1C+UVYm/cu+UXr/fsvXAruQVzvMwN5R4s3b/O39zj717gb27uP5tZ4mvvX5Mx+eTj
+        TvKpKP7OcPMJKYf/oe9N/PVDEv/Db7O/A9pPXdzdFQAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1828']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:31 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2085']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:05 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <trolley_add_order><describe_trolley /><user_id>whitelabel-testuser</user_id><order_token>E2--5eH5_vuupAjgQcgXHwMpTe9X9qgSl2Y0lXp5covwU1ss4IWYBA-RU8_g3PLu8IKzgerz_3Hl033oI-VMEczh0ACvOMWY84zu53eWCfAgAX2v47y8gZlotLi4soNNf8tYetkXqZoP-N1hlKUJkwZdbW0CSxe6UymaEdjSXrzwO0O_DORRcWp6xIeRBq_gkx4Wu9YZJPsOK5CeE-apF_L3wCpdqKeS3P6_3QZAvRVTdRGBuSzS-XHJpV6utMn-uLK1XaipNu8tDIAOlNAM8GDGcPYYRpF_3_rHi9pUQMOLZiyBM9BhcnyLGC8TiUOTaOxTSW98HodDDCuLqymE1MWcmVXSh6xJsVunc4mtPXPNxl7-Z</order_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsUDfEXxcUCHyqYlLXHoXFHrOkiCFhc3j34smOD16W2zX2VOT-TnkryAjJ8N15iPw8qeHlWzsKzFfY</crypto_block></trolley_add_order>'
+    body: !!binary |
+      PG1ha2VfcmVzZXJ2YXRpb24+PHNlbGZfcHJpbnRfbW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+
+      PGNyeXB0b19ibG9jaz5jXy0tNi1ic2pXT2psUmdyZS1zRGJKUjlPQmNmOGhLNnhxU05mR3ROU1BC
+      UGI2MWwweUFpYnBGVGdSUTNLZFpJekRpc2d6cXRzOWRWSFVCcl95aWlsSWcybzQ4V252ZVlTT1Zi
+      WGxHc1ZvUHFXRFd3N2JiUTFlVkhWRnAtY3IxemlaeWVhV2NnVkZxQXpyRC1ZPC9jcnlwdG9fYmxv
+      Y2s+PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjxkZXNjcmliZV90cm9sbGV5IC8+PHVzZXJfaWQ+ZGVt
+      bzwvdXNlcl9pZD48dHJvbGxleV90b2tlbj42My0tdF9xZnQ4TFlrMnctUE5pSDVVNFNRZDFNaGVu
+      Q0RkRzV5ZXJ3R2JXdjBSWVNiWnRsYVlyQ2ZEYW5SYWlwX2VOaWphblJBaHNKaEEzNWpkNVFUSUpS
+      Z0dObFhJZzdEV0xYelEtNTNzR0M0Rml2TWt6VXVpcU5Ka0J5dHFabjZjMkxneHktZUl3RWNROXJf
+      VG1uWUtaazVPbnJ2SDdaN2QxbFRkOGFkaUt0M01TZGR5dUxoRkpCLTUyRExwLXlfakU5Ymx1ekNR
+      Mk80ZGJkWTJxVENvS0tIN2lDMF96dEFVR19DcnVDMzllYjVaQ0pfMVExb3E0WWNwWHc0dzFMX0pj
+      RVZkN3BuQkE3a2NxNE1NR3U5Qm9sOFljMXk3U1RWZGdzUGhZU0RCdUFqM2VwN2VxenlvTmt1NW4y
+      OERjX0E2NzVUdmJWYW5Zc09MWkJMbHZUQ1AxR3EyV3QzOFhCdmJCSVN6V1JXVXpyWnNxTEJUQ2pO
+      Zk4xWGJfNkRZWjYxM1FSMlk3Zk1xVHJZR1JZZlBLWWpXUFlSQUVQZTVRR3l4dFVzSERZWVhfeVF4
+      XzhwLUVyYm1URHAwLS1aPC90cm9sbGV5X3Rva2VuPjwvbWFrZV9yZXNlcnZhdGlvbj4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['694']
+      Content-Length: ['791']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61YyZbiOBbd91fQualFN4HNTB6X6zBGkBAQASYYNj7GEth4DEsGzO/Un/SXtWzJ
-        I2R1ZnXmIgPdd5+GpzdZwh9XyyydoYd0x/79C//EfSlBW3WAbh9//7KSRuX2lz/EfwjYc0wTBrIC
-        gOx4AHqyB5FvYlFA/h44lqLbso8IrCN5rwAxgEioPBYJqhe42JH3pqMa4koul8+Ge+gY/Y67asz3
-        5aPnHACPny/q7G17qkEVnWqDLd88vRtzbru2B2dLmmhoNTgMN1d11X8JPrfmdPPibEYv3tzQ+yNN
-        rZ1qdWTNB3xzXb1tqh9zqSzZhhd0T9/aM76hv13an/DFXN/Q5DY6bIVKbk9CeErXQUjfm5AeJYck
-        1sCOAW2xWS+XdamGlY+2U61hua87DXgz24u1PaqCi2J9PtvX7jV4GV1ul+m5DgdtUJ4fpE7Dfx13
-        WvBtMzPQ+HX8MeeWo8PGOrsjvfF5Ac83/Tg4OtaQO43gDh28+lXvfszWvqoFL9bQ3pd372tzLUNi
-        JSmozdu93v6wQB/c+MOWDbDRpt3XRb87O/Dqdbp7vaKPPexIvU/34jacz8ZAA9Kwf3h2LP0KBsRQ
-        Jv/+8aENXv25Xquqp9bu1IDBYHDqtnby+HZsD/zF1Lm0x3Z9vXr+9N6Pi5GM3qA0WS6MUc/aYvXZ
-        qLfxoXY4ti4zs76a11cvcEXOic6b3vR96kp+Q7+1LEM78/K6Pmmure6u6jRWBuirE9ezTe+0rIE3
-        tf920s6X3nZX7WxXxjoYDYddaXRDw/Gnuw9UHQwnx8GmCYatjS55U74qvbQG0sUdztZcT/12la5b
-        ubpuapfn+rLz3us/j8G3YATWPe/sHSdL3ZSnr+f9rnXrgWALlU79E8tb6CxtY+bOvr2OVz17NBnM
-        p4FR3uh827QMeJPVzRyM7IVuBDO3vz+eaiCAg0bQHu93XvtdW3S0/UwbvzfLO6GSd5DEX2jkqI5v
-        Y5FPWVk49D0IZB1DS7Z9aw+9kHkPxnOKwt63QeiU9G9xjQdozESO76mQgACK8IplDBHmEo2stKAB
-        IFJFibBLywCRPZV20HOKihEpVsQOVkwyl7XXbQjEaucpXaggK6ogLNa4p8YdHeEClSzoKljVRP6O
-        nYjyGggq2PV0FYrV5t2GUmFBiZxOU7wjFGv3OolMUH3PI4k0SH9RUx73Lsk2OShlHBQVO+TCOS7D
-        YWDKYh7QrjYzrNgtEsA1FRUisZrhMCjDIVaUUWDtHbOShT3IUPE/f2b1UzxFRQHAvU52KKuao0fz
-        MyCVUIfRYGngW1ZQ6iseKA2oTKjkSImKbmN49BRMypIMFKxUUpGtWFAE4UypcoQlDBy4d4wIS4bp
-        r3TbUYyEk1BnoRvqh1Gm4tLBc6wSJkc4Q9uHoXaWlSpZEGsOyADRFffnvXlGh157ZkicOfLaPPR/
-        biUsv8Ry4mwlkfUzvFiQUiPjqHT+DDGxWfFwOmKppBDSaRTHFHrWpbQaDGcSmSoHp6xo60vsA2jj
-        Erl2mKHSY9mO7ByiqERhXssOmQzrqgGz0hgQioGeie1COGciuJKeEhJLh6nZgwrd+HBNcnIyooJo
-        m0PSSgUXDXqQEVga1I++K58V04c0urOAoOqYpQLTsYFjl32DmDIBqTyaaBrJmZBOrZoKQuwP5RPX
-        UHC4gQzG5HEgZuV0GtKcRZ0anS7qefJQaERiG9kgNYetUIksGYNhJ8iosWaC5OZLeQ+mNHSAHk9L
-        D8LkOSylRGcZKZZuBhkSPWElXbcSGy28Xo+ZOTJ6FkjEkf7KJuUXlCakMSZNbUplt+DpxNtIU3zW
-        4UV2IamAYf2NEvlDkUAiEMqeYh+hDG3Axux+/H+X+DbWSl3/6JMqW+V4kupTAuX6WCVOfkCQFMhm
-        uFARTWkIqsRxSGTUW3yj3uBy7FhI6QH5Z1mABDRZlGvzbcZMcHK5TrvJ8XIEKzYgYUZyb0gvc+0y
-        35b4ztca95Xj/sXxX8OVHiuweYsWoGOEFQ/f2aTKE2N0SeCav9IkTb7arNV/2CT1Kv9TJqmXq/zf
-        MQkzQZR6qD+GeXzR7U+GC6GSgRklMsOrgkkgXUo90oPZ8DdUmpHjeApJg94/YyVqL/pbB2JzPIol
-        ZMRwk3i5kyaSLMgYZHvYR6KpnxM5g2ICLTKVeBzVEqRbbtgtRYk51qNVhv72XQRNkyyFcG6Pw/s9
-        fm/vIT5ZZfHKg7mP0JFpETRJkxEWHrERleBkKJBkfKQ/y9wTH4oSQKik+pqCZFJvSGAfkGiTPjgH
-        hLkwLDcQJEmQDQVLucqeb9vErPT++SpxjTtUsEjOfMArooINyTcCgC7xG590aqEvRft5hDOyTzus
-        DC1GKCE8g+NZiq2y7+A7VAh7SFoT+/yiVJdmQiWB4gRPKikO2bJhiRwrwEVcQJoTpccDPQ59Qchj
-        wnc+WXLfKn/9kZL7OokaKNahdAfT4WK5Hk6nS6GSETASbVAU0ut7JKzWxJFQTGPlhTUJfysaC597
-        uQ+9nLXTjLeGgGTEVlglfn1GbJHE/xMZsXWXEb8XomFsuI5jss4tuuQCFkaMqVthtY38MjP8X4m2
-        9aOJNnIpurtyt9MlLssAJkHyWc+8/hRBykozHPVQksZYd/jBVFJIuA/gfPCG/9OLaz3VuNLbq1BJ
-        ISrVNMsiXQvfqUUFPIvR9dKYDHtbeR+eN1o9PGABynLCNSo5JD1aeCekd/n0IUoyvO0kEAS0my5S
-        BJriMxbojxf96TDcdkGQo9JWyyWnKam6p5owr8Cs8eg1ofiMQMeFr4Z7MMfLfEE8goXHzwZ37wUP
-        HwruXgh+NK+wz9JfnPoq8bNR/AjFHjLuHqdy+E+9ZFWSJ6rKd5+P/wu8uhIsgBYAAA==
+        H4sIAAAAAAAAA7VZ2ZajyBF991fozIP9YNOABFrGDHPQgvalBFpKL5wEUhISmyARon7Hf+Ivc7IJ
+        tLSnZ+zp06eKvHEjl8jIiMgs7tebZVau0PMNx/7lJ/ob9VMF2pqjG/bhl59Wskg0f/qV/wtngTNU
+        POhD7woQpsbfgYl4zg9U3bGAYSsBFiqGr6hA522HI99LOM2LXOQoquloZ/7MEsQVnlcTEaF+i6rN
+        jxvhZDnzju4HPeNz3HPqLqNZN3HlnpQmS6y3t7m229uNScdUw9FoM+tLLiV/SIY17Vs9rz+tBjva
+        2NvVjXY6Lzxh7Qv7nVwbSoN6i3CadbTdXyxBEjqdT1ogrvvNsEu1Tv5nZyGuPvR2uHQdeyOozS7Y
+        BOdBqK/Yz6FQHUKDCgK9Rwez4Wm7bDEbYeR3ewOFgkzjaC1UYmk4t+FBukmeGg3G5kpct8YaOkbn
+        fkitPkTx67TSAsXv+Iqp19fUvN+QiHEohwM22g9sobGaL9np4kuNFFdcivBzMPu4TYdedzIc6/3l
+        oD9e1B1IKbvmNThcdjt20Ghs6qPWWdwfZldXEFyNmrS8RW9/9M49GYyaSvU869zCvm5KcNUEdUat
+        DdtsU/0YIcIRvWu3HX7tN5eF0v047mgp8E9T35myp8WG8JqqMmXWorOSow5xrpm24JwO8+WmtT0u
+        BqPFZN8N3Vv12IjkviO36NmtKVojoUENzbG9msz69a1KeBeJXV7c6NyS+65tzKfMthGxNuoKDgU+
+        1sLamY+ZKeHfuhp93SKma2vm1bzsI3VCy+5uILRdSwyFHUs5ysCjJTda3S4ba0t/RjUiXNFRcHY6
+        673ao9fTsFo3Z+Hu40SF1319LlxHxFR2t6euoYNww842/vir/bXf39RR2JZb3lqejI7elepD7XPb
+        asMNszlXG9fPfheth5sxK0+AQhA7jnzwVQ55wPaBlri/ofMyRVEEFf9o1MdNol8XOhz5xOEsww4Q
+        xLsO90hJjw0+QpCn2W9YkyO/J8eDOaYJIwU5Z2jzdYYgLB19XN2hOJHWvQ4Trm/YcOhsO5dq0Owa
+        fl0a9+ubhXFbzaqdLVsdygZT2x2PVZpRwsbyMGpBeTdQV+bsgzkf1FZT9Rft1fomdWqb0Vf45SEz
+        mO8WQqSMw7PcVTrKVh63w72kilHrRJhVv6lQvsZGbtNVELOd1KpD82xvnQGtGM5SxTboXmab5s24
+        9ZuT9XI0ji7ADZ3NQA1GfqC1DwZNd9mLsBOW8qAhU5Oxh9cuSquJhOxru3lR+xP2criKDhUxX4yp
+        7Ndmh53Q0+W4Ouk0xHrzSq3bktsV1VA/9KdycPOCRt/93DLLqVWtTk8LOB02h83ZdA4u4WzxZSHp
+        Q1wfo8uiI6zO9VGvpkmNcLysGz1XIbaTxmgubrZNi576a6d30RCsisJxaGpt1hKjo8ZWN4eg+kl/
+        qZ22ZM7E8+eRGfhUjYHb1c36aqhKbaoqJ307Y5mz9Hk6j1ugy54/vNrlVlvXRcZzGca9LC7BCrTm
+        M3ZOHER5rSpoNLjM65tuY0ybzclSbWhg3jy2j5KsgK9Zf9Hfserh7Hp1UbOF/ugGANKb49PI2M/W
+        o3X7yMS++eggd39xPB0HW80JbMTTBasM51yeUwNbN2H++1n3DZozfSfwNIhBHfLwhhTswoi6a5Sl
+        Txo69DW+d0PQs4FZkbFapQ00vAK98qKfcHN95CBg4i4t1bChztda3wr+k+xZxUc8Q31jX+g+eqLi
+        AV2AtCNPv7DvokcNHwLkeoYG+Rr7MqFC+KSEV3cE3gHyzKvOXcZpgefhVBwVX6lFD6qLI9MDVDD2
+        OPY4Hk/HseUZLFh2YKnQ45vVeomVgQXLNYEGfb5a4mRQiYOtqPiRpTomWYY9mKH8v/9V1i/wAuW5
+        xMV4LjdyuvOd2Ek1VNl7jlVBR4irFDuAHPnIKpQsiI6OXgIS03Tm7XlJJzVXqYmdINntR+h/nEpc
+        +gAE+NlKxuOXeLmgoKLIhbyW9l8iJnCpfV+c4Wcn8ekoFN6fU9K1Ct3VRMYdPYAFJ5m4oONSruIj
+        YOvA00vkdFm2ozj7xJv9OCyUm5kMGfgIl6U5wD0fkNKZyHrAWXI2Y6gGR8b50tDxoAgYZuxkjhnn
+        0ESWfXP7wEw+MpW8yeHqEqdOhHtGUFeuBgyTGvQNzHlOmPbAkdlnMhUcw26pecgYcIEH8KHB32R5
+        TmQ266czXDq2ZLFFELsJ/gU8CFK79zYcWbRSQRoRcQUehUfowYyQWl4zUHbCTcfWHZsIztgUdzCV
+        J9RJIs+EmbIJfD/7lfKBh3xMKYBMmDoBFlb+Ciz3n5UOdocgnkpJHFs4KebTbiPoJ9YtQbEVsRWU
+        M84s8UhkYqwciS8KGS9XuyMPnRW85/50YGvwfafpcnLCA1hwknW0AT5qKFto90khXSlZTIHMjRhv
+        qJeZPdmEMnAXJ/or28DOVhnjGxS+/xTUbFc8Ax8O7JWxMyouxIkuzrZJvH4r4nDAwFcvYB+ggtNk
+        1k46k4/BPyo0TqESdBGMo3elStE4pheUlB0gDZ/KvQ8RX6vHQz2jBc2HGnYlfJSZRrXBMo/sXJjS
+        I/zPsnSdjwelWhSdMe843ml85aJoJYFxdMFxwYIJnaBaBEXLdOvnGvUzRf2don+OR3qvkPX7bIO0
+        jcOWh16swqJjZQqi/6c96lWmUaN+2B4sxf4ue7D4/x+xR7b+JNak7hhnnaXQGfeWHFmCM0pihilA
+        OI2FlTautGz4N78yw8vx4kLMq8g9Sc4VU5ul3zhQ1odiLonDZvplYkd3eNwdQHHMKIMZA6ewI09i
+        ZcJKxyXUZFzCJ+z7uERcQ5K5fqKSqeMVosDnTeN67z6DckKaVcm8nSRP37DcuKxKMlGul6bV9Dtw
+        fYizh2n46GGJvdcl4q/pgCrj5Js+DtBR0uxuAmSgANucxbVFtVWn6RpOVneUw9H8kH4S1DeawjvM
+        1nGZVcAcWXR2BL6CsyqOB3s/SWoPQBxN45yEM38eRrMmZ4Gb4gW2jbci9Ru6Gt84n9H4jvqO94xy
+        NoRxJsSZMc4OiU8m83mHZ+TAS16LSrQcSQnxGhzPisNwOv0XlIsrzDR5duhlhZFx2r5DeYrAKRfF
+        bOVs8VRWZjzjnH90kqi6T5eTDPeEcd+51zxcaH7oJvNwhUnev95F/HcCLqkt07EkoTvpLaVNbzKR
+        OLIkyEhJ9xLA1wcPn+ENdkU/p2WpLCtB/vDRx6nMym8GOL6Xm9zDNhUhdgN1nJXoPyMAt1o08+MB
+        mH5NSN+LZPGRch3HzMraxDeesPigmYYV5/a8tMybvxHX6R/Oc4knprMjBGqBPT0DMomPS1jfUM3M
+        e5/BlFVEw9SxccjLqs91plJA3Ou5fzzz8c904xrfalRlMeXIAkqlx6Nl4RqJbqXJsYyl4xVHOS78
+        FTVeb3o3wfInqMyJxyAfkGJpScXuwUsA/Xs2sJ07BPW0Un+mcGk6KFmgM1x2Jr142k+CB2pa2Ll4
+        NRXN8DQTPipk1nj3RPH8NpG2n65Ur+ADr3S9egdz798iXh4h3r4+vDw7/Ghkye7sf07EJPOXqT/y
+        5pq/eWUPKy9vYQ/473o4I+8vZ3t8HcSZKpH6ZJ7NQGQl5Ra+RZfTWRnmgKbhah2o8QwwEF8uEjz+
+        mdYnwII3fBu4t1NRekmzIN5LYFd6NxdfbP2Mlhmt6KjcnQXiG7DznR6nD9Lf6AgfLE9Lngi+09cT
+        4b92h6MW+E5H60L00AX5ajw/cF0H3w4V1TDjolMBuh5bJvsT1HeEyX75CsQ3TvNB4x2ekcEh3kQP
+        7mH8agVL9GdJXGS9/3PZfwDkFdTTbxsAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2158']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:32 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2875']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:05 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <make_reservation><describe_trolley /><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><trolley_token>64--iT3taV8o23t_Cio5ezl8RWnF2dwamqGnxAxyHFwzwLv4eD8d-OfT95uMI97ePXNksIMIVO0SFfXmvpFi5qwdGzigDgomE0jFeZsfr4xiAVNWuchyHmEnb-ZQWlW_eYj3Ty3O8BBbfRsV0IVn_kdXhLAMRCANf1cxLZMxsVbe9TBqpwp5oq5DhdTECfGomixdD6W2l1QVVhDMuOi32cj7Zj5eyDDjA7Z_Izg8DuRLow8In4WUGqrQgRF_sPeTKSRkFBmYtcGk48tf3fg7wNl4UO4UHeUT95svXBLQLpTu5iz7mkhv1_W4K6WmAZ2o5UkdCcKprnlrjS3dPcCPjhvwBYZ29YUkWyFEEATFzsEIqpbycidEKgDX6dE7XiTrL12TH7DTwpENW0BcJxTxY_2W6hwG4S9QBCGIdJyFdWBrvrgKSil_LMvbZ7zBdyYea94qt_YeoSnkNpNJMIUBnFKDOLyk-Xi18lmkez_cXOdFnRikyNpCbgj3dyeD5y8IbZr8QhR9hbNhIQ6-Z</trolley_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsUDfEXxcUCHyqYlLXHoXFHrOkiCFhc3j34smOD16W2zX2VOT-TnkryAjJ8N15iPw8qeHlWzsKzFfY</crypto_block></make_reservation>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['895']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61Z15bqyBV991fg++IHWxeJoHCXhllCZAQ0IjYvWiWpFBrlAIjf8Z/4y1wKIBHu
-        eGY8/dBdtc8+FY7qhKpmf73YVu0Eg9B0nV++Ed/xbzXoKK5qOvov3zbrAUZ/+7XzN9YGRygFMITB
-        CUSImrZjK+qwYSyrrg1MR4qRUDJDSQZqJ4EhW38vYpUg8SJXki1XOXZCEsOs5ZJoMa4guPJhvlvg
-        EJM0TdJa26PkJ76otKZ4d7XTFu1hkw9I1Rbk/Z5Yzq5eU792F1dMIg5jzGo0VJqeKe3wwIMrvvuc
-        Sequ7WNXbUgFvU/K8IYtkhHG41mTOu9P3YVm+5/D2UjYAyc6SX2coS3cIiM9YbbywJV31gJwhh5O
-        cc9xzmuuedhPlsZQXnFjfDyWW+Qq8LnFfq3vLic9UIY2fqTxw3DlJY0RPfz4XET71fqoNxv+pSUb
-        al/Zjemr3peOAx9jPIHzVzotR/2dfUi25MSfCow01eaiJDL05SIkhxa+bhhbwY4v7SBuqR+XhBOo
-        gylNTavfbR+GI2OVrAaKwCijjdJfJ2FXxbvmYJ5EeKt3pIiNctKaDIXH3Hx0xEZbb//JfNrGfmbO
-        WzIpLc777hfW51rkRaXHWM/ZJ+eAkOUFPVenPFSBtPo6+yPYsw3m1DCPbXcacYsxs8MWF1Mh5nP5
-        Q1xZwOF9nOo75/jkfSx2ZjeM2uBjdOh9MZed2Az3B239sWsd4pNm+W7QYHBcWWjHjSOeP4LG6nz0
-        rb3UxY/N2dDmT4Cazd0ecNWTcF1f6dMnvcQ5l95cxtMFT0y7eHdzkTlha5jMUME0HbtYugoo1T2e
-        ujO8+4X3rtQH7jMX12MGKiGtsAU+kWRbvSZ8a3NeT0aT9sWf2QNP3Gw5Kxhry0jsDWbKdDn5WqnL
-        +dmGykYzt02/P5leTXxOj3e2hK32aChhLmrDOFgy+1ET6ucFN+eihj/+oA6rJR3tnPbGF4Y9mtPo
-        8ybeDpvMua/vcZ8zULerQsbD18cRqROJsdvqk16IY9iBrT/4AhsFwAmBkvmXqXYOOI5jePqrSVEi
-        NukSDFt/4rC26cQRDCULapGU+yXyUdgh8e9Ik63/TI4mcy0LJlLkHqHT6bcxbMIfZ/xVGvcOnise
-        DWkmbePmcJU4n0KX5zF1aOw+1ovQ08fKhie6V3kum0LiE7zgWBIjMkpjxmMkT54DYaOtyCX80i5D
-        Ec6H3uekfZwQOLHZa8SE30ThnuOCzWglULwzIOPQ2rscnPZ9PeAXnCEk21lLUe2pIDW7R2y26+HD
-        ZOSchSjYDzcCh6aS1JGl9lrMKsCmHhS3oSFsg3BIibvpgqCPEj7QFiZjBl9T+mr1pq4wX4Fzr7sl
-        +m0gRO6Yb7fh5IOhwPQ8ogXdWPsCPxnLE11bN70NtT1fSYMhJ+pCJPr99Xbt2ecTxZ8Wn1LbtyWT
-        2yqHZHYYtI7RVGUcjRL5ZbvtB1YTEMrHNtHtidw1DewczrkuSWFrbJ4cR9seoAazPqdN97PFaafp
-        M5EPZLgm572wsZ2tD0tm0VidUHwTxXm82ewIqUVp4BNHccvxhS5ozjcGOrkGQaBDzu94Q8FOpKmO
-        vdWXpFmWRA6+fPEyEJIubU+8oBWdI10l5Y0wJLRxVxpO4J6OxbGpL2gXbInzYSscluFwflLtZiMm
-        z4sgWIwMKmnMuB23ufq7o5dwfTVZzrDPJqbLUY/YJgSYaJvZUjwbqmaMP+YWIzYGpHNIhD7OrSa+
-        fKKsHgpijYb4Cezrl4jzK4rWLjO/6wgXTDVno107PfuPB/B+Ht1ARclCcWMn6hAlqwrfuB1Wjh3V
-        gre/z7pv0BszdONAgQhUYQdeIgm5SITfNarSJw0Vhkpnjdi1VRJG0K4dYOA+K2akm2LkRsBCY9my
-        6UC102C+lxM9yZ5VwqjTxL+3X+hh9ERFE3ogUowO8cK+ix41QggiLzAV2GmQLwsqhU9KaHcGCHTY
-        ab7q3GWsEgcBKiKSspWbUpc9FPIeoJKhoaDmBh0iDVrPYMlyYluGQYdukBVWAZYszwIKDDuNCqeA
-        KhxkRSlMbNm16lU4gAXa+c+/q/olXqIdVoWyiVYoKYZrZuMXQCnJD4wBa73YtpMaDwK11stlbP2B
-        dFcxnQjqQV5nqSAC9VLkABt21HSkUjnD7owo8V4YGXbvlq1y2ZmPpIPkhyVfEJ96mRLVtMC1axHa
-        wgk6MUy1q6xSyYaR4aoVIPvE/KK7qOjkn73SRYc5O7WP0P+5lLT2RJbrzDdrNH+FdxOU1Mw4Sj5+
-        hXi32fPmzLAIJU8uXXrxjZLvdbXe9PrzNRrqAS5Z2dJXUaxCJ6qhzw4r1Hxbjiu5WuaVYRrXqt1C
-        FpnKEValN4B9dvSKbxcjoDJiu2zSSDUtKEwVTRoB00qdxbXSIiOTFW1Wi62sUajcuiwq71FtEaGR
-        I6hKJxOeOw4KjG9gNnDP+QhsvWhmS0FB+JIbp54CHkC2cAPUrlfXVC9W/RSLKuGnXn4iiI4J+gMC
-        CHKr93dsvezlgszGfXQHSs4GDGBBKGK4qceedAJWDPPQVAVYxYyKOGa5juo6WHxEhrqDuTwbSMjk
-        hTAfWrFAGBZ/cj461yBKF1DBCvktilTl+TDIwNkdKx8uu3g9QqltkW2kI0qYxQz1zIo3ML3DFdSb
-        5h15GK/kvRnyaKrh+2HzjRTyB6ykZHsZANu0kgop32G9nLd+M1r6eYPCzJnRq8BdnOlvHBMdvdoU
-        3WjRdbSkFl8hMJGroDOaHk3Jgyh9p8VDloXeilgUPtBVGDg6lKCjFv3i+8T/qhF0ZNS4WI9RidDA
-        CZSnSkLOjSMFeagWQpTdyXSiZ7SkhVBBBwe5dYsi2q02/sC+CXN6gn5sW0XRCE2K0wRdMO84+rgu
-        TeKElMHAUVGMQIkjpWM4jRH0mmB+NPEfOP5PnPiRzvReoRj32QJ5P4xAEL3YpEEgY3Ao6lh/pUlI
-        okE2W7/bJK0G8YdM0sIaxJ8xSWGCLPTk5zFNQiLHT/siW6/ABSUzwwxEyJHOtS4qIB34j7A2R9sJ
-        AIrhwd9vSrm98jaKmeR4cJOkETRvWeiUu2UgqYIFAy0visOOZZ7u8gK6EfIMWb/1s0QYmraXlnpZ
-        Vrnp5Skyb8deCFEmsMwwelhj/3WNP1t7ik83Vbz+ZmwdulKewS1UIaVZs9PO6od7l0XBWM+bGP6d
-        SEV3gK2X+gYIJZQskWNrYZarHoA0FqapBqr3IFh0WRtcpCB2HGTW/PsTjfSm/Yymd/N3vGeUdSBM
-        ExxKeFGMysz0LGXreYcX5DgvDyu0G5IT0j24gQ0clOez5b+gbFoA5zmRJ8Raaz1n63foFuBRJo1S
-        tnS0O3hRPTzjbGi4WXjU8u3kb3+PGPuT+9bDReu3b1gPV6us+ivKK64n9MXVri8IK7ZeERSkvLoC
-        6KISILfaoYMU3mhFeimKhD/ljSi12Lf7R1pAVbrsg7XLiLeDKoqIVJol/vqISKHA/wciIvUSEX/m
-        oqlveK5rFWVn9pGfsNRjLNNOs+2t9Lt1/1egpX5voM2OVL46jGM4dGQLoJCEqMQMTdkqjuEzmLPK
-        CJefUBTGiupwW6iUEPvqwI/Om/7OPxz1vYnXPmZsvYRyqWHYNqpaCKaZJfAqls9X+mRamEtyut9s
-        9nSDT1CVk85Rf0DKrWUVdQD9GIb3CO+4dwiqeSX9TGHzEF+xAD8WeaGfLvtJ8EDNSy0P7aammIFi
-        wUeFwhrvnkKe30Dy/tOV5xV84FWuP+9g9v2bx8tjx9tXjpfnjd8bV4o79V8c+uq3N68/81p8e00r
-        Xm5eXtke8D/0JFe/v8lp6J6Gck0mDeu3fAQSOyt8QKBWE1IVZoGiQC8CcroCBKR1foanv/Niwwbp
-        XRKZpIRyaRG2q9LCXOUQjwMh+wZp/6djPRF+czgUX8BPBtqWooch6q+7DWPPc4MolGTTSms2Cagq
-        ujyHt3+n/USaWTiUILqjWXfwVhg84wUZ6KnZA6jB9CELVujPkrSwef+/v/8COeB4eDwcAAA=
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3017']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:32 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/MakeReservationTests.test_string_properties.yaml
+++ b/tests/interface_objects/cassettes/MakeReservationTests.test_string_properties.yaml
@@ -1,628 +1,599 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:32 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:06 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:33 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:06 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:33 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:06 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGNyeXB0b19ibG9jaz5FMC0tRXhJNTJKUkNxLWdMRHN2eDR3blVa
+      elpTV1NZRHFxZXZKRkd2bDRwb0NpdkNxVVVmdlVMQVhnOWJwOVhnNi1jY0s1THRRSlN2Um1MZXZl
+      eGUxMzBpNXo1UWdFV3puMVdtRTJ5WHdnVnhkTm85U21KZmNlWHlZN0tNTnQ4enV5Vkp3OWFSWE9T
+      ajV5Rk5wLTB3QWR2MktCSHZwaDZjRnFST2NyejktNGxEaHV4MlhIYUFtMUY0U2JuZEoybXF3a1Jn
+      WjwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bm9fb2ZfdGlja2V0cz4xPC9u
+      b19vZl90aWNrZXRzPjxiYW5kX3Rva2VuPi0xLS1RMW16UTBaV0tTZWNaazl6NFdQN1pCSi1GazFR
+      bGpSTGVIODl4djlzQ1llOGJFZXYxM2hoRkhheXlfNllkVWJIQUd5d0VSNlNSeW5ZLUJlWGhUd3Ey
+      YWQtYzVoQXc4WmhLcEpubTNONjJLZnpNM3B5QnNtUC1Dd0NVSVktY2dzV3F2S1kxcS1CUUFfQ1N3
+      SmE4SFJjdGZ2WlFpSktYN3JGZGNGTHlwQzZjQ29DWGdPaF9vc3ZXY295UU1MWjd1SWlpYk9Sa1ly
+      NFV2dEl3el8xbWhvVzNQVVdmRGVnUzJzWkpzV0RpcU56bXJkZ243Tlg4cjlfZmFaRGhPSDdjOUpi
+      WjwvYmFuZF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkZXNwYXRjaF90b2tlbj5jXy0t
+      RnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJYaWgtWnkyeFNwU09EZEhh
+      SHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5OC1zaExzUlpJRW45TEJX
+      M1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tlbj48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['449']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS0HvDihIg7XFxZDKMgoBCj+Tv9Jf1kHg4Je
+        O4fKzLeqlauS2GfHCeLEOWcHJvPHxbYqEfADw3V+/0R8xj9VgKO6muEcfv+0EgdY89Mf7b8xmhGo
+        buhAyfUgYgaSD4LQgm0mCBXNtWXDkcIA+JIRSIqstR2Xqb62MCACDpon+0CW0DqgzW6YajHKDBoI
+        1DaLXis+68AHOSFFGdWAcca1XEdzHSw0mWoBZvaUOkntuTGfbMlBkP+V8WUfBohSALkx5XeQsfJ3
+        2fb+Xemh7YbJq5TMDNpUusPMbQyQp0eICYDsq7pkgjhdqYriUiBJ9HLebdodeXBW8J79abKjgtdO
+        s+3cCA9gwUn30ZUtC8B8o/2nCdlOq8UrVG9BTBLCz8OeHkIZuJvT+SvHgECrjFFaoaQoqPmp+AY0
+        VJRTkQHOkgd8NckRAscR8aWJ0WQIJF92DkACjpaPU2eiHv6rQgSwsgQeBLYC/AqJE3WmWlAydghV
+        yd3vAwDbVD1Z6hktaAFQUSoFbYJukI0a/ci+GTN6jP6zbU1rJ4viLZzImXccnbTbrOOElMKyo0nQ
+        sEFKx/AWhhMi0fqNwn/D8X/ixG/JSq8n5H6fY5CNA4iS40NUalCvTOX4Z8ajTtINCv/meNTw2nfF
+        o4b+/Jl45PtPe02WjvxK7Amd3pgVmGoJzilpGKYyhDo4V7pu6DvgH0GFR9vxZdVEKSSyS/E2MYtZ
+        9mxo7fpwcLMYt/4mWSjR3TZyJ8OkZ5TBnOHJUG9X0WTMztbFlHRdLMCc+7oYBAGs3uanU/LpaIcw
+        DNqWEd3d59CNgNqvDOXqbQxjD7QDw/YsgAKGnMPbvNSSs0IvAJaF3jSAD1tkP24RPU05vIxXX/g4
+        ADc5KLnNWDI0YIhiXiM+18hWnSCoBlO9owzq5ofsEcM/Ezg64VqdRIQ7zFQLZ7ocSI6b9IN9kKrN
+        A5B0U9QRUce5t9F8yNjyRfJDx0FHkeUNQaI9fEAZG3XdF7xnlHEA0FBGeCjfkDqkOZm+zys8J4e+
+        nGhoiXZDMkKyB9e3kzacvf4HlPHcAGbi2SOECi3yTPUO3SQCSTZM2JJpt/HP+F0jyjgT6G7aVffZ
+        dtLlnjAmQHmJ6KlzcEH5gnIycVeCb5xMty8Q+I5sVURErHSTRHa0SjEjq5/0UvCq478yMCixwnyt
+        Zac/YYXlhp1Mlky1ZMhJqfulrFnARzW8QakY3Gi5lOVXkIeIFt1wAzQkIMSv6JWtFkF/e68kPmrH
+        /2s6SfZ7rmulaZ7fHZ6wpCYsw05kOM280vArLZj4ZklKkyZ7O6yDz1FS5kBuCaTICAzFyhPtGcxY
+        RePKchB1p/yiuM6nFBDzsUQfyzP5f3Zwjc8UXplPmWoBZVZdt210nSFamY6VsWy9e46ofuxBV1Is
+        VzXbUwrDvHkNEtSBlVXalIXudWeTuhutBMPhuVlgkuo4UubOUbCgNrqQvd4RP9dbR77FLk5S5F35
+        2DT7K8FuGrQ+6jkreFUipdk5cUNLBc3x3pZ74tjXvL1lDYQmO5KPVmO6dq3RwWxQxHKCNa5DsS/W
+        pS0fen2bVcXTGIZDSu1btBoC1rBFZ4L7RmdPc7EAIHccWoK4PMCVt2GbEmsv+krUeANrsyX68/gw
+        P+v6ecguW+bUtg+z/uy9f9VDq7GmG5sWL0Flya3mZ3eh0YOr1j8tsV204eaDbp/g5pG55jcTjDxv
+        V9Pu+0ggllA4jKlOIOG0wq5rltPz9my0cFW18cZe6xam6ZFKBRNtAPvyXMPm516NdJeu4hIgNiPB
+        Hg1mKuQ9TtqO3ll8Rtgrj+pq/JEfnrjxmxWc1V7EwcF+KncGrLAJ3wMruA58F9DcdQ4243ptSvOD
+        3di3CfXisFAzzoPl5djvw+OkT485stsYyjVX0YQ3BXawXXLXLJ0vo1iyg1RSKj59HCtOS+e1pfhG
+        SuuqTaHqfUQYNfR99HUVF09ZGh8UD63+ABWMvaxC189vw09gwXLC5KrbbpL1EisHC5ZnySoI2mSJ
+        k0MlDhISKYhtxbWqZRipWIa2//uf8vwCL9AiGMFDXNCNAH8IS3JFQLLt7qViAo0U7wm6+0Dfh0rg
+        WiFqO4EcoTrPpO0ZRB8ftmI4qLdRrcR+HxYvk0a5019NxNILZaG/D7NvQA19+VUSzdRkXyuRcz34
+        yu7uQ+giHWyrOIadTKzVXY/jCx5zw8b727pPDh1BdLX94rR78whpEZIUy5HN96CGMm0VXTWcvcwI
+        +mw1WHuwhz2ObACbr8VU1xodD1YwkMddthlxTTpyur6+UehtxxjESmfKc9vOarzAj9aJXkP7PD5z
+        /MzpT8QemG0Wi94+gkGzZfqboOGdotp+PhiMdmezNbXOHe1AKFdlI7sxPFIm5UbWdGlSfJeXVq7W
+        s2EX7weqUbP2FuYd9dF4PN4u+ucBuSsFIdt1KQrJZbMcpez2iVQAKSfK1VyasgFKDSd7lJ4O9IWh
+        RE4Uz/MN1LOp2iO7sJTp6Fqiy/4BtOkn9t1QYmeXZ+m1/wcjk9WfJEeyYcmJwiFF/4Ax+SVHPhQ5
+        nQrPE8ikTiUlkdsseRHrCSpzkvSsPiCFsvryGU1woHEI3TDIbwgEuo6/NKR06ELZemKWMeY56KVQ
+        PwW4FNYXwXwMYbWo/D/dA0jiSz2gxw0n/a/0gJ5uWFoF3dLBj9Y/hup/MrPtKdcbqoPpZLVRjAO2
+        ssfieL2bAKTbI3vcXGMY2Y+3w51CBCJ+4PZCPzk6QG8miq0vunWjX9eIix7hsqGe4vCs26ap2dtA
+        wSSIBHl42I07kWVKFKcvWuxA1nbS25BerhoT1msK727Ei+PT6r0xmVDXQcvvXqh+h++1LrPNynwb
+        rsH1elI9aYdhX61l4gdqOTuYb61lovldtUx9by0/+/+rlu9BeVnL1JdqOZv3C2r5i3q+FFd9lv+a
+        oi+TnxMc+FPq2UT17GPxebJddlnWqznX/ZD2uzzRiHrWfOny5mEyn7iR8z7ZHvsX8chpR65Xj+Z2
+        NI15DzojxdKN6I2bDa2Q3bwfV+pKEt6l3tCGbOOkHK52d79Vh6fNsYOu9cLaP8lig641u9dQsE7u
+        uaY3LouDyHbZCF3FLd7t4cPl2TwbyKUn7bueQY5YZbicjI6NWcemPPYwmR2c4/xiYS3K655W5D6O
+        pyuBvtRngIhtasg1AqMJTD7e94Y0JvC0EPaImo3PZuTX+wH5I/3gu7SdrP/afvDs/69+cA/K9/eD
+        bN7P7wfUF7V91pl/rRcAx3D9impA4wqcn9IS6qglDEyKmxgcTte6Y0ne4wK7D4TgeMbttdUYGWK0
+        ah6W0LlsKa+3vhr+vjmCO6G31UdGf2SbMqV350rY6h54rTkX45ALdV912bXWXEN/esa242406ZHH
+        eG1uZ4Sxj5quxQn8pkZOehoei9KFvC75GPi7S3PhHWcCCXbXGqmfSJ2iRKsf8EJwUtXjEA99bo6j
+        b3TaOknfIPfUj1zdv0vuyV8s98/+/yrve1D+RHl/We7vj0H2W2VRkrprJD8/3H+x/GAp5dvTvz3/
+        D1lRoYe8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:33 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:07 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkaXNjb3VudF90b2tlbj5jMC0t
+      cWstOUJWS3l4MHlISTdZR1ZEMkluUlRvZGZRcVpHcDFfUXUyM0VIMjhZczVhbmtVdnpkMEV4TzE0
+      d2w3RW1GZnRDSDI3ZW1ONXkzQmxKamdsc0ZhS0JFOHZIODR2bkJyaFdiNFhBaUZ5YkFNTkhYQVVL
+      UTBqbHE0VnRtd0t3SE5PbkRMVENlT1dRUUNmdnRzODlrcldzN3BxdjVmUEZGSlp3azlNbHdBZGcx
+      YnpiV2FveXRqM2szb3ZsTVNrM05CTl9Vb2RDbXRCMERzY2k1bGZsLXBqaEpLS0tYUUR3RjJaPC9k
+      aXNjb3VudF90b2tlbj48cHV6emxlZD55ZXM8L3B1enpsZWQ+PGRlc3BhdGNoX3Rva2VuPmNfLS1G
+      eUpWRGY4RHlFRGhNWVU2Zllsa29BMUcxempMbnZkVndoN0tMSmticlhpaC1aeTJ4U3BTT0RkSGFI
+      emR5YUdqLXBySGQ0N0s3dmZDUkZYdU1FSnVValJLQnNHbldScW1IdDk4LXNoTHNSWklFbjlMQlcz
+      V1ZLczNQLS13Sm5RSE9fenB5WnV5VWlBLVk8L2Rlc3BhdGNoX3Rva2VuPjxjcnlwdG9fYmxvY2s+
+      TTMtLXBQNXQxM2dFYWM0a2FSQnpabTJob3ZVUmluTkhPc2syY0t2YlBualJsdGRKeDJDQ2owdzY5
+      ak45RVFxX3Zwek55a2tEVVJtOGk0aEpDblV0emJ2YjhBcUhJbGNlOEtmbWFDVEtyZHBmbGxGUjhF
+      SmFqbDdNVm9sSmdrNzMxU0wtN3pJVERUNl9YTnVwRG1FY1RxS3R1STNjRGw0Y3VlRWltVG5MMHJp
+      QWY0SHlSZXRIaklsUlRTZ3RVcFdFOF9FbVFEYnY3R2VWazlUclB5Z1B3aGh3SUVTOWtNbW1nT0RP
+      WUR6aHVsN1Y0N1c5Tl90YlNIVVB3b1FkNEZ6ZERxUy1adldIUEZCRDFIUHZrVk5XTC0yd1hVTUJZ
+      SlIxU3RSZ0szQXNfMDRiRVY1bG5DcGZFdlFvY2M3R0V6NmwtZGh2YzNzTGRGdERhUGQtUHdDNTJv
+      U29ibzFleWt2Um1KRk9jdE5wSF9YSllFME8xbVVwM0JkTmpOSXFIS0dsc3djQ3ZIdEZmTWFBRkVS
+      V3VZc2xzekZyb2U0SHpQZVdLNjVNNE5GWktybTFjeG5FdGRpd0ZTeGpERHRqTEQ0S0gyQjdJYTVv
+      YmRSR2J0QS1aPC9jcnlwdG9fYmxvY2s+PC9jcmVhdGVfb3JkZXI+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1148']
+      Content-Length: ['1008']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
+        H4sIAAAAAAAAA7VY2XLjuBV9z1ew+mHmIaG5aO9wOKW9ZVleJFmS/cLiAkm0SEICQC3+nfxJviyX
+        BChSsqbSmSSuLps491wA9+IuQBu/H8NA2iNCfRz99k27U79JKHKx50er3769Tnty/dvv5l8MlyCb
+        IQsTDxGLIBoHzDRo7Hg4tP3IiinAPrUc2zMjbCi3JYYbEwKzn/IvC5ZC5srZGsollDOWtsswMTVV
+        LXAEmLOiOHQQMet6tcASYM7aBraLqKkXOAIqcDBlFj2FDg6UIkyQQM1//qOon+M5CnrktGXYcgLs
+        bkzXkuWq7NCP+dNHMF4RJNOOcz9uPLXcZX09rB53k8dlnz1OnlvPTlUL1FPTd7a96Wr8Uhp674PP
+        jk9XnztGG97sx2uLWCffDwYrHZfr82iP3iZPM2cR9OkMP+/mnfmh5jgvGpr9mPW2sku0T//9hOy5
+        u5r1ds1P0pHfYKfF/Rn8XBneoMis6rL8flRlbRAd2/t5a9hYdtnboq82WAc1SbsfPcz6h9Wu8mPR
+        H9XR8TCddOo7/aU/6O3wptq+Xyx71n21/PBWZq1HN3Le41pVnSH/1B2w8eDw2Qg6u8FLadHc6c1h
+        975B1eWL3w3aeDhh6nTf7ez9Zs/W/U515I7eV/KijJv3R28dbYa91uKw9BalaIlaFW0zGNn68Zmw
+        oFtvfp68NVKX/rv9uWmMYxmTUml3Qp3RyDno88/jev/08sZG+DirnWrTYzir3J9au1Kz9XL/OGnY
+        4Xo/bTmd9kelNNdPVth2lg3NPtgf8vuQ6m5ra+nHwJ8ebH+kq4/DnX2oTiqzUT0s43c3Umn51WrY
+        nWnY1/36y3bufiw+P96qbzPWWw/cx2CNdtFC7i+I68z1Pn43lKLLuf9Nw0N0azN3bcGHa7ZxECCX
+        SUuCQ4mtEaRpFCNDuWTlSiFia+wVgDSR2k+tp4IOT67CkDJTu6tcMAD6L7eS5L/NbPPxdQrrF3iZ
+        IKey0xaZLp+/QEzhwvhsnE9dHEewQxeHjh8hzyw17pLSkA3PFG5rs/P6MIWJLsCck2686UE9kyiz
+        I88mXoHMzYqwhZcWhQpITc1QikMhY767QUVpBhgJbUt8F5mlSrLNfAzlk7hrm6yQWU4l52G+AdNA
+        4Gn4Y0P95Vvvzg0lH3FBus0uVPHTYY0IEgS+eddnoqQGOPJwJMcbcNYZ5PKU+pDKhVAoBzal4g/n
+        24RRoOSAEHI/glD6xQ63f5fa4NE42UpBbEAfSJsCn/aEYKZLKHEXeMHaoFO6kpI6LEOShiN4mdoZ
+        uZgs513P59mRi25Pys3JCBdgzkntaNkQrUwY2rlS4JYq+RaUzInJgRLh9vQQisBZnOq/Rj5DnjSE
+        Lgx9NKeKUyE+xBe04b2PDtYWETeJEd4gb4oML2nexI5WyEKRJ8bpZNN1/DdJo0yaoC1DSbuUdFWD
+        JppTODtmLgT2kiJmlqrJUtdoTqPIhVCCbCjX9FqlfMnOhJx+gp8w9DwzWVRtqJpgnnE4aVyvqpqV
+        wpCgkFohSumy2pBVbao1vpfU76r6V1X7nqx0W0HMe+0DPobMJ+yLVypsLY3s0//SH1W9XCupP+2P
+        ilr5j/xRgX9/xh/C/rTW8HBMCve42R52x4ZSgAUldcPIZtAJDlILxyRCv1LpEcwhNtQ9Ik27k2mm
+        yH3Gv33PrA56mQRGAg8g0LEJ09ksqRlFUDCgC6xNBZTlkK8rO+m6MpWj87oyQ5QpmX6qItTBQhZT
+        M/D35+kFlBF4Y1Kycdp/qB9uAySKeabHOxP/jrcUBQHslLILE7tfTYSv0Q+1iCs35lghbPEGGdjM
+        ZzH4vALtWW9UNa1UM5QzakA1X/FPWb3TVDjhShXutTlsKPlka5ta0JigHixpekG/AJJqmvQlaJ5Z
+        GRVDI7SPFomjCI6Cx42mgw1fUCOEqnuDd40aEUIeRMQW4g26QxqT6X5u4YIcE7AZRwVahnBCYgMm
+        YVKG+fa/oEZypefNs62NpfL00VDOUNYioOWyhG1tQlMVnfoaN+gap1V1yc1Jl7vCDApxCfR0cnSE
+        eIGYTKYrwBmH9+0jQySyA2kKRKmVBHLkSbkGz5/0HXWr4t8SGOn1jK81aXYeuuPJvPvwMDGUgkCQ
+        0uknthcgAjk8h1CkGU20MnEF+dOpD60szJ5iST0qDI2LY8pL7Bx50JW0/0cBbjS08s8XYO1rQ/qj
+        Spak1BbjQNwM09i4wpJEC/ww6e1pOBeG/6auaz/d59JI5LuTm+ozRLoAhIRae5/6TiCi9xrkrLwa
+        8sCGkidunzOhkkPG17y/zPnkNz+42l1JlZ5HhpJDXLpehyHckbQGb45FjK+Xp3Jyd7acxF5+vQf5
+        FVTkJGsoF0huWnImkDm7GNFzN4jwGUIev61fUwzeDgoeaA/G7Ydusu0rwQWVX+y2YI3k+sQN0KWC
+        8AZmdmBdPW2uQEG6epV8BS94hRfKLVhwr18r12hGu3y5XIM/XVnEs1e59b9L/wL2/DbImhIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:34 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1879']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:07 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order><crypto_block>E7--NuwIhns8SF9pSFmOCtayGoPi5orsAykdVtQtCufnKnVXd5ijHtnqR7hewEY9Siu9mKWZXgSi50wUnsm6QPTTn5Ap3rEh2y8qt7LQOigLgEgeiLH4ylijiJOz3cCcGHfmz-mr55XI7fNrF6K5mYhYQ3qn1nCceIO3_pGh-y2ODATK_1unwgfaRcvmf9rRBGVuoIht5KuL4JvyIf1HGwjOVpnEZgHPJm7kxU7hRzZCGSznxEZHloNsR7I2pTbq40t7v2mLo1javANm8iUGKktt-5o16BpnLLteyP0yqrtW48EZlb91SwCaca-PJX0S8BvzKCatNcVD_hETlolGxPekOoYcRxyhOS0oqh4PNL4fG5MfxXXjHxpdCbQvBrDibivFS6vhbjmFeBcQYWikaldIWXGQFooHSH2dWMs_BXrsAz6-j8VMn40F2LZish9H3g6jBjVkrnayZ4NMPTq5FtXcdK_5L7WFk2ASLauJCqJowO_bV8X2sPX_At8097h3QpXw1Kh0OkgxfUXvzDHbFI_bN0XSMiJ0al9y_p-VXab83-6hG9eHDURd6DtENaA6ZdPR1b2kCR_toknr_BpFKcDNzxpBDj9-GWfRRbpiCUM9rPYDDkijx5sFQiucuV4RNL_xRMwwjtm79e8Q_Ffs_Rbj0MXC_rEfuYOIlmhROtFCXJpXG4CNo46bV1NKHU8emAOPjTy5eN5yHKnfgvMsrKq0Ix6-yFmDNxXSz4pazVchj_p8eOwdiIe_aY0Ybh9RJBrav76RZUsxDdWqMKRqoWJyL_--Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>k0--5q_Eg4_-x1Nz1FPUkY_jXomw7H7E1_PjxiUKNYUK3emm0ERjusgvnWUYFQqZHjDGEekx61hC9iIriru1LpexlQdiFWf9oohhZR3m54tmVkLEMIItGP0eGhqQULniBgRbrSIgFusujEyS0Rw91TvO3pqX8rgNeFy0FDAL-H3GFetfBUfLnD1Zi-94KcFBeU0CKwDSXAHtxFWU5WZiFJ-wMeIriNlK_uoAMR58EAI8VqC-Z</discount_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></create_order>'
+    body: !!binary |
+      PHRyb2xsZXlfYWRkX29yZGVyPjxwdXp6bGVkPnllczwvcHV6emxlZD48dXNlcl9pZD5kZW1vPC91
+      c2VyX2lkPjxkZXNjcmliZV90cm9sbGV5IC8+PGNyeXB0b19ibG9jaz5jXy0tNi1ic2pXT2psUmdy
+      ZS1zRGJKUjlPQmNmOGhLNnhxU05mR3ROU1BCUGI2MWwweUFpYnBGVGdSUTNLZFpJekRpc2d6cXRz
+      OWRWSFVCcl95aWlsSWcybzQ4V252ZVlTT1ZiWGxHc1ZvUHFXRFd3N2JiUTFlVkhWRnAtY3Ixemla
+      eWVhV2NnVkZxQXpyRC1ZPC9jcnlwdG9fYmxvY2s+PG9yZGVyX3Rva2VuPjYyLS1aeDAtMUlueEN2
+      V0JLOWZFdFlYRzA5dERlQXJDR25MVkd3Z3E1SFhHTThleHdUU0Q4cTJRR0lGcW9rNkNKWGZGX0o2
+      NExZNHRCTmNuYlp1NzYwVmVpeUVJdFJJd3o5bERxSVEzWEFxMkFLRUo5czBmUWlFbENvS1N0MFR2
+      RUR2aUFGYTJpRDZNY01aZy1YNG9BSnhkaG5rS0ZCWHdmZFgzbmZlQjUxa0lNYTJ4UHJ0bEU4QXp5
+      ZGhlMGZpWmF6azlSdS1vcjMzcXllRE1NYncyV3p4aHZPUVl0TW94Vjd5N1R4bVY1SnlCcTNBQlFK
+      TlM5YW1odlRCYkRDajUzVzJ5X21DYmY5MWF3YWotWktzMmNCcF8yeGxpVHdhaU0yME5LcWF3NlM1
+      Vk04bTRvWmNuMHM0VV85YURUbUcyaThRcFdjalh6alk2WVZ0RmhJY05saGVxblgtR1hyY2JXMkdv
+      Wjwvb3JkZXJfdG9rZW4+PC90cm9sbGV5X2FkZF9vcmRlcj4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1384']
+      Content-Length: ['662']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61Y23arNhB971e456UPLQGM7eCzKF2O7cSJr8eX2M4LC4NsEwMiSPj2O/2TflkH
-        JAw47urpJQ8J2rMljUaaPVK0346eW9qjkDjY//WLfCd9KSHfwrbjb379Mps+CuqX3/QfNCtEJkUG
-        Dm0UGiEikUt1jUQrG3um4xsRAdghxsq09RMimnjbpFlRGMLwp+zLgLmQvlkFmliEMsbatCgOdVmS
-        chwOZiw/8lYo1NVyLcfiYMYKXNNCRC/nOBzKcTChBjl5K+yKeThEHNX/+D3fP8MzFPqFp4BiY+Vi
-        a6fPDEHY74J1fdesB7PqcCVsQry2Zfp0sAaj5buCLPKutJZy7f3bbigt535r7027WzJrrduLozVr
-        dk4fS7e36ODFYycc7pzm49ZS3pUK8YYtuTYvnxfl1+FUmPq78NR4f1EHctUZHdQP1HHnZ9I9P66X
-        4F3eJ41tJsU75OvtsiBUUadq7KMoaLxvvlmbRefQD6aovqh/bCZueSm5i6Bq4f1hJhNSeZ4vHxrC
-        eKYaG2XUi9Tn7nmDwrOhdFxJUfCz8NpvW+et1Gjuh/35Uq2co6qC5s11Y9NYlPeV+5O6eXMx7TkV
-        ggeDtUqXiO4WH294JAzkrdudvewOb/ZqLjUnR1SbnTyzbb9PFuH5MJSGRms4HlvzoHZ8RuOHD2Oz
-        O1bmUX359jIiw261idqCGTwaPeXQDOyPLpooo5qhfHtr7MevU3v89BBNzhNh0XkJXmsR7ftC1OvK
-        C9MJBpFKW8+NoTto9NWn1pM1Wi7HMJJihB0Htu5bf9h7c04P/frD1vJPvaemOnVmw6k5PE4n87ra
-        wXar1Yx6HyevLffnlve6mGxrxxfyGvlWxaOjxWhwdO+FN03Mh5/tha7ZiAQmtbYGfFh6E7susmhp
-        HWKvRLcI8tSPkCYWWVknD9EttnNAkkjN4cMw14clV65JqC7fVQsMgP6jK3H+m9TUB7MpzJ/jpYaM
-        Sk8B0i02fo6YwLn2ZXEOsXDkg4cW9laOj2y9XL+LpSFtXihsrZPprNUeTGGoApyxEtcnNLKRT0sh
-        yFyOypblYwOvDQISSHRZE/NNbqOOtUN5awpoMS0IHQvp5VrsZtYG/QytrRlukK4klkszc0DXEEQa
-        /pggwMzx9lwTsxYzJG62QcZPhy0KEScw51fOJgqMvelGiGloHtAsh3LBdbFvY8iEHYTyAjJ7MlAv
-        sXMjG9pyTUL4H8aHo2HS2IEcxu1Jl2nRzoaB6pCUCjZcUj+KUBxEiI2xQ6d0BjGJZArGpYhT054X
-        pDBexrsx5M6xye1h2UK4vYBllGQtj6bnuKccia1QzOYV06DF2xvyMCdBzwMXc9J/5jsU2aUuFGWo
-        qhmV70LowGmDqrx30MEIUGjFJ4aVy5smzY5reWj6G2Qg3+Ztvj/RLyVZpdtSI9pEhJbKkgwFNSMw
-        bkQtOORrgqiu1OKJrtGMRpAFBwcyo3IvVytVqcBOjYx+gh/PsyGhYVJJlVXOvOCwuVitSbKRwKZv
-        Q5p5KKELkirI6lSuf1Wkr5L0syR/jWe63YGPex0B1ibUDOmnmJRlCEYDEtf9P0NSk8s1pfLdIamU
-        5X8UkopQlv9NSHgIEulh5zHW8XGj2W2PNTEHc0oShr5JIZEOpQcchT76iZQGsJzQBBkMf0w7sXix
-        b8fWa8+PqQVaHHfhlONMSPIgZ4B7NCK66+wvdg6lBFZkxLSd1BLieIGLuDCn/ViVYd9RQJDrwlSE
-        Fnxsf/bxr3yP8e4sj4s3xt4gbLAi6JrUiQuPXk1K8KWpgRhv2Kcg3cmx6QJoYtZ/axID6g0k9pro
-        PtbEAhBrYVxukH0RQd7UPPNohJHvQ1jZ/stlOBqfUM0DzbzBu0Y1HyEbdjeAcxPBfTg+S4k/t3BO
-        jqDUwqMjR0sRRojXgEPP9KFUJu5/QrX4ps5qYlMelyrTgSZeoFTgoZLSmG3sPF3iBfga18gWJ/K4
-        ZsthT5giphE410BPBkdHODqI0Hi4HJxymGyAvTQ5EYq80hsK8YXKkiC5QPEbSqPVa48n83avN9HE
-        nIGT2AXFtF0UQlrN4SCRlMbLC78k/KtshNLipQ+lWB5yTa0Q7Uzx5sgGRbyPq8T/r4j3IPz/QBHv
-        PyniX6VonBsBxi6/uSWbfIXFGeM6Xlxtk3OZa/6d0N5/r9AmR4p5JzTqDTiyHOAWYuwd4qxcfgyv
-        QcbKFI6dUJAxfjt85V0ySPucwMXkjX+zjbu/U6TSqK+JGcSs263nwa1FritJAc9jbL4sJ+O7Lbz2
-        Yb3J7PECr6A8J55DLCDZ0uI9gbvLR4TIReF9fIGQzW7T1xSNSXwuAs3ncbPXjt2+MhSo7KoVwGpK
-        lhNaLip24NHA1HSNq6fHFchJV6+Gz2CBl3tB3II59/o1cY2mtOLL4hr8bl3hz1Lx1r9//gSe8Zbz
-        OxIAAA==
+        H4sIAAAAAAAAA7VY2XLqSBJ9n68g7sPMw4wsiZ07anWwGS+A2TG8KLQUIKONqhK2+J35k/6yTqkk
+        tMCNud0z7XDY0smTVZVZWZlZkn79sq3SGWFius4v38QH4VsJObprmM7+l2/LxSPX/Par/DeJYtey
+        UKCohqG42EBYwYj4FpUl4muGa6umo/gEYJMommrIjivx9yWSjgOPuopmufpR1hWOq3Ma+Vi/fViz
+        PUYc6Wkvs9ZbR981D6/1r9N8vBvQ8XzSmWh10RKCtql5j4v9bFp5NbbPl55J9pcTJS1j9bTsYCUw
+        Tet5X3arzbVzRpv520p7twZk5U5O6976s6FpUxGtnlaPHqdj8WJuA6Su9f3q8dS+4B63kfjc+qTQ
+        YM8lxNQsJAeISHwOuTqGukfkyPUKx1HltKPN4eZY/uQmY/OptqzOp4Y4OiCn2zMGtQDhz4G2Pguz
+        zVzbUkvd4O6upzoz1fQUNDY/4LF9IC+HdqX2YdSmi+eX2X4wtt6f943eevh+mXK1Chl0q4/meXS8
+        LH3zNH45dgJ62jp1vTzcfwUcev7s69MWVha2s3ndHmtvDj4/NbYNQ7QWRlM1zFdaGc0NI/CHh8eX
+        Dlcr94YeFygf/ZZm+ZfutPxWNTRjUz4tuu7r61PD7ArKhbaXA6WL/W6lhbTatvuiiFPRPVU3uvf+
+        Wf0Uh8qL3l8ZDc/ptBtH/VQdjQZ+q+NazY0uBo35YmXsyeSwmfc6fvujgrwGOl0Cd3z0a0652dOV
+        dr1RW5y1lepsyNtw2xla50V3Ig5O5TWtNN87Z63zPL+sZ+vlBW/JadhZdD/Gu7H4rin13mZbFyvT
+        WXnT2I1OC7wZzDa7yevmYz3ZzNr9CapNB8EXXZKn3mbzrgTTL6XpcX2s2YueJ3DcVuLzm3ndWxbw
+        uus7VBZTVhYO4wQZikmRrTi+rSEcMm/BZExZ0nzHCAOI/S/OcQdNmMT1sY4ANJCMvqhCEaHCVSMr
+        LWgYiOhy/4si7KhWaQFqpY6qg6VG6UY/4ib61KWqBUPamukgQ660HlJ+QVZUIVSuCg+1GzqhBSpM
+        6KlUP8jiDfsqymsQpFIPmzqSK7WbBaXCghJYd1DxHsnVW52rTNJ9jCENBukT8+he8yBB5KCUsVN1
+        6sK+C0KGE4MpKw6EZrmeYSXRcQU8S9URkcsZTgxlOOBFhQS25lp8FsYoRuXf/pPVT/EUlaUoxGQp
+        cTLb+W4YpDot7bBrl+gBQYVwfCTxeVaqZCN6cI0MELmm+9Z5y+gwd2VeIQii3c5D/+NSwqqjUlUe
+        Lxcwf4aXCFIqDTwk62z8DDGCM+9X40wSn8TCUUijP6EwW9u95XABA+XAlBMtvG1AFS0RqjqGio0M
+        mZnluIq7i6KZhGkh+xrLqAlHOCtNAKl4QDJnonAMMpHPp1Yi8HSY2TBS2dL7a0hp1zcmYEkFGojg
+        84Awigls8bpJ40NiuY7hOpx/BGddQSaPqMNIHgtjZUslJP7H+CqmUH4zQCxkfgRh6e+q7f271AWP
+        +uFSMmIJuo+oFWHDRoU8D4XuAi8oR0jO4Ux85LAECducmJeoXZHcYCmvOJ6hOjq6PygzJyHkwJQT
+        2dFRIVppbGivoMAs5dMl8IkTww3FsdujTcgCV3Gkv3SgXhmlV2gAoXtLqfGuYBPiC5q/s4k+FQ9B
+        rQgLVpTy7ookOHNIwaqzRwpUmvg9Gmxx8P9VEqEKzZEHJRISYKksiJAWUwpj+1SHwN4RROVKPZyq
+        iKY0gnQIJTgN1Ua5Uavm2YmQ0QP4sW3DkMNJhZYgxswrDjvtNuuCqEQwHFA4WjaK6JzQ4gRxIba+
+        V4TvgvBPQfweznRfIR636AP2Dicf0xuv1OihNFKD/6c/6uVqoyL8tD9qQu0P+aMGv3/GH7H9Ua5h
+        4Rgm7lm7+9qfSXwGjimRG0YqhUrwWepAs+Kgf5DSGMzBYS+DS4v+fJEoMp+xZ9OQ68+PiQTeYtyC
+        QHdlGE6lYc7IgjEDqsBB5kGZs9m8nBbNyxHOuc7LhW0Yn+hHKrE6WEh9Ilvm+Tp8DCUEVpj45D2q
+        P8S0vbAziZJ5oscqE3v2PYIsC1ZKaM7E/q2J8DR6ErI4f2eMPXIVViAtlZrUB5/XoDyXW3VRrDQk
+        /opKkM337JETHkQBdrhWh04lhSU+HeygEgUKE+SDHYmuhTkgzKZhXYLimaTR+FWy1S8F+44DW8Hi
+        RiyDDTeoZEPWvcMropKDoBc3kAfxBtUhisloPffwmOxjsNl1MrQEYYTQBhfbYRpmy79BpbBJY8Wz
+        K85K1cVY4q9QUiKg5NKQrRxtWYgrdRGXyMGNsuqOmRNNV8CkH1wNcneCn7oM5G4B0e39Xsa/J5Ci
+        9ozNNW/3hv3ZfN0fDucSnxHEpGj4uQodOIYzvIZQJAktLmVxC/Knj37hPpa7ieW2KU2xa2RAVRL/
+        igTcaonVn0/A4m1B+lEmC4+U57pW3BlGsVHAwoNmmXZY26Nwzrz+l7wu/nSdiyKRrY5rCxOI9BiI
+        JUQ5m5kPKUWQsdJsyAIbUl7cfa5ilRSSbs99/syHf9nGNR4qQmkygtv7FWLSw8G2oUcSW6w4ZjE2
+        X3qUw95Z0UJ7WXsP8gKU5YRz8DkkNS3cEzg5Jx+RazVw3CuEDNatFykSKwcZD3SfZ91hP1x2QZCj
+        ssbOA2tKuol1C+UVYm/cu+UXr/fsvXAruQVzvMwN5R4s3b/O39zj717gb27uP5tZ4mvvX5Mx+eTj
+        TvKpKP7OcPMJKYf/oe9N/PVDEv/Db7O/A9pPXdzdFQAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1828']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:34 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2085']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:07 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <trolley_add_order><describe_trolley /><user_id>whitelabel-testuser</user_id><order_token>E2--5eH5_vuupAjgQcgXHwMpTe9X9qgSl2Y0lXp5covwU1ss4IWYBA-RU8_g3PLu8IKzgerz_3Hl033oI-VMEczh0ACvOMWY84zu53eWCfAgAX2v47y8gZlotLi4soNNf8tYetkXqZoP-N1hlKUJkwZdbW0CSxe6UymaEdjSXrzwO0O_DORRcWp6xIeRBq_gkx4Wu9YZJPsOK5CeE-apF_L3wCpdqKeS3P6_3QZAvRVTdRGBuSzS-XHJpV6utMn-uLK1XaipNu8tDIAOlNAM8GDGcPYYRpF_3_rHi9pUQMOLZiyBM9BhcnyLGC8TiUOTaOxTSW98HodDDCuLqymE1MWcmVXSh6xJsVunc4mtPXPNxl7-Z</order_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsUDfEXxcUCHyqYlLXHoXFHrOkiCFhc3j34smOD16W2zX2VOT-TnkryAjJ8N15iPw8qeHlWzsKzFfY</crypto_block></trolley_add_order>'
+    body: !!binary |
+      PG1ha2VfcmVzZXJ2YXRpb24+PHNlbGZfcHJpbnRfbW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+
+      PGNyeXB0b19ibG9jaz5jXy0tNi1ic2pXT2psUmdyZS1zRGJKUjlPQmNmOGhLNnhxU05mR3ROU1BC
+      UGI2MWwweUFpYnBGVGdSUTNLZFpJekRpc2d6cXRzOWRWSFVCcl95aWlsSWcybzQ4V252ZVlTT1Zi
+      WGxHc1ZvUHFXRFd3N2JiUTFlVkhWRnAtY3IxemlaeWVhV2NnVkZxQXpyRC1ZPC9jcnlwdG9fYmxv
+      Y2s+PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjxkZXNjcmliZV90cm9sbGV5IC8+PHVzZXJfaWQ+ZGVt
+      bzwvdXNlcl9pZD48dHJvbGxleV90b2tlbj42My0tdF9xZnQ4TFlrMnctUE5pSDVVNFNRZDFNaGVu
+      Q0RkRzV5ZXJ3R2JXdjBSWVNiWnRsYVlyQ2ZEYW5SYWlwX2VOaWphblJBaHNKaEEzNWpkNVFUSUpS
+      Z0dObFhJZzdEV0xYelEtNTNzR0M0Rml2TWt6VXVpcU5Ka0J5dHFabjZjMkxneHktZUl3RWNROXJf
+      VG1uWUtaazVPbnJ2SDdaN2QxbFRkOGFkaUt0M01TZGR5dUxoRkpCLTUyRExwLXlfakU5Ymx1ekNR
+      Mk80ZGJkWTJxVENvS0tIN2lDMF96dEFVR19DcnVDMzllYjVaQ0pfMVExb3E0WWNwWHc0dzFMX0pj
+      RVZkN3BuQkE3a2NxNE1NR3U5Qm9sOFljMXk3U1RWZGdzUGhZU0RCdUFqM2VwN2VxenlvTmt1NW4y
+      OERjX0E2NzVUdmJWYW5Zc09MWkJMbHZUQ1AxR3EyV3QzOFhCdmJCSVN6V1JXVXpyWnNxTEJUQ2pO
+      Zk4xWGJfNkRZWjYxM1FSMlk3Zk1xVHJZR1JZZlBLWWpXUFlSQUVQZTVRR3l4dFVzSERZWVhfeVF4
+      XzhwLUVyYm1URHAwLS1aPC90cm9sbGV5X3Rva2VuPjwvbWFrZV9yZXNlcnZhdGlvbj4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['694']
+      Content-Length: ['791']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61YyZbiOBbd91fQualFN4HNTB6X6zBGkBAQASYYNj7GEth4DEsGzO/Un/SXtWzJ
-        I2R1ZnXmIgPdd5+GpzdZwh9XyyydoYd0x/79C//EfSlBW3WAbh9//7KSRuX2lz/EfwjYc0wTBrIC
-        gOx4AHqyB5FvYlFA/h44lqLbso8IrCN5rwAxgEioPBYJqhe42JH3pqMa4koul8+Ge+gY/Y67asz3
-        5aPnHACPny/q7G17qkEVnWqDLd88vRtzbru2B2dLmmhoNTgMN1d11X8JPrfmdPPibEYv3tzQ+yNN
-        rZ1qdWTNB3xzXb1tqh9zqSzZhhd0T9/aM76hv13an/DFXN/Q5DY6bIVKbk9CeErXQUjfm5AeJYck
-        1sCOAW2xWS+XdamGlY+2U61hua87DXgz24u1PaqCi2J9PtvX7jV4GV1ul+m5DgdtUJ4fpE7Dfx13
-        WvBtMzPQ+HX8MeeWo8PGOrsjvfF5Ac83/Tg4OtaQO43gDh28+lXvfszWvqoFL9bQ3pd372tzLUNi
-        JSmozdu93v6wQB/c+MOWDbDRpt3XRb87O/Dqdbp7vaKPPexIvU/34jacz8ZAA9Kwf3h2LP0KBsRQ
-        Jv/+8aENXv25Xquqp9bu1IDBYHDqtnby+HZsD/zF1Lm0x3Z9vXr+9N6Pi5GM3qA0WS6MUc/aYvXZ
-        qLfxoXY4ti4zs76a11cvcEXOic6b3vR96kp+Q7+1LEM78/K6Pmmure6u6jRWBuirE9ezTe+0rIE3
-        tf920s6X3nZX7WxXxjoYDYddaXRDw/Gnuw9UHQwnx8GmCYatjS55U74qvbQG0sUdztZcT/12la5b
-        ubpuapfn+rLz3us/j8G3YATWPe/sHSdL3ZSnr+f9rnXrgWALlU79E8tb6CxtY+bOvr2OVz17NBnM
-        p4FR3uh827QMeJPVzRyM7IVuBDO3vz+eaiCAg0bQHu93XvtdW3S0/UwbvzfLO6GSd5DEX2jkqI5v
-        Y5FPWVk49D0IZB1DS7Z9aw+9kHkPxnOKwt63QeiU9G9xjQdozESO76mQgACK8IplDBHmEo2stKAB
-        IFJFibBLywCRPZV20HOKihEpVsQOVkwyl7XXbQjEaucpXaggK6ogLNa4p8YdHeEClSzoKljVRP6O
-        nYjyGggq2PV0FYrV5t2GUmFBiZxOU7wjFGv3OolMUH3PI4k0SH9RUx73Lsk2OShlHBQVO+TCOS7D
-        YWDKYh7QrjYzrNgtEsA1FRUisZrhMCjDIVaUUWDtHbOShT3IUPE/f2b1UzxFRQHAvU52KKuao0fz
-        MyCVUIfRYGngW1ZQ6iseKA2oTKjkSImKbmN49BRMypIMFKxUUpGtWFAE4UypcoQlDBy4d4wIS4bp
-        r3TbUYyEk1BnoRvqh1Gm4tLBc6wSJkc4Q9uHoXaWlSpZEGsOyADRFffnvXlGh157ZkicOfLaPPR/
-        biUsv8Ry4mwlkfUzvFiQUiPjqHT+DDGxWfFwOmKppBDSaRTHFHrWpbQaDGcSmSoHp6xo60vsA2jj
-        Erl2mKHSY9mO7ByiqERhXssOmQzrqgGz0hgQioGeie1COGciuJKeEhJLh6nZgwrd+HBNcnIyooJo
-        m0PSSgUXDXqQEVga1I++K58V04c0urOAoOqYpQLTsYFjl32DmDIBqTyaaBrJmZBOrZoKQuwP5RPX
-        UHC4gQzG5HEgZuV0GtKcRZ0anS7qefJQaERiG9kgNYetUIksGYNhJ8iosWaC5OZLeQ+mNHSAHk9L
-        D8LkOSylRGcZKZZuBhkSPWElXbcSGy28Xo+ZOTJ6FkjEkf7KJuUXlCakMSZNbUplt+DpxNtIU3zW
-        4UV2IamAYf2NEvlDkUAiEMqeYh+hDG3Axux+/H+X+DbWSl3/6JMqW+V4kupTAuX6WCVOfkCQFMhm
-        uFARTWkIqsRxSGTUW3yj3uBy7FhI6QH5Z1mABDRZlGvzbcZMcHK5TrvJ8XIEKzYgYUZyb0gvc+0y
-        35b4ztca95Xj/sXxX8OVHiuweYsWoGOEFQ/f2aTKE2N0SeCav9IkTb7arNV/2CT1Kv9TJqmXq/zf
-        MQkzQZR6qD+GeXzR7U+GC6GSgRklMsOrgkkgXUo90oPZ8DdUmpHjeApJg94/YyVqL/pbB2JzPIol
-        ZMRwk3i5kyaSLMgYZHvYR6KpnxM5g2ICLTKVeBzVEqRbbtgtRYk51qNVhv72XQRNkyyFcG6Pw/s9
-        fm/vIT5ZZfHKg7mP0JFpETRJkxEWHrERleBkKJBkfKQ/y9wTH4oSQKik+pqCZFJvSGAfkGiTPjgH
-        hLkwLDcQJEmQDQVLucqeb9vErPT++SpxjTtUsEjOfMArooINyTcCgC7xG590aqEvRft5hDOyTzus
-        DC1GKCE8g+NZiq2y7+A7VAh7SFoT+/yiVJdmQiWB4gRPKikO2bJhiRwrwEVcQJoTpccDPQ59Qchj
-        wnc+WXLfKn/9kZL7OokaKNahdAfT4WK5Hk6nS6GSETASbVAU0ut7JKzWxJFQTGPlhTUJfysaC597
-        uQ+9nLXTjLeGgGTEVlglfn1GbJHE/xMZsXWXEb8XomFsuI5jss4tuuQCFkaMqVthtY38MjP8X4m2
-        9aOJNnIpurtyt9MlLssAJkHyWc+8/hRBykozHPVQksZYd/jBVFJIuA/gfPCG/9OLaz3VuNLbq1BJ
-        ISrVNMsiXQvfqUUFPIvR9dKYDHtbeR+eN1o9PGABynLCNSo5JD1aeCekd/n0IUoyvO0kEAS0my5S
-        BJriMxbojxf96TDcdkGQo9JWyyWnKam6p5owr8Cs8eg1ofiMQMeFr4Z7MMfLfEE8goXHzwZ37wUP
-        HwruXgh+NK+wz9JfnPoq8bNR/AjFHjLuHqdy+E+9ZFWSJ6rKd5+P/wu8uhIsgBYAAA==
+        H4sIAAAAAAAAA7VZ2ZajyBF991fo9IP9YNOAhAS0GeZo30slCa0vHJaUQKwiE22/4z/xlznZBFrK
+        0zP29OlTRd64kUtkZERklvDrxbFLJxBA03N/+UZ/p76VgKt5uunuf/m2kDoE9+1X8S+Co1hADgAE
+        wUlBmBp9hzYSBRiquucopiuHWCibUFYVXXQ9gXwvEbTg6iNPVm1Ps0SrShAnYC1GHYS6/OqjUylf
+        ZlZlHwz5E9L8br0/0dx9eDNOy5osD+zDfDJfwYtzHKzr5ryidtabXpN3Nqfljro0wYZRXHY27W1V
+        Rhqx3W7Pdhe2caDBoEG3ob+2dtr2dAp2rX59JqOPZXh258zw2lgcuC2qMoOFPEOd+WZMjzrctWlv
+        1Ns0kA3mwA76lTnT4XtWr9xrNKRraxNqHlujkLf9REyr1pXkD3TjNm2FXnx0utR43dw4yyEL7dDq
+        ghUfTg+Lso1q1LTXhM6sGe7YCjuBO7fp1GALyO6nRLCt1d6VPHZnX7nPc9iRqNl4IB8837yWt8TU
+        27MHras2F9dPNayDG7ddI+cMrK7cWVmadZL1umvMtWGtbzdum+WYLR9n827/uuXQtHPiO4BinTnD
+        TT57B0vi5PlqRffXrc3q2Flvtcmy7/Cyw+ttL9QbKm06hsEf2Jqv95teQ/080I0tcejLCtemq0dK
+        WQ/Zmncb+Nx+y5bB2XInft+7XKanaiAT5tD3j76+WB/4/aGKV26Hl/L4uBnPzNW+47fKtlWRLsRw
+        3wkn4camiV4Nwc6ueq1uWxTYBhXUPw9snmXtjYKks372ViqEsM80z0fN42hYK9/80Y1b7x1b2XT8
+        U3XQNJXzkj9/VLRWhecWzlixd3jhZXfA9uobY9nzaK/Xq/DSwHTAqbFkB6HaZfmrvf3Ue9ZwNeGk
+        bn/V6XszoB2OmrklCGIrkA++KqBAcaGixe5v6qJEURRBRT/Y2pAj+hzDC+QTR3BMN0QAyjbYITk5
+        NvgIAZGufseaAvmVHA/m2Ta4ysizgCu2GYJwdDQ9+f3OaL7s9wA14zc75fwBdKvLKxXNcabuwu10
+        jGkwMaRZ9dYdtbs7c76tMMiRQ6WprQ/Tfd3YjrdE7/MinVbWemEEi6YG52aFchlnXXY+4DSc0Y39
+        wKPW9r6jqtcmpzj04QgpyzLMNsePpUuVP+9nNel43pr26eIN9e5uUA5mxOdt2LMZo9qd7pe7nVY7
+        yFdLPRJDf9CiThd2MDkQi0rrfCZ65ys3MvdH7rPWG4ZEz1vTtY/Dmh+4DO/XDYOWRhfpqFqrWXke
+        EKGDDh2mOnAvc/UCyzuTRgZX2c04bw7LRnDYW4OZ7DMjiQtMl5+Grf713HClG8f23c5sNV02dvUR
+        1Voo4yndDxuTGeObI2s5pNwP9yovbks0cODIBntnVIfaanA5sVy48oKDcbZqTUm7fUzM7cCtGypa
+        mt2lTU1aunypnHv0yLH14Lqw+E+tonrVCuW718ZneJtNG7e+CezBnGOQGdrN4UVeGwt0dtFmcwon
+        Z12irGPQlPVrX9amJsvo3frH0R0057fzunurT1dLZk3U6fn0QFuNi7ZhA37qSzRbHg7sNgAs5xPt
+        QHWklk/FfvroLHff8QIdB17NC10k0jmrCGdcUVBDV7dB9vtZ9w2aMaEXBhrAoA5EcEEydmdE3TWK
+        0icNHUBNbF8QCFzFLklYrdRQNLwCvfSiH3MzfeQhxcZdOqrpAl2s8N9z/pPsWQUikaG+V1/oED1R
+        8YC+gjRDpF/Yd9GjBgQK8gNTA2Kl+jKhXPikhFdnKMEeiMyrzl0maGEQ4LR8zb8Si+5VH0epByhn
+        7HAc8gKRjuLMM5iz3NBRQSBy5VqBlYI5y7cVDUCxXOCkUIGDrSjDq6N6NlmEA5Ci4r//VdTP8RwV
+        hdjFRCEzcrLzzchJNVTaBZ5TQgbAFYsbAoF8ZOVKDkCGpxeA2DTNSWNS0EnMVWhiJ4h3+xH6H6cS
+        lUEKUsSPhYTHL/AyQU5FVx+IWtJ/gRjDhfZ9cSZMT+LTUci9P6Mka623FiMJd/QA5px44nUdl3Ul
+        iBRXVwK9QE6W5Xqyt4u9GUZhodhMZcjER7gozQDh+YAUzkTaA86Y7W6ZwapR7jR1PChSTDtyMs+O
+        8mksS7+FXWjHH6lK1hRwpYnTKMI9I6DLJxOc43r0DSwE3jnpQSDTz3gqOIZdEvOQEeArgYIPDf4m
+        i3Mi01k/neHCsSXzLQLYTfAvJQBKYvf2SiDzViJIIiKuxq9nAwQgJSSW10yUnnDbc3XPJUILm+IO
+        JvKYOorlqTBVthUI018JXwkQxJQcSIWJE2Bh6a+K4/+z1MTuEEZTKYgjC8eFfdLtFcDYugUosiK2
+        gmzhzBKNRMbGypDo0pDyMrU78tBZznvuT1dcDbzvNFlORngAc068joaCjxpKF9p6UkhWSuZTIDMj
+        RhsapGaPN6EI3MWx/sI1sbOVhvg2he9COTXdlcDEhwN7ZeSMsg9woouybRyv34oEHDDwNUxx90DG
+        aTJtx51JRviPEo1T6Bz4CETRu1SmaBzTc0rCDpGGT+UOAiRWatFQz2hOg0DDroSPMsOW2SrzyM6E
+        Cf2K/zmOjk8oHpTiKTpl3nG80x5Xo2g5hnF0wXHBATGdoHiCoiWa/1GhflDU3yn6RzTSe4W032cb
+        JG0ctgL0YpUqMkpj5fr/tEetzLAV6qftUaWqv8seVfz/j9gjXX8caxJ3jLLOrN4ctmcCWYBTSmyG
+        sYJwGjuXGrjScsHfYOkDLyeICrGgJLXnUqaY2Cz5xoGy1u9kkihsJl82dnRPxN0pKIoZRTBl4BRm
+        iCRWJpxkXEKNxyUg4d7HJaIaksz0Y5VUHa8QhVC0zdO9+xTKCElWJbN2nDyh6fhRWRVnokwvSavJ
+        d+hDgLOHbUL0sMT26xLx17hHFXHyTR974MlJdrcVZKIQ27yKa4syX6PpCiuQd1TA0XyffBLUd5rC
+        O1yt4TIrhwUy78xQoIyzKo4HOxgntQcgiqZRTsKZPwujaVNwlIschK6LtyLxG7oc3T6f0ei++o73
+        jAouAFEmxJkxyg6xT8bzeYen5DCIX44KtAxJCNEavMCJwnAy/RdUiCrMJHk26VmJkT4E8g5lKQKn
+        XBSxZcsRqbTMeMYFaHhxVN0ly4mHe8KEL+41Dxean7rJPFxh4rewdxH/nUCIa8tkrHm9NWrP5qv2
+        aDQXyIIgJcXdzxV8fQjwGV5hV4QZLU1laQnyh48+TmVOdjOISrRCU3jYpjzEroCOsxL9ZwRgnqeZ
+        nw/A9GtC+iqSRUfK9zw7LWtj33jCooNmm06U27PSMmv+RlynfzrPxZ6YzI6oU5/Y01MglUBcwkJT
+        tVPvfQYTVh4NE8fGIS+tPpepSg4Jr+f+8cxHP5ONY79XqNLnWCBzKJEahuPgGonmk+RYxJLx8qMc
+        Ff6yGq03uZtg+RNU5ERjkA9IvrS4Yg/AMQTwng1c7w4BPanUnylCkg4KFmj2Z81RO5r2k+CBmhR2
+        Pl5NSTMDzQaPCqk13j1RPL9NJO2nK9Ur+MArXK/ewcL7t4iXR4i3rw8vzw4/G1nSO/ufEzHJ7GXq
+        j7y/Zm9e6cPKy1vYA/67Hs7I+8vZDl8HcaaKpZDMsplydeJyC9+ii+msCAuKpuFqXVGjGWAgulzE
+        ePQzqU8UB1zwbeDeTkTJJc0BeC8Vt9S++PhiC1NaarS8o2J3jhLdgL0vehw/SH+jI3ywAi1+Ivii
+        ryfCf+0ORy3li46WueihC/LVeDD0fQ/fDmXVtKOiU1Z0PbJM+ueoL4TxfkEZ4Bun/aDxDk/Jyj7a
+        xADsQPRqBQr0Z0lUZL3/09l/AMx+09l7GwAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2158']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:34 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2877']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:08 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <make_reservation><describe_trolley /><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><trolley_token>64--iT3taV8o23t_Cio5ezl8RWnF2dwamqGnxAxyHFwzwLv4eD8d-OfT95uMI97ePXNksIMIVO0SFfXmvpFi5qwdGzigDgomE0jFeZsfr4xiAVNWuchyHmEnb-ZQWlW_eYj3Ty3O8BBbfRsV0IVn_kdXhLAMRCANf1cxLZMxsVbe9TBqpwp5oq5DhdTECfGomixdD6W2l1QVVhDMuOi32cj7Zj5eyDDjA7Z_Izg8DuRLow8In4WUGqrQgRF_sPeTKSRkFBmYtcGk48tf3fg7wNl4UO4UHeUT95svXBLQLpTu5iz7mkhv1_W4K6WmAZ2o5UkdCcKprnlrjS3dPcCPjhvwBYZ29YUkWyFEEATFzsEIqpbycidEKgDX6dE7XiTrL12TH7DTwpENW0BcJxTxY_2W6hwG4S9QBCGIdJyFdWBrvrgKSil_LMvbZ7zBdyYea94qt_YeoSnkNpNJMIUBnFKDOLyk-Xi18lmkez_cXOdFnRikyNpCbgj3dyeD5y8IbZr8QhR9hbNhIQ6-Z</trolley_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsUDfEXxcUCHyqYlLXHoXFHrOkiCFhc3j34smOD16W2zX2VOT-TnkryAjJ8N15iPw8qeHlWzsKzFfY</crypto_block></make_reservation>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['895']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61Z15bqyBV991fg++IHWxclJLhLwyxAZBA5NC9aCqWAYkslkPgd/4m/zKUAEtB3
-        PDOefuiu2mefCkd1QlVzv8aOXbuAIDQ995dvxHf8Ww24iqearv7Lt912gDW//dr+G+dIFhADEILg
-        IkFETduRDdtcGMmq50imK0ZIKJqhKEtqOwEhV/9axClB4kNPlG1PsdoWg2GjaWeC7/cDEJwIitYa
-        zs4SZzNy7k/5rr2eT+j+VZhfLx455QcLrxt9jE4msTm0xqfWfosThtiNQ/40ks3BMqYi8lOWLuoB
-        KsfDZLse8kNFNXsWOQaQibYnXWJtZmD6c0pdCy2tY0O65QDrdttS/mCz8NfMIhjQQ8eODDgH3kTn
-        KX1vrLVEDHrDFYt/fso0g58mGAtimg3FDjvTJuH1GskDZXyEq/3HdseK8XDKzrHxSidU79LvamdJ
-        ZId9ZcDi9l4jG4cz5m4iPInGsTwJToelPZaIjWsFyafvi83pbaCqsQ8+heHi2gtPZJcmT9bc3YEe
-        ltBKs8e3Pi/jSdTqjGaJfz62buDSJS2tddNnxOHEi0tnMrZiLQa23oAwbLRWI5O8+HGTYPDBwv+g
-        TsZ0CeW+domau+vZnCzAjCE1c37ZHfhYm7AbeOrjU1NaLHWbXWuN7dGa+kftBNhkvQI928fW0efg
-        lOB0t9UTeqQiwIY3XB91mTZapu96urIy4aBhN2aMBKTtPJqb/VM/6OlzrNFo+a0dpTPMcqVctvEs
-        HkaThuwKh2AOGoOFtvOOhwWNfUizzy3w9oMB7PdAsFgnlE+J+uoaDK4SaZNHjw87+s5rumPq47wD
-        7ufqhE2wgc37N5/0xtYOzkLa8HRJj1ya4E1AJL7inwxxv4/9zfK6GdFL06W6zQWmi17oJecxPmRH
-        nf1aVsk9y5zZzqI5mjdY/EiprXkr1g82KxwEZSgp18uFxVk4mVwGdBAm+547x8JwlqwVvBOvSa+z
-        OfW9dc8lgJGA4ccMOzXkz+uxh524+tP552AguaGkZD5lqu0TjuMYnv6iWHaNTTuDPld/4XCO6UYQ
-        hKINNCjmvoj8ErQZ/DvS5Oo/k6PJPNsGiQg9C7jtfgPDBP6YTHlxdgspstdaHHpMMGEvmzPZkUnk
-        8Y42WlDi7bix5qw99keTVVNmzkn00TeUVUzO3NtUZciptlmomvxxNi7dcV/b3fo+uwj5MS/v8c5k
-        t9ka40Wg0Y3+MqFxYUdHvcVSEa3hVTzhC7lJbinG8oXjhhoDLN4MDZxQ9t7hSvSm9kZexpLtuQLP
-        EMacZj4YYjxwWrg9lPqKxcpCOJCFzoJXY/7AqkSLB6qAW4v17YNy+LnFu3aXmPTO9PlKCrdlvyVa
-        AkWQqjVcE9Y0Ds7QVm9KfwHPByfGVs7EmR2MxKA3Cc2oZGxeTGBgV/FMW0s/XNw2rYY6mW5EX2Jw
-        49ileWbmDA0NhQJ7NhA/XHus0qphEJAVKZ4iR/hgtCYpxRFaMnYdY43l+ZNcWo2TecRO44vD+sDd
-        CxbuDN3x/Noz5ldJAcL40p3JAkmQzPYkJGZ/sNRboBtt9yNtoW1jnwwllZhPb6shIE4Tv9PXrd1q
-        sAo6vjm+0h/mQL1eQdyg4GFGdtZOeCCW7mi99ratTZeaHYfHwEcnSTluu8J80zwZwmx2MBu9TrDa
-        9ldiE37wyy6DDzFN75gmvzhcedud90aH1UxYLXx3vlWU41Q4r5irRIUDeAzGQ/lKaHxMq1elOwyn
-        amxvQ82fUEzAdrouwEd4/9Ttpmf/+QA+zqMXqChBKF7kwjZRsqrwndvm5MhVbXD/+6r7BXpnhl4U
-        KACBKmiDGIrIRSD+0KhKXzRUECrtLWLXNkkIgVM7gcB7VcxId0XoQclGYzmy6QK1Tba+lxO9yF5V
-        Qtim8O+NN3oIX6hoQl+CitEm3tgP0bNGCCToB6YC2iTztqBS+KKEdmdIgQ7a1LvOQ8YpURCgwiEp
-        W7kpddlHIe8JKhkaCmpe0CbSoPUKliw3cmQQtJskU2EVYMnybeQ8YZuscAqowkFWFMPEkT27XoUD
-        UKDt//y7ql/iJdrmVCCbaIWiYnhmNn4BlJL8wBigxkeOk9R6UqDW+FzG1Z9IDxXThUAP8tpKlaBU
-        L0Wu5IC2mo5UKmfYgwET/42RYY9u2SqXnflIOkh+WPIF9VIvU2BNCzynBtEWLsCNQKpdZZVKDoCG
-        p1aA7BP3Ft1FRSf/7JUuOszZqX2G/s+lpPUmslxb2G3R/BXeXVBSM+Mo+fgV4sNmr5szwyKUvLh0
-        6cV3Sr7XzXbH94UtGuoJLlnZ0jcwUoELa+izgwo135briZ6WeWWYxrVqt5BBU7FAVXoHuFdHr/h2
-        MQIqI0ZdgkWytKAwVTQplEw7dRbPTouMTFa0OS2ys0ahcu9yqKRHtQVEI0OgiihZXtsuCoxfwFzg
-        XfMRuHrRzJaCgnCcG6eeAr6EbOEFqF2vrqlerPolFlXCT738RAAdE/RHCoCUW71/4OplLxdkNu6j
-        e09yNUAACkIRw0098sWLZEcgD01VgFNMWMQxVJaonotFFjLUA8zl2UCzTF4I86EVWwrD4k/OR+da
-        gukCKlghv0eRqjwfBhk4u1flw2WXrWcotS2yjWihhFnMUM+seAfTe1tBvWs+kKfxSt4XQ1qmGn49
-        bL6RQv6ElZRsLwPJMe2kQsp3WC/nrd+Nln7eoDBzZvQq8BBn+jvXREevNkW3WHQFLanFVwhM5Cro
-        jKZHU/QBSt9p8ZBloS9FHAof6PoruToQgasW/eL7RP+qEU1o1DqRHqESgcQJlKdKQs6NoII8VAsB
-        yu5MOtErWtJCoKCDg9yaZokG3cCf2HdhTk/Qj+OoKBqhSfEm0SyYDxx9XK/J4ISYwZKrohiBEkdK
-        x/AmRjS3ROsHhf/A8X/ixI90pq8VinFfLZD3QygF8M0mJIGM0UFRx/4rTcKgspiif7dJaJL4Qyah
-        MZL4MyYpTJCFnvw8pklo3elN+2uuXoELSmaGuQSRI11rXVRAuuAfYU1A2wkkFMODv9+VcnvlbRQz
-        mfHgLkkjaN6y0Sn3ykBSBQsGWh6MwrZtXh7yAroT8gxZv/ezRBiajp+WellWuevlKTJvR34IUCaw
-        zRA+rbH/vsafrT3Fp7sqXv9ibB14Yp7BbVQhpVmz3cjqh0eXQ8FYz5sY/p1IRQ+Aq5f6hhSKKFki
-        x9bCLFc9AWksTFMNUB9BsOhyjhSLQeS6yKz59yfI9Kb9iqZ38694ryjnApAmOJTwYITKzPQsZev5
-        Ci/IUV4eVmh3JCeke/ACR3JRns+W/4ZyaQGc58Qesa7RW4GrP6B7gEeZFKZs0XLaeFE9vOJcaHhZ
-        eNTy7eTvfc8Y95P71tNF67dvWE9Xq6z6K8qrDj/rrzeH/my24eoVQUHKqysJXVQC5FYHdJDCO61I
-        L0WR8Ke8EaUW537/QOGl2uWerF1GvANQUURk0yzx10dEFgX+PxAR2beI+DMXTX3D9zy7KDuzj/yC
-        pR5jm06abe+l3737vwIt+3sDbXak8tVhnVYHHdkCKCQhKjFDU7aLY/gK5qwywuUnFIWxojrcFyol
-        xL078LPzpr/zD8d+p/Dacs7VSyiXGobjoKqFaFFZAq9i+XylT6aFuSin+81mTzf4AlU56Rz1J6Tc
-        WlZRB+AzAuEjwrveAwJqXkm/Urg8xFcs0Buve7P05fFV8ETNSy0f7aammIFig2eFwhpfPYW8voHk
-        /Zcrzzv4xKtcf76Cua/fPN4eO7585Xh73vi9caW4U//Foa9+f/P6M6/F99e04uXm7ZXtCf9DT3L1
-        x5uchu5pKNdk0rB+z0dS4mSFjxSo1YRUhTlJUYAPJTldAQLSOj/D0995seFI6V0SmaSEcmkRtqvS
-        wlzlEM8DIfsGaf+nY70QfnM4FF+knwy0L0VPQ9TfdxtGvu8FMBRl005rNlFSVXR5Du//QvuJNLNw
-        KAJ0R7Mf4L0weMULsqSnZg+ABtKHLFChv0rSwubr//f9F86xVGcwHAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3006']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:34 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/OrderTests.test_concession.yaml
+++ b/tests/interface_objects/cassettes/OrderTests.test_concession.yaml
@@ -1,475 +1,427 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:40 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:47 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:40 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:47 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:40 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:49 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGNyeXB0b19ibG9jaz5FMC0tRXhJNTJKUkNxLWdMRHN2eDR3blVa
+      elpTV1NZRHFxZXZKRkd2bDRwb0NpdkNxVVVmdlVMQVhnOWJwOVhnNi1jY0s1THRRSlN2Um1MZXZl
+      eGUxMzBpNXo1UWdFV3puMVdtRTJ5WHdnVnhkTm85U21KZmNlWHlZN0tNTnQ4enV5Vkp3OWFSWE9T
+      ajV5Rk5wLTB3QWR2MktCSHZwaDZjRnFST2NyejktNGxEaHV4MlhIYUFtMUY0U2JuZEoybXF3a1Jn
+      WjwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bm9fb2ZfdGlja2V0cz4xPC9u
+      b19vZl90aWNrZXRzPjxiYW5kX3Rva2VuPi0xLS1RMW16UTBaV0tTZWNaazl6NFdQN1pCSi1GazFR
+      bGpSTGVIODl4djlzQ1llOGJFZXYxM2hoRkhheXlfNllkVWJIQUd5d0VSNlNSeW5ZLUJlWGhUd3Ey
+      YWQtYzVoQXc4WmhLcEpubTNONjJLZnpNM3B5QnNtUC1Dd0NVSVktY2dzV3F2S1kxcS1CUUFfQ1N3
+      SmE4SFJjdGZ2WlFpSktYN3JGZGNGTHlwQzZjQ29DWGdPaF9vc3ZXY295UU1MWjd1SWlpYk9Sa1ly
+      NFV2dEl3el8xbWhvVzNQVVdmRGVnUzJzWkpzV0RpcU56bXJkZ243Tlg4cjlfZmFaRGhPSDdjOUpi
+      WjwvYmFuZF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkZXNwYXRjaF90b2tlbj5jXy0t
+      RnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJYaWgtWnkyeFNwU09EZEhh
+      SHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5OC1zaExzUlpJRW45TEJX
+      M1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tlbj48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['449']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS0HvDihIg7XFxZDKMgoBCj+Tv9Jf1kHg4Je
+        O4fKzLeqlauS2GfHCeLEOWcHJvPHxbYqEfADw3V+/0R8xj9VgKO6muEcfv+0EgdY89Mf7b8xmhGo
+        buhAyfUgYgaSD4LQgm0mCBXNtWXDkcIA+JIRSIqstR2Xqb62MCACDpon+0CW0DqgzW6YajHKDBoI
+        1DaLXis+68AHOSFFGdWAcca1XEdzHSw0mWoBZvaUOkntuTGfbMlBkP+V8WUfBohSALkx5XeQsfJ3
+        2fb+Xemh7YbJq5TMDNpUusPMbQyQp0eICYDsq7pkgjhdqYriUiBJ9HLebdodeXBW8J79abKjgtdO
+        s+3cCA9gwUn30ZUtC8B8o/2nCdlOq8UrVG9BTBLCz8OeHkIZuJvT+SvHgECrjFFaoaQoqPmp+AY0
+        VJRTkQHOkgd8NckRAscR8aWJ0WQIJF92DkACjpaPU2eiHv6rQgSwsgQeBLYC/AqJE3WmWlAydghV
+        yd3vAwDbVD1Z6hktaAFQUSoFbYJukI0a/ci+GTN6jP6zbU1rJ4viLZzImXccnbTbrOOElMKyo0nQ
+        sEFKx/AWhhMi0fqNwn/D8X/ixG/JSq8n5H6fY5CNA4iS40NUalCvTOX4Z8ajTtINCv/meNTw2nfF
+        o4b+/Jl45PtPe02WjvxK7Amd3pgVmGoJzilpGKYyhDo4V7pu6DvgH0GFR9vxZdVEKSSyS/E2MYtZ
+        9mxo7fpwcLMYt/4mWSjR3TZyJ8OkZ5TBnOHJUG9X0WTMztbFlHRdLMCc+7oYBAGs3uanU/LpaIcw
+        DNqWEd3d59CNgNqvDOXqbQxjD7QDw/YsgAKGnMPbvNSSs0IvAJaF3jSAD1tkP24RPU05vIxXX/g4
+        ADc5KLnNWDI0YIhiXiM+18hWnSCoBlO9owzq5ofsEcM/Ezg64VqdRIQ7zFQLZ7ocSI6b9IN9kKrN
+        A5B0U9QRUce5t9F8yNjyRfJDx0FHkeUNQaI9fEAZG3XdF7xnlHEA0FBGeCjfkDqkOZm+zys8J4e+
+        nGhoiXZDMkKyB9e3kzacvf4HlPHcAGbi2SOECi3yTPUO3SQCSTZM2JJpt/HP+F0jyjgT6G7aVffZ
+        dtLlnjAmQHmJ6KlzcEH5gnIycVeCb5xMty8Q+I5sVURErHSTRHa0SjEjq5/0UvCq478yMCixwnyt
+        Zac/YYXlhp1Mlky1ZMhJqfulrFnARzW8QakY3Gi5lOVXkIeIFt1wAzQkIMSv6JWtFkF/e68kPmrH
+        /2s6SfZ7rmulaZ7fHZ6wpCYsw05kOM280vArLZj4ZklKkyZ7O6yDz1FS5kBuCaTICAzFyhPtGcxY
+        RePKchB1p/yiuM6nFBDzsUQfyzP5f3Zwjc8UXplPmWoBZVZdt210nSFamY6VsWy9e46ofuxBV1Is
+        VzXbUwrDvHkNEtSBlVXalIXudWeTuhutBMPhuVlgkuo4UubOUbCgNrqQvd4RP9dbR77FLk5S5F35
+        2DT7K8FuGrQ+6jkreFUipdk5cUNLBc3x3pZ74tjXvL1lDYQmO5KPVmO6dq3RwWxQxHKCNa5DsS/W
+        pS0fen2bVcXTGIZDSu1btBoC1rBFZ4L7RmdPc7EAIHccWoK4PMCVt2GbEmsv+krUeANrsyX68/gw
+        P+v6ecguW+bUtg+z/uy9f9VDq7GmG5sWL0Flya3mZ3eh0YOr1j8tsV204eaDbp/g5pG55jcTjDxv
+        V9Pu+0ggllA4jKlOIOG0wq5rltPz9my0cFW18cZe6xam6ZFKBRNtAPvyXMPm516NdJeu4hIgNiPB
+        Hg1mKuQ9TtqO3ll8Rtgrj+pq/JEfnrjxmxWc1V7EwcF+KncGrLAJ3wMruA58F9DcdQ4243ptSvOD
+        3di3CfXisFAzzoPl5djvw+OkT485stsYyjVX0YQ3BXawXXLXLJ0vo1iyg1RSKj59HCtOS+e1pfhG
+        SuuqTaHqfUQYNfR99HUVF09ZGh8UD63+ABWMvaxC189vw09gwXLC5KrbbpL1EisHC5ZnySoI2mSJ
+        k0MlDhISKYhtxbWqZRipWIa2//uf8vwCL9AiGMFDXNCNAH8IS3JFQLLt7qViAo0U7wm6+0Dfh0rg
+        WiFqO4EcoTrPpO0ZRB8ftmI4qLdRrcR+HxYvk0a5019NxNILZaG/D7NvQA19+VUSzdRkXyuRcz34
+        yu7uQ+giHWyrOIadTKzVXY/jCx5zw8b727pPDh1BdLX94rR78whpEZIUy5HN96CGMm0VXTWcvcwI
+        +mw1WHuwhz2ObACbr8VU1xodD1YwkMddthlxTTpyur6+UehtxxjESmfKc9vOarzAj9aJXkP7PD5z
+        /MzpT8QemG0Wi94+gkGzZfqboOGdotp+PhiMdmezNbXOHe1AKFdlI7sxPFIm5UbWdGlSfJeXVq7W
+        s2EX7weqUbP2FuYd9dF4PN4u+ucBuSsFIdt1KQrJZbMcpez2iVQAKSfK1VyasgFKDSd7lJ4O9IWh
+        RE4Uz/MN1LOp2iO7sJTp6Fqiy/4BtOkn9t1QYmeXZ+m1/wcjk9WfJEeyYcmJwiFF/4Ax+SVHPhQ5
+        nQrPE8ikTiUlkdsseRHrCSpzkvSsPiCFsvryGU1woHEI3TDIbwgEuo6/NKR06ELZemKWMeY56KVQ
+        PwW4FNYXwXwMYbWo/D/dA0jiSz2gxw0n/a/0gJ5uWFoF3dLBj9Y/hup/MrPtKdcbqoPpZLVRjAO2
+        ssfieL2bAKTbI3vcXGMY2Y+3w51CBCJ+4PZCPzk6QG8miq0vunWjX9eIix7hsqGe4vCs26ap2dtA
+        wSSIBHl42I07kWVKFKcvWuxA1nbS25BerhoT1msK727Ei+PT6r0xmVDXQcvvXqh+h++1LrPNynwb
+        rsH1elI9aYdhX61l4gdqOTuYb61lovldtUx9by0/+/+rlu9BeVnL1JdqOZv3C2r5i3q+FFd9lv+a
+        oi+TnxMc+FPq2UT17GPxebJddlnWqznX/ZD2uzzRiHrWfOny5mEyn7iR8z7ZHvsX8chpR65Xj+Z2
+        NI15DzojxdKN6I2bDa2Q3bwfV+pKEt6l3tCGbOOkHK52d79Vh6fNsYOu9cLaP8lig641u9dQsE7u
+        uaY3LouDyHbZCF3FLd7t4cPl2TwbyKUn7bueQY5YZbicjI6NWcemPPYwmR2c4/xiYS3K655W5D6O
+        pyuBvtRngIhtasg1AqMJTD7e94Y0JvC0EPaImo3PZuTX+wH5I/3gu7SdrP/afvDs/69+cA/K9/eD
+        bN7P7wfUF7V91pl/rRcAx3D9impA4wqcn9IS6qglDEyKmxgcTte6Y0ne4wK7D4TgeMbttdUYGWK0
+        ah6W0LlsKa+3vhr+vjmCO6G31UdGf2SbMqV350rY6h54rTkX45ALdV912bXWXEN/esa242406ZHH
+        eG1uZ4Sxj5quxQn8pkZOehoei9KFvC75GPi7S3PhHWcCCXbXGqmfSJ2iRKsf8EJwUtXjEA99bo6j
+        b3TaOknfIPfUj1zdv0vuyV8s98/+/yrve1D+RHl/We7vj0H2W2VRkrprJD8/3H+x/GAp5dvTvz3/
+        D1lRoYe8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:41 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:50 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkaXNjb3VudF90b2tlbj5jMC0t
+      cWstOUJWS3l4MHlISTdZR1ZEMkluUlRvZGZRcVpHcDFfUXUyM0VIMjhZczVhbmtVdnpkMEV4TzE0
+      d2w3RW1GZnRDSDI3ZW1ONXkzQmxKamdsc0ZhS0JFOHZIODR2bkJyaFdiNFhBaUZ5YkFNTkhYQVVL
+      UTBqbHE0VnRtd0t3SE5PbkRMVENlT1dRUUNmdnRzODlrcldzN3BxdjVmUEZGSlp3azlNbHdBZGcx
+      YnpiV2FveXRqM2szb3ZsTVNrM05CTl9Vb2RDbXRCMERzY2k1bGZsLXBqaEpLS0tYUUR3RjJaPC9k
+      aXNjb3VudF90b2tlbj48cHV6emxlZD55ZXM8L3B1enpsZWQ+PGRlc3BhdGNoX3Rva2VuPmNfLS1G
+      eUpWRGY4RHlFRGhNWVU2Zllsa29BMUcxempMbnZkVndoN0tMSmticlhpaC1aeTJ4U3BTT0RkSGFI
+      emR5YUdqLXBySGQ0N0s3dmZDUkZYdU1FSnVValJLQnNHbldScW1IdDk4LXNoTHNSWklFbjlMQlcz
+      V1ZLczNQLS13Sm5RSE9fenB5WnV5VWlBLVk8L2Rlc3BhdGNoX3Rva2VuPjxjcnlwdG9fYmxvY2s+
+      TTMtLXBQNXQxM2dFYWM0a2FSQnpabTJob3ZVUmluTkhPc2syY0t2YlBualJsdGRKeDJDQ2owdzY5
+      ak45RVFxX3Zwek55a2tEVVJtOGk0aEpDblV0emJ2YjhBcUhJbGNlOEtmbWFDVEtyZHBmbGxGUjhF
+      SmFqbDdNVm9sSmdrNzMxU0wtN3pJVERUNl9YTnVwRG1FY1RxS3R1STNjRGw0Y3VlRWltVG5MMHJp
+      QWY0SHlSZXRIaklsUlRTZ3RVcFdFOF9FbVFEYnY3R2VWazlUclB5Z1B3aGh3SUVTOWtNbW1nT0RP
+      WUR6aHVsN1Y0N1c5Tl90YlNIVVB3b1FkNEZ6ZERxUy1adldIUEZCRDFIUHZrVk5XTC0yd1hVTUJZ
+      SlIxU3RSZ0szQXNfMDRiRVY1bG5DcGZFdlFvY2M3R0V6NmwtZGh2YzNzTGRGdERhUGQtUHdDNTJv
+      U29ibzFleWt2Um1KRk9jdE5wSF9YSllFME8xbVVwM0JkTmpOSXFIS0dsc3djQ3ZIdEZmTWFBRkVS
+      V3VZc2xzekZyb2U0SHpQZVdLNjVNNE5GWktybTFjeG5FdGRpd0ZTeGpERHRqTEQ0S0gyQjdJYTVv
+      YmRSR2J0QS1aPC9jcnlwdG9fYmxvY2s+PC9jcmVhdGVfb3JkZXI+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1148']
+      Content-Length: ['1008']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
+        H4sIAAAAAAAAA7VY2XLjuBV9z1ew+mHmIaG5aO9wOKW9ZVleJFmS/cLiAkm0SEICQC3+nfxJviyX
+        BChSsqbSmSSuLps491wA9+IuQBu/H8NA2iNCfRz99k27U79JKHKx50er3769Tnty/dvv5l8MlyCb
+        IQsTDxGLIBoHzDRo7Hg4tP3IiinAPrUc2zMjbCi3JYYbEwKzn/IvC5ZC5srZGsollDOWtsswMTVV
+        LXAEmLOiOHQQMet6tcASYM7aBraLqKkXOAIqcDBlFj2FDg6UIkyQQM1//qOon+M5CnrktGXYcgLs
+        bkzXkuWq7NCP+dNHMF4RJNOOcz9uPLXcZX09rB53k8dlnz1OnlvPTlUL1FPTd7a96Wr8Uhp674PP
+        jk9XnztGG97sx2uLWCffDwYrHZfr82iP3iZPM2cR9OkMP+/mnfmh5jgvGpr9mPW2sku0T//9hOy5
+        u5r1ds1P0pHfYKfF/Rn8XBneoMis6rL8flRlbRAd2/t5a9hYdtnboq82WAc1SbsfPcz6h9Wu8mPR
+        H9XR8TCddOo7/aU/6O3wptq+Xyx71n21/PBWZq1HN3Le41pVnSH/1B2w8eDw2Qg6u8FLadHc6c1h
+        975B1eWL3w3aeDhh6nTf7ez9Zs/W/U515I7eV/KijJv3R28dbYa91uKw9BalaIlaFW0zGNn68Zmw
+        oFtvfp68NVKX/rv9uWmMYxmTUml3Qp3RyDno88/jev/08sZG+DirnWrTYzir3J9au1Kz9XL/OGnY
+        4Xo/bTmd9kelNNdPVth2lg3NPtgf8vuQ6m5ra+nHwJ8ebH+kq4/DnX2oTiqzUT0s43c3Umn51WrY
+        nWnY1/36y3bufiw+P96qbzPWWw/cx2CNdtFC7i+I68z1Pn43lKLLuf9Nw0N0azN3bcGHa7ZxECCX
+        SUuCQ4mtEaRpFCNDuWTlSiFia+wVgDSR2k+tp4IOT67CkDJTu6tcMAD6L7eS5L/NbPPxdQrrF3iZ
+        IKey0xaZLp+/QEzhwvhsnE9dHEewQxeHjh8hzyw17pLSkA3PFG5rs/P6MIWJLsCck2686UE9kyiz
+        I88mXoHMzYqwhZcWhQpITc1QikMhY767QUVpBhgJbUt8F5mlSrLNfAzlk7hrm6yQWU4l52G+AdNA
+        4Gn4Y0P95Vvvzg0lH3FBus0uVPHTYY0IEgS+eddnoqQGOPJwJMcbcNYZ5PKU+pDKhVAoBzal4g/n
+        24RRoOSAEHI/glD6xQ63f5fa4NE42UpBbEAfSJsCn/aEYKZLKHEXeMHaoFO6kpI6LEOShiN4mdoZ
+        uZgs513P59mRi25Pys3JCBdgzkntaNkQrUwY2rlS4JYq+RaUzInJgRLh9vQQisBZnOq/Rj5DnjSE
+        Lgx9NKeKUyE+xBe04b2PDtYWETeJEd4gb4oML2nexI5WyEKRJ8bpZNN1/DdJo0yaoC1DSbuUdFWD
+        JppTODtmLgT2kiJmlqrJUtdoTqPIhVCCbCjX9FqlfMnOhJx+gp8w9DwzWVRtqJpgnnE4aVyvqpqV
+        wpCgkFohSumy2pBVbao1vpfU76r6V1X7nqx0W0HMe+0DPobMJ+yLVypsLY3s0//SH1W9XCupP+2P
+        ilr5j/xRgX9/xh/C/rTW8HBMCve42R52x4ZSgAUldcPIZtAJDlILxyRCv1LpEcwhNtQ9Ik27k2mm
+        yH3Gv33PrA56mQRGAg8g0LEJ09ksqRlFUDCgC6xNBZTlkK8rO+m6MpWj87oyQ5QpmX6qItTBQhZT
+        M/D35+kFlBF4Y1Kycdp/qB9uAySKeabHOxP/jrcUBQHslLILE7tfTYSv0Q+1iCs35lghbPEGGdjM
+        ZzH4vALtWW9UNa1UM5QzakA1X/FPWb3TVDjhShXutTlsKPlka5ta0JigHixpekG/AJJqmvQlaJ5Z
+        GRVDI7SPFomjCI6Cx42mgw1fUCOEqnuDd40aEUIeRMQW4g26QxqT6X5u4YIcE7AZRwVahnBCYgMm
+        YVKG+fa/oEZypefNs62NpfL00VDOUNYioOWyhG1tQlMVnfoaN+gap1V1yc1Jl7vCDApxCfR0cnSE
+        eIGYTKYrwBmH9+0jQySyA2kKRKmVBHLkSbkGz5/0HXWr4t8SGOn1jK81aXYeuuPJvPvwMDGUgkCQ
+        0uknthcgAjk8h1CkGU20MnEF+dOpD60szJ5iST0qDI2LY8pL7Bx50JW0/0cBbjS08s8XYO1rQ/qj
+        Spak1BbjQNwM09i4wpJEC/ww6e1pOBeG/6auaz/d59JI5LuTm+ozRLoAhIRae5/6TiCi9xrkrLwa
+        8sCGkidunzOhkkPG17y/zPnkNz+42l1JlZ5HhpJDXLpehyHckbQGb45FjK+Xp3Jyd7acxF5+vQf5
+        FVTkJGsoF0huWnImkDm7GNFzN4jwGUIev61fUwzeDgoeaA/G7Ydusu0rwQWVX+y2YI3k+sQN0KWC
+        8AZmdmBdPW2uQEG6epV8BS94hRfKLVhwr18r12hGu3y5XIM/XVnEs1e59b9L/wL2/DbImhIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:41 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1879']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:51 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order><crypto_block>E7--NuwIhns8SF9pSFmOCtayGoPi5orsAykdVtQtCufnKnVXd5ijHtnqR7hewEY9Siu9mKWZXgSi50wUnsm6QPTTn5Ap3rEh2y8qt7LQOigLgEgeiLH4ylijiJOz3cCcGHfmz-mr55XI7fNrF6K5mYhYQ3qn1nCceIO3_pGh-y2ODATK_1unwgfaRcvmf9rRBGVuoIht5KuL4JvyIf1HGwjOVpnEZgHPJm7kxU7hRzZCGSznxEZHloNsR7I2pTbq40t7v2mLo1javANm8iUGKktt-5o16BpnLLteyP0yqrtW48EZlb91SwCaca-PJX0S8BvzKCatNcVD_hETlolGxPekOoYcRxyhOS0oqh4PNL4fG5MfxXXjHxpdCbQvBrDibivFS6vhbjmFeBcQYWikaldIWXGQFooHSH2dWMs_BXrsAz6-j8VMn40F2LZish9H3g6jBjVkrnayZ4NMPTq5FtXcdK_5L7WFk2ASLauJCqJowO_bV8X2sPX_At8097h3QpXw1Kh0OkgxfUXvzDHbFI_bN0XSMiJ0al9y_p-VXab83-6hG9eHDURd6DtENaA6ZdPR1b2kCR_toknr_BpFKcDNzxpBDj9-GWfRRbpiCUM9rPYDDkijx5sFQiucuV4RNL_xRMwwjtm79e8Q_Ffs_Rbj0MXC_rEfuYOIlmhROtFCXJpXG4CNo46bV1NKHU8emAOPjTy5eN5yHKnfgvMsrKq0Ix6-yFmDNxXSz4pazVchj_p8eOwdiIe_aY0Ybh9RJBrav76RZUsxDdWqMKRqoWJyL_--Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>k0--5q_Eg4_-x1Nz1FPUkY_jXomw7H7E1_PjxiUKNYUK3emm0ERjusgvnWUYFQqZHjDGEekx61hC9iIriru1LpexlQdiFWf9oohhZR3m54tmVkLEMIItGP0eGhqQULniBgRbrSIgFusujEyS0Rw91TvO3pqX8rgNeFy0FDAL-H3GFetfBUfLnD1Zi-94KcFBeU0CKwDSXAHtxFWU5WZiFJ-wMeIriNlK_uoAMR58EAI8VqC-Z</discount_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></create_order>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['1384']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61Y23arNhB971e456UPLQGM7eCzKF2O7cSJr8eX2M4LC4NsEwMiSPj2O/2TflkH
-        JAw47urpJQ8J2rMljUaaPVK0346eW9qjkDjY//WLfCd9KSHfwrbjb379Mps+CuqX3/QfNCtEJkUG
-        Dm0UGiEikUt1jUQrG3um4xsRAdghxsq09RMimnjbpFlRGMLwp+zLgLmQvlkFmliEMsbatCgOdVmS
-        chwOZiw/8lYo1NVyLcfiYMYKXNNCRC/nOBzKcTChBjl5K+yKeThEHNX/+D3fP8MzFPqFp4BiY+Vi
-        a6fPDEHY74J1fdesB7PqcCVsQry2Zfp0sAaj5buCLPKutJZy7f3bbigt535r7027WzJrrduLozVr
-        dk4fS7e36ODFYycc7pzm49ZS3pUK8YYtuTYvnxfl1+FUmPq78NR4f1EHctUZHdQP1HHnZ9I9P66X
-        4F3eJ41tJsU75OvtsiBUUadq7KMoaLxvvlmbRefQD6aovqh/bCZueSm5i6Bq4f1hJhNSeZ4vHxrC
-        eKYaG2XUi9Tn7nmDwrOhdFxJUfCz8NpvW+et1Gjuh/35Uq2co6qC5s11Y9NYlPeV+5O6eXMx7TkV
-        ggeDtUqXiO4WH294JAzkrdudvewOb/ZqLjUnR1SbnTyzbb9PFuH5MJSGRms4HlvzoHZ8RuOHD2Oz
-        O1bmUX359jIiw261idqCGTwaPeXQDOyPLpooo5qhfHtr7MevU3v89BBNzhNh0XkJXmsR7ftC1OvK
-        C9MJBpFKW8+NoTto9NWn1pM1Wi7HMJJihB0Htu5bf9h7c04P/frD1vJPvaemOnVmw6k5PE4n87ra
-        wXar1Yx6HyevLffnlve6mGxrxxfyGvlWxaOjxWhwdO+FN03Mh5/tha7ZiAQmtbYGfFh6E7susmhp
-        HWKvRLcI8tSPkCYWWVknD9EttnNAkkjN4cMw14clV65JqC7fVQsMgP6jK3H+m9TUB7MpzJ/jpYaM
-        Sk8B0i02fo6YwLn2ZXEOsXDkg4cW9laOj2y9XL+LpSFtXihsrZPprNUeTGGoApyxEtcnNLKRT0sh
-        yFyOypblYwOvDQISSHRZE/NNbqOOtUN5awpoMS0IHQvp5VrsZtYG/QytrRlukK4klkszc0DXEEQa
-        /pggwMzx9lwTsxYzJG62QcZPhy0KEScw51fOJgqMvelGiGloHtAsh3LBdbFvY8iEHYTyAjJ7MlAv
-        sXMjG9pyTUL4H8aHo2HS2IEcxu1Jl2nRzoaB6pCUCjZcUj+KUBxEiI2xQ6d0BjGJZArGpYhT054X
-        pDBexrsx5M6xye1h2UK4vYBllGQtj6bnuKccia1QzOYV06DF2xvyMCdBzwMXc9J/5jsU2aUuFGWo
-        qhmV70LowGmDqrx30MEIUGjFJ4aVy5smzY5reWj6G2Qg3+Ztvj/RLyVZpdtSI9pEhJbKkgwFNSMw
-        bkQtOORrgqiu1OKJrtGMRpAFBwcyo3IvVytVqcBOjYx+gh/PsyGhYVJJlVXOvOCwuVitSbKRwKZv
-        Q5p5KKELkirI6lSuf1Wkr5L0syR/jWe63YGPex0B1ibUDOmnmJRlCEYDEtf9P0NSk8s1pfLdIamU
-        5X8UkopQlv9NSHgIEulh5zHW8XGj2W2PNTEHc0oShr5JIZEOpQcchT76iZQGsJzQBBkMf0w7sXix
-        b8fWa8+PqQVaHHfhlONMSPIgZ4B7NCK66+wvdg6lBFZkxLSd1BLieIGLuDCn/ViVYd9RQJDrwlSE
-        Fnxsf/bxr3yP8e4sj4s3xt4gbLAi6JrUiQuPXk1K8KWpgRhv2Kcg3cmx6QJoYtZ/axID6g0k9pro
-        PtbEAhBrYVxukH0RQd7UPPNohJHvQ1jZ/stlOBqfUM0DzbzBu0Y1HyEbdjeAcxPBfTg+S4k/t3BO
-        jqDUwqMjR0sRRojXgEPP9KFUJu5/QrX4ps5qYlMelyrTgSZeoFTgoZLSmG3sPF3iBfga18gWJ/K4
-        ZsthT5giphE410BPBkdHODqI0Hi4HJxymGyAvTQ5EYq80hsK8YXKkiC5QPEbSqPVa48n83avN9HE
-        nIGT2AXFtF0UQlrN4SCRlMbLC78k/KtshNLipQ+lWB5yTa0Q7Uzx5sgGRbyPq8T/r4j3IPz/QBHv
-        PyniX6VonBsBxi6/uSWbfIXFGeM6Xlxtk3OZa/6d0N5/r9AmR4p5JzTqDTiyHOAWYuwd4qxcfgyv
-        QcbKFI6dUJAxfjt85V0ySPucwMXkjX+zjbu/U6TSqK+JGcSs263nwa1FritJAc9jbL4sJ+O7Lbz2
-        Yb3J7PECr6A8J55DLCDZ0uI9gbvLR4TIReF9fIGQzW7T1xSNSXwuAs3ncbPXjt2+MhSo7KoVwGpK
-        lhNaLip24NHA1HSNq6fHFchJV6+Gz2CBl3tB3II59/o1cY2mtOLL4hr8bl3hz1Lx1r9//gSe8Zbz
-        OxIAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1828']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:42 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/OrderTests.test_despatch_method.yaml
+++ b/tests/interface_objects/cassettes/OrderTests.test_despatch_method.yaml
@@ -1,475 +1,427 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:42 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:51 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:42 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:52 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:42 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:52 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGNyeXB0b19ibG9jaz5FMC0tRXhJNTJKUkNxLWdMRHN2eDR3blVa
+      elpTV1NZRHFxZXZKRkd2bDRwb0NpdkNxVVVmdlVMQVhnOWJwOVhnNi1jY0s1THRRSlN2Um1MZXZl
+      eGUxMzBpNXo1UWdFV3puMVdtRTJ5WHdnVnhkTm85U21KZmNlWHlZN0tNTnQ4enV5Vkp3OWFSWE9T
+      ajV5Rk5wLTB3QWR2MktCSHZwaDZjRnFST2NyejktNGxEaHV4MlhIYUFtMUY0U2JuZEoybXF3a1Jn
+      WjwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bm9fb2ZfdGlja2V0cz4xPC9u
+      b19vZl90aWNrZXRzPjxiYW5kX3Rva2VuPi0xLS1RMW16UTBaV0tTZWNaazl6NFdQN1pCSi1GazFR
+      bGpSTGVIODl4djlzQ1llOGJFZXYxM2hoRkhheXlfNllkVWJIQUd5d0VSNlNSeW5ZLUJlWGhUd3Ey
+      YWQtYzVoQXc4WmhLcEpubTNONjJLZnpNM3B5QnNtUC1Dd0NVSVktY2dzV3F2S1kxcS1CUUFfQ1N3
+      SmE4SFJjdGZ2WlFpSktYN3JGZGNGTHlwQzZjQ29DWGdPaF9vc3ZXY295UU1MWjd1SWlpYk9Sa1ly
+      NFV2dEl3el8xbWhvVzNQVVdmRGVnUzJzWkpzV0RpcU56bXJkZ243Tlg4cjlfZmFaRGhPSDdjOUpi
+      WjwvYmFuZF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkZXNwYXRjaF90b2tlbj5jXy0t
+      RnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJYaWgtWnkyeFNwU09EZEhh
+      SHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5OC1zaExzUlpJRW45TEJX
+      M1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tlbj48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['449']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS0HvDihIg7XFxZDKMgoBCj+Tv9Jf1kHg4Je
+        O4fKzLeqlauS2GfHCeLEOWcHJvPHxbYqEfADw3V+/0R8xj9VgKO6muEcfv+0EgdY89Mf7b8xmhGo
+        buhAyfUgYgaSD4LQgm0mCBXNtWXDkcIA+JIRSIqstR2Xqb62MCACDpon+0CW0DqgzW6YajHKDBoI
+        1DaLXis+68AHOSFFGdWAcca1XEdzHSw0mWoBZvaUOkntuTGfbMlBkP+V8WUfBohSALkx5XeQsfJ3
+        2fb+Xemh7YbJq5TMDNpUusPMbQyQp0eICYDsq7pkgjhdqYriUiBJ9HLebdodeXBW8J79abKjgtdO
+        s+3cCA9gwUn30ZUtC8B8o/2nCdlOq8UrVG9BTBLCz8OeHkIZuJvT+SvHgECrjFFaoaQoqPmp+AY0
+        VJRTkQHOkgd8NckRAscR8aWJ0WQIJF92DkACjpaPU2eiHv6rQgSwsgQeBLYC/AqJE3WmWlAydghV
+        yd3vAwDbVD1Z6hktaAFQUSoFbYJukI0a/ci+GTN6jP6zbU1rJ4viLZzImXccnbTbrOOElMKyo0nQ
+        sEFKx/AWhhMi0fqNwn/D8X/ixG/JSq8n5H6fY5CNA4iS40NUalCvTOX4Z8ajTtINCv/meNTw2nfF
+        o4b+/Jl45PtPe02WjvxK7Amd3pgVmGoJzilpGKYyhDo4V7pu6DvgH0GFR9vxZdVEKSSyS/E2MYtZ
+        9mxo7fpwcLMYt/4mWSjR3TZyJ8OkZ5TBnOHJUG9X0WTMztbFlHRdLMCc+7oYBAGs3uanU/LpaIcw
+        DNqWEd3d59CNgNqvDOXqbQxjD7QDw/YsgAKGnMPbvNSSs0IvAJaF3jSAD1tkP24RPU05vIxXX/g4
+        ADc5KLnNWDI0YIhiXiM+18hWnSCoBlO9owzq5ofsEcM/Ezg64VqdRIQ7zFQLZ7ocSI6b9IN9kKrN
+        A5B0U9QRUce5t9F8yNjyRfJDx0FHkeUNQaI9fEAZG3XdF7xnlHEA0FBGeCjfkDqkOZm+zys8J4e+
+        nGhoiXZDMkKyB9e3kzacvf4HlPHcAGbi2SOECi3yTPUO3SQCSTZM2JJpt/HP+F0jyjgT6G7aVffZ
+        dtLlnjAmQHmJ6KlzcEH5gnIycVeCb5xMty8Q+I5sVURErHSTRHa0SjEjq5/0UvCq478yMCixwnyt
+        Zac/YYXlhp1Mlky1ZMhJqfulrFnARzW8QakY3Gi5lOVXkIeIFt1wAzQkIMSv6JWtFkF/e68kPmrH
+        /2s6SfZ7rmulaZ7fHZ6wpCYsw05kOM280vArLZj4ZklKkyZ7O6yDz1FS5kBuCaTICAzFyhPtGcxY
+        RePKchB1p/yiuM6nFBDzsUQfyzP5f3Zwjc8UXplPmWoBZVZdt210nSFamY6VsWy9e46ofuxBV1Is
+        VzXbUwrDvHkNEtSBlVXalIXudWeTuhutBMPhuVlgkuo4UubOUbCgNrqQvd4RP9dbR77FLk5S5F35
+        2DT7K8FuGrQ+6jkreFUipdk5cUNLBc3x3pZ74tjXvL1lDYQmO5KPVmO6dq3RwWxQxHKCNa5DsS/W
+        pS0fen2bVcXTGIZDSu1btBoC1rBFZ4L7RmdPc7EAIHccWoK4PMCVt2GbEmsv+krUeANrsyX68/gw
+        P+v6ecguW+bUtg+z/uy9f9VDq7GmG5sWL0Flya3mZ3eh0YOr1j8tsV204eaDbp/g5pG55jcTjDxv
+        V9Pu+0ggllA4jKlOIOG0wq5rltPz9my0cFW18cZe6xam6ZFKBRNtAPvyXMPm516NdJeu4hIgNiPB
+        Hg1mKuQ9TtqO3ll8Rtgrj+pq/JEfnrjxmxWc1V7EwcF+KncGrLAJ3wMruA58F9DcdQ4243ptSvOD
+        3di3CfXisFAzzoPl5djvw+OkT485stsYyjVX0YQ3BXawXXLXLJ0vo1iyg1RSKj59HCtOS+e1pfhG
+        SuuqTaHqfUQYNfR99HUVF09ZGh8UD63+ABWMvaxC189vw09gwXLC5KrbbpL1EisHC5ZnySoI2mSJ
+        k0MlDhISKYhtxbWqZRipWIa2//uf8vwCL9AiGMFDXNCNAH8IS3JFQLLt7qViAo0U7wm6+0Dfh0rg
+        WiFqO4EcoTrPpO0ZRB8ftmI4qLdRrcR+HxYvk0a5019NxNILZaG/D7NvQA19+VUSzdRkXyuRcz34
+        yu7uQ+giHWyrOIadTKzVXY/jCx5zw8b727pPDh1BdLX94rR78whpEZIUy5HN96CGMm0VXTWcvcwI
+        +mw1WHuwhz2ObACbr8VU1xodD1YwkMddthlxTTpyur6+UehtxxjESmfKc9vOarzAj9aJXkP7PD5z
+        /MzpT8QemG0Wi94+gkGzZfqboOGdotp+PhiMdmezNbXOHe1AKFdlI7sxPFIm5UbWdGlSfJeXVq7W
+        s2EX7weqUbP2FuYd9dF4PN4u+ucBuSsFIdt1KQrJZbMcpez2iVQAKSfK1VyasgFKDSd7lJ4O9IWh
+        RE4Uz/MN1LOp2iO7sJTp6Fqiy/4BtOkn9t1QYmeXZ+m1/wcjk9WfJEeyYcmJwiFF/4Ax+SVHPhQ5
+        nQrPE8ikTiUlkdsseRHrCSpzkvSsPiCFsvryGU1woHEI3TDIbwgEuo6/NKR06ELZemKWMeY56KVQ
+        PwW4FNYXwXwMYbWo/D/dA0jiSz2gxw0n/a/0gJ5uWFoF3dLBj9Y/hup/MrPtKdcbqoPpZLVRjAO2
+        ssfieL2bAKTbI3vcXGMY2Y+3w51CBCJ+4PZCPzk6QG8miq0vunWjX9eIix7hsqGe4vCs26ap2dtA
+        wSSIBHl42I07kWVKFKcvWuxA1nbS25BerhoT1msK727Ei+PT6r0xmVDXQcvvXqh+h++1LrPNynwb
+        rsH1elI9aYdhX61l4gdqOTuYb61lovldtUx9by0/+/+rlu9BeVnL1JdqOZv3C2r5i3q+FFd9lv+a
+        oi+TnxMc+FPq2UT17GPxebJddlnWqznX/ZD2uzzRiHrWfOny5mEyn7iR8z7ZHvsX8chpR65Xj+Z2
+        NI15DzojxdKN6I2bDa2Q3bwfV+pKEt6l3tCGbOOkHK52d79Vh6fNsYOu9cLaP8lig641u9dQsE7u
+        uaY3LouDyHbZCF3FLd7t4cPl2TwbyKUn7bueQY5YZbicjI6NWcemPPYwmR2c4/xiYS3K655W5D6O
+        pyuBvtRngIhtasg1AqMJTD7e94Y0JvC0EPaImo3PZuTX+wH5I/3gu7SdrP/afvDs/69+cA/K9/eD
+        bN7P7wfUF7V91pl/rRcAx3D9impA4wqcn9IS6qglDEyKmxgcTte6Y0ne4wK7D4TgeMbttdUYGWK0
+        ah6W0LlsKa+3vhr+vjmCO6G31UdGf2SbMqV350rY6h54rTkX45ALdV912bXWXEN/esa242406ZHH
+        eG1uZ4Sxj5quxQn8pkZOehoei9KFvC75GPi7S3PhHWcCCXbXGqmfSJ2iRKsf8EJwUtXjEA99bo6j
+        b3TaOknfIPfUj1zdv0vuyV8s98/+/yrve1D+RHl/We7vj0H2W2VRkrprJD8/3H+x/GAp5dvTvz3/
+        D1lRoYe8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:43 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:53 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkaXNjb3VudF90b2tlbj5jMC0t
+      cWstOUJWS3l4MHlISTdZR1ZEMkluUlRvZGZRcVpHcDFfUXUyM0VIMjhZczVhbmtVdnpkMEV4TzE0
+      d2w3RW1GZnRDSDI3ZW1ONXkzQmxKamdsc0ZhS0JFOHZIODR2bkJyaFdiNFhBaUZ5YkFNTkhYQVVL
+      UTBqbHE0VnRtd0t3SE5PbkRMVENlT1dRUUNmdnRzODlrcldzN3BxdjVmUEZGSlp3azlNbHdBZGcx
+      YnpiV2FveXRqM2szb3ZsTVNrM05CTl9Vb2RDbXRCMERzY2k1bGZsLXBqaEpLS0tYUUR3RjJaPC9k
+      aXNjb3VudF90b2tlbj48cHV6emxlZD55ZXM8L3B1enpsZWQ+PGRlc3BhdGNoX3Rva2VuPmNfLS1G
+      eUpWRGY4RHlFRGhNWVU2Zllsa29BMUcxempMbnZkVndoN0tMSmticlhpaC1aeTJ4U3BTT0RkSGFI
+      emR5YUdqLXBySGQ0N0s3dmZDUkZYdU1FSnVValJLQnNHbldScW1IdDk4LXNoTHNSWklFbjlMQlcz
+      V1ZLczNQLS13Sm5RSE9fenB5WnV5VWlBLVk8L2Rlc3BhdGNoX3Rva2VuPjxjcnlwdG9fYmxvY2s+
+      TTMtLXBQNXQxM2dFYWM0a2FSQnpabTJob3ZVUmluTkhPc2syY0t2YlBualJsdGRKeDJDQ2owdzY5
+      ak45RVFxX3Zwek55a2tEVVJtOGk0aEpDblV0emJ2YjhBcUhJbGNlOEtmbWFDVEtyZHBmbGxGUjhF
+      SmFqbDdNVm9sSmdrNzMxU0wtN3pJVERUNl9YTnVwRG1FY1RxS3R1STNjRGw0Y3VlRWltVG5MMHJp
+      QWY0SHlSZXRIaklsUlRTZ3RVcFdFOF9FbVFEYnY3R2VWazlUclB5Z1B3aGh3SUVTOWtNbW1nT0RP
+      WUR6aHVsN1Y0N1c5Tl90YlNIVVB3b1FkNEZ6ZERxUy1adldIUEZCRDFIUHZrVk5XTC0yd1hVTUJZ
+      SlIxU3RSZ0szQXNfMDRiRVY1bG5DcGZFdlFvY2M3R0V6NmwtZGh2YzNzTGRGdERhUGQtUHdDNTJv
+      U29ibzFleWt2Um1KRk9jdE5wSF9YSllFME8xbVVwM0JkTmpOSXFIS0dsc3djQ3ZIdEZmTWFBRkVS
+      V3VZc2xzekZyb2U0SHpQZVdLNjVNNE5GWktybTFjeG5FdGRpd0ZTeGpERHRqTEQ0S0gyQjdJYTVv
+      YmRSR2J0QS1aPC9jcnlwdG9fYmxvY2s+PC9jcmVhdGVfb3JkZXI+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1148']
+      Content-Length: ['1008']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
+        H4sIAAAAAAAAA7VY2XLjuBV9z1ew+mHmIaG5aO9wOKW9ZVleJFmS/cLiAkm0SEICQC3+nfxJviyX
+        BChSsqbSmSSuLps491wA9+IuQBu/H8NA2iNCfRz99k27U79JKHKx50er3769Tnty/dvv5l8MlyCb
+        IQsTDxGLIBoHzDRo7Hg4tP3IiinAPrUc2zMjbCi3JYYbEwKzn/IvC5ZC5srZGsollDOWtsswMTVV
+        LXAEmLOiOHQQMet6tcASYM7aBraLqKkXOAIqcDBlFj2FDg6UIkyQQM1//qOon+M5CnrktGXYcgLs
+        bkzXkuWq7NCP+dNHMF4RJNOOcz9uPLXcZX09rB53k8dlnz1OnlvPTlUL1FPTd7a96Wr8Uhp674PP
+        jk9XnztGG97sx2uLWCffDwYrHZfr82iP3iZPM2cR9OkMP+/mnfmh5jgvGpr9mPW2sku0T//9hOy5
+        u5r1ds1P0pHfYKfF/Rn8XBneoMis6rL8flRlbRAd2/t5a9hYdtnboq82WAc1SbsfPcz6h9Wu8mPR
+        H9XR8TCddOo7/aU/6O3wptq+Xyx71n21/PBWZq1HN3Le41pVnSH/1B2w8eDw2Qg6u8FLadHc6c1h
+        975B1eWL3w3aeDhh6nTf7ez9Zs/W/U515I7eV/KijJv3R28dbYa91uKw9BalaIlaFW0zGNn68Zmw
+        oFtvfp68NVKX/rv9uWmMYxmTUml3Qp3RyDno88/jev/08sZG+DirnWrTYzir3J9au1Kz9XL/OGnY
+        4Xo/bTmd9kelNNdPVth2lg3NPtgf8vuQ6m5ra+nHwJ8ebH+kq4/DnX2oTiqzUT0s43c3Umn51WrY
+        nWnY1/36y3bufiw+P96qbzPWWw/cx2CNdtFC7i+I68z1Pn43lKLLuf9Nw0N0azN3bcGHa7ZxECCX
+        SUuCQ4mtEaRpFCNDuWTlSiFia+wVgDSR2k+tp4IOT67CkDJTu6tcMAD6L7eS5L/NbPPxdQrrF3iZ
+        IKey0xaZLp+/QEzhwvhsnE9dHEewQxeHjh8hzyw17pLSkA3PFG5rs/P6MIWJLsCck2686UE9kyiz
+        I88mXoHMzYqwhZcWhQpITc1QikMhY767QUVpBhgJbUt8F5mlSrLNfAzlk7hrm6yQWU4l52G+AdNA
+        4Gn4Y0P95Vvvzg0lH3FBus0uVPHTYY0IEgS+eddnoqQGOPJwJMcbcNYZ5PKU+pDKhVAoBzal4g/n
+        24RRoOSAEHI/glD6xQ63f5fa4NE42UpBbEAfSJsCn/aEYKZLKHEXeMHaoFO6kpI6LEOShiN4mdoZ
+        uZgs513P59mRi25Pys3JCBdgzkntaNkQrUwY2rlS4JYq+RaUzInJgRLh9vQQisBZnOq/Rj5DnjSE
+        Lgx9NKeKUyE+xBe04b2PDtYWETeJEd4gb4oML2nexI5WyEKRJ8bpZNN1/DdJo0yaoC1DSbuUdFWD
+        JppTODtmLgT2kiJmlqrJUtdoTqPIhVCCbCjX9FqlfMnOhJx+gp8w9DwzWVRtqJpgnnE4aVyvqpqV
+        wpCgkFohSumy2pBVbao1vpfU76r6V1X7nqx0W0HMe+0DPobMJ+yLVypsLY3s0//SH1W9XCupP+2P
+        ilr5j/xRgX9/xh/C/rTW8HBMCve42R52x4ZSgAUldcPIZtAJDlILxyRCv1LpEcwhNtQ9Ik27k2mm
+        yH3Gv33PrA56mQRGAg8g0LEJ09ksqRlFUDCgC6xNBZTlkK8rO+m6MpWj87oyQ5QpmX6qItTBQhZT
+        M/D35+kFlBF4Y1Kycdp/qB9uAySKeabHOxP/jrcUBQHslLILE7tfTYSv0Q+1iCs35lghbPEGGdjM
+        ZzH4vALtWW9UNa1UM5QzakA1X/FPWb3TVDjhShXutTlsKPlka5ta0JigHixpekG/AJJqmvQlaJ5Z
+        GRVDI7SPFomjCI6Cx42mgw1fUCOEqnuDd40aEUIeRMQW4g26QxqT6X5u4YIcE7AZRwVahnBCYgMm
+        YVKG+fa/oEZypefNs62NpfL00VDOUNYioOWyhG1tQlMVnfoaN+gap1V1yc1Jl7vCDApxCfR0cnSE
+        eIGYTKYrwBmH9+0jQySyA2kKRKmVBHLkSbkGz5/0HXWr4t8SGOn1jK81aXYeuuPJvPvwMDGUgkCQ
+        0uknthcgAjk8h1CkGU20MnEF+dOpD60szJ5iST0qDI2LY8pL7Bx50JW0/0cBbjS08s8XYO1rQ/qj
+        Spak1BbjQNwM09i4wpJEC/ww6e1pOBeG/6auaz/d59JI5LuTm+ozRLoAhIRae5/6TiCi9xrkrLwa
+        8sCGkidunzOhkkPG17y/zPnkNz+42l1JlZ5HhpJDXLpehyHckbQGb45FjK+Xp3Jyd7acxF5+vQf5
+        FVTkJGsoF0huWnImkDm7GNFzN4jwGUIev61fUwzeDgoeaA/G7Ydusu0rwQWVX+y2YI3k+sQN0KWC
+        8AZmdmBdPW2uQEG6epV8BS94hRfKLVhwr18r12hGu3y5XIM/XVnEs1e59b9L/wL2/DbImhIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:43 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1879']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:53 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order><crypto_block>E7--NuwIhns8SF9pSFmOCtayGoPi5orsAykdVtQtCufnKnVXd5ijHtnqR7hewEY9Siu9mKWZXgSi50wUnsm6QPTTn5Ap3rEh2y8qt7LQOigLgEgeiLH4ylijiJOz3cCcGHfmz-mr55XI7fNrF6K5mYhYQ3qn1nCceIO3_pGh-y2ODATK_1unwgfaRcvmf9rRBGVuoIht5KuL4JvyIf1HGwjOVpnEZgHPJm7kxU7hRzZCGSznxEZHloNsR7I2pTbq40t7v2mLo1javANm8iUGKktt-5o16BpnLLteyP0yqrtW48EZlb91SwCaca-PJX0S8BvzKCatNcVD_hETlolGxPekOoYcRxyhOS0oqh4PNL4fG5MfxXXjHxpdCbQvBrDibivFS6vhbjmFeBcQYWikaldIWXGQFooHSH2dWMs_BXrsAz6-j8VMn40F2LZish9H3g6jBjVkrnayZ4NMPTq5FtXcdK_5L7WFk2ASLauJCqJowO_bV8X2sPX_At8097h3QpXw1Kh0OkgxfUXvzDHbFI_bN0XSMiJ0al9y_p-VXab83-6hG9eHDURd6DtENaA6ZdPR1b2kCR_toknr_BpFKcDNzxpBDj9-GWfRRbpiCUM9rPYDDkijx5sFQiucuV4RNL_xRMwwjtm79e8Q_Ffs_Rbj0MXC_rEfuYOIlmhROtFCXJpXG4CNo46bV1NKHU8emAOPjTy5eN5yHKnfgvMsrKq0Ix6-yFmDNxXSz4pazVchj_p8eOwdiIe_aY0Ybh9RJBrav76RZUsxDdWqMKRqoWJyL_--Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>k0--5q_Eg4_-x1Nz1FPUkY_jXomw7H7E1_PjxiUKNYUK3emm0ERjusgvnWUYFQqZHjDGEekx61hC9iIriru1LpexlQdiFWf9oohhZR3m54tmVkLEMIItGP0eGhqQULniBgRbrSIgFusujEyS0Rw91TvO3pqX8rgNeFy0FDAL-H3GFetfBUfLnD1Zi-94KcFBeU0CKwDSXAHtxFWU5WZiFJ-wMeIriNlK_uoAMR58EAI8VqC-Z</discount_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></create_order>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['1384']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61Y23arNhB971e456UPLQGM7eCzKF2O7cSJr8eX2M4LC4NsEwMiSPj2O/2TflkH
-        JAw47urpJQ8J2rMljUaaPVK0346eW9qjkDjY//WLfCd9KSHfwrbjb379Mps+CuqX3/QfNCtEJkUG
-        Dm0UGiEikUt1jUQrG3um4xsRAdghxsq09RMimnjbpFlRGMLwp+zLgLmQvlkFmliEMsbatCgOdVmS
-        chwOZiw/8lYo1NVyLcfiYMYKXNNCRC/nOBzKcTChBjl5K+yKeThEHNX/+D3fP8MzFPqFp4BiY+Vi
-        a6fPDEHY74J1fdesB7PqcCVsQry2Zfp0sAaj5buCLPKutJZy7f3bbigt535r7027WzJrrduLozVr
-        dk4fS7e36ODFYycc7pzm49ZS3pUK8YYtuTYvnxfl1+FUmPq78NR4f1EHctUZHdQP1HHnZ9I9P66X
-        4F3eJ41tJsU75OvtsiBUUadq7KMoaLxvvlmbRefQD6aovqh/bCZueSm5i6Bq4f1hJhNSeZ4vHxrC
-        eKYaG2XUi9Tn7nmDwrOhdFxJUfCz8NpvW+et1Gjuh/35Uq2co6qC5s11Y9NYlPeV+5O6eXMx7TkV
-        ggeDtUqXiO4WH294JAzkrdudvewOb/ZqLjUnR1SbnTyzbb9PFuH5MJSGRms4HlvzoHZ8RuOHD2Oz
-        O1bmUX359jIiw261idqCGTwaPeXQDOyPLpooo5qhfHtr7MevU3v89BBNzhNh0XkJXmsR7ftC1OvK
-        C9MJBpFKW8+NoTto9NWn1pM1Wi7HMJJihB0Htu5bf9h7c04P/frD1vJPvaemOnVmw6k5PE4n87ra
-        wXar1Yx6HyevLffnlve6mGxrxxfyGvlWxaOjxWhwdO+FN03Mh5/tha7ZiAQmtbYGfFh6E7susmhp
-        HWKvRLcI8tSPkCYWWVknD9EttnNAkkjN4cMw14clV65JqC7fVQsMgP6jK3H+m9TUB7MpzJ/jpYaM
-        Sk8B0i02fo6YwLn2ZXEOsXDkg4cW9laOj2y9XL+LpSFtXihsrZPprNUeTGGoApyxEtcnNLKRT0sh
-        yFyOypblYwOvDQISSHRZE/NNbqOOtUN5awpoMS0IHQvp5VrsZtYG/QytrRlukK4klkszc0DXEEQa
-        /pggwMzx9lwTsxYzJG62QcZPhy0KEScw51fOJgqMvelGiGloHtAsh3LBdbFvY8iEHYTyAjJ7MlAv
-        sXMjG9pyTUL4H8aHo2HS2IEcxu1Jl2nRzoaB6pCUCjZcUj+KUBxEiI2xQ6d0BjGJZArGpYhT054X
-        pDBexrsx5M6xye1h2UK4vYBllGQtj6bnuKccia1QzOYV06DF2xvyMCdBzwMXc9J/5jsU2aUuFGWo
-        qhmV70LowGmDqrx30MEIUGjFJ4aVy5smzY5reWj6G2Qg3+Ztvj/RLyVZpdtSI9pEhJbKkgwFNSMw
-        bkQtOORrgqiu1OKJrtGMRpAFBwcyo3IvVytVqcBOjYx+gh/PsyGhYVJJlVXOvOCwuVitSbKRwKZv
-        Q5p5KKELkirI6lSuf1Wkr5L0syR/jWe63YGPex0B1ibUDOmnmJRlCEYDEtf9P0NSk8s1pfLdIamU
-        5X8UkopQlv9NSHgIEulh5zHW8XGj2W2PNTEHc0oShr5JIZEOpQcchT76iZQGsJzQBBkMf0w7sXix
-        b8fWa8+PqQVaHHfhlONMSPIgZ4B7NCK66+wvdg6lBFZkxLSd1BLieIGLuDCn/ViVYd9RQJDrwlSE
-        Fnxsf/bxr3yP8e4sj4s3xt4gbLAi6JrUiQuPXk1K8KWpgRhv2Kcg3cmx6QJoYtZ/axID6g0k9pro
-        PtbEAhBrYVxukH0RQd7UPPNohJHvQ1jZ/stlOBqfUM0DzbzBu0Y1HyEbdjeAcxPBfTg+S4k/t3BO
-        jqDUwqMjR0sRRojXgEPP9KFUJu5/QrX4ps5qYlMelyrTgSZeoFTgoZLSmG3sPF3iBfga18gWJ/K4
-        ZsthT5giphE410BPBkdHODqI0Hi4HJxymGyAvTQ5EYq80hsK8YXKkiC5QPEbSqPVa48n83avN9HE
-        nIGT2AXFtF0UQlrN4SCRlMbLC78k/KtshNLipQ+lWB5yTa0Q7Uzx5sgGRbyPq8T/r4j3IPz/QBHv
-        PyniX6VonBsBxi6/uSWbfIXFGeM6Xlxtk3OZa/6d0N5/r9AmR4p5JzTqDTiyHOAWYuwd4qxcfgyv
-        QcbKFI6dUJAxfjt85V0ySPucwMXkjX+zjbu/U6TSqK+JGcSs263nwa1FritJAc9jbL4sJ+O7Lbz2
-        Yb3J7PECr6A8J55DLCDZ0uI9gbvLR4TIReF9fIGQzW7T1xSNSXwuAs3ncbPXjt2+MhSo7KoVwGpK
-        lhNaLip24NHA1HSNq6fHFchJV6+Gz2CBl3tB3II59/o1cY2mtOLL4hr8bl3hz1Lx1r9//gSe8Zbz
-        OxIAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1828']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:44 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/OrderTests.test_event.yaml
+++ b/tests/interface_objects/cassettes/OrderTests.test_event.yaml
@@ -1,475 +1,427 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:44 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:53 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:44 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:54 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:44 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:54 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGNyeXB0b19ibG9jaz5FMC0tRXhJNTJKUkNxLWdMRHN2eDR3blVa
+      elpTV1NZRHFxZXZKRkd2bDRwb0NpdkNxVVVmdlVMQVhnOWJwOVhnNi1jY0s1THRRSlN2Um1MZXZl
+      eGUxMzBpNXo1UWdFV3puMVdtRTJ5WHdnVnhkTm85U21KZmNlWHlZN0tNTnQ4enV5Vkp3OWFSWE9T
+      ajV5Rk5wLTB3QWR2MktCSHZwaDZjRnFST2NyejktNGxEaHV4MlhIYUFtMUY0U2JuZEoybXF3a1Jn
+      WjwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bm9fb2ZfdGlja2V0cz4xPC9u
+      b19vZl90aWNrZXRzPjxiYW5kX3Rva2VuPi0xLS1RMW16UTBaV0tTZWNaazl6NFdQN1pCSi1GazFR
+      bGpSTGVIODl4djlzQ1llOGJFZXYxM2hoRkhheXlfNllkVWJIQUd5d0VSNlNSeW5ZLUJlWGhUd3Ey
+      YWQtYzVoQXc4WmhLcEpubTNONjJLZnpNM3B5QnNtUC1Dd0NVSVktY2dzV3F2S1kxcS1CUUFfQ1N3
+      SmE4SFJjdGZ2WlFpSktYN3JGZGNGTHlwQzZjQ29DWGdPaF9vc3ZXY295UU1MWjd1SWlpYk9Sa1ly
+      NFV2dEl3el8xbWhvVzNQVVdmRGVnUzJzWkpzV0RpcU56bXJkZ243Tlg4cjlfZmFaRGhPSDdjOUpi
+      WjwvYmFuZF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkZXNwYXRjaF90b2tlbj5jXy0t
+      RnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJYaWgtWnkyeFNwU09EZEhh
+      SHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5OC1zaExzUlpJRW45TEJX
+      M1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tlbj48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['449']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS0HvDihIg7XFxZDKMgoBCj+Tv9Jf1kHg4Je
+        O4fKzLeqlauS2GfHCeLEOWcHJvPHxbYqEfADw3V+/0R8xj9VgKO6muEcfv+0EgdY89Mf7b8xmhGo
+        buhAyfUgYgaSD4LQgm0mCBXNtWXDkcIA+JIRSIqstR2Xqb62MCACDpon+0CW0DqgzW6YajHKDBoI
+        1DaLXis+68AHOSFFGdWAcca1XEdzHSw0mWoBZvaUOkntuTGfbMlBkP+V8WUfBohSALkx5XeQsfJ3
+        2fb+Xemh7YbJq5TMDNpUusPMbQyQp0eICYDsq7pkgjhdqYriUiBJ9HLebdodeXBW8J79abKjgtdO
+        s+3cCA9gwUn30ZUtC8B8o/2nCdlOq8UrVG9BTBLCz8OeHkIZuJvT+SvHgECrjFFaoaQoqPmp+AY0
+        VJRTkQHOkgd8NckRAscR8aWJ0WQIJF92DkACjpaPU2eiHv6rQgSwsgQeBLYC/AqJE3WmWlAydghV
+        yd3vAwDbVD1Z6hktaAFQUSoFbYJukI0a/ci+GTN6jP6zbU1rJ4viLZzImXccnbTbrOOElMKyo0nQ
+        sEFKx/AWhhMi0fqNwn/D8X/ixG/JSq8n5H6fY5CNA4iS40NUalCvTOX4Z8ajTtINCv/meNTw2nfF
+        o4b+/Jl45PtPe02WjvxK7Amd3pgVmGoJzilpGKYyhDo4V7pu6DvgH0GFR9vxZdVEKSSyS/E2MYtZ
+        9mxo7fpwcLMYt/4mWSjR3TZyJ8OkZ5TBnOHJUG9X0WTMztbFlHRdLMCc+7oYBAGs3uanU/LpaIcw
+        DNqWEd3d59CNgNqvDOXqbQxjD7QDw/YsgAKGnMPbvNSSs0IvAJaF3jSAD1tkP24RPU05vIxXX/g4
+        ADc5KLnNWDI0YIhiXiM+18hWnSCoBlO9owzq5ofsEcM/Ezg64VqdRIQ7zFQLZ7ocSI6b9IN9kKrN
+        A5B0U9QRUce5t9F8yNjyRfJDx0FHkeUNQaI9fEAZG3XdF7xnlHEA0FBGeCjfkDqkOZm+zys8J4e+
+        nGhoiXZDMkKyB9e3kzacvf4HlPHcAGbi2SOECi3yTPUO3SQCSTZM2JJpt/HP+F0jyjgT6G7aVffZ
+        dtLlnjAmQHmJ6KlzcEH5gnIycVeCb5xMty8Q+I5sVURErHSTRHa0SjEjq5/0UvCq478yMCixwnyt
+        Zac/YYXlhp1Mlky1ZMhJqfulrFnARzW8QakY3Gi5lOVXkIeIFt1wAzQkIMSv6JWtFkF/e68kPmrH
+        /2s6SfZ7rmulaZ7fHZ6wpCYsw05kOM280vArLZj4ZklKkyZ7O6yDz1FS5kBuCaTICAzFyhPtGcxY
+        RePKchB1p/yiuM6nFBDzsUQfyzP5f3Zwjc8UXplPmWoBZVZdt210nSFamY6VsWy9e46ofuxBV1Is
+        VzXbUwrDvHkNEtSBlVXalIXudWeTuhutBMPhuVlgkuo4UubOUbCgNrqQvd4RP9dbR77FLk5S5F35
+        2DT7K8FuGrQ+6jkreFUipdk5cUNLBc3x3pZ74tjXvL1lDYQmO5KPVmO6dq3RwWxQxHKCNa5DsS/W
+        pS0fen2bVcXTGIZDSu1btBoC1rBFZ4L7RmdPc7EAIHccWoK4PMCVt2GbEmsv+krUeANrsyX68/gw
+        P+v6ecguW+bUtg+z/uy9f9VDq7GmG5sWL0Flya3mZ3eh0YOr1j8tsV204eaDbp/g5pG55jcTjDxv
+        V9Pu+0ggllA4jKlOIOG0wq5rltPz9my0cFW18cZe6xam6ZFKBRNtAPvyXMPm516NdJeu4hIgNiPB
+        Hg1mKuQ9TtqO3ll8Rtgrj+pq/JEfnrjxmxWc1V7EwcF+KncGrLAJ3wMruA58F9DcdQ4243ptSvOD
+        3di3CfXisFAzzoPl5djvw+OkT485stsYyjVX0YQ3BXawXXLXLJ0vo1iyg1RSKj59HCtOS+e1pfhG
+        SuuqTaHqfUQYNfR99HUVF09ZGh8UD63+ABWMvaxC189vw09gwXLC5KrbbpL1EisHC5ZnySoI2mSJ
+        k0MlDhISKYhtxbWqZRipWIa2//uf8vwCL9AiGMFDXNCNAH8IS3JFQLLt7qViAo0U7wm6+0Dfh0rg
+        WiFqO4EcoTrPpO0ZRB8ftmI4qLdRrcR+HxYvk0a5019NxNILZaG/D7NvQA19+VUSzdRkXyuRcz34
+        yu7uQ+giHWyrOIadTKzVXY/jCx5zw8b727pPDh1BdLX94rR78whpEZIUy5HN96CGMm0VXTWcvcwI
+        +mw1WHuwhz2ObACbr8VU1xodD1YwkMddthlxTTpyur6+UehtxxjESmfKc9vOarzAj9aJXkP7PD5z
+        /MzpT8QemG0Wi94+gkGzZfqboOGdotp+PhiMdmezNbXOHe1AKFdlI7sxPFIm5UbWdGlSfJeXVq7W
+        s2EX7weqUbP2FuYd9dF4PN4u+ucBuSsFIdt1KQrJZbMcpez2iVQAKSfK1VyasgFKDSd7lJ4O9IWh
+        RE4Uz/MN1LOp2iO7sJTp6Fqiy/4BtOkn9t1QYmeXZ+m1/wcjk9WfJEeyYcmJwiFF/4Ax+SVHPhQ5
+        nQrPE8ikTiUlkdsseRHrCSpzkvSsPiCFsvryGU1woHEI3TDIbwgEuo6/NKR06ELZemKWMeY56KVQ
+        PwW4FNYXwXwMYbWo/D/dA0jiSz2gxw0n/a/0gJ5uWFoF3dLBj9Y/hup/MrPtKdcbqoPpZLVRjAO2
+        ssfieL2bAKTbI3vcXGMY2Y+3w51CBCJ+4PZCPzk6QG8miq0vunWjX9eIix7hsqGe4vCs26ap2dtA
+        wSSIBHl42I07kWVKFKcvWuxA1nbS25BerhoT1msK727Ei+PT6r0xmVDXQcvvXqh+h++1LrPNynwb
+        rsH1elI9aYdhX61l4gdqOTuYb61lovldtUx9by0/+/+rlu9BeVnL1JdqOZv3C2r5i3q+FFd9lv+a
+        oi+TnxMc+FPq2UT17GPxebJddlnWqznX/ZD2uzzRiHrWfOny5mEyn7iR8z7ZHvsX8chpR65Xj+Z2
+        NI15DzojxdKN6I2bDa2Q3bwfV+pKEt6l3tCGbOOkHK52d79Vh6fNsYOu9cLaP8lig641u9dQsE7u
+        uaY3LouDyHbZCF3FLd7t4cPl2TwbyKUn7bueQY5YZbicjI6NWcemPPYwmR2c4/xiYS3K655W5D6O
+        pyuBvtRngIhtasg1AqMJTD7e94Y0JvC0EPaImo3PZuTX+wH5I/3gu7SdrP/afvDs/69+cA/K9/eD
+        bN7P7wfUF7V91pl/rRcAx3D9impA4wqcn9IS6qglDEyKmxgcTte6Y0ne4wK7D4TgeMbttdUYGWK0
+        ah6W0LlsKa+3vhr+vjmCO6G31UdGf2SbMqV350rY6h54rTkX45ALdV912bXWXEN/esa242406ZHH
+        eG1uZ4Sxj5quxQn8pkZOehoei9KFvC75GPi7S3PhHWcCCXbXGqmfSJ2iRKsf8EJwUtXjEA99bo6j
+        b3TaOknfIPfUj1zdv0vuyV8s98/+/yrve1D+RHl/We7vj0H2W2VRkrprJD8/3H+x/GAp5dvTvz3/
+        D1lRoYe8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:45 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:54 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkaXNjb3VudF90b2tlbj5jMC0t
+      cWstOUJWS3l4MHlISTdZR1ZEMkluUlRvZGZRcVpHcDFfUXUyM0VIMjhZczVhbmtVdnpkMEV4TzE0
+      d2w3RW1GZnRDSDI3ZW1ONXkzQmxKamdsc0ZhS0JFOHZIODR2bkJyaFdiNFhBaUZ5YkFNTkhYQVVL
+      UTBqbHE0VnRtd0t3SE5PbkRMVENlT1dRUUNmdnRzODlrcldzN3BxdjVmUEZGSlp3azlNbHdBZGcx
+      YnpiV2FveXRqM2szb3ZsTVNrM05CTl9Vb2RDbXRCMERzY2k1bGZsLXBqaEpLS0tYUUR3RjJaPC9k
+      aXNjb3VudF90b2tlbj48cHV6emxlZD55ZXM8L3B1enpsZWQ+PGRlc3BhdGNoX3Rva2VuPmNfLS1G
+      eUpWRGY4RHlFRGhNWVU2Zllsa29BMUcxempMbnZkVndoN0tMSmticlhpaC1aeTJ4U3BTT0RkSGFI
+      emR5YUdqLXBySGQ0N0s3dmZDUkZYdU1FSnVValJLQnNHbldScW1IdDk4LXNoTHNSWklFbjlMQlcz
+      V1ZLczNQLS13Sm5RSE9fenB5WnV5VWlBLVk8L2Rlc3BhdGNoX3Rva2VuPjxjcnlwdG9fYmxvY2s+
+      TTMtLXBQNXQxM2dFYWM0a2FSQnpabTJob3ZVUmluTkhPc2syY0t2YlBualJsdGRKeDJDQ2owdzY5
+      ak45RVFxX3Zwek55a2tEVVJtOGk0aEpDblV0emJ2YjhBcUhJbGNlOEtmbWFDVEtyZHBmbGxGUjhF
+      SmFqbDdNVm9sSmdrNzMxU0wtN3pJVERUNl9YTnVwRG1FY1RxS3R1STNjRGw0Y3VlRWltVG5MMHJp
+      QWY0SHlSZXRIaklsUlRTZ3RVcFdFOF9FbVFEYnY3R2VWazlUclB5Z1B3aGh3SUVTOWtNbW1nT0RP
+      WUR6aHVsN1Y0N1c5Tl90YlNIVVB3b1FkNEZ6ZERxUy1adldIUEZCRDFIUHZrVk5XTC0yd1hVTUJZ
+      SlIxU3RSZ0szQXNfMDRiRVY1bG5DcGZFdlFvY2M3R0V6NmwtZGh2YzNzTGRGdERhUGQtUHdDNTJv
+      U29ibzFleWt2Um1KRk9jdE5wSF9YSllFME8xbVVwM0JkTmpOSXFIS0dsc3djQ3ZIdEZmTWFBRkVS
+      V3VZc2xzekZyb2U0SHpQZVdLNjVNNE5GWktybTFjeG5FdGRpd0ZTeGpERHRqTEQ0S0gyQjdJYTVv
+      YmRSR2J0QS1aPC9jcnlwdG9fYmxvY2s+PC9jcmVhdGVfb3JkZXI+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1148']
+      Content-Length: ['1008']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
+        H4sIAAAAAAAAA7VY2XLjuBV9z1ew+mHmIaG5aO9wOKW9ZVleJFmS/cLiAkm0SEICQC3+nfxJviyX
+        BChSsqbSmSSuLps491wA9+IuQBu/H8NA2iNCfRz99k27U79JKHKx50er3769Tnty/dvv5l8MlyCb
+        IQsTDxGLIBoHzDRo7Hg4tP3IiinAPrUc2zMjbCi3JYYbEwKzn/IvC5ZC5srZGsollDOWtsswMTVV
+        LXAEmLOiOHQQMet6tcASYM7aBraLqKkXOAIqcDBlFj2FDg6UIkyQQM1//qOon+M5CnrktGXYcgLs
+        bkzXkuWq7NCP+dNHMF4RJNOOcz9uPLXcZX09rB53k8dlnz1OnlvPTlUL1FPTd7a96Wr8Uhp674PP
+        jk9XnztGG97sx2uLWCffDwYrHZfr82iP3iZPM2cR9OkMP+/mnfmh5jgvGpr9mPW2sku0T//9hOy5
+        u5r1ds1P0pHfYKfF/Rn8XBneoMis6rL8flRlbRAd2/t5a9hYdtnboq82WAc1SbsfPcz6h9Wu8mPR
+        H9XR8TCddOo7/aU/6O3wptq+Xyx71n21/PBWZq1HN3Le41pVnSH/1B2w8eDw2Qg6u8FLadHc6c1h
+        975B1eWL3w3aeDhh6nTf7ez9Zs/W/U515I7eV/KijJv3R28dbYa91uKw9BalaIlaFW0zGNn68Zmw
+        oFtvfp68NVKX/rv9uWmMYxmTUml3Qp3RyDno88/jev/08sZG+DirnWrTYzir3J9au1Kz9XL/OGnY
+        4Xo/bTmd9kelNNdPVth2lg3NPtgf8vuQ6m5ra+nHwJ8ebH+kq4/DnX2oTiqzUT0s43c3Umn51WrY
+        nWnY1/36y3bufiw+P96qbzPWWw/cx2CNdtFC7i+I68z1Pn43lKLLuf9Nw0N0azN3bcGHa7ZxECCX
+        SUuCQ4mtEaRpFCNDuWTlSiFia+wVgDSR2k+tp4IOT67CkDJTu6tcMAD6L7eS5L/NbPPxdQrrF3iZ
+        IKey0xaZLp+/QEzhwvhsnE9dHEewQxeHjh8hzyw17pLSkA3PFG5rs/P6MIWJLsCck2686UE9kyiz
+        I88mXoHMzYqwhZcWhQpITc1QikMhY767QUVpBhgJbUt8F5mlSrLNfAzlk7hrm6yQWU4l52G+AdNA
+        4Gn4Y0P95Vvvzg0lH3FBus0uVPHTYY0IEgS+eddnoqQGOPJwJMcbcNYZ5PKU+pDKhVAoBzal4g/n
+        24RRoOSAEHI/glD6xQ63f5fa4NE42UpBbEAfSJsCn/aEYKZLKHEXeMHaoFO6kpI6LEOShiN4mdoZ
+        uZgs513P59mRi25Pys3JCBdgzkntaNkQrUwY2rlS4JYq+RaUzInJgRLh9vQQisBZnOq/Rj5DnjSE
+        Lgx9NKeKUyE+xBe04b2PDtYWETeJEd4gb4oML2nexI5WyEKRJ8bpZNN1/DdJo0yaoC1DSbuUdFWD
+        JppTODtmLgT2kiJmlqrJUtdoTqPIhVCCbCjX9FqlfMnOhJx+gp8w9DwzWVRtqJpgnnE4aVyvqpqV
+        wpCgkFohSumy2pBVbao1vpfU76r6V1X7nqx0W0HMe+0DPobMJ+yLVypsLY3s0//SH1W9XCupP+2P
+        ilr5j/xRgX9/xh/C/rTW8HBMCve42R52x4ZSgAUldcPIZtAJDlILxyRCv1LpEcwhNtQ9Ik27k2mm
+        yH3Gv33PrA56mQRGAg8g0LEJ09ksqRlFUDCgC6xNBZTlkK8rO+m6MpWj87oyQ5QpmX6qItTBQhZT
+        M/D35+kFlBF4Y1Kycdp/qB9uAySKeabHOxP/jrcUBQHslLILE7tfTYSv0Q+1iCs35lghbPEGGdjM
+        ZzH4vALtWW9UNa1UM5QzakA1X/FPWb3TVDjhShXutTlsKPlka5ta0JigHixpekG/AJJqmvQlaJ5Z
+        GRVDI7SPFomjCI6Cx42mgw1fUCOEqnuDd40aEUIeRMQW4g26QxqT6X5u4YIcE7AZRwVahnBCYgMm
+        YVKG+fa/oEZypefNs62NpfL00VDOUNYioOWyhG1tQlMVnfoaN+gap1V1yc1Jl7vCDApxCfR0cnSE
+        eIGYTKYrwBmH9+0jQySyA2kKRKmVBHLkSbkGz5/0HXWr4t8SGOn1jK81aXYeuuPJvPvwMDGUgkCQ
+        0uknthcgAjk8h1CkGU20MnEF+dOpD60szJ5iST0qDI2LY8pL7Bx50JW0/0cBbjS08s8XYO1rQ/qj
+        Spak1BbjQNwM09i4wpJEC/ww6e1pOBeG/6auaz/d59JI5LuTm+ozRLoAhIRae5/6TiCi9xrkrLwa
+        8sCGkidunzOhkkPG17y/zPnkNz+42l1JlZ5HhpJDXLpehyHckbQGb45FjK+Xp3Jyd7acxF5+vQf5
+        FVTkJGsoF0huWnImkDm7GNFzN4jwGUIev61fUwzeDgoeaA/G7Ydusu0rwQWVX+y2YI3k+sQN0KWC
+        8AZmdmBdPW2uQEG6epV8BS94hRfKLVhwr18r12hGu3y5XIM/XVnEs1e59b9L/wL2/DbImhIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:45 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1879']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:55 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order><crypto_block>E7--NuwIhns8SF9pSFmOCtayGoPi5orsAykdVtQtCufnKnVXd5ijHtnqR7hewEY9Siu9mKWZXgSi50wUnsm6QPTTn5Ap3rEh2y8qt7LQOigLgEgeiLH4ylijiJOz3cCcGHfmz-mr55XI7fNrF6K5mYhYQ3qn1nCceIO3_pGh-y2ODATK_1unwgfaRcvmf9rRBGVuoIht5KuL4JvyIf1HGwjOVpnEZgHPJm7kxU7hRzZCGSznxEZHloNsR7I2pTbq40t7v2mLo1javANm8iUGKktt-5o16BpnLLteyP0yqrtW48EZlb91SwCaca-PJX0S8BvzKCatNcVD_hETlolGxPekOoYcRxyhOS0oqh4PNL4fG5MfxXXjHxpdCbQvBrDibivFS6vhbjmFeBcQYWikaldIWXGQFooHSH2dWMs_BXrsAz6-j8VMn40F2LZish9H3g6jBjVkrnayZ4NMPTq5FtXcdK_5L7WFk2ASLauJCqJowO_bV8X2sPX_At8097h3QpXw1Kh0OkgxfUXvzDHbFI_bN0XSMiJ0al9y_p-VXab83-6hG9eHDURd6DtENaA6ZdPR1b2kCR_toknr_BpFKcDNzxpBDj9-GWfRRbpiCUM9rPYDDkijx5sFQiucuV4RNL_xRMwwjtm79e8Q_Ffs_Rbj0MXC_rEfuYOIlmhROtFCXJpXG4CNo46bV1NKHU8emAOPjTy5eN5yHKnfgvMsrKq0Ix6-yFmDNxXSz4pazVchj_p8eOwdiIe_aY0Ybh9RJBrav76RZUsxDdWqMKRqoWJyL_--Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>k0--5q_Eg4_-x1Nz1FPUkY_jXomw7H7E1_PjxiUKNYUK3emm0ERjusgvnWUYFQqZHjDGEekx61hC9iIriru1LpexlQdiFWf9oohhZR3m54tmVkLEMIItGP0eGhqQULniBgRbrSIgFusujEyS0Rw91TvO3pqX8rgNeFy0FDAL-H3GFetfBUfLnD1Zi-94KcFBeU0CKwDSXAHtxFWU5WZiFJ-wMeIriNlK_uoAMR58EAI8VqC-Z</discount_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></create_order>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['1384']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61Y23arNhB971e456UPLQGM7eCzKF2O7cSJr8eX2M4LC4NsEwMiSPj2O/2TflkH
-        JAw47urpJQ8J2rMljUaaPVK0346eW9qjkDjY//WLfCd9KSHfwrbjb379Mps+CuqX3/QfNCtEJkUG
-        Dm0UGiEikUt1jUQrG3um4xsRAdghxsq09RMimnjbpFlRGMLwp+zLgLmQvlkFmliEMsbatCgOdVmS
-        chwOZiw/8lYo1NVyLcfiYMYKXNNCRC/nOBzKcTChBjl5K+yKeThEHNX/+D3fP8MzFPqFp4BiY+Vi
-        a6fPDEHY74J1fdesB7PqcCVsQry2Zfp0sAaj5buCLPKutJZy7f3bbigt535r7027WzJrrduLozVr
-        dk4fS7e36ODFYycc7pzm49ZS3pUK8YYtuTYvnxfl1+FUmPq78NR4f1EHctUZHdQP1HHnZ9I9P66X
-        4F3eJ41tJsU75OvtsiBUUadq7KMoaLxvvlmbRefQD6aovqh/bCZueSm5i6Bq4f1hJhNSeZ4vHxrC
-        eKYaG2XUi9Tn7nmDwrOhdFxJUfCz8NpvW+et1Gjuh/35Uq2co6qC5s11Y9NYlPeV+5O6eXMx7TkV
-        ggeDtUqXiO4WH294JAzkrdudvewOb/ZqLjUnR1SbnTyzbb9PFuH5MJSGRms4HlvzoHZ8RuOHD2Oz
-        O1bmUX359jIiw261idqCGTwaPeXQDOyPLpooo5qhfHtr7MevU3v89BBNzhNh0XkJXmsR7ftC1OvK
-        C9MJBpFKW8+NoTto9NWn1pM1Wi7HMJJihB0Htu5bf9h7c04P/frD1vJPvaemOnVmw6k5PE4n87ra
-        wXar1Yx6HyevLffnlve6mGxrxxfyGvlWxaOjxWhwdO+FN03Mh5/tha7ZiAQmtbYGfFh6E7susmhp
-        HWKvRLcI8tSPkCYWWVknD9EttnNAkkjN4cMw14clV65JqC7fVQsMgP6jK3H+m9TUB7MpzJ/jpYaM
-        Sk8B0i02fo6YwLn2ZXEOsXDkg4cW9laOj2y9XL+LpSFtXihsrZPprNUeTGGoApyxEtcnNLKRT0sh
-        yFyOypblYwOvDQISSHRZE/NNbqOOtUN5awpoMS0IHQvp5VrsZtYG/QytrRlukK4klkszc0DXEEQa
-        /pggwMzx9lwTsxYzJG62QcZPhy0KEScw51fOJgqMvelGiGloHtAsh3LBdbFvY8iEHYTyAjJ7MlAv
-        sXMjG9pyTUL4H8aHo2HS2IEcxu1Jl2nRzoaB6pCUCjZcUj+KUBxEiI2xQ6d0BjGJZArGpYhT054X
-        pDBexrsx5M6xye1h2UK4vYBllGQtj6bnuKccia1QzOYV06DF2xvyMCdBzwMXc9J/5jsU2aUuFGWo
-        qhmV70LowGmDqrx30MEIUGjFJ4aVy5smzY5reWj6G2Qg3+Ztvj/RLyVZpdtSI9pEhJbKkgwFNSMw
-        bkQtOORrgqiu1OKJrtGMRpAFBwcyo3IvVytVqcBOjYx+gh/PsyGhYVJJlVXOvOCwuVitSbKRwKZv
-        Q5p5KKELkirI6lSuf1Wkr5L0syR/jWe63YGPex0B1ibUDOmnmJRlCEYDEtf9P0NSk8s1pfLdIamU
-        5X8UkopQlv9NSHgIEulh5zHW8XGj2W2PNTEHc0oShr5JIZEOpQcchT76iZQGsJzQBBkMf0w7sXix
-        b8fWa8+PqQVaHHfhlONMSPIgZ4B7NCK66+wvdg6lBFZkxLSd1BLieIGLuDCn/ViVYd9RQJDrwlSE
-        Fnxsf/bxr3yP8e4sj4s3xt4gbLAi6JrUiQuPXk1K8KWpgRhv2Kcg3cmx6QJoYtZ/axID6g0k9pro
-        PtbEAhBrYVxukH0RQd7UPPNohJHvQ1jZ/stlOBqfUM0DzbzBu0Y1HyEbdjeAcxPBfTg+S4k/t3BO
-        jqDUwqMjR0sRRojXgEPP9KFUJu5/QrX4ps5qYlMelyrTgSZeoFTgoZLSmG3sPF3iBfga18gWJ/K4
-        ZsthT5giphE410BPBkdHODqI0Hi4HJxymGyAvTQ5EYq80hsK8YXKkiC5QPEbSqPVa48n83avN9HE
-        nIGT2AXFtF0UQlrN4SCRlMbLC78k/KtshNLipQ+lWB5yTa0Q7Uzx5sgGRbyPq8T/r4j3IPz/QBHv
-        PyniX6VonBsBxi6/uSWbfIXFGeM6Xlxtk3OZa/6d0N5/r9AmR4p5JzTqDTiyHOAWYuwd4qxcfgyv
-        QcbKFI6dUJAxfjt85V0ySPucwMXkjX+zjbu/U6TSqK+JGcSs263nwa1FritJAc9jbL4sJ+O7Lbz2
-        Yb3J7PECr6A8J55DLCDZ0uI9gbvLR4TIReF9fIGQzW7T1xSNSXwuAs3ncbPXjt2+MhSo7KoVwGpK
-        lhNaLip24NHA1HSNq6fHFchJV6+Gz2CBl3tB3II59/o1cY2mtOLL4hr8bl3hz1Lx1r9//gSe8Zbz
-        OxIAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1828']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:46 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/OrderTests.test_int_properties.yaml
+++ b/tests/interface_objects/cassettes/OrderTests.test_int_properties.yaml
@@ -1,475 +1,427 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:46 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:56 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:46 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:57 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:47 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:58 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGNyeXB0b19ibG9jaz5FMC0tRXhJNTJKUkNxLWdMRHN2eDR3blVa
+      elpTV1NZRHFxZXZKRkd2bDRwb0NpdkNxVVVmdlVMQVhnOWJwOVhnNi1jY0s1THRRSlN2Um1MZXZl
+      eGUxMzBpNXo1UWdFV3puMVdtRTJ5WHdnVnhkTm85U21KZmNlWHlZN0tNTnQ4enV5Vkp3OWFSWE9T
+      ajV5Rk5wLTB3QWR2MktCSHZwaDZjRnFST2NyejktNGxEaHV4MlhIYUFtMUY0U2JuZEoybXF3a1Jn
+      WjwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bm9fb2ZfdGlja2V0cz4xPC9u
+      b19vZl90aWNrZXRzPjxiYW5kX3Rva2VuPi0xLS1RMW16UTBaV0tTZWNaazl6NFdQN1pCSi1GazFR
+      bGpSTGVIODl4djlzQ1llOGJFZXYxM2hoRkhheXlfNllkVWJIQUd5d0VSNlNSeW5ZLUJlWGhUd3Ey
+      YWQtYzVoQXc4WmhLcEpubTNONjJLZnpNM3B5QnNtUC1Dd0NVSVktY2dzV3F2S1kxcS1CUUFfQ1N3
+      SmE4SFJjdGZ2WlFpSktYN3JGZGNGTHlwQzZjQ29DWGdPaF9vc3ZXY295UU1MWjd1SWlpYk9Sa1ly
+      NFV2dEl3el8xbWhvVzNQVVdmRGVnUzJzWkpzV0RpcU56bXJkZ243Tlg4cjlfZmFaRGhPSDdjOUpi
+      WjwvYmFuZF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkZXNwYXRjaF90b2tlbj5jXy0t
+      RnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJYaWgtWnkyeFNwU09EZEhh
+      SHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5OC1zaExzUlpJRW45TEJX
+      M1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tlbj48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['449']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS0HvDihIg7XFxZDKMgoBCj+Tv9Jf1kHg4Je
+        O4fKzLeqlauS2GfHCeLEOWcHJvPHxbYqEfADw3V+/0R8xj9VgKO6muEcfv+0EgdY89Mf7b8xmhGo
+        buhAyfUgYgaSD4LQgm0mCBXNtWXDkcIA+JIRSIqstR2Xqb62MCACDpon+0CW0DqgzW6YajHKDBoI
+        1DaLXis+68AHOSFFGdWAcca1XEdzHSw0mWoBZvaUOkntuTGfbMlBkP+V8WUfBohSALkx5XeQsfJ3
+        2fb+Xemh7YbJq5TMDNpUusPMbQyQp0eICYDsq7pkgjhdqYriUiBJ9HLebdodeXBW8J79abKjgtdO
+        s+3cCA9gwUn30ZUtC8B8o/2nCdlOq8UrVG9BTBLCz8OeHkIZuJvT+SvHgECrjFFaoaQoqPmp+AY0
+        VJRTkQHOkgd8NckRAscR8aWJ0WQIJF92DkACjpaPU2eiHv6rQgSwsgQeBLYC/AqJE3WmWlAydghV
+        yd3vAwDbVD1Z6hktaAFQUSoFbYJukI0a/ci+GTN6jP6zbU1rJ4viLZzImXccnbTbrOOElMKyo0nQ
+        sEFKx/AWhhMi0fqNwn/D8X/ixG/JSq8n5H6fY5CNA4iS40NUalCvTOX4Z8ajTtINCv/meNTw2nfF
+        o4b+/Jl45PtPe02WjvxK7Amd3pgVmGoJzilpGKYyhDo4V7pu6DvgH0GFR9vxZdVEKSSyS/E2MYtZ
+        9mxo7fpwcLMYt/4mWSjR3TZyJ8OkZ5TBnOHJUG9X0WTMztbFlHRdLMCc+7oYBAGs3uanU/LpaIcw
+        DNqWEd3d59CNgNqvDOXqbQxjD7QDw/YsgAKGnMPbvNSSs0IvAJaF3jSAD1tkP24RPU05vIxXX/g4
+        ADc5KLnNWDI0YIhiXiM+18hWnSCoBlO9owzq5ofsEcM/Ezg64VqdRIQ7zFQLZ7ocSI6b9IN9kKrN
+        A5B0U9QRUce5t9F8yNjyRfJDx0FHkeUNQaI9fEAZG3XdF7xnlHEA0FBGeCjfkDqkOZm+zys8J4e+
+        nGhoiXZDMkKyB9e3kzacvf4HlPHcAGbi2SOECi3yTPUO3SQCSTZM2JJpt/HP+F0jyjgT6G7aVffZ
+        dtLlnjAmQHmJ6KlzcEH5gnIycVeCb5xMty8Q+I5sVURErHSTRHa0SjEjq5/0UvCq478yMCixwnyt
+        Zac/YYXlhp1Mlky1ZMhJqfulrFnARzW8QakY3Gi5lOVXkIeIFt1wAzQkIMSv6JWtFkF/e68kPmrH
+        /2s6SfZ7rmulaZ7fHZ6wpCYsw05kOM280vArLZj4ZklKkyZ7O6yDz1FS5kBuCaTICAzFyhPtGcxY
+        RePKchB1p/yiuM6nFBDzsUQfyzP5f3Zwjc8UXplPmWoBZVZdt210nSFamY6VsWy9e46ofuxBV1Is
+        VzXbUwrDvHkNEtSBlVXalIXudWeTuhutBMPhuVlgkuo4UubOUbCgNrqQvd4RP9dbR77FLk5S5F35
+        2DT7K8FuGrQ+6jkreFUipdk5cUNLBc3x3pZ74tjXvL1lDYQmO5KPVmO6dq3RwWxQxHKCNa5DsS/W
+        pS0fen2bVcXTGIZDSu1btBoC1rBFZ4L7RmdPc7EAIHccWoK4PMCVt2GbEmsv+krUeANrsyX68/gw
+        P+v6ecguW+bUtg+z/uy9f9VDq7GmG5sWL0Flya3mZ3eh0YOr1j8tsV204eaDbp/g5pG55jcTjDxv
+        V9Pu+0ggllA4jKlOIOG0wq5rltPz9my0cFW18cZe6xam6ZFKBRNtAPvyXMPm516NdJeu4hIgNiPB
+        Hg1mKuQ9TtqO3ll8Rtgrj+pq/JEfnrjxmxWc1V7EwcF+KncGrLAJ3wMruA58F9DcdQ4243ptSvOD
+        3di3CfXisFAzzoPl5djvw+OkT485stsYyjVX0YQ3BXawXXLXLJ0vo1iyg1RSKj59HCtOS+e1pfhG
+        SuuqTaHqfUQYNfR99HUVF09ZGh8UD63+ABWMvaxC189vw09gwXLC5KrbbpL1EisHC5ZnySoI2mSJ
+        k0MlDhISKYhtxbWqZRipWIa2//uf8vwCL9AiGMFDXNCNAH8IS3JFQLLt7qViAo0U7wm6+0Dfh0rg
+        WiFqO4EcoTrPpO0ZRB8ftmI4qLdRrcR+HxYvk0a5019NxNILZaG/D7NvQA19+VUSzdRkXyuRcz34
+        yu7uQ+giHWyrOIadTKzVXY/jCx5zw8b727pPDh1BdLX94rR78whpEZIUy5HN96CGMm0VXTWcvcwI
+        +mw1WHuwhz2ObACbr8VU1xodD1YwkMddthlxTTpyur6+UehtxxjESmfKc9vOarzAj9aJXkP7PD5z
+        /MzpT8QemG0Wi94+gkGzZfqboOGdotp+PhiMdmezNbXOHe1AKFdlI7sxPFIm5UbWdGlSfJeXVq7W
+        s2EX7weqUbP2FuYd9dF4PN4u+ucBuSsFIdt1KQrJZbMcpez2iVQAKSfK1VyasgFKDSd7lJ4O9IWh
+        RE4Uz/MN1LOp2iO7sJTp6Fqiy/4BtOkn9t1QYmeXZ+m1/wcjk9WfJEeyYcmJwiFF/4Ax+SVHPhQ5
+        nQrPE8ikTiUlkdsseRHrCSpzkvSsPiCFsvryGU1woHEI3TDIbwgEuo6/NKR06ELZemKWMeY56KVQ
+        PwW4FNYXwXwMYbWo/D/dA0jiSz2gxw0n/a/0gJ5uWFoF3dLBj9Y/hup/MrPtKdcbqoPpZLVRjAO2
+        ssfieL2bAKTbI3vcXGMY2Y+3w51CBCJ+4PZCPzk6QG8miq0vunWjX9eIix7hsqGe4vCs26ap2dtA
+        wSSIBHl42I07kWVKFKcvWuxA1nbS25BerhoT1msK727Ei+PT6r0xmVDXQcvvXqh+h++1LrPNynwb
+        rsH1elI9aYdhX61l4gdqOTuYb61lovldtUx9by0/+/+rlu9BeVnL1JdqOZv3C2r5i3q+FFd9lv+a
+        oi+TnxMc+FPq2UT17GPxebJddlnWqznX/ZD2uzzRiHrWfOny5mEyn7iR8z7ZHvsX8chpR65Xj+Z2
+        NI15DzojxdKN6I2bDa2Q3bwfV+pKEt6l3tCGbOOkHK52d79Vh6fNsYOu9cLaP8lig641u9dQsE7u
+        uaY3LouDyHbZCF3FLd7t4cPl2TwbyKUn7bueQY5YZbicjI6NWcemPPYwmR2c4/xiYS3K655W5D6O
+        pyuBvtRngIhtasg1AqMJTD7e94Y0JvC0EPaImo3PZuTX+wH5I/3gu7SdrP/afvDs/69+cA/K9/eD
+        bN7P7wfUF7V91pl/rRcAx3D9impA4wqcn9IS6qglDEyKmxgcTte6Y0ne4wK7D4TgeMbttdUYGWK0
+        ah6W0LlsKa+3vhr+vjmCO6G31UdGf2SbMqV350rY6h54rTkX45ALdV912bXWXEN/esa242406ZHH
+        eG1uZ4Sxj5quxQn8pkZOehoei9KFvC75GPi7S3PhHWcCCXbXGqmfSJ2iRKsf8EJwUtXjEA99bo6j
+        b3TaOknfIPfUj1zdv0vuyV8s98/+/yrve1D+RHl/We7vj0H2W2VRkrprJD8/3H+x/GAp5dvTvz3/
+        D1lRoYe8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:47 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:59 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkaXNjb3VudF90b2tlbj5jMC0t
+      cWstOUJWS3l4MHlISTdZR1ZEMkluUlRvZGZRcVpHcDFfUXUyM0VIMjhZczVhbmtVdnpkMEV4TzE0
+      d2w3RW1GZnRDSDI3ZW1ONXkzQmxKamdsc0ZhS0JFOHZIODR2bkJyaFdiNFhBaUZ5YkFNTkhYQVVL
+      UTBqbHE0VnRtd0t3SE5PbkRMVENlT1dRUUNmdnRzODlrcldzN3BxdjVmUEZGSlp3azlNbHdBZGcx
+      YnpiV2FveXRqM2szb3ZsTVNrM05CTl9Vb2RDbXRCMERzY2k1bGZsLXBqaEpLS0tYUUR3RjJaPC9k
+      aXNjb3VudF90b2tlbj48cHV6emxlZD55ZXM8L3B1enpsZWQ+PGRlc3BhdGNoX3Rva2VuPmNfLS1G
+      eUpWRGY4RHlFRGhNWVU2Zllsa29BMUcxempMbnZkVndoN0tMSmticlhpaC1aeTJ4U3BTT0RkSGFI
+      emR5YUdqLXBySGQ0N0s3dmZDUkZYdU1FSnVValJLQnNHbldScW1IdDk4LXNoTHNSWklFbjlMQlcz
+      V1ZLczNQLS13Sm5RSE9fenB5WnV5VWlBLVk8L2Rlc3BhdGNoX3Rva2VuPjxjcnlwdG9fYmxvY2s+
+      TTMtLXBQNXQxM2dFYWM0a2FSQnpabTJob3ZVUmluTkhPc2syY0t2YlBualJsdGRKeDJDQ2owdzY5
+      ak45RVFxX3Zwek55a2tEVVJtOGk0aEpDblV0emJ2YjhBcUhJbGNlOEtmbWFDVEtyZHBmbGxGUjhF
+      SmFqbDdNVm9sSmdrNzMxU0wtN3pJVERUNl9YTnVwRG1FY1RxS3R1STNjRGw0Y3VlRWltVG5MMHJp
+      QWY0SHlSZXRIaklsUlRTZ3RVcFdFOF9FbVFEYnY3R2VWazlUclB5Z1B3aGh3SUVTOWtNbW1nT0RP
+      WUR6aHVsN1Y0N1c5Tl90YlNIVVB3b1FkNEZ6ZERxUy1adldIUEZCRDFIUHZrVk5XTC0yd1hVTUJZ
+      SlIxU3RSZ0szQXNfMDRiRVY1bG5DcGZFdlFvY2M3R0V6NmwtZGh2YzNzTGRGdERhUGQtUHdDNTJv
+      U29ibzFleWt2Um1KRk9jdE5wSF9YSllFME8xbVVwM0JkTmpOSXFIS0dsc3djQ3ZIdEZmTWFBRkVS
+      V3VZc2xzekZyb2U0SHpQZVdLNjVNNE5GWktybTFjeG5FdGRpd0ZTeGpERHRqTEQ0S0gyQjdJYTVv
+      YmRSR2J0QS1aPC9jcnlwdG9fYmxvY2s+PC9jcmVhdGVfb3JkZXI+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1148']
+      Content-Length: ['1008']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
+        H4sIAAAAAAAAA7VY2XLjuBV9z1ew+mHmIaG5aO9wOKW9ZVleJFmS/cLiAkm0SEICQC3+nfxJviyX
+        BChSsqbSmSSuLps491wA9+IuQBu/H8NA2iNCfRz99k27U79JKHKx50er3769Tnty/dvv5l8MlyCb
+        IQsTDxGLIBoHzDRo7Hg4tP3IiinAPrUc2zMjbCi3JYYbEwKzn/IvC5ZC5srZGsollDOWtsswMTVV
+        LXAEmLOiOHQQMet6tcASYM7aBraLqKkXOAIqcDBlFj2FDg6UIkyQQM1//qOon+M5CnrktGXYcgLs
+        bkzXkuWq7NCP+dNHMF4RJNOOcz9uPLXcZX09rB53k8dlnz1OnlvPTlUL1FPTd7a96Wr8Uhp674PP
+        jk9XnztGG97sx2uLWCffDwYrHZfr82iP3iZPM2cR9OkMP+/mnfmh5jgvGpr9mPW2sku0T//9hOy5
+        u5r1ds1P0pHfYKfF/Rn8XBneoMis6rL8flRlbRAd2/t5a9hYdtnboq82WAc1SbsfPcz6h9Wu8mPR
+        H9XR8TCddOo7/aU/6O3wptq+Xyx71n21/PBWZq1HN3Le41pVnSH/1B2w8eDw2Qg6u8FLadHc6c1h
+        975B1eWL3w3aeDhh6nTf7ez9Zs/W/U515I7eV/KijJv3R28dbYa91uKw9BalaIlaFW0zGNn68Zmw
+        oFtvfp68NVKX/rv9uWmMYxmTUml3Qp3RyDno88/jev/08sZG+DirnWrTYzir3J9au1Kz9XL/OGnY
+        4Xo/bTmd9kelNNdPVth2lg3NPtgf8vuQ6m5ra+nHwJ8ebH+kq4/DnX2oTiqzUT0s43c3Umn51WrY
+        nWnY1/36y3bufiw+P96qbzPWWw/cx2CNdtFC7i+I68z1Pn43lKLLuf9Nw0N0azN3bcGHa7ZxECCX
+        SUuCQ4mtEaRpFCNDuWTlSiFia+wVgDSR2k+tp4IOT67CkDJTu6tcMAD6L7eS5L/NbPPxdQrrF3iZ
+        IKey0xaZLp+/QEzhwvhsnE9dHEewQxeHjh8hzyw17pLSkA3PFG5rs/P6MIWJLsCck2686UE9kyiz
+        I88mXoHMzYqwhZcWhQpITc1QikMhY767QUVpBhgJbUt8F5mlSrLNfAzlk7hrm6yQWU4l52G+AdNA
+        4Gn4Y0P95Vvvzg0lH3FBus0uVPHTYY0IEgS+eddnoqQGOPJwJMcbcNYZ5PKU+pDKhVAoBzal4g/n
+        24RRoOSAEHI/glD6xQ63f5fa4NE42UpBbEAfSJsCn/aEYKZLKHEXeMHaoFO6kpI6LEOShiN4mdoZ
+        uZgs513P59mRi25Pys3JCBdgzkntaNkQrUwY2rlS4JYq+RaUzInJgRLh9vQQisBZnOq/Rj5DnjSE
+        Lgx9NKeKUyE+xBe04b2PDtYWETeJEd4gb4oML2nexI5WyEKRJ8bpZNN1/DdJo0yaoC1DSbuUdFWD
+        JppTODtmLgT2kiJmlqrJUtdoTqPIhVCCbCjX9FqlfMnOhJx+gp8w9DwzWVRtqJpgnnE4aVyvqpqV
+        wpCgkFohSumy2pBVbao1vpfU76r6V1X7nqx0W0HMe+0DPobMJ+yLVypsLY3s0//SH1W9XCupP+2P
+        ilr5j/xRgX9/xh/C/rTW8HBMCve42R52x4ZSgAUldcPIZtAJDlILxyRCv1LpEcwhNtQ9Ik27k2mm
+        yH3Gv33PrA56mQRGAg8g0LEJ09ksqRlFUDCgC6xNBZTlkK8rO+m6MpWj87oyQ5QpmX6qItTBQhZT
+        M/D35+kFlBF4Y1Kycdp/qB9uAySKeabHOxP/jrcUBQHslLILE7tfTYSv0Q+1iCs35lghbPEGGdjM
+        ZzH4vALtWW9UNa1UM5QzakA1X/FPWb3TVDjhShXutTlsKPlka5ta0JigHixpekG/AJJqmvQlaJ5Z
+        GRVDI7SPFomjCI6Cx42mgw1fUCOEqnuDd40aEUIeRMQW4g26QxqT6X5u4YIcE7AZRwVahnBCYgMm
+        YVKG+fa/oEZypefNs62NpfL00VDOUNYioOWyhG1tQlMVnfoaN+gap1V1yc1Jl7vCDApxCfR0cnSE
+        eIGYTKYrwBmH9+0jQySyA2kKRKmVBHLkSbkGz5/0HXWr4t8SGOn1jK81aXYeuuPJvPvwMDGUgkCQ
+        0uknthcgAjk8h1CkGU20MnEF+dOpD60szJ5iST0qDI2LY8pL7Bx50JW0/0cBbjS08s8XYO1rQ/qj
+        Spak1BbjQNwM09i4wpJEC/ww6e1pOBeG/6auaz/d59JI5LuTm+ozRLoAhIRae5/6TiCi9xrkrLwa
+        8sCGkidunzOhkkPG17y/zPnkNz+42l1JlZ5HhpJDXLpehyHckbQGb45FjK+Xp3Jyd7acxF5+vQf5
+        FVTkJGsoF0huWnImkDm7GNFzN4jwGUIev61fUwzeDgoeaA/G7Ydusu0rwQWVX+y2YI3k+sQN0KWC
+        8AZmdmBdPW2uQEG6epV8BS94hRfKLVhwr18r12hGu3y5XIM/XVnEs1e59b9L/wL2/DbImhIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:48 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1879']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:00 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order><crypto_block>E7--NuwIhns8SF9pSFmOCtayGoPi5orsAykdVtQtCufnKnVXd5ijHtnqR7hewEY9Siu9mKWZXgSi50wUnsm6QPTTn5Ap3rEh2y8qt7LQOigLgEgeiLH4ylijiJOz3cCcGHfmz-mr55XI7fNrF6K5mYhYQ3qn1nCceIO3_pGh-y2ODATK_1unwgfaRcvmf9rRBGVuoIht5KuL4JvyIf1HGwjOVpnEZgHPJm7kxU7hRzZCGSznxEZHloNsR7I2pTbq40t7v2mLo1javANm8iUGKktt-5o16BpnLLteyP0yqrtW48EZlb91SwCaca-PJX0S8BvzKCatNcVD_hETlolGxPekOoYcRxyhOS0oqh4PNL4fG5MfxXXjHxpdCbQvBrDibivFS6vhbjmFeBcQYWikaldIWXGQFooHSH2dWMs_BXrsAz6-j8VMn40F2LZish9H3g6jBjVkrnayZ4NMPTq5FtXcdK_5L7WFk2ASLauJCqJowO_bV8X2sPX_At8097h3QpXw1Kh0OkgxfUXvzDHbFI_bN0XSMiJ0al9y_p-VXab83-6hG9eHDURd6DtENaA6ZdPR1b2kCR_toknr_BpFKcDNzxpBDj9-GWfRRbpiCUM9rPYDDkijx5sFQiucuV4RNL_xRMwwjtm79e8Q_Ffs_Rbj0MXC_rEfuYOIlmhROtFCXJpXG4CNo46bV1NKHU8emAOPjTy5eN5yHKnfgvMsrKq0Ix6-yFmDNxXSz4pazVchj_p8eOwdiIe_aY0Ybh9RJBrav76RZUsxDdWqMKRqoWJyL_--Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>k0--5q_Eg4_-x1Nz1FPUkY_jXomw7H7E1_PjxiUKNYUK3emm0ERjusgvnWUYFQqZHjDGEekx61hC9iIriru1LpexlQdiFWf9oohhZR3m54tmVkLEMIItGP0eGhqQULniBgRbrSIgFusujEyS0Rw91TvO3pqX8rgNeFy0FDAL-H3GFetfBUfLnD1Zi-94KcFBeU0CKwDSXAHtxFWU5WZiFJ-wMeIriNlK_uoAMR58EAI8VqC-Z</discount_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></create_order>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['1384']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61Y23arNhB971e456UPLQGM7eCzKF2O7cSJr8eX2M4LC4NsEwMiSPj2O/2TflkH
-        JAw47urpJQ8J2rMljUaaPVK0346eW9qjkDjY//WLfCd9KSHfwrbjb379Mps+CuqX3/QfNCtEJkUG
-        Dm0UGiEikUt1jUQrG3um4xsRAdghxsq09RMimnjbpFlRGMLwp+zLgLmQvlkFmliEMsbatCgOdVmS
-        chwOZiw/8lYo1NVyLcfiYMYKXNNCRC/nOBzKcTChBjl5K+yKeThEHNX/+D3fP8MzFPqFp4BiY+Vi
-        a6fPDEHY74J1fdesB7PqcCVsQry2Zfp0sAaj5buCLPKutJZy7f3bbigt535r7027WzJrrduLozVr
-        dk4fS7e36ODFYycc7pzm49ZS3pUK8YYtuTYvnxfl1+FUmPq78NR4f1EHctUZHdQP1HHnZ9I9P66X
-        4F3eJ41tJsU75OvtsiBUUadq7KMoaLxvvlmbRefQD6aovqh/bCZueSm5i6Bq4f1hJhNSeZ4vHxrC
-        eKYaG2XUi9Tn7nmDwrOhdFxJUfCz8NpvW+et1Gjuh/35Uq2co6qC5s11Y9NYlPeV+5O6eXMx7TkV
-        ggeDtUqXiO4WH294JAzkrdudvewOb/ZqLjUnR1SbnTyzbb9PFuH5MJSGRms4HlvzoHZ8RuOHD2Oz
-        O1bmUX359jIiw261idqCGTwaPeXQDOyPLpooo5qhfHtr7MevU3v89BBNzhNh0XkJXmsR7ftC1OvK
-        C9MJBpFKW8+NoTto9NWn1pM1Wi7HMJJihB0Htu5bf9h7c04P/frD1vJPvaemOnVmw6k5PE4n87ra
-        wXar1Yx6HyevLffnlve6mGxrxxfyGvlWxaOjxWhwdO+FN03Mh5/tha7ZiAQmtbYGfFh6E7susmhp
-        HWKvRLcI8tSPkCYWWVknD9EttnNAkkjN4cMw14clV65JqC7fVQsMgP6jK3H+m9TUB7MpzJ/jpYaM
-        Sk8B0i02fo6YwLn2ZXEOsXDkg4cW9laOj2y9XL+LpSFtXihsrZPprNUeTGGoApyxEtcnNLKRT0sh
-        yFyOypblYwOvDQISSHRZE/NNbqOOtUN5awpoMS0IHQvp5VrsZtYG/QytrRlukK4klkszc0DXEEQa
-        /pggwMzx9lwTsxYzJG62QcZPhy0KEScw51fOJgqMvelGiGloHtAsh3LBdbFvY8iEHYTyAjJ7MlAv
-        sXMjG9pyTUL4H8aHo2HS2IEcxu1Jl2nRzoaB6pCUCjZcUj+KUBxEiI2xQ6d0BjGJZArGpYhT054X
-        pDBexrsx5M6xye1h2UK4vYBllGQtj6bnuKccia1QzOYV06DF2xvyMCdBzwMXc9J/5jsU2aUuFGWo
-        qhmV70LowGmDqrx30MEIUGjFJ4aVy5smzY5reWj6G2Qg3+Ztvj/RLyVZpdtSI9pEhJbKkgwFNSMw
-        bkQtOORrgqiu1OKJrtGMRpAFBwcyo3IvVytVqcBOjYx+gh/PsyGhYVJJlVXOvOCwuVitSbKRwKZv
-        Q5p5KKELkirI6lSuf1Wkr5L0syR/jWe63YGPex0B1ibUDOmnmJRlCEYDEtf9P0NSk8s1pfLdIamU
-        5X8UkopQlv9NSHgIEulh5zHW8XGj2W2PNTEHc0oShr5JIZEOpQcchT76iZQGsJzQBBkMf0w7sXix
-        b8fWa8+PqQVaHHfhlONMSPIgZ4B7NCK66+wvdg6lBFZkxLSd1BLieIGLuDCn/ViVYd9RQJDrwlSE
-        Fnxsf/bxr3yP8e4sj4s3xt4gbLAi6JrUiQuPXk1K8KWpgRhv2Kcg3cmx6QJoYtZ/axID6g0k9pro
-        PtbEAhBrYVxukH0RQd7UPPNohJHvQ1jZ/stlOBqfUM0DzbzBu0Y1HyEbdjeAcxPBfTg+S4k/t3BO
-        jqDUwqMjR0sRRojXgEPP9KFUJu5/QrX4ps5qYlMelyrTgSZeoFTgoZLSmG3sPF3iBfga18gWJ/K4
-        ZsthT5giphE410BPBkdHODqI0Hi4HJxymGyAvTQ5EYq80hsK8YXKkiC5QPEbSqPVa48n83avN9HE
-        nIGT2AXFtF0UQlrN4SCRlMbLC78k/KtshNLipQ+lWB5yTa0Q7Uzx5sgGRbyPq8T/r4j3IPz/QBHv
-        PyniX6VonBsBxi6/uSWbfIXFGeM6Xlxtk3OZa/6d0N5/r9AmR4p5JzTqDTiyHOAWYuwd4qxcfgyv
-        QcbKFI6dUJAxfjt85V0ySPucwMXkjX+zjbu/U6TSqK+JGcSs263nwa1FritJAc9jbL4sJ+O7Lbz2
-        Yb3J7PECr6A8J55DLCDZ0uI9gbvLR4TIReF9fIGQzW7T1xSNSXwuAs3ncbPXjt2+MhSo7KoVwGpK
-        lhNaLip24NHA1HSNq6fHFchJV6+Gz2CBl3tB3II59/o1cY2mtOLL4hr8bl3hz1Lx1r9//gSe8Zbz
-        OxIAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1828']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:48 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/OrderTests.test_performance.yaml
+++ b/tests/interface_objects/cassettes/OrderTests.test_performance.yaml
@@ -1,475 +1,427 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:48 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:00 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:48 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:00 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:49 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:01 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGNyeXB0b19ibG9jaz5FMC0tRXhJNTJKUkNxLWdMRHN2eDR3blVa
+      elpTV1NZRHFxZXZKRkd2bDRwb0NpdkNxVVVmdlVMQVhnOWJwOVhnNi1jY0s1THRRSlN2Um1MZXZl
+      eGUxMzBpNXo1UWdFV3puMVdtRTJ5WHdnVnhkTm85U21KZmNlWHlZN0tNTnQ4enV5Vkp3OWFSWE9T
+      ajV5Rk5wLTB3QWR2MktCSHZwaDZjRnFST2NyejktNGxEaHV4MlhIYUFtMUY0U2JuZEoybXF3a1Jn
+      WjwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bm9fb2ZfdGlja2V0cz4xPC9u
+      b19vZl90aWNrZXRzPjxiYW5kX3Rva2VuPi0xLS1RMW16UTBaV0tTZWNaazl6NFdQN1pCSi1GazFR
+      bGpSTGVIODl4djlzQ1llOGJFZXYxM2hoRkhheXlfNllkVWJIQUd5d0VSNlNSeW5ZLUJlWGhUd3Ey
+      YWQtYzVoQXc4WmhLcEpubTNONjJLZnpNM3B5QnNtUC1Dd0NVSVktY2dzV3F2S1kxcS1CUUFfQ1N3
+      SmE4SFJjdGZ2WlFpSktYN3JGZGNGTHlwQzZjQ29DWGdPaF9vc3ZXY295UU1MWjd1SWlpYk9Sa1ly
+      NFV2dEl3el8xbWhvVzNQVVdmRGVnUzJzWkpzV0RpcU56bXJkZ243Tlg4cjlfZmFaRGhPSDdjOUpi
+      WjwvYmFuZF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkZXNwYXRjaF90b2tlbj5jXy0t
+      RnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJYaWgtWnkyeFNwU09EZEhh
+      SHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5OC1zaExzUlpJRW45TEJX
+      M1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tlbj48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['449']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS0HvDihIg7XFxZDKMgoBCj+Tv9Jf1kHg4Je
+        O4fKzLeqlauS2GfHCeLEOWcHJvPHxbYqEfADw3V+/0R8xj9VgKO6muEcfv+0EgdY89Mf7b8xmhGo
+        buhAyfUgYgaSD4LQgm0mCBXNtWXDkcIA+JIRSIqstR2Xqb62MCACDpon+0CW0DqgzW6YajHKDBoI
+        1DaLXis+68AHOSFFGdWAcca1XEdzHSw0mWoBZvaUOkntuTGfbMlBkP+V8WUfBohSALkx5XeQsfJ3
+        2fb+Xemh7YbJq5TMDNpUusPMbQyQp0eICYDsq7pkgjhdqYriUiBJ9HLebdodeXBW8J79abKjgtdO
+        s+3cCA9gwUn30ZUtC8B8o/2nCdlOq8UrVG9BTBLCz8OeHkIZuJvT+SvHgECrjFFaoaQoqPmp+AY0
+        VJRTkQHOkgd8NckRAscR8aWJ0WQIJF92DkACjpaPU2eiHv6rQgSwsgQeBLYC/AqJE3WmWlAydghV
+        yd3vAwDbVD1Z6hktaAFQUSoFbYJukI0a/ci+GTN6jP6zbU1rJ4viLZzImXccnbTbrOOElMKyo0nQ
+        sEFKx/AWhhMi0fqNwn/D8X/ixG/JSq8n5H6fY5CNA4iS40NUalCvTOX4Z8ajTtINCv/meNTw2nfF
+        o4b+/Jl45PtPe02WjvxK7Amd3pgVmGoJzilpGKYyhDo4V7pu6DvgH0GFR9vxZdVEKSSyS/E2MYtZ
+        9mxo7fpwcLMYt/4mWSjR3TZyJ8OkZ5TBnOHJUG9X0WTMztbFlHRdLMCc+7oYBAGs3uanU/LpaIcw
+        DNqWEd3d59CNgNqvDOXqbQxjD7QDw/YsgAKGnMPbvNSSs0IvAJaF3jSAD1tkP24RPU05vIxXX/g4
+        ADc5KLnNWDI0YIhiXiM+18hWnSCoBlO9owzq5ofsEcM/Ezg64VqdRIQ7zFQLZ7ocSI6b9IN9kKrN
+        A5B0U9QRUce5t9F8yNjyRfJDx0FHkeUNQaI9fEAZG3XdF7xnlHEA0FBGeCjfkDqkOZm+zys8J4e+
+        nGhoiXZDMkKyB9e3kzacvf4HlPHcAGbi2SOECi3yTPUO3SQCSTZM2JJpt/HP+F0jyjgT6G7aVffZ
+        dtLlnjAmQHmJ6KlzcEH5gnIycVeCb5xMty8Q+I5sVURErHSTRHa0SjEjq5/0UvCq478yMCixwnyt
+        Zac/YYXlhp1Mlky1ZMhJqfulrFnARzW8QakY3Gi5lOVXkIeIFt1wAzQkIMSv6JWtFkF/e68kPmrH
+        /2s6SfZ7rmulaZ7fHZ6wpCYsw05kOM280vArLZj4ZklKkyZ7O6yDz1FS5kBuCaTICAzFyhPtGcxY
+        RePKchB1p/yiuM6nFBDzsUQfyzP5f3Zwjc8UXplPmWoBZVZdt210nSFamY6VsWy9e46ofuxBV1Is
+        VzXbUwrDvHkNEtSBlVXalIXudWeTuhutBMPhuVlgkuo4UubOUbCgNrqQvd4RP9dbR77FLk5S5F35
+        2DT7K8FuGrQ+6jkreFUipdk5cUNLBc3x3pZ74tjXvL1lDYQmO5KPVmO6dq3RwWxQxHKCNa5DsS/W
+        pS0fen2bVcXTGIZDSu1btBoC1rBFZ4L7RmdPc7EAIHccWoK4PMCVt2GbEmsv+krUeANrsyX68/gw
+        P+v6ecguW+bUtg+z/uy9f9VDq7GmG5sWL0Flya3mZ3eh0YOr1j8tsV204eaDbp/g5pG55jcTjDxv
+        V9Pu+0ggllA4jKlOIOG0wq5rltPz9my0cFW18cZe6xam6ZFKBRNtAPvyXMPm516NdJeu4hIgNiPB
+        Hg1mKuQ9TtqO3ll8Rtgrj+pq/JEfnrjxmxWc1V7EwcF+KncGrLAJ3wMruA58F9DcdQ4243ptSvOD
+        3di3CfXisFAzzoPl5djvw+OkT485stsYyjVX0YQ3BXawXXLXLJ0vo1iyg1RSKj59HCtOS+e1pfhG
+        SuuqTaHqfUQYNfR99HUVF09ZGh8UD63+ABWMvaxC189vw09gwXLC5KrbbpL1EisHC5ZnySoI2mSJ
+        k0MlDhISKYhtxbWqZRipWIa2//uf8vwCL9AiGMFDXNCNAH8IS3JFQLLt7qViAo0U7wm6+0Dfh0rg
+        WiFqO4EcoTrPpO0ZRB8ftmI4qLdRrcR+HxYvk0a5019NxNILZaG/D7NvQA19+VUSzdRkXyuRcz34
+        yu7uQ+giHWyrOIadTKzVXY/jCx5zw8b727pPDh1BdLX94rR78whpEZIUy5HN96CGMm0VXTWcvcwI
+        +mw1WHuwhz2ObACbr8VU1xodD1YwkMddthlxTTpyur6+UehtxxjESmfKc9vOarzAj9aJXkP7PD5z
+        /MzpT8QemG0Wi94+gkGzZfqboOGdotp+PhiMdmezNbXOHe1AKFdlI7sxPFIm5UbWdGlSfJeXVq7W
+        s2EX7weqUbP2FuYd9dF4PN4u+ucBuSsFIdt1KQrJZbMcpez2iVQAKSfK1VyasgFKDSd7lJ4O9IWh
+        RE4Uz/MN1LOp2iO7sJTp6Fqiy/4BtOkn9t1QYmeXZ+m1/wcjk9WfJEeyYcmJwiFF/4Ax+SVHPhQ5
+        nQrPE8ikTiUlkdsseRHrCSpzkvSsPiCFsvryGU1woHEI3TDIbwgEuo6/NKR06ELZemKWMeY56KVQ
+        PwW4FNYXwXwMYbWo/D/dA0jiSz2gxw0n/a/0gJ5uWFoF3dLBj9Y/hup/MrPtKdcbqoPpZLVRjAO2
+        ssfieL2bAKTbI3vcXGMY2Y+3w51CBCJ+4PZCPzk6QG8miq0vunWjX9eIix7hsqGe4vCs26ap2dtA
+        wSSIBHl42I07kWVKFKcvWuxA1nbS25BerhoT1msK727Ei+PT6r0xmVDXQcvvXqh+h++1LrPNynwb
+        rsH1elI9aYdhX61l4gdqOTuYb61lovldtUx9by0/+/+rlu9BeVnL1JdqOZv3C2r5i3q+FFd9lv+a
+        oi+TnxMc+FPq2UT17GPxebJddlnWqznX/ZD2uzzRiHrWfOny5mEyn7iR8z7ZHvsX8chpR65Xj+Z2
+        NI15DzojxdKN6I2bDa2Q3bwfV+pKEt6l3tCGbOOkHK52d79Vh6fNsYOu9cLaP8lig641u9dQsE7u
+        uaY3LouDyHbZCF3FLd7t4cPl2TwbyKUn7bueQY5YZbicjI6NWcemPPYwmR2c4/xiYS3K655W5D6O
+        pyuBvtRngIhtasg1AqMJTD7e94Y0JvC0EPaImo3PZuTX+wH5I/3gu7SdrP/afvDs/69+cA/K9/eD
+        bN7P7wfUF7V91pl/rRcAx3D9impA4wqcn9IS6qglDEyKmxgcTte6Y0ne4wK7D4TgeMbttdUYGWK0
+        ah6W0LlsKa+3vhr+vjmCO6G31UdGf2SbMqV350rY6h54rTkX45ALdV912bXWXEN/esa242406ZHH
+        eG1uZ4Sxj5quxQn8pkZOehoei9KFvC75GPi7S3PhHWcCCXbXGqmfSJ2iRKsf8EJwUtXjEA99bo6j
+        b3TaOknfIPfUj1zdv0vuyV8s98/+/yrve1D+RHl/We7vj0H2W2VRkrprJD8/3H+x/GAp5dvTvz3/
+        D1lRoYe8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:49 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:01 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkaXNjb3VudF90b2tlbj5jMC0t
+      cWstOUJWS3l4MHlISTdZR1ZEMkluUlRvZGZRcVpHcDFfUXUyM0VIMjhZczVhbmtVdnpkMEV4TzE0
+      d2w3RW1GZnRDSDI3ZW1ONXkzQmxKamdsc0ZhS0JFOHZIODR2bkJyaFdiNFhBaUZ5YkFNTkhYQVVL
+      UTBqbHE0VnRtd0t3SE5PbkRMVENlT1dRUUNmdnRzODlrcldzN3BxdjVmUEZGSlp3azlNbHdBZGcx
+      YnpiV2FveXRqM2szb3ZsTVNrM05CTl9Vb2RDbXRCMERzY2k1bGZsLXBqaEpLS0tYUUR3RjJaPC9k
+      aXNjb3VudF90b2tlbj48cHV6emxlZD55ZXM8L3B1enpsZWQ+PGRlc3BhdGNoX3Rva2VuPmNfLS1G
+      eUpWRGY4RHlFRGhNWVU2Zllsa29BMUcxempMbnZkVndoN0tMSmticlhpaC1aeTJ4U3BTT0RkSGFI
+      emR5YUdqLXBySGQ0N0s3dmZDUkZYdU1FSnVValJLQnNHbldScW1IdDk4LXNoTHNSWklFbjlMQlcz
+      V1ZLczNQLS13Sm5RSE9fenB5WnV5VWlBLVk8L2Rlc3BhdGNoX3Rva2VuPjxjcnlwdG9fYmxvY2s+
+      TTMtLXBQNXQxM2dFYWM0a2FSQnpabTJob3ZVUmluTkhPc2syY0t2YlBualJsdGRKeDJDQ2owdzY5
+      ak45RVFxX3Zwek55a2tEVVJtOGk0aEpDblV0emJ2YjhBcUhJbGNlOEtmbWFDVEtyZHBmbGxGUjhF
+      SmFqbDdNVm9sSmdrNzMxU0wtN3pJVERUNl9YTnVwRG1FY1RxS3R1STNjRGw0Y3VlRWltVG5MMHJp
+      QWY0SHlSZXRIaklsUlRTZ3RVcFdFOF9FbVFEYnY3R2VWazlUclB5Z1B3aGh3SUVTOWtNbW1nT0RP
+      WUR6aHVsN1Y0N1c5Tl90YlNIVVB3b1FkNEZ6ZERxUy1adldIUEZCRDFIUHZrVk5XTC0yd1hVTUJZ
+      SlIxU3RSZ0szQXNfMDRiRVY1bG5DcGZFdlFvY2M3R0V6NmwtZGh2YzNzTGRGdERhUGQtUHdDNTJv
+      U29ibzFleWt2Um1KRk9jdE5wSF9YSllFME8xbVVwM0JkTmpOSXFIS0dsc3djQ3ZIdEZmTWFBRkVS
+      V3VZc2xzekZyb2U0SHpQZVdLNjVNNE5GWktybTFjeG5FdGRpd0ZTeGpERHRqTEQ0S0gyQjdJYTVv
+      YmRSR2J0QS1aPC9jcnlwdG9fYmxvY2s+PC9jcmVhdGVfb3JkZXI+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1148']
+      Content-Length: ['1008']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
+        H4sIAAAAAAAAA7VY2XLjuBV9z1ew+mHmIaG5aO9wOKW9ZVleJFmS/cLiAkm0SEICQC3+nfxJviyX
+        BChSsqbSmSSuLps491wA9+IuQBu/H8NA2iNCfRz99k27U79JKHKx50er3769Tnty/dvv5l8MlyCb
+        IQsTDxGLIBoHzDRo7Hg4tP3IiinAPrUc2zMjbCi3JYYbEwKzn/IvC5ZC5srZGsollDOWtsswMTVV
+        LXAEmLOiOHQQMet6tcASYM7aBraLqKkXOAIqcDBlFj2FDg6UIkyQQM1//qOon+M5CnrktGXYcgLs
+        bkzXkuWq7NCP+dNHMF4RJNOOcz9uPLXcZX09rB53k8dlnz1OnlvPTlUL1FPTd7a96Wr8Uhp674PP
+        jk9XnztGG97sx2uLWCffDwYrHZfr82iP3iZPM2cR9OkMP+/mnfmh5jgvGpr9mPW2sku0T//9hOy5
+        u5r1ds1P0pHfYKfF/Rn8XBneoMis6rL8flRlbRAd2/t5a9hYdtnboq82WAc1SbsfPcz6h9Wu8mPR
+        H9XR8TCddOo7/aU/6O3wptq+Xyx71n21/PBWZq1HN3Le41pVnSH/1B2w8eDw2Qg6u8FLadHc6c1h
+        975B1eWL3w3aeDhh6nTf7ez9Zs/W/U515I7eV/KijJv3R28dbYa91uKw9BalaIlaFW0zGNn68Zmw
+        oFtvfp68NVKX/rv9uWmMYxmTUml3Qp3RyDno88/jev/08sZG+DirnWrTYzir3J9au1Kz9XL/OGnY
+        4Xo/bTmd9kelNNdPVth2lg3NPtgf8vuQ6m5ra+nHwJ8ebH+kq4/DnX2oTiqzUT0s43c3Umn51WrY
+        nWnY1/36y3bufiw+P96qbzPWWw/cx2CNdtFC7i+I68z1Pn43lKLLuf9Nw0N0azN3bcGHa7ZxECCX
+        SUuCQ4mtEaRpFCNDuWTlSiFia+wVgDSR2k+tp4IOT67CkDJTu6tcMAD6L7eS5L/NbPPxdQrrF3iZ
+        IKey0xaZLp+/QEzhwvhsnE9dHEewQxeHjh8hzyw17pLSkA3PFG5rs/P6MIWJLsCck2686UE9kyiz
+        I88mXoHMzYqwhZcWhQpITc1QikMhY767QUVpBhgJbUt8F5mlSrLNfAzlk7hrm6yQWU4l52G+AdNA
+        4Gn4Y0P95Vvvzg0lH3FBus0uVPHTYY0IEgS+eddnoqQGOPJwJMcbcNYZ5PKU+pDKhVAoBzal4g/n
+        24RRoOSAEHI/glD6xQ63f5fa4NE42UpBbEAfSJsCn/aEYKZLKHEXeMHaoFO6kpI6LEOShiN4mdoZ
+        uZgs513P59mRi25Pys3JCBdgzkntaNkQrUwY2rlS4JYq+RaUzInJgRLh9vQQisBZnOq/Rj5DnjSE
+        Lgx9NKeKUyE+xBe04b2PDtYWETeJEd4gb4oML2nexI5WyEKRJ8bpZNN1/DdJo0yaoC1DSbuUdFWD
+        JppTODtmLgT2kiJmlqrJUtdoTqPIhVCCbCjX9FqlfMnOhJx+gp8w9DwzWVRtqJpgnnE4aVyvqpqV
+        wpCgkFohSumy2pBVbao1vpfU76r6V1X7nqx0W0HMe+0DPobMJ+yLVypsLY3s0//SH1W9XCupP+2P
+        ilr5j/xRgX9/xh/C/rTW8HBMCve42R52x4ZSgAUldcPIZtAJDlILxyRCv1LpEcwhNtQ9Ik27k2mm
+        yH3Gv33PrA56mQRGAg8g0LEJ09ksqRlFUDCgC6xNBZTlkK8rO+m6MpWj87oyQ5QpmX6qItTBQhZT
+        M/D35+kFlBF4Y1Kycdp/qB9uAySKeabHOxP/jrcUBQHslLILE7tfTYSv0Q+1iCs35lghbPEGGdjM
+        ZzH4vALtWW9UNa1UM5QzakA1X/FPWb3TVDjhShXutTlsKPlka5ta0JigHixpekG/AJJqmvQlaJ5Z
+        GRVDI7SPFomjCI6Cx42mgw1fUCOEqnuDd40aEUIeRMQW4g26QxqT6X5u4YIcE7AZRwVahnBCYgMm
+        YVKG+fa/oEZypefNs62NpfL00VDOUNYioOWyhG1tQlMVnfoaN+gap1V1yc1Jl7vCDApxCfR0cnSE
+        eIGYTKYrwBmH9+0jQySyA2kKRKmVBHLkSbkGz5/0HXWr4t8SGOn1jK81aXYeuuPJvPvwMDGUgkCQ
+        0uknthcgAjk8h1CkGU20MnEF+dOpD60szJ5iST0qDI2LY8pL7Bx50JW0/0cBbjS08s8XYO1rQ/qj
+        Spak1BbjQNwM09i4wpJEC/ww6e1pOBeG/6auaz/d59JI5LuTm+ozRLoAhIRae5/6TiCi9xrkrLwa
+        8sCGkidunzOhkkPG17y/zPnkNz+42l1JlZ5HhpJDXLpehyHckbQGb45FjK+Xp3Jyd7acxF5+vQf5
+        FVTkJGsoF0huWnImkDm7GNFzN4jwGUIev61fUwzeDgoeaA/G7Ydusu0rwQWVX+y2YI3k+sQN0KWC
+        8AZmdmBdPW2uQEG6epV8BS94hRfKLVhwr18r12hGu3y5XIM/XVnEs1e59b9L/wL2/DbImhIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:49 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1879']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:02 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order><crypto_block>E7--NuwIhns8SF9pSFmOCtayGoPi5orsAykdVtQtCufnKnVXd5ijHtnqR7hewEY9Siu9mKWZXgSi50wUnsm6QPTTn5Ap3rEh2y8qt7LQOigLgEgeiLH4ylijiJOz3cCcGHfmz-mr55XI7fNrF6K5mYhYQ3qn1nCceIO3_pGh-y2ODATK_1unwgfaRcvmf9rRBGVuoIht5KuL4JvyIf1HGwjOVpnEZgHPJm7kxU7hRzZCGSznxEZHloNsR7I2pTbq40t7v2mLo1javANm8iUGKktt-5o16BpnLLteyP0yqrtW48EZlb91SwCaca-PJX0S8BvzKCatNcVD_hETlolGxPekOoYcRxyhOS0oqh4PNL4fG5MfxXXjHxpdCbQvBrDibivFS6vhbjmFeBcQYWikaldIWXGQFooHSH2dWMs_BXrsAz6-j8VMn40F2LZish9H3g6jBjVkrnayZ4NMPTq5FtXcdK_5L7WFk2ASLauJCqJowO_bV8X2sPX_At8097h3QpXw1Kh0OkgxfUXvzDHbFI_bN0XSMiJ0al9y_p-VXab83-6hG9eHDURd6DtENaA6ZdPR1b2kCR_toknr_BpFKcDNzxpBDj9-GWfRRbpiCUM9rPYDDkijx5sFQiucuV4RNL_xRMwwjtm79e8Q_Ffs_Rbj0MXC_rEfuYOIlmhROtFCXJpXG4CNo46bV1NKHU8emAOPjTy5eN5yHKnfgvMsrKq0Ix6-yFmDNxXSz4pazVchj_p8eOwdiIe_aY0Ybh9RJBrav76RZUsxDdWqMKRqoWJyL_--Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>k0--5q_Eg4_-x1Nz1FPUkY_jXomw7H7E1_PjxiUKNYUK3emm0ERjusgvnWUYFQqZHjDGEekx61hC9iIriru1LpexlQdiFWf9oohhZR3m54tmVkLEMIItGP0eGhqQULniBgRbrSIgFusujEyS0Rw91TvO3pqX8rgNeFy0FDAL-H3GFetfBUfLnD1Zi-94KcFBeU0CKwDSXAHtxFWU5WZiFJ-wMeIriNlK_uoAMR58EAI8VqC-Z</discount_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></create_order>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['1384']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61Y23arNhB971e456UPLQGM7eCzKF2O7cSJr8eX2M4LC4NsEwMiSPj2O/2TflkH
-        JAw47urpJQ8J2rMljUaaPVK0346eW9qjkDjY//WLfCd9KSHfwrbjb379Mps+CuqX3/QfNCtEJkUG
-        Dm0UGiEikUt1jUQrG3um4xsRAdghxsq09RMimnjbpFlRGMLwp+zLgLmQvlkFmliEMsbatCgOdVmS
-        chwOZiw/8lYo1NVyLcfiYMYKXNNCRC/nOBzKcTChBjl5K+yKeThEHNX/+D3fP8MzFPqFp4BiY+Vi
-        a6fPDEHY74J1fdesB7PqcCVsQry2Zfp0sAaj5buCLPKutJZy7f3bbigt535r7027WzJrrduLozVr
-        dk4fS7e36ODFYycc7pzm49ZS3pUK8YYtuTYvnxfl1+FUmPq78NR4f1EHctUZHdQP1HHnZ9I9P66X
-        4F3eJ41tJsU75OvtsiBUUadq7KMoaLxvvlmbRefQD6aovqh/bCZueSm5i6Bq4f1hJhNSeZ4vHxrC
-        eKYaG2XUi9Tn7nmDwrOhdFxJUfCz8NpvW+et1Gjuh/35Uq2co6qC5s11Y9NYlPeV+5O6eXMx7TkV
-        ggeDtUqXiO4WH294JAzkrdudvewOb/ZqLjUnR1SbnTyzbb9PFuH5MJSGRms4HlvzoHZ8RuOHD2Oz
-        O1bmUX359jIiw261idqCGTwaPeXQDOyPLpooo5qhfHtr7MevU3v89BBNzhNh0XkJXmsR7ftC1OvK
-        C9MJBpFKW8+NoTto9NWn1pM1Wi7HMJJihB0Htu5bf9h7c04P/frD1vJPvaemOnVmw6k5PE4n87ra
-        wXar1Yx6HyevLffnlve6mGxrxxfyGvlWxaOjxWhwdO+FN03Mh5/tha7ZiAQmtbYGfFh6E7susmhp
-        HWKvRLcI8tSPkCYWWVknD9EttnNAkkjN4cMw14clV65JqC7fVQsMgP6jK3H+m9TUB7MpzJ/jpYaM
-        Sk8B0i02fo6YwLn2ZXEOsXDkg4cW9laOj2y9XL+LpSFtXihsrZPprNUeTGGoApyxEtcnNLKRT0sh
-        yFyOypblYwOvDQISSHRZE/NNbqOOtUN5awpoMS0IHQvp5VrsZtYG/QytrRlukK4klkszc0DXEEQa
-        /pggwMzx9lwTsxYzJG62QcZPhy0KEScw51fOJgqMvelGiGloHtAsh3LBdbFvY8iEHYTyAjJ7MlAv
-        sXMjG9pyTUL4H8aHo2HS2IEcxu1Jl2nRzoaB6pCUCjZcUj+KUBxEiI2xQ6d0BjGJZArGpYhT054X
-        pDBexrsx5M6xye1h2UK4vYBllGQtj6bnuKccia1QzOYV06DF2xvyMCdBzwMXc9J/5jsU2aUuFGWo
-        qhmV70LowGmDqrx30MEIUGjFJ4aVy5smzY5reWj6G2Qg3+Ztvj/RLyVZpdtSI9pEhJbKkgwFNSMw
-        bkQtOORrgqiu1OKJrtGMRpAFBwcyo3IvVytVqcBOjYx+gh/PsyGhYVJJlVXOvOCwuVitSbKRwKZv
-        Q5p5KKELkirI6lSuf1Wkr5L0syR/jWe63YGPex0B1ibUDOmnmJRlCEYDEtf9P0NSk8s1pfLdIamU
-        5X8UkopQlv9NSHgIEulh5zHW8XGj2W2PNTEHc0oShr5JIZEOpQcchT76iZQGsJzQBBkMf0w7sXix
-        b8fWa8+PqQVaHHfhlONMSPIgZ4B7NCK66+wvdg6lBFZkxLSd1BLieIGLuDCn/ViVYd9RQJDrwlSE
-        Fnxsf/bxr3yP8e4sj4s3xt4gbLAi6JrUiQuPXk1K8KWpgRhv2Kcg3cmx6QJoYtZ/axID6g0k9pro
-        PtbEAhBrYVxukH0RQd7UPPNohJHvQ1jZ/stlOBqfUM0DzbzBu0Y1HyEbdjeAcxPBfTg+S4k/t3BO
-        jqDUwqMjR0sRRojXgEPP9KFUJu5/QrX4ps5qYlMelyrTgSZeoFTgoZLSmG3sPF3iBfga18gWJ/K4
-        ZsthT5giphE410BPBkdHODqI0Hi4HJxymGyAvTQ5EYq80hsK8YXKkiC5QPEbSqPVa48n83avN9HE
-        nIGT2AXFtF0UQlrN4SCRlMbLC78k/KtshNLipQ+lWB5yTa0Q7Uzx5sgGRbyPq8T/r4j3IPz/QBHv
-        PyniX6VonBsBxi6/uSWbfIXFGeM6Xlxtk3OZa/6d0N5/r9AmR4p5JzTqDTiyHOAWYuwd4qxcfgyv
-        QcbKFI6dUJAxfjt85V0ySPucwMXkjX+zjbu/U6TSqK+JGcSs263nwa1FritJAc9jbL4sJ+O7Lbz2
-        Yb3J7PECr6A8J55DLCDZ0uI9gbvLR4TIReF9fIGQzW7T1xSNSXwuAs3ncbPXjt2+MhSo7KoVwGpK
-        lhNaLip24NHA1HSNq6fHFchJV6+Gz2CBl3tB3II59/o1cY2mtOLL4hr8bl3hz1Lx1r9//gSe8Zbz
-        OxIAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1828']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:50 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/OrderTests.test_string_properties.yaml
+++ b/tests/interface_objects/cassettes/OrderTests.test_string_properties.yaml
@@ -1,475 +1,427 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:50 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:02 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:50 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:02 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:51 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:03 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGNyeXB0b19ibG9jaz5FMC0tRXhJNTJKUkNxLWdMRHN2eDR3blVa
+      elpTV1NZRHFxZXZKRkd2bDRwb0NpdkNxVVVmdlVMQVhnOWJwOVhnNi1jY0s1THRRSlN2Um1MZXZl
+      eGUxMzBpNXo1UWdFV3puMVdtRTJ5WHdnVnhkTm85U21KZmNlWHlZN0tNTnQ4enV5Vkp3OWFSWE9T
+      ajV5Rk5wLTB3QWR2MktCSHZwaDZjRnFST2NyejktNGxEaHV4MlhIYUFtMUY0U2JuZEoybXF3a1Jn
+      WjwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bm9fb2ZfdGlja2V0cz4xPC9u
+      b19vZl90aWNrZXRzPjxiYW5kX3Rva2VuPi0xLS1RMW16UTBaV0tTZWNaazl6NFdQN1pCSi1GazFR
+      bGpSTGVIODl4djlzQ1llOGJFZXYxM2hoRkhheXlfNllkVWJIQUd5d0VSNlNSeW5ZLUJlWGhUd3Ey
+      YWQtYzVoQXc4WmhLcEpubTNONjJLZnpNM3B5QnNtUC1Dd0NVSVktY2dzV3F2S1kxcS1CUUFfQ1N3
+      SmE4SFJjdGZ2WlFpSktYN3JGZGNGTHlwQzZjQ29DWGdPaF9vc3ZXY295UU1MWjd1SWlpYk9Sa1ly
+      NFV2dEl3el8xbWhvVzNQVVdmRGVnUzJzWkpzV0RpcU56bXJkZ243Tlg4cjlfZmFaRGhPSDdjOUpi
+      WjwvYmFuZF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkZXNwYXRjaF90b2tlbj5jXy0t
+      RnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJYaWgtWnkyeFNwU09EZEhh
+      SHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5OC1zaExzUlpJRW45TEJX
+      M1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tlbj48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['449']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS0HvDihIg7XFxZDKMgoBCj+Tv9Jf1kHg4Je
+        O4fKzLeqlauS2GfHCeLEOWcHJvPHxbYqEfADw3V+/0R8xj9VgKO6muEcfv+0EgdY89Mf7b8xmhGo
+        buhAyfUgYgaSD4LQgm0mCBXNtWXDkcIA+JIRSIqstR2Xqb62MCACDpon+0CW0DqgzW6YajHKDBoI
+        1DaLXis+68AHOSFFGdWAcca1XEdzHSw0mWoBZvaUOkntuTGfbMlBkP+V8WUfBohSALkx5XeQsfJ3
+        2fb+Xemh7YbJq5TMDNpUusPMbQyQp0eICYDsq7pkgjhdqYriUiBJ9HLebdodeXBW8J79abKjgtdO
+        s+3cCA9gwUn30ZUtC8B8o/2nCdlOq8UrVG9BTBLCz8OeHkIZuJvT+SvHgECrjFFaoaQoqPmp+AY0
+        VJRTkQHOkgd8NckRAscR8aWJ0WQIJF92DkACjpaPU2eiHv6rQgSwsgQeBLYC/AqJE3WmWlAydghV
+        yd3vAwDbVD1Z6hktaAFQUSoFbYJukI0a/ci+GTN6jP6zbU1rJ4viLZzImXccnbTbrOOElMKyo0nQ
+        sEFKx/AWhhMi0fqNwn/D8X/ixG/JSq8n5H6fY5CNA4iS40NUalCvTOX4Z8ajTtINCv/meNTw2nfF
+        o4b+/Jl45PtPe02WjvxK7Amd3pgVmGoJzilpGKYyhDo4V7pu6DvgH0GFR9vxZdVEKSSyS/E2MYtZ
+        9mxo7fpwcLMYt/4mWSjR3TZyJ8OkZ5TBnOHJUG9X0WTMztbFlHRdLMCc+7oYBAGs3uanU/LpaIcw
+        DNqWEd3d59CNgNqvDOXqbQxjD7QDw/YsgAKGnMPbvNSSs0IvAJaF3jSAD1tkP24RPU05vIxXX/g4
+        ADc5KLnNWDI0YIhiXiM+18hWnSCoBlO9owzq5ofsEcM/Ezg64VqdRIQ7zFQLZ7ocSI6b9IN9kKrN
+        A5B0U9QRUce5t9F8yNjyRfJDx0FHkeUNQaI9fEAZG3XdF7xnlHEA0FBGeCjfkDqkOZm+zys8J4e+
+        nGhoiXZDMkKyB9e3kzacvf4HlPHcAGbi2SOECi3yTPUO3SQCSTZM2JJpt/HP+F0jyjgT6G7aVffZ
+        dtLlnjAmQHmJ6KlzcEH5gnIycVeCb5xMty8Q+I5sVURErHSTRHa0SjEjq5/0UvCq478yMCixwnyt
+        Zac/YYXlhp1Mlky1ZMhJqfulrFnARzW8QakY3Gi5lOVXkIeIFt1wAzQkIMSv6JWtFkF/e68kPmrH
+        /2s6SfZ7rmulaZ7fHZ6wpCYsw05kOM280vArLZj4ZklKkyZ7O6yDz1FS5kBuCaTICAzFyhPtGcxY
+        RePKchB1p/yiuM6nFBDzsUQfyzP5f3Zwjc8UXplPmWoBZVZdt210nSFamY6VsWy9e46ofuxBV1Is
+        VzXbUwrDvHkNEtSBlVXalIXudWeTuhutBMPhuVlgkuo4UubOUbCgNrqQvd4RP9dbR77FLk5S5F35
+        2DT7K8FuGrQ+6jkreFUipdk5cUNLBc3x3pZ74tjXvL1lDYQmO5KPVmO6dq3RwWxQxHKCNa5DsS/W
+        pS0fen2bVcXTGIZDSu1btBoC1rBFZ4L7RmdPc7EAIHccWoK4PMCVt2GbEmsv+krUeANrsyX68/gw
+        P+v6ecguW+bUtg+z/uy9f9VDq7GmG5sWL0Flya3mZ3eh0YOr1j8tsV204eaDbp/g5pG55jcTjDxv
+        V9Pu+0ggllA4jKlOIOG0wq5rltPz9my0cFW18cZe6xam6ZFKBRNtAPvyXMPm516NdJeu4hIgNiPB
+        Hg1mKuQ9TtqO3ll8Rtgrj+pq/JEfnrjxmxWc1V7EwcF+KncGrLAJ3wMruA58F9DcdQ4243ptSvOD
+        3di3CfXisFAzzoPl5djvw+OkT485stsYyjVX0YQ3BXawXXLXLJ0vo1iyg1RSKj59HCtOS+e1pfhG
+        SuuqTaHqfUQYNfR99HUVF09ZGh8UD63+ABWMvaxC189vw09gwXLC5KrbbpL1EisHC5ZnySoI2mSJ
+        k0MlDhISKYhtxbWqZRipWIa2//uf8vwCL9AiGMFDXNCNAH8IS3JFQLLt7qViAo0U7wm6+0Dfh0rg
+        WiFqO4EcoTrPpO0ZRB8ftmI4qLdRrcR+HxYvk0a5019NxNILZaG/D7NvQA19+VUSzdRkXyuRcz34
+        yu7uQ+giHWyrOIadTKzVXY/jCx5zw8b727pPDh1BdLX94rR78whpEZIUy5HN96CGMm0VXTWcvcwI
+        +mw1WHuwhz2ObACbr8VU1xodD1YwkMddthlxTTpyur6+UehtxxjESmfKc9vOarzAj9aJXkP7PD5z
+        /MzpT8QemG0Wi94+gkGzZfqboOGdotp+PhiMdmezNbXOHe1AKFdlI7sxPFIm5UbWdGlSfJeXVq7W
+        s2EX7weqUbP2FuYd9dF4PN4u+ucBuSsFIdt1KQrJZbMcpez2iVQAKSfK1VyasgFKDSd7lJ4O9IWh
+        RE4Uz/MN1LOp2iO7sJTp6Fqiy/4BtOkn9t1QYmeXZ+m1/wcjk9WfJEeyYcmJwiFF/4Ax+SVHPhQ5
+        nQrPE8ikTiUlkdsseRHrCSpzkvSsPiCFsvryGU1woHEI3TDIbwgEuo6/NKR06ELZemKWMeY56KVQ
+        PwW4FNYXwXwMYbWo/D/dA0jiSz2gxw0n/a/0gJ5uWFoF3dLBj9Y/hup/MrPtKdcbqoPpZLVRjAO2
+        ssfieL2bAKTbI3vcXGMY2Y+3w51CBCJ+4PZCPzk6QG8miq0vunWjX9eIix7hsqGe4vCs26ap2dtA
+        wSSIBHl42I07kWVKFKcvWuxA1nbS25BerhoT1msK727Ei+PT6r0xmVDXQcvvXqh+h++1LrPNynwb
+        rsH1elI9aYdhX61l4gdqOTuYb61lovldtUx9by0/+/+rlu9BeVnL1JdqOZv3C2r5i3q+FFd9lv+a
+        oi+TnxMc+FPq2UT17GPxebJddlnWqznX/ZD2uzzRiHrWfOny5mEyn7iR8z7ZHvsX8chpR65Xj+Z2
+        NI15DzojxdKN6I2bDa2Q3bwfV+pKEt6l3tCGbOOkHK52d79Vh6fNsYOu9cLaP8lig641u9dQsE7u
+        uaY3LouDyHbZCF3FLd7t4cPl2TwbyKUn7bueQY5YZbicjI6NWcemPPYwmR2c4/xiYS3K655W5D6O
+        pyuBvtRngIhtasg1AqMJTD7e94Y0JvC0EPaImo3PZuTX+wH5I/3gu7SdrP/afvDs/69+cA/K9/eD
+        bN7P7wfUF7V91pl/rRcAx3D9impA4wqcn9IS6qglDEyKmxgcTte6Y0ne4wK7D4TgeMbttdUYGWK0
+        ah6W0LlsKa+3vhr+vjmCO6G31UdGf2SbMqV350rY6h54rTkX45ALdV912bXWXEN/esa242406ZHH
+        eG1uZ4Sxj5quxQn8pkZOehoei9KFvC75GPi7S3PhHWcCCXbXGqmfSJ2iRKsf8EJwUtXjEA99bo6j
+        b3TaOknfIPfUj1zdv0vuyV8s98/+/yrve1D+RHl/We7vj0H2W2VRkrprJD8/3H+x/GAp5dvTvz3/
+        D1lRoYe8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:51 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:03 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkaXNjb3VudF90b2tlbj5jMC0t
+      cWstOUJWS3l4MHlISTdZR1ZEMkluUlRvZGZRcVpHcDFfUXUyM0VIMjhZczVhbmtVdnpkMEV4TzE0
+      d2w3RW1GZnRDSDI3ZW1ONXkzQmxKamdsc0ZhS0JFOHZIODR2bkJyaFdiNFhBaUZ5YkFNTkhYQVVL
+      UTBqbHE0VnRtd0t3SE5PbkRMVENlT1dRUUNmdnRzODlrcldzN3BxdjVmUEZGSlp3azlNbHdBZGcx
+      YnpiV2FveXRqM2szb3ZsTVNrM05CTl9Vb2RDbXRCMERzY2k1bGZsLXBqaEpLS0tYUUR3RjJaPC9k
+      aXNjb3VudF90b2tlbj48cHV6emxlZD55ZXM8L3B1enpsZWQ+PGRlc3BhdGNoX3Rva2VuPmNfLS1G
+      eUpWRGY4RHlFRGhNWVU2Zllsa29BMUcxempMbnZkVndoN0tMSmticlhpaC1aeTJ4U3BTT0RkSGFI
+      emR5YUdqLXBySGQ0N0s3dmZDUkZYdU1FSnVValJLQnNHbldScW1IdDk4LXNoTHNSWklFbjlMQlcz
+      V1ZLczNQLS13Sm5RSE9fenB5WnV5VWlBLVk8L2Rlc3BhdGNoX3Rva2VuPjxjcnlwdG9fYmxvY2s+
+      TTMtLXBQNXQxM2dFYWM0a2FSQnpabTJob3ZVUmluTkhPc2syY0t2YlBualJsdGRKeDJDQ2owdzY5
+      ak45RVFxX3Zwek55a2tEVVJtOGk0aEpDblV0emJ2YjhBcUhJbGNlOEtmbWFDVEtyZHBmbGxGUjhF
+      SmFqbDdNVm9sSmdrNzMxU0wtN3pJVERUNl9YTnVwRG1FY1RxS3R1STNjRGw0Y3VlRWltVG5MMHJp
+      QWY0SHlSZXRIaklsUlRTZ3RVcFdFOF9FbVFEYnY3R2VWazlUclB5Z1B3aGh3SUVTOWtNbW1nT0RP
+      WUR6aHVsN1Y0N1c5Tl90YlNIVVB3b1FkNEZ6ZERxUy1adldIUEZCRDFIUHZrVk5XTC0yd1hVTUJZ
+      SlIxU3RSZ0szQXNfMDRiRVY1bG5DcGZFdlFvY2M3R0V6NmwtZGh2YzNzTGRGdERhUGQtUHdDNTJv
+      U29ibzFleWt2Um1KRk9jdE5wSF9YSllFME8xbVVwM0JkTmpOSXFIS0dsc3djQ3ZIdEZmTWFBRkVS
+      V3VZc2xzekZyb2U0SHpQZVdLNjVNNE5GWktybTFjeG5FdGRpd0ZTeGpERHRqTEQ0S0gyQjdJYTVv
+      YmRSR2J0QS1aPC9jcnlwdG9fYmxvY2s+PC9jcmVhdGVfb3JkZXI+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1148']
+      Content-Length: ['1008']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
+        H4sIAAAAAAAAA7VY2XLjuBV9z1ew+mHmIaG5aO9wOKW9ZVleJFmS/cLiAkm0SEICQC3+nfxJviyX
+        BChSsqbSmSSuLps491wA9+IuQBu/H8NA2iNCfRz99k27U79JKHKx50er3769Tnty/dvv5l8MlyCb
+        IQsTDxGLIBoHzDRo7Hg4tP3IiinAPrUc2zMjbCi3JYYbEwKzn/IvC5ZC5srZGsollDOWtsswMTVV
+        LXAEmLOiOHQQMet6tcASYM7aBraLqKkXOAIqcDBlFj2FDg6UIkyQQM1//qOon+M5CnrktGXYcgLs
+        bkzXkuWq7NCP+dNHMF4RJNOOcz9uPLXcZX09rB53k8dlnz1OnlvPTlUL1FPTd7a96Wr8Uhp674PP
+        jk9XnztGG97sx2uLWCffDwYrHZfr82iP3iZPM2cR9OkMP+/mnfmh5jgvGpr9mPW2sku0T//9hOy5
+        u5r1ds1P0pHfYKfF/Rn8XBneoMis6rL8flRlbRAd2/t5a9hYdtnboq82WAc1SbsfPcz6h9Wu8mPR
+        H9XR8TCddOo7/aU/6O3wptq+Xyx71n21/PBWZq1HN3Le41pVnSH/1B2w8eDw2Qg6u8FLadHc6c1h
+        975B1eWL3w3aeDhh6nTf7ez9Zs/W/U515I7eV/KijJv3R28dbYa91uKw9BalaIlaFW0zGNn68Zmw
+        oFtvfp68NVKX/rv9uWmMYxmTUml3Qp3RyDno88/jev/08sZG+DirnWrTYzir3J9au1Kz9XL/OGnY
+        4Xo/bTmd9kelNNdPVth2lg3NPtgf8vuQ6m5ra+nHwJ8ebH+kq4/DnX2oTiqzUT0s43c3Umn51WrY
+        nWnY1/36y3bufiw+P96qbzPWWw/cx2CNdtFC7i+I68z1Pn43lKLLuf9Nw0N0azN3bcGHa7ZxECCX
+        SUuCQ4mtEaRpFCNDuWTlSiFia+wVgDSR2k+tp4IOT67CkDJTu6tcMAD6L7eS5L/NbPPxdQrrF3iZ
+        IKey0xaZLp+/QEzhwvhsnE9dHEewQxeHjh8hzyw17pLSkA3PFG5rs/P6MIWJLsCck2686UE9kyiz
+        I88mXoHMzYqwhZcWhQpITc1QikMhY767QUVpBhgJbUt8F5mlSrLNfAzlk7hrm6yQWU4l52G+AdNA
+        4Gn4Y0P95Vvvzg0lH3FBus0uVPHTYY0IEgS+eddnoqQGOPJwJMcbcNYZ5PKU+pDKhVAoBzal4g/n
+        24RRoOSAEHI/glD6xQ63f5fa4NE42UpBbEAfSJsCn/aEYKZLKHEXeMHaoFO6kpI6LEOShiN4mdoZ
+        uZgs513P59mRi25Pys3JCBdgzkntaNkQrUwY2rlS4JYq+RaUzInJgRLh9vQQisBZnOq/Rj5DnjSE
+        Lgx9NKeKUyE+xBe04b2PDtYWETeJEd4gb4oML2nexI5WyEKRJ8bpZNN1/DdJo0yaoC1DSbuUdFWD
+        JppTODtmLgT2kiJmlqrJUtdoTqPIhVCCbCjX9FqlfMnOhJx+gp8w9DwzWVRtqJpgnnE4aVyvqpqV
+        wpCgkFohSumy2pBVbao1vpfU76r6V1X7nqx0W0HMe+0DPobMJ+yLVypsLY3s0//SH1W9XCupP+2P
+        ilr5j/xRgX9/xh/C/rTW8HBMCve42R52x4ZSgAUldcPIZtAJDlILxyRCv1LpEcwhNtQ9Ik27k2mm
+        yH3Gv33PrA56mQRGAg8g0LEJ09ksqRlFUDCgC6xNBZTlkK8rO+m6MpWj87oyQ5QpmX6qItTBQhZT
+        M/D35+kFlBF4Y1Kycdp/qB9uAySKeabHOxP/jrcUBQHslLILE7tfTYSv0Q+1iCs35lghbPEGGdjM
+        ZzH4vALtWW9UNa1UM5QzakA1X/FPWb3TVDjhShXutTlsKPlka5ta0JigHixpekG/AJJqmvQlaJ5Z
+        GRVDI7SPFomjCI6Cx42mgw1fUCOEqnuDd40aEUIeRMQW4g26QxqT6X5u4YIcE7AZRwVahnBCYgMm
+        YVKG+fa/oEZypefNs62NpfL00VDOUNYioOWyhG1tQlMVnfoaN+gap1V1yc1Jl7vCDApxCfR0cnSE
+        eIGYTKYrwBmH9+0jQySyA2kKRKmVBHLkSbkGz5/0HXWr4t8SGOn1jK81aXYeuuPJvPvwMDGUgkCQ
+        0uknthcgAjk8h1CkGU20MnEF+dOpD60szJ5iST0qDI2LY8pL7Bx50JW0/0cBbjS08s8XYO1rQ/qj
+        Spak1BbjQNwM09i4wpJEC/ww6e1pOBeG/6auaz/d59JI5LuTm+ozRLoAhIRae5/6TiCi9xrkrLwa
+        8sCGkidunzOhkkPG17y/zPnkNz+42l1JlZ5HhpJDXLpehyHckbQGb45FjK+Xp3Jyd7acxF5+vQf5
+        FVTkJGsoF0huWnImkDm7GNFzN4jwGUIev61fUwzeDgoeaA/G7Ydusu0rwQWVX+y2YI3k+sQN0KWC
+        8AZmdmBdPW2uQEG6epV8BS94hRfKLVhwr18r12hGu3y5XIM/XVnEs1e59b9L/wL2/DbImhIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:51 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1879']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:03 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order><crypto_block>E7--NuwIhns8SF9pSFmOCtayGoPi5orsAykdVtQtCufnKnVXd5ijHtnqR7hewEY9Siu9mKWZXgSi50wUnsm6QPTTn5Ap3rEh2y8qt7LQOigLgEgeiLH4ylijiJOz3cCcGHfmz-mr55XI7fNrF6K5mYhYQ3qn1nCceIO3_pGh-y2ODATK_1unwgfaRcvmf9rRBGVuoIht5KuL4JvyIf1HGwjOVpnEZgHPJm7kxU7hRzZCGSznxEZHloNsR7I2pTbq40t7v2mLo1javANm8iUGKktt-5o16BpnLLteyP0yqrtW48EZlb91SwCaca-PJX0S8BvzKCatNcVD_hETlolGxPekOoYcRxyhOS0oqh4PNL4fG5MfxXXjHxpdCbQvBrDibivFS6vhbjmFeBcQYWikaldIWXGQFooHSH2dWMs_BXrsAz6-j8VMn40F2LZish9H3g6jBjVkrnayZ4NMPTq5FtXcdK_5L7WFk2ASLauJCqJowO_bV8X2sPX_At8097h3QpXw1Kh0OkgxfUXvzDHbFI_bN0XSMiJ0al9y_p-VXab83-6hG9eHDURd6DtENaA6ZdPR1b2kCR_toknr_BpFKcDNzxpBDj9-GWfRRbpiCUM9rPYDDkijx5sFQiucuV4RNL_xRMwwjtm79e8Q_Ffs_Rbj0MXC_rEfuYOIlmhROtFCXJpXG4CNo46bV1NKHU8emAOPjTy5eN5yHKnfgvMsrKq0Ix6-yFmDNxXSz4pazVchj_p8eOwdiIe_aY0Ybh9RJBrav76RZUsxDdWqMKRqoWJyL_--Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>k0--5q_Eg4_-x1Nz1FPUkY_jXomw7H7E1_PjxiUKNYUK3emm0ERjusgvnWUYFQqZHjDGEekx61hC9iIriru1LpexlQdiFWf9oohhZR3m54tmVkLEMIItGP0eGhqQULniBgRbrSIgFusujEyS0Rw91TvO3pqX8rgNeFy0FDAL-H3GFetfBUfLnD1Zi-94KcFBeU0CKwDSXAHtxFWU5WZiFJ-wMeIriNlK_uoAMR58EAI8VqC-Z</discount_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></create_order>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['1384']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61Y23arNhB971e456UPLQGM7eCzKF2O7cSJr8eX2M4LC4NsEwMiSPj2O/2TflkH
-        JAw47urpJQ8J2rMljUaaPVK0346eW9qjkDjY//WLfCd9KSHfwrbjb379Mps+CuqX3/QfNCtEJkUG
-        Dm0UGiEikUt1jUQrG3um4xsRAdghxsq09RMimnjbpFlRGMLwp+zLgLmQvlkFmliEMsbatCgOdVmS
-        chwOZiw/8lYo1NVyLcfiYMYKXNNCRC/nOBzKcTChBjl5K+yKeThEHNX/+D3fP8MzFPqFp4BiY+Vi
-        a6fPDEHY74J1fdesB7PqcCVsQry2Zfp0sAaj5buCLPKutJZy7f3bbigt535r7027WzJrrduLozVr
-        dk4fS7e36ODFYycc7pzm49ZS3pUK8YYtuTYvnxfl1+FUmPq78NR4f1EHctUZHdQP1HHnZ9I9P66X
-        4F3eJ41tJsU75OvtsiBUUadq7KMoaLxvvlmbRefQD6aovqh/bCZueSm5i6Bq4f1hJhNSeZ4vHxrC
-        eKYaG2XUi9Tn7nmDwrOhdFxJUfCz8NpvW+et1Gjuh/35Uq2co6qC5s11Y9NYlPeV+5O6eXMx7TkV
-        ggeDtUqXiO4WH294JAzkrdudvewOb/ZqLjUnR1SbnTyzbb9PFuH5MJSGRms4HlvzoHZ8RuOHD2Oz
-        O1bmUX359jIiw261idqCGTwaPeXQDOyPLpooo5qhfHtr7MevU3v89BBNzhNh0XkJXmsR7ftC1OvK
-        C9MJBpFKW8+NoTto9NWn1pM1Wi7HMJJihB0Htu5bf9h7c04P/frD1vJPvaemOnVmw6k5PE4n87ra
-        wXar1Yx6HyevLffnlve6mGxrxxfyGvlWxaOjxWhwdO+FN03Mh5/tha7ZiAQmtbYGfFh6E7susmhp
-        HWKvRLcI8tSPkCYWWVknD9EttnNAkkjN4cMw14clV65JqC7fVQsMgP6jK3H+m9TUB7MpzJ/jpYaM
-        Sk8B0i02fo6YwLn2ZXEOsXDkg4cW9laOj2y9XL+LpSFtXihsrZPprNUeTGGoApyxEtcnNLKRT0sh
-        yFyOypblYwOvDQISSHRZE/NNbqOOtUN5awpoMS0IHQvp5VrsZtYG/QytrRlukK4klkszc0DXEEQa
-        /pggwMzx9lwTsxYzJG62QcZPhy0KEScw51fOJgqMvelGiGloHtAsh3LBdbFvY8iEHYTyAjJ7MlAv
-        sXMjG9pyTUL4H8aHo2HS2IEcxu1Jl2nRzoaB6pCUCjZcUj+KUBxEiI2xQ6d0BjGJZArGpYhT054X
-        pDBexrsx5M6xye1h2UK4vYBllGQtj6bnuKccia1QzOYV06DF2xvyMCdBzwMXc9J/5jsU2aUuFGWo
-        qhmV70LowGmDqrx30MEIUGjFJ4aVy5smzY5reWj6G2Qg3+Ztvj/RLyVZpdtSI9pEhJbKkgwFNSMw
-        bkQtOORrgqiu1OKJrtGMRpAFBwcyo3IvVytVqcBOjYx+gh/PsyGhYVJJlVXOvOCwuVitSbKRwKZv
-        Q5p5KKELkirI6lSuf1Wkr5L0syR/jWe63YGPex0B1ibUDOmnmJRlCEYDEtf9P0NSk8s1pfLdIamU
-        5X8UkopQlv9NSHgIEulh5zHW8XGj2W2PNTEHc0oShr5JIZEOpQcchT76iZQGsJzQBBkMf0w7sXix
-        b8fWa8+PqQVaHHfhlONMSPIgZ4B7NCK66+wvdg6lBFZkxLSd1BLieIGLuDCn/ViVYd9RQJDrwlSE
-        Fnxsf/bxr3yP8e4sj4s3xt4gbLAi6JrUiQuPXk1K8KWpgRhv2Kcg3cmx6QJoYtZ/axID6g0k9pro
-        PtbEAhBrYVxukH0RQd7UPPNohJHvQ1jZ/stlOBqfUM0DzbzBu0Y1HyEbdjeAcxPBfTg+S4k/t3BO
-        jqDUwqMjR0sRRojXgEPP9KFUJu5/QrX4ps5qYlMelyrTgSZeoFTgoZLSmG3sPF3iBfga18gWJ/K4
-        ZsthT5giphE410BPBkdHODqI0Hi4HJxymGyAvTQ5EYq80hsK8YXKkiC5QPEbSqPVa48n83avN9HE
-        nIGT2AXFtF0UQlrN4SCRlMbLC78k/KtshNLipQ+lWB5yTa0Q7Uzx5sgGRbyPq8T/r4j3IPz/QBHv
-        PyniX6VonBsBxi6/uSWbfIXFGeM6Xlxtk3OZa/6d0N5/r9AmR4p5JzTqDTiyHOAWYuwd4qxcfgyv
-        QcbKFI6dUJAxfjt85V0ySPucwMXkjX+zjbu/U6TSqK+JGcSs263nwa1FritJAc9jbL4sJ+O7Lbz2
-        Yb3J7PECr6A8J55DLCDZ0uI9gbvLR4TIReF9fIGQzW7T1xSNSXwuAs3ncbPXjt2+MhSo7KoVwGpK
-        lhNaLip24NHA1HSNq6fHFchJV6+Gz2CBl3tB3II59/o1cY2mtOLL4hr8bl3hz1Lx1r9//gSe8Zbz
-        OxIAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1828']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:52 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/OrderTests.test_unicode_properties.yaml
+++ b/tests/interface_objects/cassettes/OrderTests.test_unicode_properties.yaml
@@ -1,475 +1,427 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:52 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:04 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:52 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:05 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:53 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:05 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGNyeXB0b19ibG9jaz5FMC0tRXhJNTJKUkNxLWdMRHN2eDR3blVa
+      elpTV1NZRHFxZXZKRkd2bDRwb0NpdkNxVVVmdlVMQVhnOWJwOVhnNi1jY0s1THRRSlN2Um1MZXZl
+      eGUxMzBpNXo1UWdFV3puMVdtRTJ5WHdnVnhkTm85U21KZmNlWHlZN0tNTnQ4enV5Vkp3OWFSWE9T
+      ajV5Rk5wLTB3QWR2MktCSHZwaDZjRnFST2NyejktNGxEaHV4MlhIYUFtMUY0U2JuZEoybXF3a1Jn
+      WjwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bm9fb2ZfdGlja2V0cz4xPC9u
+      b19vZl90aWNrZXRzPjxiYW5kX3Rva2VuPi0xLS1RMW16UTBaV0tTZWNaazl6NFdQN1pCSi1GazFR
+      bGpSTGVIODl4djlzQ1llOGJFZXYxM2hoRkhheXlfNllkVWJIQUd5d0VSNlNSeW5ZLUJlWGhUd3Ey
+      YWQtYzVoQXc4WmhLcEpubTNONjJLZnpNM3B5QnNtUC1Dd0NVSVktY2dzV3F2S1kxcS1CUUFfQ1N3
+      SmE4SFJjdGZ2WlFpSktYN3JGZGNGTHlwQzZjQ29DWGdPaF9vc3ZXY295UU1MWjd1SWlpYk9Sa1ly
+      NFV2dEl3el8xbWhvVzNQVVdmRGVnUzJzWkpzV0RpcU56bXJkZ243Tlg4cjlfZmFaRGhPSDdjOUpi
+      WjwvYmFuZF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkZXNwYXRjaF90b2tlbj5jXy0t
+      RnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJYaWgtWnkyeFNwU09EZEhh
+      SHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5OC1zaExzUlpJRW45TEJX
+      M1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tlbj48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['449']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS0HvDihIg7XFxZDKMgoBCj+Tv9Jf1kHg4Je
+        O4fKzLeqlauS2GfHCeLEOWcHJvPHxbYqEfADw3V+/0R8xj9VgKO6muEcfv+0EgdY89Mf7b8xmhGo
+        buhAyfUgYgaSD4LQgm0mCBXNtWXDkcIA+JIRSIqstR2Xqb62MCACDpon+0CW0DqgzW6YajHKDBoI
+        1DaLXis+68AHOSFFGdWAcca1XEdzHSw0mWoBZvaUOkntuTGfbMlBkP+V8WUfBohSALkx5XeQsfJ3
+        2fb+Xemh7YbJq5TMDNpUusPMbQyQp0eICYDsq7pkgjhdqYriUiBJ9HLebdodeXBW8J79abKjgtdO
+        s+3cCA9gwUn30ZUtC8B8o/2nCdlOq8UrVG9BTBLCz8OeHkIZuJvT+SvHgECrjFFaoaQoqPmp+AY0
+        VJRTkQHOkgd8NckRAscR8aWJ0WQIJF92DkACjpaPU2eiHv6rQgSwsgQeBLYC/AqJE3WmWlAydghV
+        yd3vAwDbVD1Z6hktaAFQUSoFbYJukI0a/ci+GTN6jP6zbU1rJ4viLZzImXccnbTbrOOElMKyo0nQ
+        sEFKx/AWhhMi0fqNwn/D8X/ixG/JSq8n5H6fY5CNA4iS40NUalCvTOX4Z8ajTtINCv/meNTw2nfF
+        o4b+/Jl45PtPe02WjvxK7Amd3pgVmGoJzilpGKYyhDo4V7pu6DvgH0GFR9vxZdVEKSSyS/E2MYtZ
+        9mxo7fpwcLMYt/4mWSjR3TZyJ8OkZ5TBnOHJUG9X0WTMztbFlHRdLMCc+7oYBAGs3uanU/LpaIcw
+        DNqWEd3d59CNgNqvDOXqbQxjD7QDw/YsgAKGnMPbvNSSs0IvAJaF3jSAD1tkP24RPU05vIxXX/g4
+        ADc5KLnNWDI0YIhiXiM+18hWnSCoBlO9owzq5ofsEcM/Ezg64VqdRIQ7zFQLZ7ocSI6b9IN9kKrN
+        A5B0U9QRUce5t9F8yNjyRfJDx0FHkeUNQaI9fEAZG3XdF7xnlHEA0FBGeCjfkDqkOZm+zys8J4e+
+        nGhoiXZDMkKyB9e3kzacvf4HlPHcAGbi2SOECi3yTPUO3SQCSTZM2JJpt/HP+F0jyjgT6G7aVffZ
+        dtLlnjAmQHmJ6KlzcEH5gnIycVeCb5xMty8Q+I5sVURErHSTRHa0SjEjq5/0UvCq478yMCixwnyt
+        Zac/YYXlhp1Mlky1ZMhJqfulrFnARzW8QakY3Gi5lOVXkIeIFt1wAzQkIMSv6JWtFkF/e68kPmrH
+        /2s6SfZ7rmulaZ7fHZ6wpCYsw05kOM280vArLZj4ZklKkyZ7O6yDz1FS5kBuCaTICAzFyhPtGcxY
+        RePKchB1p/yiuM6nFBDzsUQfyzP5f3Zwjc8UXplPmWoBZVZdt210nSFamY6VsWy9e46ofuxBV1Is
+        VzXbUwrDvHkNEtSBlVXalIXudWeTuhutBMPhuVlgkuo4UubOUbCgNrqQvd4RP9dbR77FLk5S5F35
+        2DT7K8FuGrQ+6jkreFUipdk5cUNLBc3x3pZ74tjXvL1lDYQmO5KPVmO6dq3RwWxQxHKCNa5DsS/W
+        pS0fen2bVcXTGIZDSu1btBoC1rBFZ4L7RmdPc7EAIHccWoK4PMCVt2GbEmsv+krUeANrsyX68/gw
+        P+v6ecguW+bUtg+z/uy9f9VDq7GmG5sWL0Flya3mZ3eh0YOr1j8tsV204eaDbp/g5pG55jcTjDxv
+        V9Pu+0ggllA4jKlOIOG0wq5rltPz9my0cFW18cZe6xam6ZFKBRNtAPvyXMPm516NdJeu4hIgNiPB
+        Hg1mKuQ9TtqO3ll8Rtgrj+pq/JEfnrjxmxWc1V7EwcF+KncGrLAJ3wMruA58F9DcdQ4243ptSvOD
+        3di3CfXisFAzzoPl5djvw+OkT485stsYyjVX0YQ3BXawXXLXLJ0vo1iyg1RSKj59HCtOS+e1pfhG
+        SuuqTaHqfUQYNfR99HUVF09ZGh8UD63+ABWMvaxC189vw09gwXLC5KrbbpL1EisHC5ZnySoI2mSJ
+        k0MlDhISKYhtxbWqZRipWIa2//uf8vwCL9AiGMFDXNCNAH8IS3JFQLLt7qViAo0U7wm6+0Dfh0rg
+        WiFqO4EcoTrPpO0ZRB8ftmI4qLdRrcR+HxYvk0a5019NxNILZaG/D7NvQA19+VUSzdRkXyuRcz34
+        yu7uQ+giHWyrOIadTKzVXY/jCx5zw8b727pPDh1BdLX94rR78whpEZIUy5HN96CGMm0VXTWcvcwI
+        +mw1WHuwhz2ObACbr8VU1xodD1YwkMddthlxTTpyur6+UehtxxjESmfKc9vOarzAj9aJXkP7PD5z
+        /MzpT8QemG0Wi94+gkGzZfqboOGdotp+PhiMdmezNbXOHe1AKFdlI7sxPFIm5UbWdGlSfJeXVq7W
+        s2EX7weqUbP2FuYd9dF4PN4u+ucBuSsFIdt1KQrJZbMcpez2iVQAKSfK1VyasgFKDSd7lJ4O9IWh
+        RE4Uz/MN1LOp2iO7sJTp6Fqiy/4BtOkn9t1QYmeXZ+m1/wcjk9WfJEeyYcmJwiFF/4Ax+SVHPhQ5
+        nQrPE8ikTiUlkdsseRHrCSpzkvSsPiCFsvryGU1woHEI3TDIbwgEuo6/NKR06ELZemKWMeY56KVQ
+        PwW4FNYXwXwMYbWo/D/dA0jiSz2gxw0n/a/0gJ5uWFoF3dLBj9Y/hup/MrPtKdcbqoPpZLVRjAO2
+        ssfieL2bAKTbI3vcXGMY2Y+3w51CBCJ+4PZCPzk6QG8miq0vunWjX9eIix7hsqGe4vCs26ap2dtA
+        wSSIBHl42I07kWVKFKcvWuxA1nbS25BerhoT1msK727Ei+PT6r0xmVDXQcvvXqh+h++1LrPNynwb
+        rsH1elI9aYdhX61l4gdqOTuYb61lovldtUx9by0/+/+rlu9BeVnL1JdqOZv3C2r5i3q+FFd9lv+a
+        oi+TnxMc+FPq2UT17GPxebJddlnWqznX/ZD2uzzRiHrWfOny5mEyn7iR8z7ZHvsX8chpR65Xj+Z2
+        NI15DzojxdKN6I2bDa2Q3bwfV+pKEt6l3tCGbOOkHK52d79Vh6fNsYOu9cLaP8lig641u9dQsE7u
+        uaY3LouDyHbZCF3FLd7t4cPl2TwbyKUn7bueQY5YZbicjI6NWcemPPYwmR2c4/xiYS3K655W5D6O
+        pyuBvtRngIhtasg1AqMJTD7e94Y0JvC0EPaImo3PZuTX+wH5I/3gu7SdrP/afvDs/69+cA/K9/eD
+        bN7P7wfUF7V91pl/rRcAx3D9impA4wqcn9IS6qglDEyKmxgcTte6Y0ne4wK7D4TgeMbttdUYGWK0
+        ah6W0LlsKa+3vhr+vjmCO6G31UdGf2SbMqV350rY6h54rTkX45ALdV912bXWXEN/esa242406ZHH
+        eG1uZ4Sxj5quxQn8pkZOehoei9KFvC75GPi7S3PhHWcCCXbXGqmfSJ2iRKsf8EJwUtXjEA99bo6j
+        b3TaOknfIPfUj1zdv0vuyV8s98/+/yrve1D+RHl/We7vj0H2W2VRkrprJD8/3H+x/GAp5dvTvz3/
+        D1lRoYe8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:53 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:06 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkaXNjb3VudF90b2tlbj5jMC0t
+      cWstOUJWS3l4MHlISTdZR1ZEMkluUlRvZGZRcVpHcDFfUXUyM0VIMjhZczVhbmtVdnpkMEV4TzE0
+      d2w3RW1GZnRDSDI3ZW1ONXkzQmxKamdsc0ZhS0JFOHZIODR2bkJyaFdiNFhBaUZ5YkFNTkhYQVVL
+      UTBqbHE0VnRtd0t3SE5PbkRMVENlT1dRUUNmdnRzODlrcldzN3BxdjVmUEZGSlp3azlNbHdBZGcx
+      YnpiV2FveXRqM2szb3ZsTVNrM05CTl9Vb2RDbXRCMERzY2k1bGZsLXBqaEpLS0tYUUR3RjJaPC9k
+      aXNjb3VudF90b2tlbj48cHV6emxlZD55ZXM8L3B1enpsZWQ+PGRlc3BhdGNoX3Rva2VuPmNfLS1G
+      eUpWRGY4RHlFRGhNWVU2Zllsa29BMUcxempMbnZkVndoN0tMSmticlhpaC1aeTJ4U3BTT0RkSGFI
+      emR5YUdqLXBySGQ0N0s3dmZDUkZYdU1FSnVValJLQnNHbldScW1IdDk4LXNoTHNSWklFbjlMQlcz
+      V1ZLczNQLS13Sm5RSE9fenB5WnV5VWlBLVk8L2Rlc3BhdGNoX3Rva2VuPjxjcnlwdG9fYmxvY2s+
+      TTMtLXBQNXQxM2dFYWM0a2FSQnpabTJob3ZVUmluTkhPc2syY0t2YlBualJsdGRKeDJDQ2owdzY5
+      ak45RVFxX3Zwek55a2tEVVJtOGk0aEpDblV0emJ2YjhBcUhJbGNlOEtmbWFDVEtyZHBmbGxGUjhF
+      SmFqbDdNVm9sSmdrNzMxU0wtN3pJVERUNl9YTnVwRG1FY1RxS3R1STNjRGw0Y3VlRWltVG5MMHJp
+      QWY0SHlSZXRIaklsUlRTZ3RVcFdFOF9FbVFEYnY3R2VWazlUclB5Z1B3aGh3SUVTOWtNbW1nT0RP
+      WUR6aHVsN1Y0N1c5Tl90YlNIVVB3b1FkNEZ6ZERxUy1adldIUEZCRDFIUHZrVk5XTC0yd1hVTUJZ
+      SlIxU3RSZ0szQXNfMDRiRVY1bG5DcGZFdlFvY2M3R0V6NmwtZGh2YzNzTGRGdERhUGQtUHdDNTJv
+      U29ibzFleWt2Um1KRk9jdE5wSF9YSllFME8xbVVwM0JkTmpOSXFIS0dsc3djQ3ZIdEZmTWFBRkVS
+      V3VZc2xzekZyb2U0SHpQZVdLNjVNNE5GWktybTFjeG5FdGRpd0ZTeGpERHRqTEQ0S0gyQjdJYTVv
+      YmRSR2J0QS1aPC9jcnlwdG9fYmxvY2s+PC9jcmVhdGVfb3JkZXI+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1148']
+      Content-Length: ['1008']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
+        H4sIAAAAAAAAA7VY2XLjuBV9z1ew+mHmIaG5aO9wOKW9ZVleJFmS/cLiAkm0SEICQC3+nfxJviyX
+        BChSsqbSmSSuLps491wA9+IuQBu/H8NA2iNCfRz99k27U79JKHKx50er3769Tnty/dvv5l8MlyCb
+        IQsTDxGLIBoHzDRo7Hg4tP3IiinAPrUc2zMjbCi3JYYbEwKzn/IvC5ZC5srZGsollDOWtsswMTVV
+        LXAEmLOiOHQQMet6tcASYM7aBraLqKkXOAIqcDBlFj2FDg6UIkyQQM1//qOon+M5CnrktGXYcgLs
+        bkzXkuWq7NCP+dNHMF4RJNOOcz9uPLXcZX09rB53k8dlnz1OnlvPTlUL1FPTd7a96Wr8Uhp674PP
+        jk9XnztGG97sx2uLWCffDwYrHZfr82iP3iZPM2cR9OkMP+/mnfmh5jgvGpr9mPW2sku0T//9hOy5
+        u5r1ds1P0pHfYKfF/Rn8XBneoMis6rL8flRlbRAd2/t5a9hYdtnboq82WAc1SbsfPcz6h9Wu8mPR
+        H9XR8TCddOo7/aU/6O3wptq+Xyx71n21/PBWZq1HN3Le41pVnSH/1B2w8eDw2Qg6u8FLadHc6c1h
+        975B1eWL3w3aeDhh6nTf7ez9Zs/W/U515I7eV/KijJv3R28dbYa91uKw9BalaIlaFW0zGNn68Zmw
+        oFtvfp68NVKX/rv9uWmMYxmTUml3Qp3RyDno88/jev/08sZG+DirnWrTYzir3J9au1Kz9XL/OGnY
+        4Xo/bTmd9kelNNdPVth2lg3NPtgf8vuQ6m5ra+nHwJ8ebH+kq4/DnX2oTiqzUT0s43c3Umn51WrY
+        nWnY1/36y3bufiw+P96qbzPWWw/cx2CNdtFC7i+I68z1Pn43lKLLuf9Nw0N0azN3bcGHa7ZxECCX
+        SUuCQ4mtEaRpFCNDuWTlSiFia+wVgDSR2k+tp4IOT67CkDJTu6tcMAD6L7eS5L/NbPPxdQrrF3iZ
+        IKey0xaZLp+/QEzhwvhsnE9dHEewQxeHjh8hzyw17pLSkA3PFG5rs/P6MIWJLsCck2686UE9kyiz
+        I88mXoHMzYqwhZcWhQpITc1QikMhY767QUVpBhgJbUt8F5mlSrLNfAzlk7hrm6yQWU4l52G+AdNA
+        4Gn4Y0P95Vvvzg0lH3FBus0uVPHTYY0IEgS+eddnoqQGOPJwJMcbcNYZ5PKU+pDKhVAoBzal4g/n
+        24RRoOSAEHI/glD6xQ63f5fa4NE42UpBbEAfSJsCn/aEYKZLKHEXeMHaoFO6kpI6LEOShiN4mdoZ
+        uZgs513P59mRi25Pys3JCBdgzkntaNkQrUwY2rlS4JYq+RaUzInJgRLh9vQQisBZnOq/Rj5DnjSE
+        Lgx9NKeKUyE+xBe04b2PDtYWETeJEd4gb4oML2nexI5WyEKRJ8bpZNN1/DdJo0yaoC1DSbuUdFWD
+        JppTODtmLgT2kiJmlqrJUtdoTqPIhVCCbCjX9FqlfMnOhJx+gp8w9DwzWVRtqJpgnnE4aVyvqpqV
+        wpCgkFohSumy2pBVbao1vpfU76r6V1X7nqx0W0HMe+0DPobMJ+yLVypsLY3s0//SH1W9XCupP+2P
+        ilr5j/xRgX9/xh/C/rTW8HBMCve42R52x4ZSgAUldcPIZtAJDlILxyRCv1LpEcwhNtQ9Ik27k2mm
+        yH3Gv33PrA56mQRGAg8g0LEJ09ksqRlFUDCgC6xNBZTlkK8rO+m6MpWj87oyQ5QpmX6qItTBQhZT
+        M/D35+kFlBF4Y1Kycdp/qB9uAySKeabHOxP/jrcUBQHslLILE7tfTYSv0Q+1iCs35lghbPEGGdjM
+        ZzH4vALtWW9UNa1UM5QzakA1X/FPWb3TVDjhShXutTlsKPlka5ta0JigHixpekG/AJJqmvQlaJ5Z
+        GRVDI7SPFomjCI6Cx42mgw1fUCOEqnuDd40aEUIeRMQW4g26QxqT6X5u4YIcE7AZRwVahnBCYgMm
+        YVKG+fa/oEZypefNs62NpfL00VDOUNYioOWyhG1tQlMVnfoaN+gap1V1yc1Jl7vCDApxCfR0cnSE
+        eIGYTKYrwBmH9+0jQySyA2kKRKmVBHLkSbkGz5/0HXWr4t8SGOn1jK81aXYeuuPJvPvwMDGUgkCQ
+        0uknthcgAjk8h1CkGU20MnEF+dOpD60szJ5iST0qDI2LY8pL7Bx50JW0/0cBbjS08s8XYO1rQ/qj
+        Spak1BbjQNwM09i4wpJEC/ww6e1pOBeG/6auaz/d59JI5LuTm+ozRLoAhIRae5/6TiCi9xrkrLwa
+        8sCGkidunzOhkkPG17y/zPnkNz+42l1JlZ5HhpJDXLpehyHckbQGb45FjK+Xp3Jyd7acxF5+vQf5
+        FVTkJGsoF0huWnImkDm7GNFzN4jwGUIev61fUwzeDgoeaA/G7Ydusu0rwQWVX+y2YI3k+sQN0KWC
+        8AZmdmBdPW2uQEG6epV8BS94hRfKLVhwr18r12hGu3y5XIM/XVnEs1e59b9L/wL2/DbImhIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:53 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1879']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:07 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order><crypto_block>E7--NuwIhns8SF9pSFmOCtayGoPi5orsAykdVtQtCufnKnVXd5ijHtnqR7hewEY9Siu9mKWZXgSi50wUnsm6QPTTn5Ap3rEh2y8qt7LQOigLgEgeiLH4ylijiJOz3cCcGHfmz-mr55XI7fNrF6K5mYhYQ3qn1nCceIO3_pGh-y2ODATK_1unwgfaRcvmf9rRBGVuoIht5KuL4JvyIf1HGwjOVpnEZgHPJm7kxU7hRzZCGSznxEZHloNsR7I2pTbq40t7v2mLo1javANm8iUGKktt-5o16BpnLLteyP0yqrtW48EZlb91SwCaca-PJX0S8BvzKCatNcVD_hETlolGxPekOoYcRxyhOS0oqh4PNL4fG5MfxXXjHxpdCbQvBrDibivFS6vhbjmFeBcQYWikaldIWXGQFooHSH2dWMs_BXrsAz6-j8VMn40F2LZish9H3g6jBjVkrnayZ4NMPTq5FtXcdK_5L7WFk2ASLauJCqJowO_bV8X2sPX_At8097h3QpXw1Kh0OkgxfUXvzDHbFI_bN0XSMiJ0al9y_p-VXab83-6hG9eHDURd6DtENaA6ZdPR1b2kCR_toknr_BpFKcDNzxpBDj9-GWfRRbpiCUM9rPYDDkijx5sFQiucuV4RNL_xRMwwjtm79e8Q_Ffs_Rbj0MXC_rEfuYOIlmhROtFCXJpXG4CNo46bV1NKHU8emAOPjTy5eN5yHKnfgvMsrKq0Ix6-yFmDNxXSz4pazVchj_p8eOwdiIe_aY0Ybh9RJBrav76RZUsxDdWqMKRqoWJyL_--Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>k0--5q_Eg4_-x1Nz1FPUkY_jXomw7H7E1_PjxiUKNYUK3emm0ERjusgvnWUYFQqZHjDGEekx61hC9iIriru1LpexlQdiFWf9oohhZR3m54tmVkLEMIItGP0eGhqQULniBgRbrSIgFusujEyS0Rw91TvO3pqX8rgNeFy0FDAL-H3GFetfBUfLnD1Zi-94KcFBeU0CKwDSXAHtxFWU5WZiFJ-wMeIriNlK_uoAMR58EAI8VqC-Z</discount_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></create_order>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['1384']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61Y23arNhB971e456UPLQGM7eCzKF2O7cSJr8eX2M4LC4NsEwMiSPj2O/2TflkH
-        JAw47urpJQ8J2rMljUaaPVK0346eW9qjkDjY//WLfCd9KSHfwrbjb379Mps+CuqX3/QfNCtEJkUG
-        Dm0UGiEikUt1jUQrG3um4xsRAdghxsq09RMimnjbpFlRGMLwp+zLgLmQvlkFmliEMsbatCgOdVmS
-        chwOZiw/8lYo1NVyLcfiYMYKXNNCRC/nOBzKcTChBjl5K+yKeThEHNX/+D3fP8MzFPqFp4BiY+Vi
-        a6fPDEHY74J1fdesB7PqcCVsQry2Zfp0sAaj5buCLPKutJZy7f3bbigt535r7027WzJrrduLozVr
-        dk4fS7e36ODFYycc7pzm49ZS3pUK8YYtuTYvnxfl1+FUmPq78NR4f1EHctUZHdQP1HHnZ9I9P66X
-        4F3eJ41tJsU75OvtsiBUUadq7KMoaLxvvlmbRefQD6aovqh/bCZueSm5i6Bq4f1hJhNSeZ4vHxrC
-        eKYaG2XUi9Tn7nmDwrOhdFxJUfCz8NpvW+et1Gjuh/35Uq2co6qC5s11Y9NYlPeV+5O6eXMx7TkV
-        ggeDtUqXiO4WH294JAzkrdudvewOb/ZqLjUnR1SbnTyzbb9PFuH5MJSGRms4HlvzoHZ8RuOHD2Oz
-        O1bmUX359jIiw261idqCGTwaPeXQDOyPLpooo5qhfHtr7MevU3v89BBNzhNh0XkJXmsR7ftC1OvK
-        C9MJBpFKW8+NoTto9NWn1pM1Wi7HMJJihB0Htu5bf9h7c04P/frD1vJPvaemOnVmw6k5PE4n87ra
-        wXar1Yx6HyevLffnlve6mGxrxxfyGvlWxaOjxWhwdO+FN03Mh5/tha7ZiAQmtbYGfFh6E7susmhp
-        HWKvRLcI8tSPkCYWWVknD9EttnNAkkjN4cMw14clV65JqC7fVQsMgP6jK3H+m9TUB7MpzJ/jpYaM
-        Sk8B0i02fo6YwLn2ZXEOsXDkg4cW9laOj2y9XL+LpSFtXihsrZPprNUeTGGoApyxEtcnNLKRT0sh
-        yFyOypblYwOvDQISSHRZE/NNbqOOtUN5awpoMS0IHQvp5VrsZtYG/QytrRlukK4klkszc0DXEEQa
-        /pggwMzx9lwTsxYzJG62QcZPhy0KEScw51fOJgqMvelGiGloHtAsh3LBdbFvY8iEHYTyAjJ7MlAv
-        sXMjG9pyTUL4H8aHo2HS2IEcxu1Jl2nRzoaB6pCUCjZcUj+KUBxEiI2xQ6d0BjGJZArGpYhT054X
-        pDBexrsx5M6xye1h2UK4vYBllGQtj6bnuKccia1QzOYV06DF2xvyMCdBzwMXc9J/5jsU2aUuFGWo
-        qhmV70LowGmDqrx30MEIUGjFJ4aVy5smzY5reWj6G2Qg3+Ztvj/RLyVZpdtSI9pEhJbKkgwFNSMw
-        bkQtOORrgqiu1OKJrtGMRpAFBwcyo3IvVytVqcBOjYx+gh/PsyGhYVJJlVXOvOCwuVitSbKRwKZv
-        Q5p5KKELkirI6lSuf1Wkr5L0syR/jWe63YGPex0B1ibUDOmnmJRlCEYDEtf9P0NSk8s1pfLdIamU
-        5X8UkopQlv9NSHgIEulh5zHW8XGj2W2PNTEHc0oShr5JIZEOpQcchT76iZQGsJzQBBkMf0w7sXix
-        b8fWa8+PqQVaHHfhlONMSPIgZ4B7NCK66+wvdg6lBFZkxLSd1BLieIGLuDCn/ViVYd9RQJDrwlSE
-        Fnxsf/bxr3yP8e4sj4s3xt4gbLAi6JrUiQuPXk1K8KWpgRhv2Kcg3cmx6QJoYtZ/axID6g0k9pro
-        PtbEAhBrYVxukH0RQd7UPPNohJHvQ1jZ/stlOBqfUM0DzbzBu0Y1HyEbdjeAcxPBfTg+S4k/t3BO
-        jqDUwqMjR0sRRojXgEPP9KFUJu5/QrX4ps5qYlMelyrTgSZeoFTgoZLSmG3sPF3iBfga18gWJ/K4
-        ZsthT5giphE410BPBkdHODqI0Hi4HJxymGyAvTQ5EYq80hsK8YXKkiC5QPEbSqPVa48n83avN9HE
-        nIGT2AXFtF0UQlrN4SCRlMbLC78k/KtshNLipQ+lWB5yTa0Q7Uzx5sgGRbyPq8T/r4j3IPz/QBHv
-        PyniX6VonBsBxi6/uSWbfIXFGeM6Xlxtk3OZa/6d0N5/r9AmR4p5JzTqDTiyHOAWYuwd4qxcfgyv
-        QcbKFI6dUJAxfjt85V0ySPucwMXkjX+zjbu/U6TSqK+JGcSs263nwa1FritJAc9jbL4sJ+O7Lbz2
-        Yb3J7PECr6A8J55DLCDZ0uI9gbvLR4TIReF9fIGQzW7T1xSNSXwuAs3ncbPXjt2+MhSo7KoVwGpK
-        lhNaLip24NHA1HSNq6fHFchJV6+Gz2CBl3tB3II59/o1cY2mtOLL4hr8bl3hz1Lx1r9//gSe8Zbz
-        OxIAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1828']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:54 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/PerformanceAvailabilityTests.test_availability_returned_event.yaml
+++ b/tests/interface_objects/cassettes/PerformanceAvailabilityTests.test_availability_returned_event.yaml
@@ -1,329 +1,255 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:58 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:14 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:58 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:15 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:58 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:17 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['449']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:58 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/PerformanceAvailabilityTests.test_despatch_methods.yaml
+++ b/tests/interface_objects/cassettes/PerformanceAvailabilityTests.test_despatch_methods.yaml
@@ -1,329 +1,255 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:59 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:17 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:59 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:17 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:59 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:18 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['449']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:00 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/PerformanceAvailabilityTests.test_despatch_methods_contains_despatch_method.yaml
+++ b/tests/interface_objects/cassettes/PerformanceAvailabilityTests.test_despatch_methods_contains_despatch_method.yaml
@@ -1,329 +1,255 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:00 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:18 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:01 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:19 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:01 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:20 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['449']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:02 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/PerformanceAvailabilityTests.test_list_properties.yaml
+++ b/tests/interface_objects/cassettes/PerformanceAvailabilityTests.test_list_properties.yaml
@@ -1,329 +1,255 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:02 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:20 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:03 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:21 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:03 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:22 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['449']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:03 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/PerformanceAvailabilityTests.test_sorted_combined_price.yaml
+++ b/tests/interface_objects/cassettes/PerformanceAvailabilityTests.test_sorted_combined_price.yaml
@@ -1,329 +1,255 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:04 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:23 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:04 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:24 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:04 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:24 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['449']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:04 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/PerformanceAvailabilityTests.test_ticket_types.yaml
+++ b/tests/interface_objects/cassettes/PerformanceAvailabilityTests.test_ticket_types.yaml
@@ -1,329 +1,255 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:05 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:24 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:05 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:25 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:05 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:25 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['449']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:06 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/PerformanceAvailabilityTests.test_ticket_types_contains_ticket_type.yaml
+++ b/tests/interface_objects/cassettes/PerformanceAvailabilityTests.test_ticket_types_contains_ticket_type.yaml
@@ -1,329 +1,255 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:07 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:25 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:07 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:26 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:07 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:26 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['449']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:08 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/PerformanceAvailabilityTests.test_unique_combined_price.yaml
+++ b/tests/interface_objects/cassettes/PerformanceAvailabilityTests.test_unique_combined_price.yaml
@@ -1,329 +1,255 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:08 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:26 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:09 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:27 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:09 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:27 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['449']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:09 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/PerformanceAvailabilityTests.test_valid_ticket_quantities.yaml
+++ b/tests/interface_objects/cassettes/PerformanceAvailabilityTests.test_valid_ticket_quantities.yaml
@@ -1,329 +1,255 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:10 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:28 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:10 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:29 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:10 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:30 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['449']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:11 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/PerformanceAvailabilityTests.test_valid_ticket_quantities_contains_int.yaml
+++ b/tests/interface_objects/cassettes/PerformanceAvailabilityTests.test_valid_ticket_quantities_contains_int.yaml
@@ -1,329 +1,255 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:11 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:31 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:11 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:32 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:12 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:33 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['449']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:12 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/PerformanceTests.test_date_is_datetime_date.yaml
+++ b/tests/interface_objects/cassettes/PerformanceTests.test_date_is_datetime_date.yaml
@@ -1,195 +1,150 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:54 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:08 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:54 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:09 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['365']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:55 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/PerformanceTests.test_required_info.yaml
+++ b/tests/interface_objects/cassettes/PerformanceTests.test_required_info.yaml
@@ -1,195 +1,150 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:55 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:09 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:55 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:10 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['365']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:55 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/PerformanceTests.test_string_properties.yaml
+++ b/tests/interface_objects/cassettes/PerformanceTests.test_string_properties.yaml
@@ -1,195 +1,150 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:56 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:11 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:56 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:11 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['365']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:56 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/PerformanceTests.test_time_is_datetime_time.yaml
+++ b/tests/interface_objects/cassettes/PerformanceTests.test_time_is_datetime_time.yaml
@@ -1,195 +1,150 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:57 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:12 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:57 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:13 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['365']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:57 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/PurchaseReservationOnCreditTests.test_purchase_succeeded.yaml
+++ b/tests/interface_objects/cassettes/PurchaseReservationOnCreditTests.test_purchase_succeeded.yaml
@@ -1,788 +1,820 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>credit-testuser</user_id><event_token_list>6IF</event_token_list><user_passwd>testing123</user_passwd><request_custom_fields
-      /><request_cost_range /></event_search>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vLWNyZWRpdDwvdXNlcl9pZD48L2V2ZW50X3NlYXJjaD4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['637']
+      Content-Length: ['614']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a3XKjOBa+n6fw9M1czNog/ulimMp2kq2uZLtn8lNd2RtKSMImBkQkEcfPM28y
-        T7biz4DttO1spybT6xRVMZ8+jo7O+STgIO/XpzQZPRLGY5r98g5M1HcjkiGK42z6y7vbm/Ox8+5X
-        /wePPJJMBJxAhmYBI7xIhO/xIsQ0hXEWFJywIOZBCLG/JNxTtjd5iC1zQYMwoWju3wbj8eM8j9z5
-        Bze/NT+H4ymjEQbiXwv06be7e50gfq+f3gHr/vf5Z/XuS3b6mN5czPiJngdPtw/21eX58hSZ4ysM
-        IuviISruPj5MT87556tssXyA6g2wPhssOE31y49nvy8f2Nn9g+MmTPvtY+bqp/PFNLnzlIFPHo65
-        gBkiPICMBI8wibGfUU/ZhtdR8T2JwEDGjPhnXzylO6sbMOHIP5MhXi5mhJGGUKFeGE+LvLRWEB+o
-        qqf0AQ/FYllbSmiGaTYu5tLdFVi3V4Yuq/amsTaNEsh586/mixmBonSghzXt1SU3w/bajMxclcba
-        XJXbIeQ1opiTZduDIvPfgaVMGmp75QoZ2Ot4W0zOY8y3m60H0rQPsI5SjeUcpnGy7JHqESpdv0ob
-        NMpFwGA2lTZCIn9XCQloFBEmsxpymhSCBBw+ymniA30iM7eOelGRJNKPNIwzgn1TK0lDrKbIMYmc
-        xYj4hr3idGBDKuS4IZMOmR1nhXmVZ51h3S1Ja2BD6izrZsfq9dcAK+NGj9X1mBOGpPjhdDVgzfSU
-        TVRKeiOAKXxa93UAVYT6+mPMXxTzzQBWyJobQ6ymDF0YQl5azvp2bKBm9KGGIPP9TNqMiWnsTBtw
-        KtbX8yZJu/OmdoaeTxww9klcn/WVxKn7Js54JnFrASzP150YYjVl6MAQ8jIacGk+ITw4rmzHle1v
-        HfPjynZc2bruHwqYifKZl+ZCvsDIR7fqyTxocR94yhqyztB2MvSdDGMnw9zJsDYZyubwqqU7QAVj
-        8i1NUtpf9QPvNMzlM+wA6hgRRIKy+jVjHexYWZGGMj2OZvVYDdix8gTKV6EydutQj1Mmmy/TkCZK
-        H5avTzXq//lH//oO95T1YQqaB5Uojqvmi1bNjfgpzzwTHCfUcUIdJ9RLJlR/FiFaZII1gqmKNn1g
-        1VzVH26zWBA8upB2MU07alPFYbGIUcDIY0wWQeNJI7mtTR6GMl11ukmGm/OmvlP8YwQcMRudFNOC
-        i5GmAinKjlBzC4HKQXEifN0qO1pHOxoniGaYy7u3DUzDVAfstrGmL+VfmmLsl52qDnAa5gr3Yk4d
-        SwVBBcMMByJOSUUfq84YODfAfa+r71X1ZxW8L3vafkFjdz0C9TkXkImNmGhABuNEpjP5liGxgGbp
-        xt4hMTRwUEiMsQZeEpImBHVBt9Ljp9ubD1cnHy7OrjylBzeUKgz/hkLMyGL0T1qwjPzER5/kcBhE
-        c8J+bC+q41X/jrFvfTxvW1al0iCRKqddIbIPNoyU4BhK3cNqgZbr3EzOK79CJ1LucyL4IhZoNkHl
-        ZKkavTiTgS3kciexPCFlsFniz4TI+XtF2X6twuWcJ1jp9SpnFM3lPFJcXR5INcJIxZpBIh2rJnEi
-        EhkhtG3VxZFq6AaBQEeT+3wqw77VAS+DMviJTAOXw5HDrc69HIqZ/027ryx6f3EMtkaAF3lOmeBB
-        6UhVRx8iQwJvvx0MME8ZKOPtyMQm8lANB1mmGdkuBpCowAAucjVDUx0L4AiYVujo0R4ySSF7KMj+
-        Ijm489cQycFO/P+JxCTyUFUj0szQhDC0IkPXELaJ5ehuKCeSoWEHmhGww90i4fL5le2vkYP7fg2N
-        HOzEW9AIBosnY6GbRZji+GmCElrgiNFMTDIidktFBuqrFrbFizyJQBAuVOVnvuSCpEGHlANJYsL2
-        UEjD3KmR/bvbLYpXHOseYthM9d97xYhceUAob7Ty9mvYNtJVHdtOiEyg2giptmngyDEsiJzdehAs
-        LqEgih/3XzcO9uA11o2DnXgL68b3oBT5iH9Uyvd4h2niFVRMxTXlEbooNKDrRNAOTWCEhmEZqmtD
-        1bGjMLRDGwCE4P7iodneq8xL3XiF29H/6NGbuEf95XrSTHmololdZGGoIcuyge7Kc9uGBjYM3XIt
-        BEwX6wfoSczY/u9EL3Xk1RV1sEdvQlHfwb1MLOjxVvYNb2VcQFFwP6keJgdQSyhCDAVU2nNB5yTr
-        lwJroG1d5vKNJS5dD+oorWhlS8Mqck6SJEhiLgblxbPN8uJzZccSv7jt48oW21NCy8KpHG0CRSwK
-        THwTTExPWZ16Cc2m9c+xOgFl0wrwlO76GeRBRsuafMSr+A+Achtk+WmC4NX+x+a02qjAiiwrtzdU
-        pVugNXsVBmj1ZXwLbx31MkJwgEkOmShlUpaBK3+24Q25YLBcBXq0FqkJ5RgoS8u9sLX7G6hXfqiq
-        t8N+AFcj4+aTnCwt1O7tbPfTBvO0/rK/Bff4jFZfNqJ6OLVOh5jH5fMqInXJevUWKWk9uOXUFX/Z
-        Prqu3jr/QxgdSbdHNBsjOSVjMQrLmnaGR1NGi3xlpS5tS8UUjcXrk9PLs6vrL2eXl9ee0mtoSNUF
-        1xAnhP3ER1+kxnhLazadNluH21k02Fj9XyirwwGVLQAA
+        H4sIAAAAAAAAA+1a3XLbNha+71NoctFetDLBfzLLshP/NWlsT2Ir9WZvOCAAWqxJkCVAW8rr9E36
+        ZHsIkiIla9dSUu9kk2aYsfjh48HBwQfwEEDw0yLPJnesEmnBf3ymH6BnE8ZJQVN+8+Ozd7PTqffs
+        p/CbgN0xLiPBcEXmUcVEnckwEHVMixynPKoFq6JURDGmIS8CbXtJQKplKYsozgpyG5JoOj3Lj28/
+        vEXZu8X98iI2zuP3i8ixXN9E1s9HL6Jfy+O79OotiqyX+enUnJ7mb4wPv73yL6Lr5fTs+hd+NOd3
+        iZ9X54vC/+d1dlgb5jR+/3JBXr659Y7Pby7Pr/XLn9Pb5Mpc3MVnb+5Pz17Xy5v5B/R2Wc9e/+Ij
+        Kf81+xUj73D6PtDW/AtoKiTmhIkIVyy6w1naNm4b3gYoDADBEYSPhSfXgTbctQWUCRKeQLSX93NW
+        sY6g0ICkctlys4LTgk/rW3BoBbblinqmyrvC7uEMC9H9afm4kgIoA9AVKv4LKJx8i/PyH5Mj6Mm6
+        cWVUHEB/qc5rzS4ZWFqHgk4Jt2ypatKgywekEUbH6x9bIWvGBt6mPdoEeLvRtjk9YQ0cOKodhzjL
+        mOwaerzxQNtSbXBB64NYCBlVmN+AvRwvwHIep5zR0DYOUKCtQYoATsqySgkLLbdnDFhLqaEZuAKT
+        9oqxgoK8iWtv0tAVYwwpwmBR93rGuBYVzt6kuWIMtfAiEjCqM9YE68ts4u815rIZFUUpYT6DzlSj
+        M+rxUA+0DWSTYTzKMB9lWI8y7EcZzkOG9rB5qg8jUlcVTNpA6X+1w+EmLkHVa9DASDCRRRXqCI04
+        HTiweJ3HrAo9wxmxOnBglRmG6bCJ3SY04jSaE8s8LjJtDMMU2qLhn3+Mnx/wQNtspvYftPx3/38l
+        /T/udFLUXFZd+9RLcwysitV8/46nktHJa9AO5CcDtXuLVqlMCaQ3dym7j0pWkead3kZoa1FAsWSt
+        HxHjtLtXxmbz+oeJLuTkipWSNfGaGEiHKA6Ull1LEhVJIpgMTaepahMdaIIRePWLULdcw7WtdXZf
+        2NKX8C/PKcy1UCnykd4xVzi8mQvPQXqkYMxpJNOcKfoU+VOkz3T/uYmeI/Q90p83NW1/oLO7GYP2
+        HvKkSj6Iii3nk3O8/Cvj4RiWa6Kd42Eje6942HB9TDy69rfJs5LjxbvZ0eWLo9cnl4E2gjuKCsM5
+        lnLO7ieHRV1x9p2YXEBzKkxuQUKzk6tZ/2Abs/Y3ZKDOq9O+ZJWPRhkIvQjBHJZNjjcGO0bOaIpB
+        +lhNKTAy5zC0QqrfL6x7067jnKaLA5IVNU2qgssDzmSgKU6Qcogx5I7NW7yERAviXmXhXMpSPNe0
+        /2pCE/DGZlQb+QBDrChhYGm+CRdBVpwgalgsMSmymZewxIqx6yKfJsgyLYZ1kxz8Vt5AR2z1I+AY
+        uiODjhHQOGi8ug9KLOfhX1q9shh8HqHYGghRl2UBSXXU+NN9no2RdUKXom9ggbYml89VOy6DC1ke
+        cWw7cX2qY4Z0S/eJb1gG8hydJrrtxJ6Z7KCdHFe/12x35exd+RMqZ29fvgDlfEK8IsXUDB8u12K2
+        5/ouhkHn665txK5JsekjzJzES7DDLM8xHpdP8+UCM22TCfFdNfSxfjydkj7Wox309FAtn5mgPmkE
+        2gwuhKzEsGMb49hJLNMg1GWOZ/oxTN6WQT1sJ7ob76AlSP2r3Weivet+wplob1++0pmILWQkmZBI
+        +14sBXwyRAPSNCRLWbWDUDrmo1LZvbon0MbulX/100jiw4UxZHyQB1quS0xkUteLia0jlxAE34E0
+        8SwHE+9xdcgqbaAoSe92n0z29uAJJ5O9ffkCJpPPUD7wZfq3fP5P5PPpuR9icBm2Ta3Ed2KKjBhj
+        N06oYcB/gmMfES9xCKOmtbuGCr7zDPSxbjx5Ury3R1/C2+zTw0YAwAa1bM/Hnm95yNYt+KKAzJAw
+        4mHfMxzbMDyEfHN3Pcn7Yk897e3Gk+tpb4/+x3pqA+u8Op3m7RrlNFZrlFMx5as1ymmTxmn9823M
+        utMDEstahJlKPtagnlDHFEus9feyuGV8vLDZAn3psoR8N22aHskUqpYrWlPSsepSsCyLslTItcXS
+        k4eLpfDr/CUa49oWGzesaJZ8ISgZfN/LmrLQ1g9sw3d03XQDbYUGWcFv2p9TdKAjB+m2YwBhBQfa
+        YGyORcSLZmchEeqdsgY0++jNegKjqw307lbtvVY1581Sg1qB1o1u+3UNVbunW3ibaMAZoxFlJa6a
+        cwFqdVv5sw3vyHWFmwlmROuRltC0oajyZgO+df8BGjS7Q+2xiSP9cmLNLmC49VB/OKA/dxHd5iFq
+        dn+34IGYF2p/Jmmb02p7HQsEqJawduV99eEBtBHcc9oTGwvJKo6zyQyIk8NG5pxOhifalXh10mXb
+        3tG2ggCEVXd1Xb04Pju5vLo+OTu7CrRRQUdS5q8wzVj1nZhcgxRFT+sOMXSHT/pBtXZK599sd6pu
+        4iMAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1971']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:21 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1885']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:47 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>credit-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLUxtRGt6UTBsVXh3eU5iMk1iWXhf
+      NjQ3OTMwNEdDQV9WcER2aVNRMF80SG1GLTMtRm1QMnpqSTlOX1d5LUxXSm5DaG52Zjltck14bzlY
+      V2xCdTIzLWJZSHhjSFBrOERNZ1JNVzFSR2lrZlMzeHZiTFB3RkxLdXlnaHowUXl1VEtKOTB0dFpU
+      VmEwOEItWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vLWNyZWRpdDwvdXNlcl9pZD48L2RhdGVfdGlt
+      ZV9vcHRpb25zPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['361']
+      Content-Length: ['352']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkgQCwdajqwjTcMlFnsMi8KIaVBhRaslMD4d+ZP5ssm
-        Ny0sLi9j91CeW1ERRiePUpk3773KPEqQ9teD60gLFGDb9/78ohzkv0jIM33L9iZ/fhkOTuTql7/q
-        /9AsI0R6aLtI9+choWI9QDhywrqGo7Hlu4bt6RFGgW5jfWxY9RXCWm53kWYGq3no62PHN2d1rMty
-        7a6lhLN7+/jIeTTx8bCmqA+KjNwhemw3ho32QPeci9srfbWadZBq3laVRbVz3xpZtR/q4vHmG1qq
-        4cP4wbMqyvR2dXJ2Nxuhm5Z/1j4uVIxl/tgpdpoXLbnSvfIGdnQR2nKpM1pVg8nyVD5szOZ2cI+m
-        0dBo3F6flE6vH5fdZvvxe7c8/nFoj+bqeKTl1tqseQhZuoXmRhBGAdKpceqer+V24drUwPocBXe6
-        Z7gIc8tsYFqEib054tiYWBUtkJf+MQJk6GRQUL15o+XSI15gIWzWm2QMV8spCpAgMFQb25Nori8M
-        J0J1JZ/XcllAM+1wxWtyfM/yPTmaka4mIC9nFV2yclHIqzYdA2Pxh/PDKTJC2oAMJsrZKYP1cl4N
-        8QrmIrw6Zp11SMPICMypPkOr+Ao54lspSF1QUOMzE2StvpS3o8qZbeHd1fKOiPI1LKWwvpwYru2s
-        MiTew1x63VxsNB+HemB4E1LHGJHPbEB0/+4OBWRUx9h3IhJw2FgQv6grxQMycpuodhc5DmmHO7Y9
-        ZNXVAiWtY5xC+hTOA9tE9VIl4aSgIEWk30ZAGqSmnATTWMvSios1StoABSmtuaimrMz1BJBUXsqw
-        0iuSYDCJ8xuTpMMFVctto8SltwzoGg+bbV2DGIGfDzZ/k823DciQjWasY5yy3oR1SHNp1Md9Uzgj
-        CwkCGe8nhq10oJaeHTalylg/HzdCen7c8mlFTw+cUnrJwGVZPxm4/EsHrvTEwG0YkB5vNmId45T1
-        BqxDmufr9AbmIKxDZoPM9kvbHDIbZLb08veR4YV0ziuWPXWNhKNt6TFeV7TcBrLJKDzLKD7LKD3L
-        UJ9llLcZue3usdStm1EQkGUgocSf+IR3Mp6TOewalDLuDDP0A77M2ARTlhe5YzI81UI5wxJgypo7
-        hkkWRoUMR0AZDh1svHLHvpPLwmTlxdH6v/+VPT/FtdxmN0N/rjOngKz5pqy5Zb/cE3MCCCgIKAio
-        twRUNopMP/LCQDgME22yQFLM9IehZ4fIklqkXst3U6pQcQI7tE09QAsbLXXREuFyO4u4FMiHG3mW
-        OBb6TvRVUqrhVGpEkwiHUiGvEKdMCZwbhSbtFEZhvVimF9pEUxpGpu9ZmNy9K4paUvNr7LiQ01fk
-        n+taVp1eNF9VqoKZ4JqN/Wo5rzBZTjc8i+mZjC7nq7JSHSi1P4r5P/L5f+aVP+iVdp8g6t20AD/G
-        oRGEWzYpKMQYDTKcznuapKwUysXSi01SKiivMklJLihvMYkwAZMuuT92hoOjXuOo1expuQwsKMwM
-        bSMMp2gpHfpR4KHfsdQh3QkMc4aC3+KTuL34Z9uql89P4hJyJHCHeLmfCpFZUDBI88II1x17kZQL
-        KCZEY9IbIxcfh6s5qmPbnTtUASctCuPzWIlgRXOMSHbJqLe8jc3tNj7Vdoq3hlk8t6PuCfKp9Y26
-        5hjkThMRQ6rKAckiyaHm+N6Ef5TzBwotSgAtl55PRWhyl6aqM2by9RpAtVSa35CViKjikK12gsjz
-        6BqJjb9SEAueNZRNr3fwNtHXyekcjAKD3l8ztBjhBNoHP3ANj+Rm1vwtVKN3O66pHyk9qTTokEQc
-        Q7FAbBGTU7Y+c/nyYAeu4am/5No96w5/9LGOaZj4NaGzytEDcR2ysqfVZeCYw9MGKZf6Kxwid4QC
-        XyLNlnxPNgNk2aE0poHhWdIk8KN5UguPD+Ixkaix3zi+bPb6N83Lyz6Zq6QFgsRO6BuWgwIScTfE
-        x3BME8q1eP7wfzdpizu+5jCmYU6JE8VLf0zr2sJeK+0XXjALysxw/rtZUP4lsyD1HWdBL17Tl98m
-        gCVazKsEMLD5z2z+DgJYHgSwzyKAvV3ahyiDzLZfNofMBpkNpH1QIiFrviZrgrQPAQUB9aEBlY2i
-        X0U6fkrLZFtbfd8Reki63TXFqLTo2C59LMEEvMzhuynSTHvjrZMbNT6vYIAowfrCxvbYEXrdJshZ
-        qRTMpTx/hrz6TJblu9KgbNi3tR/nndZFpX9e8e6PlsPF8ZF3bJ1+m9i9KyWITnolfIoqlU5rOv4m
-        t1ur2tXgpFscquePt+KKvEZR+2ou5LnmdVycQNq2jrquobK92cwtKgfFvPStTfwsgXjpdOq6mIx+
-        rcieo2Qxfr1UGv1w2Qse/sG+r/2y+d+y76v8+sWh+oJRKyjPj9qLlobFF4wa78Q7rQwL/+uVYQG2
-        s0Ja+8Q2h7QGaQ0EL1ifQ8qEvawQUBBQ+xFQuwWvk8D+KhUKnvURglexVKu+QvAq7IngVXib4KW+
-        s+CVN1qP6uT74Ef3hz/C5UK08uXiVeMBHfZviu0zfFJsPY6CR+wpZqnbqzxY1vll4xEEL5DEYTfE
-        ntocdkPAbgjY5wWZ7fPZHDIbZDaQvWCVDlkT9nlBQEFA7U1A7Za9+pH3VSqU6Nem31/2UguF8itk
-        r9KeyF6lt8lelXeWvfqNyaBzXz67jGbDcvviLlx5pYF5K7tnSG4PB9huq6taeGLhYnfy/brXD9Hk
-        HC9B9gJhHDZE7KnNYUMEbIiAfV6Q1j6ZzSGtQVoDwQvW55AyYZ8XBBQE1H4E1G7Bq+1TwUv9GMGr
-        nK+9/GcCS7QreyF4qW8TvKrvvc9LPynbre7dQ/taPXyozNTeefWyUw6j+XVf1oe6Oix0K0Xr8Wih
-        ri6no/Z9t3t1CPu8QBKH3RD7anPYDQG7IWCfF2S2z2dzyGyQ2UD2glU6ZE3Y5wUBBQG1NwH1xO95
-        ReirVCh/kOxVU1/ze17lPZG9ym+TvWpvk73o23br557pRPT9xuxn9CVMB1OaGzg+i5GekcnaE9ls
-        dZeV5fX3YrnfOFPRbaebv/Nn3km13OvcXSjehTFSEJKvjr9fnS5WV1Pj7AFkMhDSYQPFntocNlDA
-        BgrYFwZp7ZPZHNIapDUQyGA9DykT9oVBQEFA7UdA7RbIbpD1VSpUPkYgq1SV1/z+V2VPBLLK2wSy
-        xjvvC3OXo8dB7+xwdHtl+7fH3Uf77t5C19hYFqcXqn5a/WZ6x6dtZbhUfnSjc7k7ql0Nf50vQuYi
-        mt/5Czszr3AlkR4gQ7TxhkR4csQL2LWaCxSsllNE3zebotrYnkRzvtrhWS8LaCbNq6wmhzih78ns
-        Jc4JyMtZRZesXBSKdzY7Bu0C+8P5yQtvM5goF6+SWCvn1ZDRdw060WTVxS95zUDxW1BnaBVfIZe8
-        ApWCGvEXQY3PTJC1+lLejipntoV3V8s7IsrXsJTCfznQcG1nlSGJ95em183FRoMFPSzof2Wb/y0L
-        etj08otsegGpEjLbZ7E5ZDbIbKBWgrgCWRPUSggoCKi9CahsFJl+5IWBcBgm2mSBpJjpD0OPSnxS
-        i9Rr+W5KFSpOYIe2qQdoYaOlLloiXG5nERcq+XAjz9p6VahSpcppNIlw+J7SaUVRS+rLv1JbVapb
-        0unPNM6qrFRfqnHmdlqAH+PQCMJf5/Wp7/We09y2Cbg0zfyxMxwc9RpHrWYvVqy5m/LP/MvYRhhO
-        0VI69KPAQ79jqUO6ExjmDAW/xSdxez0lgPNPDvFyPxUis6BgkOaFEa479iIpF1BMSNRnfkzV4Dq2
-        3bmDSG9Ji8L4PFYiWNEcI5JdMrItb2Nzu41PtZ3irWEWz+2oe4J8an2jrjkGudNExJCqckCySHKo
-        Ob434R/l/IFCixJAy6Xn08cD5C5N5WbMHgisAVRLpfmN5MBYRBWHbLWzLYxvoWx6vYO3iWoeQhYZ
-        3Tnxm4jcU6gvsfbswgU5Cgx6f83QYoQTsro6a/4WqtG7HdfUj5SeVBp0SCKOoVggtojJKVufuXx5
-        sAPX8NRfctGedYddbgPTMPFrUzxUQA/EdcjKnlaXgWMOTxukXOqvcIjcEQp8iTRb8j3ZDJBlh2zL
-        MMk80iTwo3lSC48P4jGRqLHfOL5s9vo3zcvLPpmrpAWCxH/307AcFJCIuyE+hmOaUK7F8wfuhp98
-        6vZUJ03fcZAZ8odoZOAewhRjRy20ksJpgOiDjSy+zfK9n3MGUxtL5D/2XSSR6ZntSRTfPCe3q0k8
-        BbOnS6Lp5M6NIyes/wepCqetXqcAAA==
+        H4sIAAAAAAAAA+2c21LjOhaG7+cpXH2x52La+JBzj7d3JSFAjkASApsbl2wrsYlPseQceJ15k3my
+        kWU7dkIoGgpqgLirq4h//ZIsacXrUyCS/lrbFrOEPjJd588fwgn/g4GO5uqmM/vzx834jK3++Ev+
+        h6QDDBVs2lBxPUysSPEhCiwsSyhQddcGpqMECPqKiRQV6LLjStzhEknzNx52FdVytbnM8izbs0/n
+        j9e8dbNetdet1VWwUKb43nMXurGyEL/sXvGD3rQuiKi0tnTc8Qa23jDB5eTyUvQM4Lb65UZx2i0r
+        jyvxenDRuBsag1mdL9UeFo/XDVgf1ozHwL+4ulO9ankxWQubW5e/v39Y3k3mKOhu1mrjzhu3lTu/
+        32reabw+GsHAE9mgo1t+Q12U1sP1fb3WHeAC+7fE7dy/5ECoKzr0gI8DHyrhPNHBH9IlAyDFg/5U
+        cYANkbyBSOL2NClAZOojxTIRmWC4hE76A/gQKGR9oNy6lbj0KirQIdLkFlnOzcqAPowNVJU0E28i
+        r+U6uuuwwZwMZitG5dTao+VxYVzZAgjFPyI/GRi5+4wQF1J/nRQyfwDb+zfTJFEShLeSKZZILNDA
+        iJql87ArSQgCXzOUOdzQnjgSTqkSBl3sS6ptlZ3GUt9+ezpwNHi40Wg4iWFHTD10HA1gWRDHAz3d
+        qxCNlEtvgUsm0UVY8YEzI+3ZYE1atlXTgbpcEk94iduRqIHcJPZ8U4NysZI4Ui2yBGQYwCdNlraO
+        rSTZ4bwmTYoCdWQlakhbFKqJI9sLnc6kycLWkfbiuEoYuxYMJ+t7DnERAAeH74r4KShLS2CZupLo
+        siBxe8q+Q3zRUXjRUXzRUXrRUX7q4J4Oj66hogW+T7ICsSSvorfDTPVIVO9IqWMKNOz6ssDzGU8s
+        pi4nsFXoy1WxnHHFYuryLKCRh6OY8cRSxhPGHNrYqmtxWZk8fSNV/u9/svVTXeL2h8k9E8v5+h/J
+        +mcXXXMDB/vx+GjSzArbYvq8v3FMDHWmS2KHsE9qjbOob2JTI+i0NOEqzPFamNOjGTpYFHFXdHfQ
+        0eNr2tjYCH4yAsLMCHoYhvPFiLxAZjG1RO4Aa4o7nSKI5UI57GpfTW0IaiT1I1koVsRKqbjrTgoj
+        +4b8s22dPGtJp3yNF2LnVieZ2a2WeYGijwIcneIjtbN8jeWFsVD7VeB/8fy/eOFX2NPhCnG7+3MQ
+        XSNMkvmTWSlhg+mDzXvOR1ksVgr8b89HiS+9aj5K5P9b5iMeP2XDKBwHN+PmsN7stoYSl5FjC52G
+        PsDYgCum4Qa+A/+JmAEZjg+0OQmhcWs0TipGcxa9NnW53D5LSshVrFsk0F2ZNAdwyHhZMXZ4ABsy
+        RyqzdtQvq9J+WcQ6235ZDBHmkvq0SlydjBAHSLbM5bb5WEoMZJcBMOCSa7zxoIxM27PCDQtpHCf1
+        aEnsCjwELStL2NEQW0+HSF71L/iszh1oYwbdcKGALFmAPEIDMucl4aQk1sqCUKhI3FaVCH3Popcs
+        fyLwZIVLZfJgS2WJSxsLdwckF4XbAUT3FTtCSL8hvxC+SbA3vqTE5AeOE24maNwIYgxNOyplngO+
+        ffV1+5xIDHwQZpGMLVEiQzgG17dDbI5u/4kqhc/0aLPTFIZMcTyQuK2UIL1O5j90K3Nb5kNmO6BL
+        yHBX0aaKDod2t6dJiMQlsdPG4ZrEC4nJsLmMnHiifdYaQ98BFjMmRqYRBrKjM2mN6P1D976HnviH
+        CiQSWEHc16h+2msNR7etXm9EcnVaEJto8yOgW9An7+FbEoooscVbj3jLeHTQkgx8J5Q0oBkkvJKN
+        BQrbeqLle7OvO8SjC/NjZfN8b3bc659d9C9B/s8hNP3o13WtOPmkHwenWkh4lmmHm0rKUZnLd9tQ
+        UASK7o6t8x2CWLEQlyBlaSJTtWJs2hcjV4rhEVG5BIbkOcuy49mFuTyv3ULzZji9Zh0gqPdLcdLh
+        B5WKaEwGCOmqXr3Bd+bY8G1+PX1QzgJ/Wni4turQnrT+jnuMWoxbJyQffwg+SYq3kvQUZ3dRlv4a
+        g4ZF5aTAM1d9iUulqNQwbBuR1a9FK5/Vov5SQs0ZI2eMPMd8txyTM8Zxr/9hxjjzzZ9M+SMYo1Sq
+        FV/BGOVPwhjltzFG950Z46axrLCrqcJ7onZhzy/RQ6Wndiv1q+r80e1OrDu92H1cVR0AzHa3ObDK
+        nUXVyhnjCybgnDHyHPNdckzOGMe9/ocZYxQ4P5nqRzBGpSCKr2CM6idhjOrbGKP/zoyhVpRg5syu
+        bq3a+ciurnh/5d23mgVWV5tI6AKlZBZ0DTTH9/1+o3enWMoGn+eM8QUTcM4YeY75LjkmZ4zjXv/D
+        jNF3CWPUPoIxqkL19/9qrMTXPglj1N7GGIN3Zow2gKg3mE06k/lFQVvO4KA3aRf0eRk0u9Nm/6Kj
+        n1p1/XbCVtyO+cC2z+vj+6mXM8bXS8A5Y+Q55rvkmJwxjnv9n/l7jAD+ZAT+IyCjRsjh9yFD4D8H
+        ZAj82yDj8m2QEX6dUG47mhWE3+VkVKDNGYTBDDIeQEktanoBSvgr0XdtZ72pgaHQBtOlURLqm6q5
+        cE13c36jTW11qJ47RaER+HVjXDOMCx/nUPIFM3YOJXlS+i5JKYeS417/w1ByC3UCJcKHQElNeMVf
+        cAhPvy/3/4GS3/4a3i6UXL3zJx+gozWCud+ZmFOAW7COptdnFTy8qaOiYqwaD8pDe6H5pxpSr6F5
+        HkwEV+ED98tABvfcqQ75cQ75cQ6fFJVyGsxp4LvQQE6Dx73++XEO+XEO+XEO+XEO+XEO+XEOX/04
+        hyhavzm6PDfI6Gl56CDK/wHyj1aGylIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3214']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:21 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2134']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:47 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>credit-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW8tY3JlZGl0PC91c2VyX2lkPjxzZWxm
+      X3ByaW50X21vZGU+aHRtbDwvc2VsZl9wcmludF9tb2RlPjxjcnlwdG9fYmxvY2s+LTAtLUxtRGt6
+      UTBsVXh3SXhFd1B1cV9mdFpwb3FkaHdsczB2S1AwTkxmQTEyczV4bGR0SnBObWRCaWFPVk9PMnBo
+      YW9FTTZCNGZLNl96dzJRTkhCWFJoTmdBMDU5anF6UUJlQVI5aHp1ckhQWGJwODZxVngxeVdvMFpa
+      anZYVmtzdUt5eGJCWHBUSV9Yck1FQ1hjMGRTU2V1cDItdUpkbHJCYnE1eFJ4WkE5S050My1ZPC9j
+      cnlwdG9fYmxvY2s+PHBlcmZfdG9rZW4+ay0tLWFKY0J1a3JKVmlmYXRFZUFzZlFGN3RSVUFzNF9o
+      d0JqX2pJcWNyRGNzYlFlaUd1VjFvXzB1b2YzalFsQWVtVkVZPC9wZXJmX3Rva2VuPjxwdXp6bGVk
+      PnllczwvcHV6emxlZD48L2F2YWlsYWJpbGl0eV9vcHRpb25zPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['445']
+      Content-Length: ['436']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9lLDK/OnYdhDCgQ4pedG9ZN9dozMfQrKvCneern6x7BjmluP0mS+pLbSjlou
-        pSFfu1fcSJcGkuUmXjl43G7YY9Ur7RZ5bvnDO7vdtWvnuYO2EWe9//XaRgwS/hPaRnyhbV9ztvMu
-        L/I8uaaA1+X6gJ33fhKl57h52WEPxe9JJvGjknnZHNfRAZPRZNh8N+BWU5ltVEV2cttQH8Er665V
-        1702CNItz1NvTe7Q+EtXfO+G53+vC0f8hoBP69X4+Q5da8MwTYf8Axohl1D8iF2f97ZLnKYshyNV
-        d/90HUVgDxv2PXRn+JZT5+Ut+/gA3llZk9pe+ULC+APrBt5ZwxnA8arzgekj9MAZ/N2sutTOk+dH
-        eBCbK/ryX//52P6O39GXd6fEs53OIeIWGwa3GBzTts5ZgmVXedIMe6Cy2sHowyzPgvIRHduXLZIP
-        /v0SowAAWOhGcBjKx4l2epq6KQfsp2FA4TLXAiehwZaktN+VLnZI9ZkZn0ohcE904SVaO2J0CC82
-        OoHTJ9SJd2uVV21wXySteRpVRlriq2YRNZNtK0KkgrczNGD3E58urMrPDglEWRrU2CEaL1fJYFsp
-        O/pgBdRs5/q4nlLG4GiJumCH6VsyF1eLZJsjuYmeYAUpZsTqKCwmRjsVUCASLC7UYmHByjq7JiOH
-        Jb2GOmXz1ukAlSvXgjUR6mIyHa2NVS8IWYpZi8Uy3q8qnNqjEBstM5wE/EWXd5w3S2EtH2SacPUN
-        IGpYrRsFdNixFMfrcs7uUl/wD4Uz81hC7Qt9zs/jxXYE2+nkKGtQPN96SXtMGRR39qZrLEp2vqki
-        XIr4vYUzajSyZRlzGd2PXZNyTGEpAQxcQU3K8hslKAFVFXaWxUYhTi85GA+QhbXX3Z1uF9NlTR73
-        NtisQyDvNhYucqtNsoAUEdwRvjDy/WAFLIEkTQJ+NDuOVitKQ7mtJ0/qKW7ZrWWcmB3lzQOc3vcL
-        kYiIMBd8smZVI6F7u8h2a0dChrjjrRGKKchqVolQtO8PUFz7SIplGijYrRq2+Wm7ImN2s0ljczgS
-        Puyo4WSQ2lE26Bg8Ou++t+J4iGiXg8EtcsjKnBLkQVPfwXfWNXScU4qsfhoir/dAfTuXDfo+uORr
-        9nAtjbM8u3403x6OXMbyScUD+SzMF296QbD37HvNI32IiKFVBt4L+oH9VvHAvvns5/2/qxxfdca8
-        +fwgxIMIfYGNb4clK3jz67NYfYk+CMTVwuc48AF65JxN+/wOuUeA0joODbJ6OKDnTXWLZNAQFz+t
-        uNDrvLaSD8xHbHy3LYzf0p9XW98NiVxq7nZ9Z7Bru/c2fH6UxW9J5HcVUoEBYKNa7janZXEysddF
-        EiL2fjqiJXrDi7IyCrCN5a05o26WvnrskTInR8vZfAvpoVuHoHtqKRaXAshd5h5f7FWfsZZr1HGI
-        nakJbgVDLIDRs3AWlNJOzQp2Na8xsD5BthSwuo+14Gzj8NKUnS9yMGZStF8rdFK4S6aEJl1LUfMC
-        ClbE2lB9jEN3O3DiaJB8yrplWTFbVFvGurpaT6qWnAm6FrQzQlMtcr8lUoHdArK23lR5LPXHPZku
-        LdrUR+48d1iwxben3QxXDgmapdRahvA9nChctZKLqQ3RipadDgRmGVmE7qKctoR8NUhd5I0SudWO
-        oB6a5pTaaawIxyl/8JKDNaEUUJgjQbasj9K8Dmx5w092B5YQbG5zOALGwqnwzAs6WReiEUUS4o7R
-        djXY019TGAR9rzBvEnDLqL6hB+hP6QH4B+sB+EfoAfhDcjD9xXIw+lE1GH1TDBDwq2KAfksMru1+
-        pxgQP5IuNQZYTbekRM5ZNp+J/AJR44mLc65RHkQgX0iqDDV8uCHIIrBO8NKfdTMX9yWQnsiVy4nH
-        JevXiLHWTChQGC1BDt12yEm0BZtzlFgfibItMqQRQz21iYZPITbhYj9H1olgqlSFc15jj6RucUIA
-        T+ShFJN7AQOA7X448jKyoHCYwQhGo6Ehpy4PbGMW8CjmD2iHmIwnjQ4rtNvDYttPNkdtxkW97AMY
-        QAsItD1hslYEeBhtazhgT9rUMuBOcWy6iA6AlvkrQDgAVb8P0AgmWtwmJkG/qw6URxWdnHoFvl3B
-        ju7XGa5XC7M+DHJXMVK2PVGqUTuWVjQZ2nEjTo5XvTHKo4otDtQ8cTjzNBcmuKBRlQykHH+AJnzK
-        ItMEp9FpKgmLo8Dl+5JFjjhPiahg7hoa3nmj0ndFM6ppt1DnhOrH9nHrFm0kOgZ0RBezAGlUzOmn
-        +2xqUQcTSpvRAcz4GTtVYI44YllHLHsfnkTUWqcjYaGolK0THFbZQhYxVBfsCTuEtl6xOhVQeVRE
-        aDmdSaBJ2NRBULH5EYtTtidxcSORVJjECcQ5btvEMxeegliJqMdM7YhNSuZrb4N6K3/hWVAz/Wq6
-        BP/B6ZJ3si43TK8HUPdlukRJdFBK960EvZaGNvWgLddvWM5nxgvz9nnsN8nlw62D1+JZgEuvqgcX
-        Gw6y5vlS91WKP8LjMj9eexhk4Prx4v2X70suc3s+A4U1TCUvh8/Pj2P6dHzQ5+OD/gnje/5g63dF
-        0xoOeaVnJZdnf6XqZ5Jb+KeSW/gPTm4/9v+Lklv0h6LZ7Fcnt/APJ7fwN+MZNPp9ye213Tfi2cNl
-        wM0E7Ha2pN7aPNzOPCLX722KwaRPTlQ6ife+weuFzB25yhVuAkCJeIzBS+zIiRo9LTAIMMuomkPw
-        EHbSpXHM2VlsCFKdSMoUmtMHUyq2mVIaa9wbhRnHjBqOxnXalELRpbiM49xutqiV9WRp29Zsg+rv
-        h3LTyed3tx4/fAWCfy+kV0NIN9NuGqUw2xtFD6dDPIRCRZ3N5kWSIPuDkeJJvuBsS9UUvOMSmAsE
-        KUJgU0cnqDghFJnZRo3KYbpm9JHANfaqk/B0pNvRceGr3ImkY5qogdmSZUVqsWR1xTQ3ALUG+U3P
-        oIhu95R00GOAVyNWWg3J/QGRfVICtaJoa79Q+pR2TtEEdzbhAjPnp/VRjRVNVEeSIB4Fo/djdpen
-        dR4CJJsBKl70yn5r5nybjmCGnWzKo0dNnDrcCOXaqcvjBm4odD7vapwlGIE+UZy04Pfw/MRli1QU
-        Z1yxlJGNUVIspUw2yZH3ZfF0ZORDmZrY3OpoqBKIwpRkmNlI6kmvIALBfNWFl+lqQ+9BhNbSbbc3
-        Nho7yTHW8zK2D+FFxpGAFvVO0bHghO3AdD9MAxLFKkiBEFdT2hDZEnPYcgi42cFbOnMTUMgO2SXW
-        yPQPu07mY3ym7VtTgAALLGFuv6BnnrAezZ0+yzkpdtXJJNhyO8NTIEdRTzVoNpY0WvJOaO9n0/KQ
-        pAix2SKYQmiEvUIrKWWDzR4PNk3jVlJzQuQFOUf29JwK+aO7Byegd2qAfHBoSmsxDZAmrVfop6lc
-        Cfgqmpx6EWOGVI89rbmRQ3hrAgW+Ft4h8k8P7waLnW/Lb+H9XCK+Gt4vzI/h89bBPxA+DfYXhffL
-        2D8bH/FPGN+fHN5/6qwKQz8V3pGfDu/QHxLesX/O3dUvC+9fv7uCvxne/9C7qxgeonVoidSJbdpO
-        nJA7CUm3MKnXDB0s3Jxk5Tm1INRTbPp4CkxyF/SLgJdGEy2fBFw0xOK1YlMOZrRmc8imkgVaqwW/
-        XCLiApKcLt+RJRA7eq9OZe9kdwtNm7aO1ymbuMRm9JZQQDCekBFWoFC5SVAq2DJOu2kiWJlOlQLj
-        LRHtaRaTw5mRa5a/c/OyOW44g90TXnYQ90pPrE9HCJzHVRZr4ZRFKD7crvIkiGQwYwJ6qaxG+VKD
-        mLg5GCWazBM/CMJ6BzKpvxwFCEjiyeKw2mJCGYl2OFX7YLVdqWqaTFy+afjhxDYbsZzmGG2ImCt/
-        KQsAsLYZ0/AAIF00G3IKa8sZUqc4Ge2lFeZC5ShIPNaNVrMRh2NpalJ2q8+Nvi8AItPSY1CSEaKv
-        5aYxlJ5HSo4iSvmI2juF7pbTksWOmnH9IdXnx0Do995pffTMb+vENR79cTrxsf/v6ATyr3ynhfyo
-        SiDfFgnyd54ByH9AJLAfSYA7QQ1rWmSAkNJbngOFnaIqeLBkTiWKnaja39Xx4M1p4LlNlPgZG6l4
-        QsrrzTT1CDEsZbArZcyiGXZwFYd2bAIwPHiz4BGpoM5XXTP4iJpFxm3VWYIDyxnJhD3fFqi4rTdc
-        s816cW4pJV4cCYPiAr7bnI7oQh2ycpPR0/aEwyRLo4C4na1Ow4k+3ulqzLe0Sfp67uzszXZuTwnS
-        Oa1p0d8Zkz6x/WxfAH0tkHC3AGALLeq5chJ2iFYkI3XvsAi4H1FbxHaqFbbZ7DZCfIQWVgoEh8h0
-        jU085JGbrOvXmAaj1KJWCTBfknGPVKWbxMBCoqwVE52yWbqdIDtqrSzrjZIsFvMZ7XXxfM4RCVW3
-        JTxPDnnRCORIcE58a4idOVP7Y+FIe9oM6Bjw5RiZiVWzLXE3xbY9wlBdCXULUulQek8iMkOFvqkr
-        gWNSvCMWsbpK9UxS1WZuayBkOzGHT5283gXzrg1STJTziQFWK4iecfPDDqty7hDVBrxpWNxpJHOE
-        8slwTEMRYr9Gclc8kYm6j2m42B5jYibWoKQAvgSVGcyMKnJis9mc1fx2qe0JJCD6ZmtgllVUJ2bL
-        ixtRMxMbZQEGPLBLc7vwJS8ivp4A4396AsyIKPaW8p5LOPj1+y3skwTz1sE/kGAy4q+638LBT8d3
-        hv/08f3JCfD/B4Htn3S/9asiG/o701/0Z2+3JHly+anZD9xuyaH3JA3DTZ7+LfOOT/XZ9H/9sWuu
-        lQkAhbtZe6NRvTQTQ2yZpBy1uo3yfNVClkHMuCZuIW4WZf3+NF0fEfcIS5EeJetEXtkBwR7Jil7K
-        B30+4dZ7asPGfb9pY27epCOTIBW2R1ahwAtp0h5SB+e3XuOwaDs895def0HI98I/NYR/l6QL6iiu
-        Kl9z7V0VdFHBtNPW4thFGS4pEjgc7PoQGocT0ldBSu+go9jJQc/NpPk+yzz4oCnEqN+rVACutLbl
-        +IyJDwfSjw/TtIJCXcnAnUtazf4A84wygVlnfYIX21obkfAcVROG8Fkst8C5oCHQlAMXrrKFIKcq
-        DrbDHPRVhBhLNZK5vQ6iduyO2J2wLFijPa7S6qj2S36fxSEeVvHG6uZ0Sc8oU8NlvehXksztjqe8
-        zFeBkykew+LHHkJ9Olhvog1diy7KmMpE7SN2JXVHeTeK1GiI9k6vK30Qb3ti01NdBkBcxZK0zC4x
-        xNNX8jwxpLgOWO84WheU2yFAlZApQSw8qdrT1moqHfY0gVrlpg9Rz+ykkmMD6ZDN0/C4kds6LE/z
-        ns24kQn2m6pbuaC9AuqUVtvtUlSYtt/RKSmL80O/m86PB50xwtkKAog+LLCsljKZBSj4AHAClm86
-        veo4qQddc8R0VDrLiABwN2pTyy5YhLINGUXXzaqtRB5KXynAVdpud0LqbgE9C0LQRefAUpqiKShD
-        FcQWEe0RFJ1XPfT1MwryL/TLHgz+meCAEj8VHD5+VfLd4PCx//+nb0cw6Eejwyvza1/mY7/zy3zs
-        Z8PDdLKciYL+Q/FhaiXDzLqf+OJjnwtB0Yrx0Zhp2LZidIZleYfCAi3zouV2CppRRCwJgQFGfIpF
-        oMkzxqKGO4I6JWE19ZbKIExzYNWHDeJAbAwBB1kTcXs/jYwCs39E+Z/f/xTUsTIz8ax22BTDlki8
-        24+Nv4THw8QKq3bC+6tzb0jq1WHuPgDXVEOcDrnhe+yRUtUvl5cC3kN3xsWSs+u7cE9+madP9RCQ
-        L7/9fmh0+xX3a/G2Iy/vc4jTB95rxZ16NY8zrAvI+6ZsHMCCd3i6bMJTGm+IabLWNappT4wDQqDC
-        zOhYwDJrFZ1qq1sR1HaeZNDUOMzXGZ4Ic9tyjL6WZFNjcaNHVcLfAyNC9bn0lO51ODFTV6Rn2Zyv
-        ZtlkHTFGJAhpLUyXS4dpKidxei/EO/McvT+M8GHE5xW8vR34SLsu7NeX4/P1WYuS/J31Qb67PusB
-        e/o3hX/6X0OW/n+f2NJLBsd6yrOk++sPrdIwih9YpXhYpT2zUZpstbA5cktW+2gr+nZrF4G8RPZH
-        LNjtqmN4HMVrTWHlI+gcRZBOJ6pWkicLoZDZxGwpqV7wJIxWu3U+02qQBsTYIW0XayltTyujQuE9
-        Ge33+2MoH6aIAdomR8KA65I6xglAtcvVSabmOuipm+5Q8by8AYHvr9j5J9xfLNcgx2lUn49T15fd
-        Iu/+ztyHl+ci75svz91s/vGtuee3zp4/fdaX++WOvLn487deL/5vlPMKnKM8AAA=
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEFbNU2bBIhFIBASCHiRaQME2pBLbL8zfzJfNq6F
+        YImIjIjszKqZTivLlB8/7nK/fu+51wvV/3HyvcrBiYEbBn//DfuG/lZxAiu03WD999+mqoAwv/2j
+        8W9142C4nmG6npuc9TBKIBvosQNSL2nUQWraoW+4gZ4CJ9ZdoJuG3QjCevXtnvo+NYLkbqZG/WB4
+        rq1f8QZWrz4hzwz8QwbxIaP2IYP8kEG9ZlRfb8+Kz1ES6qYXWrtGG0UQ3JUHAUsuUqWJx1Ikhpsh
+        wm3DZKfsBRcJpjVrqbUn8kgCwZHUgpapThPZ3m2nW8c3ouFu44o8G9G0szzP973xghEUdDaYdmsz
+        rAcwmZvqGwHtKltSXJI0jiyBJxHDrhu2xvKFU3wfHGOWZAZOc7HWTzE1N9W0KwuSaEctOmbY+Upo
+        K7XLfINvLtJmDVgKrNS5veoDUeZ6CEEt69WHPdWdgxNAVzBix9Ch+ziNtlav3lpFh+0Aq9GG3nY+
+        bpzYKQk5Wrcyg+VcLwzsMEDSHXzHC1j059RB3l92loM9A4Dyn4JvxAmAlBtQduZ8DnZW/t3wo79V
+        mtCD02wpd9116Ke50xbTnh040yNUB44RWxt955zzN1Whq9+QLCBK3nXYC/Iw2Y33PJ9tBJbz9qTF
+        dq6EB/DGyffBG57nJOVGW08Dip1Wb0uoXo0YpkESl2bPD+EeeOnOx08DN3HsigjVAsb5jVqeSuwm
+        rgVl4uA6Rz1yYivzEQxFM+d5q6tuG4mjx0awdnQnsMt2Ppm6Sf+rgoGkojhR4vimE1dwFIPRd6MU
+        7DSx9HC1Ak7SIKjsVc/ojQYcC7oSaGA1GqfJ2iP72lnQz/CP79t2I3spyqJYyXzB4UmHDIVieg4b
+        ga0nru/kdARlERRTMfZ3Av0dRf8TxX7P3vT2gHLeZxsUbZBA53hlFTLZVIbG+Wfag8JrNIF+2h4k
+        Sn7JHiT870fsUe4/15rCHaWp2pxwTbE9qVfv4JKSm2FoJMnGOVb4MI0D5y+gIsHtxIa1gy6kthX1
+        OrCwWfHs2g2qJ1x7YKvEPejoYQNOZySZZtyDJSMykk2jCgcjfvFexMzfiwAkeHkvkjggqV7H50PK
+        4XCHSQoannt4mb6ErgSYUY3EqF7byTlyGsD1I8+BBoOTJ9dxeU/JSiPgeB5cKUgetth+vUX4NOyi
+        93j1jTnWTpgdlNGoewZMdSm0OYl9I3GWwjCCrldf0DpU83XxiKDfMBSeMEnB5H2D69XbZBsD6EGY
+        6cEK5AXEA5CpKVREqDgvMlo2675x0uM0COBRFH6D4XAPr9C6D1X3Dd4zWg8cx4YeEUF/g9kh98l8
+        PW/hJTmNjSzb39GuSEHI9hDGfibDxfJfofUoBEmRPJvYpFJTpXr1BbqmCBvaP2PrO7+BfkNfcsQ9
+        XgebMFfVVbGd/HVPWB1Av4T0fHLnBP0F+mQ23R185RR5+5Q4cWB4FRUSK3zmyIFduY0o4iev895S
+        /Lc66tCx0vJdCtcatCeK1h4MFFhT3TpKUj69YtieE8MY1qArgiutTGVlCfJg0Zsaao4NEwj2K7SS
+        ZbHa57USe5073hOdzPujMPRyNy9rhycsiwnP9bM0nHveXfMDCcY+nZJypylWh3DoGDplCZQ9QD+4
+        wDW90tGewYJ1E67CB6E6lYXirBxyg+qvQ/QxPLO/i4OjvxFoZTysV29Q0bvZwCoXng9b5LF7rHjf
+        i49YaRzDO8/59lSsYm1GsFB5gG6MlWElYVwWM0/gjRWkWaXSYHDqjlWCN1bkGZYDsivNM3THgTqg
+        g7Nvhl71HoYiVKCN//nv+/E3/IY2Hq5xmZ2yfFEmiih2YRCbRlZyGCYIvRT6ADAO0OiFzjyDdTP3
+        kBDKQAPBEMTeMTGvIvjwzM3HSofZDG1ORwz+yLGjXjtQZKInJx18Jp14VtDa9E5bTJSBz7NrrNMM
+        GRYzh2Z/OpsFwNMUSz8PBucjulB1gSc3ZkcZbsLERVtDzD/S+E4hk57YotxNqsmpumjLrSGlLtR9
+        3EWH55PZ4iT2sqPtRAoDgdsm54Fk2KKddNJOMCFYe0R22cm0R4o8fcSjIOl2GBunl1ita9eW46Gq
+        Ts9r5dwXWCMSBvyMXif+dBxHbXYxD058YJyQ5U6b2dME1DxuO1OngjiFV6I7i8A62TfdAIYhwWbW
+        e2lmAQvVBDpAGa5Fox6EQfGoP418o+OOnKlAfnQNgnxk33ru6VCqN0a8dhq1J/ZLxx27dJC353/o
+        rBdOrZcOBqMeevwrrF4Kv7G+uVYejE/gnTMWccdB1hN0z8nCvvqA3NQmNo5wALyPr9MwBaVqYrBE
+        ebMjpydhYnhPzHus/mz0O1M/GfjOrG8Y89GE1fsQ/KfCEaAIcnKaKykEjH5queFaI1V9SGHIRRxo
+        fu3ob/f6cN0xlypjcsZxmogzAxcAYTfB+jAdmdMAkRV1rl74PWn29TnbmfdZa4GgRNDDFzpr1ZZa
+        k2eMw5KTxUEo+C7vj0/aeRMRnV5tczzt/PGBm9WO7Opwlnpz5nBhg4RfLjsoC8JwwTbpFWabqDh1
+        ZeJywIgOeuqJq0V/KLZ4htGiNafwYbxqzoHltPBZe9htInQ37cs7sUus5PHSZFhxP5IZdKhwZ5rB
+        nf5pf9J1BHk3DGuPYeicjLxovqZRuyEJBMvAkLRfWtS1BT0sgU6c3469LPPlzPK5vkq9/KGc4NrM
+        Ij2GtRI8SZiO9azyucb8M1yPYW2WzwC9rXjMnQwWZafiSlPNAFh2GjDBwOfq/ZreXB/19vqoP2F9
+        1SdbPzR1A6aq2DG8/N3vdH1FNGtfEk30F4sm+ueJJv+TRZP9rGay35dM9AclE/2VkjmEkmntR6vW
+        mbKJEdHi9i1ekDFe6/OMPEsWrpmch8dIRZpzWDSOOm3K5C6iOFgJGL/itJpIGckRn0rrbhNdLC6h
+        Q4zN5dpQa8o0HUwAqfsKul77/HA0c0jAJTgZTdI1abY0+zxRlwFBenLqtY2+itKqZQW8tqL0bRy3
+        eoqeMPahjXXQsFOT6dH0NFN6am9u8yQSNbkOpvSGTDBZ4YceO7GPktBKktq7Moj/cDWCf6kawX9x
+        NfI8/x8ZWM2fXY3gn65G8O+GFv6D1Qj+UTVyd1MoTdCbNAftlzF3V7d7pPh/xBE0acVyY8tzHgdc
+        b2s3pPBWCqZx7MBfqOaBvYhEhwkJdzPsLUehrizUcWrYO4/2N+k2SVg6PkbrNt1n+rOZzp2YeADS
+        7Wx6PIgLocbs1htc1nihb2C+psQAG6NefBkc3PPicSllmFQfrkQ/7360g+rS3lHbRWvTEY6m7iCK
+        tGxLs5OajIiUX9dUWR+G255vsP4M61jjFSFHwnC50xHlEDm1g9A0UAMjRWXTPZL9C95czYcC2HK9
+        85I7XdpWsK2h47Ajk3tVCLWAjSa9w6xnE5a5pFyHtXcXnelsoyMAJ4vv4BOaxFQ7We1Zi1pwOE8D
+        nWWlgUst6GHiI1O1R3mof5RpdjntzvuuzchGk4jd0SU8T8RF7Si1Td+YM3Ha5IgBeekOtL1M6/KR
+        C6jptvm++nxchMk4id6KMNjC3i3CcuarIqeY4J8pcuSfVITla39rfdifsL4/tAjDv1SE4diXcgXx
+        5VyB/QvdXH9arsDezRXEd3MF9ivLsOy38SbiT1djcbI+AVV09D2Z6HuiHW3UGF3Ko95i33Q4ujvr
+        W4uajJDLQEv2A/o4ktcdxTSQVA4iv3m2OEayhobSRHophx9kLBIDSeWpU5jUZrKEHdWAEegONfQQ
+        ackIsT3BR+o8ofwZGfj03B/gZxC1F31zNCRaRwJmjONkYNlsaAojYui4nYWMaBNWFMjDOHU9QZ4u
+        B2Cv1A509K74YT9cemFfCSeM+bXh9Dz/B+FE/F++0xCfjSbiu8FUmOTrwVSM+0rhpahc/gPJJwov
+        BS41+5HkMyUXAkuuxUqJuoGxX3G7DsXBy4c9RjuCL9rDnjE4iDvZJfuD1lgadXwG9+nDSEz0cw/V
+        BC0+jby2Fx1Pi4U34vbD9rR5OPRp25AcBM77h5Za2UVup1Jk0JZJhOrIIIh5IZRbu31w5LDWxF2p
+        9Ly2W1ETWgp4utmctcdJLGOJZrTinXFmYeUUkow+UEa7gE/7/gRVPJVer2ucsOOWgTLwnK60tw7T
+        3abNr91jMvPWEy3ZcO5aotyeXDt3V4615FZ60iZ7WwdcrBFZczjMQneJL24FCfSXLWvUA9sNsqBx
+        u6nqO4maW5NlNG7G04umbcfOxQHCbiAy75ZSJP6jalKM/Kya1Ogvqcnzte9DNXme//9zcs4Ku8/J
+        yZX5jp4URnlTT8jv6Ukx7it6wnOD5khafEpQeMODOzt//hLHSspkLuJcF0nVUXjsA4voO7KeDvEJ
+        c+DEy4aWznRLnrSFVEQDurNhyKWzPNjOiVQ0mZrsL4LAbnFP9LcntRf6rLBeHmOgyIcpzi2d0WeU
+        pfr4m5dlBLrnGAfoFNAlPKf8VfU1XIcbi4zE2ty+4ntBfCfZhPYdUNyJR/yoXn3E7ikgaWDfyAdG
+        9inFSzO3ZDP0PMdKKqs49CvJxqnkP3HfDSp/rr42S4/MP4QZ8Xe8a8eNWpjHgudCOCuyx/RlIjls
+        p6seFL/DpbnHeqGCE0ii0ZrETfuDI6HyAjEwLv2+uu2ORrI03zHWeEntYwJTubacLB1idUwmFxSl
+        TGK+m24JA7O0mrTjgUB28ZgWUZqwt4MewwHmCNZmv0cPRS5ddzdDfKD3gUhm2eFphXcrzk7QKixy
+        TysO9v3jePt8xqPsY5/vng/x4fmMIVb561Qsv6rrxY4HA6sSBt75Pz51SnAVnzglAE9pvxqaNb9L
+        hAuZGcsnbcXEvExebGeYjoEU7EzdnTU7YD6dHNrd+ZGbeWEXcWMeMWNkPCJnJrLuWCePPdjzSK0Z
+        Z05uHvdgE66kFoUzEnfh24bdkRke6HPWFvS52hGCxRHQwUo7a5g/OqeiZY9XQDbOhIzSK00/pBzA
+        tYW+Fjj58uHJZb9Zvzo2KMu+m2SX2uJjQde5fXP49PGh63z348PS9s9fHVafJ/uZnzTeJq++uZHX
+        TnlDXnSk+r2vqf8XL5q/+5ItAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5861']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:22 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3839']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:48 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>credit-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGNyeXB0b19ibG9jaz5FMC0tMmlRTG45NVl1U0Myck5wS29oTS1B
+      am90a1NxRmktblU0Y1pXRVJRT05zbnc1V25EYlRVdFFka2pVamVtYXBNa2hpS0I5cDc3ZVp5WHFJ
+      UFk4RlMwVkxVSDRWMUlzMVFBVV9oRjBIU2o1S1o1NzItWnNsTjNNSGlvRFBRekFTbW1zd3I5NThM
+      ZUNZZ194cjZYYlR1SFFGTktkcEQ3cjg5WGZGRVM0elhoMmh6Tmhnczk2c2ZUWGRmSnNLUUFJLTM2
+      WjwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bm9fb2ZfdGlja2V0cz4xPC9u
+      b19vZl90aWNrZXRzPjxiYW5kX3Rva2VuPi0xLS1kazhyQlQtMk15QVhQU0c4aE1kQV8tYUJ3QTlP
+      SUVuU1EzSVF0RzJWTnhCOUZXRTdrV1lSU0xtQjlnMUdDbzg5MWJNYkpVVlZuc2xXU2NfeUxMeXcw
+      WVRfRkI1aGJHU01ob3RpMERNMW13NzJrUzV0SUtENmlodVdRdVRZRVFETTZUWVRxckgwTXl4YkRB
+      Tjl6azdkdE5vbkZBanR5TE5hZEtkdEd1R25SMzlkTzVIOVJVSTVLQjd3MnBudEhHOGQyN1oxNEhk
+      NFpQTVRUVXlnU3lKRjlhcEZMQlY3Z3RtVVBycEU5WVhueEJuYXgtWmtXVmRVdHM0bEFqVlRVRktV
+      WjwvYmFuZF90b2tlbj48dXNlcl9pZD5kZW1vLWNyZWRpdDwvdXNlcl9pZD48ZGVzcGF0Y2hfdG9r
+      ZW4+Y18tLTNlZjVJOEpRM3R2alVmSVExdHZ6Q3ExSW9TMjMtdFc3V05BVUpMdzNUQkYzTGF6SkpU
+      akhPT1FOWGs4Y1BaNnFyMzFUQUVRdFplM2Z3dFJ6MDA2YjNYa1VqM2ExY1c0TmtCc0Y1SDJyN0sw
+      NzNkakxJOEFzOHdzZ2JKSTdNS0F1Z0hoTTJMX0pzSzUtWTwvZGVzcGF0Y2hfdG9rZW4+PC9kaXNj
+      b3VudF9vcHRpb25zPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1144']
+      Content-Length: ['811']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsDbgigo
-        4W2XcH01ImBCVNKzxPDNkhUFSXhbJc8PHDFJseK8xY8Eeb4WRqM5V34wFKTrhLlmuiDCGbfGMRa/
-        0YrKU/QPT367a9camFjb6pne/3xtq2MJ/w5tq7/Ttt9LtizKwyBwr+FcVPgXLIt9F3pZ3bxG2MPw
-        M8ms/1HJvAZHvjui1Wjh4CuAwhKrRxhD3S0C6hXMWXetymMNC1LR562KKXeIe5+Kz2mY/Z1/uPrX
-        KlmajrnyHcqttu15uP+gGtVrKX7E8vfdosSI0hAFqu4GhtMU6gQhJae+7cfsXGyEc9GbdJCWdoMp
-        rAVR3Eodc4VmqJPs/KG/Uswa3PeQf5DruCYIm8YcJg1vuN4q1hzWyNPSjz1mNl0s/ForrEaCXUnZ
-        A6qPZhNojSzBAnDUo1MX7uFgcqkaHaPb23kXwotqNaVf30mRyAxr3sbezKoHn/I7BuhPqmrYtYm0
-        MuFbi6FKJf7J2mmycfR2jUhud1dJ0LdRbZiM6MEx7e+oXve0n6xCX9havenAqzvnZd2WL9tOd37x
-        z8K25wZSLNf7lXChH2gS1Y8VbxRQe+3YkjwWLrtDByGiFlBMO/RHIwTSKZkeIrSmWWHr6g1qfupo
-        hkZMBwo5Z9vHy7CjIclY8aotLNzA7Z6nwJkEG0M+p/ZkTgYHm55KI3rXrY13Z0XZ986h2dFnx3bE
-        Qx0exTlztPW9J4K2MdusoaO5Zn+tdGdiEPTmvYq5HsdqW8Hf4sIQe3Y19mlSrIy2MLYbvarF7Nv7
-        lRP5WrqlpfF0caiJSDHMoVob1deiU2nNR1oy6BwGwWmi6itWqcRTRW0hlmzU7eosVE7U0CYnjnXe
-        LZXjhe/pYl/VJVKZj+GA1NxGqobEStF0tkowdrcBevxSNhkeCZLWYrbmVKb0itORVRQ4fqS2Q3Fo
-        8NLlHLb5fYPorneyrIewsxw3oumG5x24P9dicQYTI1nRsjRSz/L4dNojr94A7EwVd7Eq63tyrHTU
-        SNglm0nf9Wx5gsSOMgiVLt2RAprRV5Q07C1Z4LUm0/0irQGplvaG/s46juNoeCD7Z4ZIRY+Xzsr8
-        QofaZWXYezVkweRkwj7O9g250e2GPGhH2rHOyNtlfObN9WE8lA/BepCOVILYZo32Q65wuqv5uMlQ
-        79dA302vMvSx5X5fvGpUs4qV8BnhjCSK8E0zvT/lkmDpuHo8Q3fGTjNQEBVXgRfwzvITTwdRk60w
-        D6wCvLNCVzNA3Kw8cArogYOLrxqnnh645UcYV/4cbf7vv4/z7/gdvTsjfvILbpzIJ7dknRRudYKd
-        ep9A4y7hBbqtga/Kehy4CZbwWDtizczbgVcQ37w8Hfq4TlQamf02vG8mr8yLJS9Ii4ct5c6/DfPS
-        nLVsPirhzgY8UIva+snpbkOcMcBvOiRB1A6qYNEqcaakCyVOl85G3SuBd6r36gKlTvdnuBxKm+Ww
-        CjyPFOR9EltHf73ciLPDtrfnuwJwzgxldxqwH8EooUYhOLszE4rrXSMIbHsrV70ajbyVMxLG/T7q
-        TknQtQ+z5ciHbUvWo3nfEpM42QvpnJRPDWpxnFTDg8JGlgTElBT51ojoVbsiQLv2cjfyeWoLiQY9
-        NMQ2WJKd4YmfK60eOovrZW29heKAOI0B3ovkDtUkaI3lGiu0+uzq0MnS6sUDDx7J+vZHj+WNPK6u
-        uCPBcVuU/HyAw8TPH9WXj/uB4YGcdRK4K8K1sMI8s++WRzpu4WwtskCz+sK+GR7Y+T1E/Xj9JyOX
-        56KqHTXoalnngG+B7zCuuN1r1j2+rwX9BeSui6p61sZcIzbrW16gR04WquUn5N6xRNoJT/ARtJIg
-        iYvOi8J93IeGKx0FSHNfmI8Y9+r0B1e/OPjBrR8489mF5bsK/Gk9qH5TD1r8cvSZGrTMxEWl7N5h
-        apH5o3pgYD0Q3GhDMoIfV70Ejk/rCquPLl1+70iCvDk7liZQ27ATOK2OXV0vnEGPWc98reGO57W6
-        lW5YpAzI7mp/BicRd0R0d3lZmYoYA3tAHlcC33LFORj0Qr9zoKoI9rY68gmRTi+ssForSd0ZMmt+
-        PaCVtFWdjioTu3uMjDHyTbK1rFrLihMySSjHx2p9boyjpbZlW9swJZlD3d6fbPIiRdGwN3Mt+rT2
-        UtShLvTeqFgTK5jPZq3zSdI+1QDqBzSg+l0aUK19lwbQ36sBr+v/rQE3p3yoAfS3NCCf9/M1oEJ9
-        SwM6vf6I/0QDOjZ0zZ/SDxA4/+nLyFIiMp4Flg+jk69vD6TU702MNFQZZzHYqPXpkidZfief/d5p
-        oRieFUZJ5ciMbfFIVA5bifa8GrneGg4xnhEL/uyT7GAFzdF6HboQpRN1QJsO6p15J9knjgkVur9V
-        /PGOhrUlVMyVqiuepIm4NelqdcjOGgwL3PGKcU7bKRX3tMlyI63kGf95Pa/8SD2nvieXKfavreev
-        6/+dyzenfH89z+f9BfX8m7k8aU0/6+2BD4OoZEAEL8D/KSnN4JQetEaaVe1u50Iy7UXTozTwvMDa
-        zQ6rmg2mq5iypWStHKYLnmeGp64q2Y1Jh0m1rUBBqaIoS4bodt21ehFS5STKmp8e+13iMDPd7S4i
-        t/RidelRtY4uMrXVUqsNZ2NbAV39EtgTk3c2PV5Z0SHfSffU0GT2h9UY6tFl2wvaUEmDNDpIYvsC
-        Z/bqsGJGhHQSOgjEFEF8nt7VHynV35Xelb84vV/X/zu9b075E+36t9P79hjnv/veU9IOYPbzw+3X
-        33eWh3h7+X/4/wM7JASWyB8AAA==
+        H4sIAAAAAAAAA+1Z2baiShJ9769w1UP3QzclkwPVXO9ynlCPiuMLiyEVFDKFBKff6T/pL+tkUNBj
+        16nx7d5V6xa5Y2ckGRkRO7HEP8+OnTsCD1sI/vGJ+Ux/ygGoI8OC2z8+zeQWVf70Z+VvomFhHQXQ
+        V9DBJ0yseAAHtl8RcaAZyFEtqAQYeIqFFU01KhCJ+dcWERwBJPNUD6gKWQdUmgsxn45igwGwXmmS
+        17qcTOCBhBChom75l5hrI2ggSAV7MZ+CsT2iSpE9MSaTbRXj5K+Yr3o+JpQUSIwRv0qMub+rzuHf
+        uTrZbhC+SsYskk1FO4zdXgDx9AiJGKiebip7cIlWypO4pEgYvYR3m3ZHHpylvGd/hgp18NppvJ0b
+        4QFMOdE+aqptAz/ZaONpQrzTfPoK+VsQw4TwkrBHh5AF7uZo/gxaPjByfZJWJClSanIqnuVbOsmp
+        owVOygF4epgjDE0T4kuTaKg+UDwVboECoJGMI2eyGfwrx2A/NwUHHzga8HIszRTFfEqJ2YGvK2iz
+        wcCvcMVwqWc0pWGgk1TCFYYvsaUC/8i+GWP6hfznOIZRCRelBZpJmHecnDQqF2lGiWAVGopvOSCi
+        U7RA0YzMCF84+gtN/5NmvoQrvZ6Q+H2OQTzGPkmOd1Ep+GZuoF5+ZTyKLF/i6G+OR4EufFc8CuTP
+        j8Qj2X/Ua+J0HM7k+qRa7zcnYj4DJ5QoDAPV901wytVQ4EHwD5wbku14qr4nKSQ3p/JtYhyz+Nky
+        KsVu62axbv1NsUmiowpxp/phz8iCCeOg+mYlTyZTTrwupUXrUpiC93UpH2A/f5sfTUmmkx36Aa7Y
+        1vHuPoFuBNJ+VV/N38b+5QAq2HIONiABI87927zIkrCCAwa2Td4U+w9bbL7fInkadOgsnn/hYwtQ
+        eFBqRbRV3/IDEvMC87nACkWG4Upi/o6KpJtv40eK/szQ5IQLRZYQ7rCYT52ZKlYgCvvBBkdq8wCE
+        3ZR0RNJx7m00GYqOela8AEJyFHHeMCzZwztUdEjXfcF7RkUIgEEy4kDyjahDlJPR+7zCE3LgqaGG
+        Zmg3JCaEe0CeE7bh+PXfoeIBYT8WzzozyfHyUMzfoZtEEMn2Q7aydyr0Z/quEVlcxCaKuuom3k60
+        3BMmYpKXhB45B2eSLyQnQ3cZ+MaJdfvsAw+qdk4mxFwtTGRo5NIZcf1El4JXHf+VQSSJFSRrTasN
+        qTmZLpqSNBXzGUNCitxPVcMGHqnhBUlFfKMlUpZcQR4imnbDBTCIgDC/o1cKAsN/e69k3mvH/2s6
+        YfYfELKjNE/uDk9YWBO25YQyHGVeZvhBC2a+WZKipInfjqrSbyQpEyCxYOVoYUuzk0R7BmNW2rji
+        HCTdKbkozpMpKSS+L9HH8gz/Hx9c6TNH594GYj6FYqtpOg65zjBCrGNZLF7vniO6dzn4SNFspO8r
+        A46iZFDuLB040mhtphRdpywtWm3kbhGNeoXj8dJrFGasdKavV5UnN6wTau7oK6uua1f22oYH1D/y
+        hgxmprfumfys3Wwu9/2x6mnXce9E75bcvqDuYG1Sr1MGDefG2dxcVNnQ6c55boy75llTaX635qHd
+        3jpq1R7N19OgcK17zgJt6huJ08Cwu8bWdVOscay0d5fV9fT8ZrjXqos7G+roDGvmgS9MRlYLCXq5
+        v5jZ67rCuUZXRZdzZ7J/s/zimWrsW9PGoeSo7rzdWmhB6Vrtl/FaId8JBfXADOvnkzQB5/GWRnRg
+        1joTeVzbwWP1qveF3UnaCbO5Z20tU722PMQehovVyqmi1WlCdXYYrmYLS2q0bep66Dc3+Kp4k8LK
+        aAu4Xr2uit0pw5/Cw57XBd1yZXPaPqG112Hn9pmbe5LDyBY1WLL6XFp2F7u+3HNbXkseds7nZb8T
+        CHh67nonv3maNE5jV9N9beiwvbpeleudZp8Rdtvpcdq91Kh1eNfMnK+o2SokKqmknz7QvkSl89qS
+        fiNFdVXhSPU+IqIeeB75urqkT3Eab7UDWf0BShkbVfeRl9yGn8CUBYPwqlsps8UMKwFT1sFWdYAr
+        bIaTQBkOERIFXxwN2fksTFQsRiv//U92foqnaBoM/BAXciOgH8ISXhGIbKONkk7gieI9QXcf5PtQ
+        w8gOSNvB6pHUeSxtzyD5+HA0C5Lexgmh/T5MXyaKcrUxk+TMC8Whvw/jb0CDfPnlQs00VM/IkBM9
+        +GB396GPiA5WdJqiOHWGedRAW2vs7o8n3ncvQ2QeTwE/XXcMeFzRb9yiiHekG+yFZce4Xhu6Bxte
+        bS7JVrdkm7q8ttuG5PabDbg8epBzoNsbdUZVtPTaYO5wPr268uxE6jr8+u1EmizX7R8sWWOn86Df
+        1oUi1ehMu9fZuojZ6vQslKr17bm775WDvjsZQbtqdlT6rLW2b12z0GIWB0Fm3vaBdtkdJkW9SA/W
+        NHRBt+j7zBkw0lC4thqzjVtu7qD5Jq0zQYh3nYlCeNnMRim+fRIVIMpJcjWRpnhAUgPGj8rTgb4w
+        ZMih4h08i/RsrvDITi1ZOrmWmKq3BRX+iX03ZNjx5Vl57f/BKMb1p6hH1bLVUOGIor/DxOSSo27T
+        nI6E5wkUI6eKFsptnLyE9QRlOWF65h+QVFk9Neyp0Le2AQpwckNgyHX8pSGi+8hX7SdmFhOfg54J
+        9VOAM2F9EczHEObTyv/hHsAyX+sB9U5XanzQA+qmZRs5cksHP1v/FKn/oWDvjxtpwlzdRYdf8VbD
+        qtcaZmC1WK/O4OP5PH8D1qjqovGgWlwcJp7ClC1t1jswRmckMGO1OTi65RJfXjlMpzmdlsZjF6AW
+        LJ0vctfxOk7b8moN3u4KvcJS15SN0evSUrs0Xeze6qOZsq5OJHfCFAKBVKwumDLG1aXQ1LWd3rM4
+        3uNGi9PKsN0pS31Yy8xP1HJ8MN9ay0z5u2qZ+95afvb/Vy3fg/Kylrmv1XI87zfU8lf1fCrPGs3h
+        R4o+DX9OgP4vqec9qWezvTIstyAIEhpKbHDaNgberFMrn9/0ztFmT/OtpmBKGe99w5dq/mCxkSBt
+        2eaEuvTqLkbGjHwzYqHK1UtCjZH0HiTpJNRX5Q0KZt65s2httGZ9AjjIT1dO2dyuGXYDe2rBmo1H
+        7a1Nq/Uebhhyvf92UZejZn2EupA3VkGfKwOtRdON7rg76lZ5arnpdUvyfj2+mlx7u+yXKZ5xekdZ
+        n6yZ6qzk7qSuVi6BqXQcgt151TYZttYBeCCh9gQWaq3Gx/2A/Zl+8F3azhZ/bz949v9XP7gH5fv7
+        QTzv1/cD7qvaPqq+fdQLALSQl9Mt37oC+EtaQpG0BGd6LFw2zHABx3OBtblejbKs/WlLL1DfMosm
+        dW1Paa9T46V+/ypfSZmhyXJs711JMQWECs7k2oDHPZHz9UEojUfc4Fhe6KMR75pLbuRKc2veuQad
+        kQ3KprUqBBdkyWO/vUUldQ5HY4bzJiTDzjw1OI0Zw9gi7SjvbNaFeOPQW69xbJn1NdfT/eKaafrS
+        kjfdCVCoj8ub+5mr+3fJPfub5f7Z/1/lfQ/KD5T31+X+/ojj3yrTkjSRFf78cP/F8p0lk29P//b8
+        P0mTKAW8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2926']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:22 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:49 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order><crypto_block>E7--NuwIhns8SF9pSFmOCtayGoPi5orsAykdVtQtCufnKnVXd5ijHtnqR7hewEY9Siu9mKWZXgSi50wUnsm6QPTTn5Ap3rEh2y8qt7LQOigLgEgeiLH4ylijiJOz3cCcGHfmz-mr55XI7fNrF6K5mYhYQ3qn1nCceIO3_pGh-y2ODATK_1unwgfaRcvmf9rRBGVuoIht5KuL4JvyIf1HGwjOVpnEZgHPJm7kxU7hRzZCGSznxEZHloNsR7I2pTbq40t7v2mLo1javANm8iUGKktt-5o16BpnLLteyP0yqrtW48EZlb91SwCaca-PJX0S8BvzKCatNcVD_hETlolGxPekOoYcRxyhOS0oqh4PNL4fG5MfxXXjHxpdCbQvBrDibivFS6vhbjmFeBcQYWikaldIWXGQFooHSH2dWMs_BXrsAz6-j8VMn40F2LZish9H3g6jBjVkrnayZ4NMPTq5FtXcdK_5L7WFk2ASLauJCqJowO_bV8X2sPX_At8097h3QpXw1Kh0OkgxfUXvzDHbFI_bN0XSMiJ0al9y_p-VXab83-6hG9eHDURd6DtENaA6ZdPR1b2kCR_toknr_BpFKcDNzxpBDj9-GWfRRbpiCUM9rPYDDkijx5sFQiucuV4RNL_xRMwwjtm79e8Q_Ffs_Rbj0MXC_rEfuYOIlmhROtFCXJpXG4CNo46bV1NKHU8emAOPjTy5eN5yHKnfgvMsrKq0Ix6-yFmDNxXSz4pazVchj_p8eOwdiIe_aY0Ybh9RJBrav76RZUsxDdWqMKRqoWJyL_--Z</crypto_block><user_id>credit-testuser</user_id><discount_token>k0--5q_Eg4_-x1Nz1FPUkY_jXomw7H7E1_PjxiUKNYUK3emm0ERjusgvnWUYFQqZHjDGEekx61hC9iIriru1LpexlQdiFWf9oohhZR3m54tmVkLEMIItGP0eGhqQULniBgRbrSIgFusujEyS0Rw91TvO3pqX8rgNeFy0FDAL-H3GFetfBUfLnD1Zi-94KcFBeU0CKwDSXAHtxFWU5WZiFJ-wMeIriNlK_uoAMR58EAI8VqC-Z</discount_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></create_order>'
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcj48dXNlcl9pZD5kZW1vLWNyZWRpdDwvdXNlcl9pZD48ZGlzY291bnRfdG9r
+      ZW4+YzAtLTNhVXM0b0RvZ2lRcWt2dzR0cXlOb2h2d3U0U1pIZG52WTBQM1c2c2pYa0trOVhIZHp6
+      RGNybkRyQlZMVGlJN2xoY1RabEdkTHFLRURuWHZybjNtbnFKT0hPQW9YckdlVm0zdDBZejQyUkxJ
+      bTRaUHdmX2kzSUtwaVRiMlNWdUtHYzk2LURIU0l6VVo2czJBU3g5N0FDZ3hJa0o4dUtxUk9ubEFo
+      SGEweGJGZ1BJaDVGMVdwOVQxUGt1YnlqcFI2YzYwTVowbnFlSTZ0dDF4ZTFMTjl6RkRVZnE4RWpu
+      aFBMWjwvZGlzY291bnRfdG9rZW4+PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjxkZXNwYXRjaF90b2tl
+      bj5jXy0tM2VmNUk4SlEzdHZqVWZJUTF0dnpDcTFJb1MyMy10VzdXTkFVSkx3M1RCRjNMYXpKSlRq
+      SE9PUU5YazhjUFo2cXIzMVRBRVF0WmUzZnd0UnowMDZiM1hrVWozYTFjVzROa0JzRjVIMnI3SzA3
+      M2RqTEk4QXM4d3NnYkpJN01LQXVnSGhNMkxfSnNLNS1ZPC9kZXNwYXRjaF90b2tlbj48Y3J5cHRv
+      X2Jsb2NrPk0zLS1UZThIWG1uT2IwYlVfNnFtOExXRkdvcWdvMG9KNXZ2eUpENVUyTHgwenphNGxs
+      ZXdvRWowejJhWkJ6MnpHbnBvS3Y0ZFRlVWhyWkpoNFVHRUVYa0tRYXJielFKdzBqWDNrNWFqbkJS
+      Q0MtZDBuVmR4aGZ5YVRkYzBIeFZkUUloeGJhMDRqWjRubEdnbWFBbE9WWlN1NXpDcm1Xb2ZDZkwz
+      YmVOSVpzaXpmNkIzMkxrcVhBWlN4UGRxekFxc0hmLXZtTkJocDQ1Uk9pRm85YzhLV1VsWkNfM3Fk
+      SWFveXhIUmtQaXQ2eC1Ea0ZTRHA3bWFxVkdGV2J1N3pBSzhzWl9uY281YXAxTkN4d0xSZXhRZzBv
+      MHVoQkhSVFFCam52QXpjSzlqd0xqOVVWcmlnaWhhekZybzJwTldZWW1Bb1l3Ui1IanNuWVVXaUxE
+      R2wtenBLRWZzel9yUjVZZEc5c0NBelk2SVMxNHdfY29kVkM5Y2lxVGhTR3dvWnJIMlZseDNWckxt
+      MVRpLU1YMmNWTFhJV2pLVEpxRnJGVE5IeHhYS0h1OXNTeElyd3RFd1JEd1FxYmN0Yk5tMkpDY0FU
+      Q0hFSzE5amdTdlNJeUItWjwvY3J5cHRvX2Jsb2NrPjwvY3JlYXRlX29yZGVyPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1380']
+      Content-Length: ['1015']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61Y23arOBJ9n69gzks/zBDA2A4+i6aXYztx4uvxJbbzwsIg28SACBK+5HfmT+bL
-        ukDCgONec7qn85CgXVulUqkuUvTfTr4nHFBEXBz8+k25k78JKLCx4wbbX7/NZ4+i9u034x+6HSGL
-        IhNHDorMCJHYo4ZO4rWDfcsNzJgA7BJzbTnGGRFdui3S7TiKQP05/zJhLWRs16EulaGcsbFsiiND
-        keUCh4M5K4j9NYoMrVIvsDiYs0LPshExKgUOhwocTKhJzv4ae1IRjhBHjf/+pzg/x3MU5kXnkGJz
-        7WF7b8xNUTzsw01j32qE89poLW4jvHEU+nS0h+PVu4ps8q62V0r9/cd+JK8WQfvgz3o7Mm9vOsuT
-        PW91zx8rr7/s4uVjNxrt3dbjzlbf1SrxR22lvqh8Liuvo5k4C/bRufn+og2Vmjs+ah+o6y0+Se/z
-        cbMC64o26ewwKd6jwOhURLGGujXzEMdh8337w94uu8dBOEONZeNjO/UqK9lbhjUbH45zhZDq82L1
-        0BQnc83cquN+rD33Prco+jTVrierKn4WXwcd+3MnN1uH0WCx0qqfcU1Fi9amuW0uK4fq/VnbvnmY
-        9t0qwcPhRqMrRPfLjzc8FofKzuvNX/bHN2e9kFvTE6rPz77Vcd6ny+jzOJJHZns0mdiLsH56RpOH
-        D3O7P1UXcWP19jImo16thTqiFT6affXYCp2PHpqq47qp/nhrHiavM2fy9BBPP6fisvsSvtZjOgjE
-        uN9TlpYbDmONtp+bI2/YHGhP7Sd7vFpNQJNqRl0Xju7HYNR/c88Pg8bDzg7O/aeWNnPno5k1Os2m
-        i4bWxU673Yr7H2e/owwWtv+6nO7qpxfyGgd21afj5Xh48u7FN10qup+dhaE7iIQWtXcmfNhGC3se
-        sqmwibAv0B2CPA1ipEtlVj7JR3SHnQKQJlJr9DAqzGHJVRgSaih3tRIDoP/TlCT/LWoZw/kM1i/w
-        MkFOpecQGTbTXyCmcGF82ZxLbBwHYKGN/bUbIMeoNO6S0pANLxS21+ls3u4MZ6CqBOes1PQpjR0U
-        UCGCMlegsm0F2MQbk0AJJIaiS8Uhl1HX3qOiNAP0hBZGro2MSj0xMx9D/YzsnRVtkaGmksswN8DQ
-        EXga/lhQgJnhnYUu5SMmSM3sQBk/H3coQpzAjF+72zg0D5YXI1ZDi4Buu5QXXA8HDoZM2IMrLyCT
-        p4r6qZwLmWrbswjhfxgfQsOiiQEFjMvTKbOynKmB7pC2CqYu7R9lKHEi+Mbco3O2gpR6MgOTVsSp
-        2cwLUtKX826o3LsOua2WbYTLS1hOSffyaPmudy6Q2A6lfF0pc1pyvBF3c+r0InARp/PngUuRI/Sg
-        KUNXzan8FCIXog268sFFRzNEkZ1EDGuXN0W6k/TyyAq2yESBw8f8fOJ/C4pGd0Iz3saEChVZgYaa
-        Exg3pjYE+YYgaqj1ZKFrNKcRZEPgQGZU75VatSaX2JmQ0c/w4/sOJDQsKmuKxpkXHA4Xa3VZMVPY
-        ChxIMx+ldFHWREWbKY3vqvxdlv8lK9+TlW5P4HqvPcDGhFoR/eKTigLOaELien+nS+pKpa5Wf9ol
-        1Yryp1xSFSvKX3EJd0Faelg8JnV80mz1OhNdKsCckrphYFFIpKPwgOMoQL8QYQjbiSwog9E/s0nM
-        X+zbdYz682MmgRHHPYhynBeSIsgZYB6NieG5h4ucQxmBNRkpG6e9hLh+6CFemLN5rMuw7zgkyPNg
-        KUJLNna+2vhHtid4b17EpRu6twibrAl6FnWTxmPU0hZ8GepQjLfsU5TvlER0AXQpn7+ziAn9BhJ7
-        Q4wA61IJSGph0m6QcymCfKj71smM4iAAt7LzVyoQGl9Q3YeaeYN3jeoBQg6cbghxE8N9OIml1J5b
-        OCfH0Grh0VGgZQgjJHvAkW8F0CpT87+genJTZz2xpUyE6myoSxcoK/DQSWnCNve+IfMGfI3rZIfT
-        8rhh22FPmDKmE4hroKfK0QlCBxGaqCvAGYeVDZAL0zOhyH9DERbAbAH6K7ykHJcK6yQxAkeAd0Ac
-        XrSw/EjvVvzy0mz3O5PpotPvT3WpIOAkdnexHA9FkHELiDGS0Xjn4feHv5So0HX87A2VVI7CUC8d
-        RF4MF8iBYnmfNJC/v1jeQ0/4E8Xy/kux/KPsTdImxNjjl7r0/K+wJJk8108acRqyheH/qsH3P1uD
-        02hj1onNRhOimQNcQsyDS9y1xyP0GmSsvPix4IUKxy+Or3xKDulfc7uc18lvdnD3d6osjAe6lENM
-        utv5PlxolIaa9vYixtbL0zW59prrZL/p6skGr6AiJ1lDKiH51pIzgWvNR4zIpfgH+AIhh120ryk6
-        q/4FD7SeJ61+JzH7SlCisltYCLsRbDeyPVSewL2BqeWZV6+SK5CTrh4UX8ESr/C4uAVz7vVD4xrN
-        aOVHxzX403WFv1ilW/8Z+h1Lf+9PVhIAAA==
+        H4sIAAAAAAAAA7VY2XbjuBF9z1fw9MPMQ0KT1EK1OhzOsTZvkryI2vzCwwUSaXEzAFqifyd/ki9L
+        kQBFStacdCaJTx+buHWrgCoUqoDWfj+EgfCBMPHj6LdvypX8TUCRE7t+tP3t29wYid+//a7/RXMw
+        sigyY+wibGJE0oDqGkltNw4tPzJTArBPTNty9SjWpMsSzUkxButZ9WXCVEjf2okmnUIVY2M5NMa6
+        Iss1DgcrVpSGNsL694ZaY3GwYiWB5SCiN2ocDtU4MaEmyUI7DqQ6jBFH9X/+o65f4RUKejhLaGza
+        QezsdMcUxXE42H0+y8H8sM+mdmNirw+m2up0m3Lrpn9tLpLBhz97ls3WbTgSm+IofGp8vu0XkRHe
+        3D58zDPaSqzuwyhcPWfT5Yp48y1puPubz42FGqtVQl+w33q7797cq3g/ne92b4v5YhJtOurCWUfb
+        wQrbB3+67sw8RRTXsNL6+jS2rzTeoUhXG6I4DQP58fl6MIhf+sr3eTa2lX3P9kdzmB8nXmc9fhWf
+        e43gmr6INFzuNncq7T2q08P8GRmP4Q3O+mR4b73dGNO1/6DuZ549d1W6QrsnedUaPbidJ2zY+K25
+        a6gjx2rgwSvGT2rmLVLj7e5+6S0zR4zRXST2JsoTenjcio1OODUy1BrIi3Zn8/D0LsuzkXL/Hr2P
+        XbW9NtveZCTPemQbW8NxY996DPZqshc3682n0x5797t4+jnvp6131LbBmNhxblaNm3jf7U/su1Zn
+        0X8ybsypKmfe5jVUW8tb9zXr7FdZs3M3SJz7AH+GCTXQLmm+G8uNF8/cJPZGj9vVgb5tkttwfI8m
+        k2Yv6T6QtztjPTl4rf1a9Q+Leb89eJzZ+88FfbbcTyu+72WvmlQPOYu/rrmIJBZ1PBM+HL0fBwFy
+        qLDBcShQD8ExjVKkSaesSilE1IvdGlAcpP5j77Gmww5XbUiorly1TxgA/ZdLyc+/RS19Ojdg/hqv
+        FFRUmiVId5j9GrGAa+Ojcz5x4jSCFTpxaPsRcvVm9yovDeXwSGG+Xg/mYwMMnYAVp1j4tQv1TCDU
+        ilwLuzUycyuKzXhjEqiARFc0qT7kMuo7O1SXloCW0xLsO0hvtvNlVmMon9jxLLxFequQHIfVAnQN
+        QaThjwX1ly19uNSkasQExTKHUMWzvYcw4gS2eMenvKQGceTGkZjuIFhHkMkL6riQcyFXDixC+B/G
+        tzAlQKkALmRxBKHwixUmfxf6ENE0X0pNrEEfKJoCM5shsHQK5eGCKJg7lBUzSUXASiRvOJxXqh2R
+        E2MV79yea0UOumyUuVMSTsCKU/jRsyBbKXd0cKbAPJWqJUhlEPMNxTzsxSbUgaO40J9HPkWu8ABd
+        GPpoReW7gn3IL2jDHz7amwnCTp4jrEFeFGlu3ryxFW2RiSKXjwtjhpf+TVAIFWYooShvl0JDVqCJ
+        VhTGTqkDib0hiOpNNZ/qHK1oBDmQSnAaWp1Gp906ZZdCRs/gJwxdV88nlbuywplHHHY6/q7KilnA
+        cEDhaIWooItyV5QVQ+n+aMo/ZPmvsvIjn+myArd7HgM2hpOP6ZeotKknTKzsfxkPtdHqNOWfjkdb
+        bv9H8WjDvz8TD+5/UWtYOuaF++W6/zB80aQazClFGCYWhU6wF3pxiiP0KxGm4A62oO5hwRjOjFKR
+        xYx9+66u3o1KCYw4HkCixzqYs2heM+ogZ0AX8HQJlMWQzSvaxbwiEaPjvCJFhEqlfqHC1cFDmhI9
+        8D+O5jlUElhjkspx0X+IHyYB4sW81GOdiX2nCUFBACsl9MTF4VcX4WtyK9dx6YKNLYpN1iADi/o0
+        hZi3oT03uqqiNDuadEQ1qOZb9inKV4oMO9xW4V5bwZpUGfMsYkJjgnqwIcUF/QTIq2nel6B5lmWU
+        D7XQOpg4jSLYCpY3SgN8+IJqIVTdC7xzVIsQciEjEsg36A5FThbruYRzcorB5ziq0UqEEXIfYhzm
+        ZZgt/wuq5Vd61jz7yovQMqaadITKFgEtl+ZscxfqMu/U57hGvLioqhvmTjHdGaYRyEugF8bRAfIF
+        cjI3V4NLDuvbB4pwZAWCAUShlydy5AqVBjs/xTvqUsW/JNCK6xmba3Y9GA9fZsvheDzTpJqAkwrz
+        M8sNEIYzvIRUJCWNtzJ+BfnTRx9aWVg+xfJ6VBtqJ9tUldglcqErKf+PAtztKq2fL8DK14b0R5Us
+        P1JJHAf8ZljkxhmWH7TAD/PeXqRzbfhv6rry032uyES2OvFafoJM5wCXEPPDJ74d8Ow9BxmrqoYs
+        saHk8dvngqtUkPb13J+e+fw327jOVVMWniaaVEFM6nlhCHckpcuaYx1j81VHOb87m3buL7veg/wM
+        qnPyOaQTpHIt3xM4Oe8pIsduEMVHCLnstn5O0Vg7qEWgf/fSHw/zZZ8JTqjsYpeAN4LjYydApwo8
+        GjG1AvPsaXMGctLZq+QreMKrvVAuwZx7/lo5R0va6cvlHPzpysKfvdKl/136F9pm3O2aEgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1849']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:23 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1878']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:50 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <trolley_add_order><describe_trolley /><user_id>credit-testuser</user_id><order_token>E2--5eH5_vuupAjgQcgXHwMpTe9X9qgSl2Y0lXp5covwU1ss4IWYBA-RU8_g3PLu8IKzgerz_3Hl033oI-VMEczh0ACvOMWY84zu53eWCfAgAX2v47y8gZlotLi4soNNf8tYetkXqZoP-N1hlKUJkwZdbW0CSxe6UymaEdjSXrzwO0O_DORRcWp6xIeRBq_gkx4Wu9YZJPsOK5CeE-apF_L3wCpdqKeS3P6_3QZAvRVTdRGBuSzS-XHJpV6utMn-uLK1XaipNu8tDIAOlNAM8GDGcPYYRpF_3_rHi9pUQMOLZiyBM9BhcnyLGC8TiUOTaOxTSW98HodDDCuLqymE1MWcmVXSh6xJsVunc4mtPXPNxl7-Z</order_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsUDfEXxcUCHyqYlLXHoXFHrOkiCFhc3j34smOD16W2zX2VOT-TnkryAjJ8N15iPw8qeHlWzsKzFfY</crypto_block></trolley_add_order>'
+    body: !!binary |
+      PHRyb2xsZXlfYWRkX29yZGVyPjxwdXp6bGVkPnllczwvcHV6emxlZD48dXNlcl9pZD5kZW1vLWNy
+      ZWRpdDwvdXNlcl9pZD48ZGVzY3JpYmVfdHJvbGxleSAvPjxjcnlwdG9fYmxvY2s+Y18tLUxtRGt6
+      UTBsVXh3eU5iMk1iWXhfNjQ3OTMwNEdDQV9WcER2aVNRMF80SG1GLTMtRm1QMnpqd1ZuVG1HSEt2
+      VXl0NHBhOUtGbVhReU5XWHNoVWdzMmR3R3pmYWUyWFhwdFJyaTRqSjlHSjZyd05Va2tqVlVWTW5m
+      NzZWY1luZ0RYcmJ4aU5ZN1NoMS0tWTwvY3J5cHRvX2Jsb2NrPjxvcmRlcl90b2tlbj42Mi0tTm1s
+      ME9RQUREb1JDMThVeUxiMXdCYmlGVUZtWHJwaDdZTFotUUIybEF0Ui10bVdrZkk2dEJPNk54VVFl
+      VE9tR3J5Q3NFSmFqR1ROWWlLNndTaGJVZDZ0WGVrUDBYNEZLZDdQclRicmozazI2RmNhMnJEWnJy
+      UDZ5aFZ1VGpJSldoV3ljLW9lSW4tQk0xUGVLT2ctMjdtTlR5ZTREMFY1N2ZLUHEwMFNGMUpxbnFM
+      ZDY1WV81aE1GMFNCc2dvYUVMMnc0T2x3NnB3LWZZZnpjNUxoSmtvTnpVQ3U0cWU1Yi0yNy03Y0dY
+      MkdvdzlDTWJJNDdWQ1BUR19ONjB5aGZabTY0V0hkWnk3d1h5MzdJRHBjSmxyem1wdFRla3AzcVRX
+      ZmhvU2Rwb2hGT2dYeHRqZnBIbUxKZU1NM0JwOUtzaklUWU14aDR3WTZpeFZVQzVET1Nid3pWdFFh
+      ZHphb0pCeVo8L29yZGVyX3Rva2VuPjwvdHJvbGxleV9hZGRfb3JkZXI+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['690']
+      Content-Length: ['669']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA71Y2ZLiOBZ9n69g6qUfZigvbKbC7Q6SJZOEBJIlWV4cXgQYrynJkOTv9J/Ml41s
-        yStUdFVNx9RDJTr3XC1Xd5PlPz5cp3IGEFm+9/sX4Sv/pQI8wzct7/D7l9VyUJW+/KH8Q8bQdxxw
-        VTXTVH1oAqhCgEIHKzIKddN3NctTQ0RgC6m6ZipXgGTuvkg24DXAvqo7vmErK7VaPdvBvm1328Gq
-        MdWrB+jvTQE/XozJbHuqAQOdar2t0Dy92lN+u/Z6Z3c5OqJVb9/ffBir7tP1feuMN0/+ZvAEp7bV
-        HRyN2qlWR+60JzTX4udGfJsuq0vPhtfO6VmaCA1rdpHewZOz/kSjz8F+K3OFPcnRKQMfIUt3AD1K
-        AUmtgX0beAoSq9XxDOjN+VwVG5eX2U58tLVXq7ludfpg/O5Y/svhfHzbue/dt9k5eB7qh0at0feb
-        ndrWWYYD//yGwsNqaq1Bw3OtTn/d1EfSeXAKHt4X7ZU4WV5f1OfxrmYf51Xj9aNpv/ZnfR2fW2/2
-        afQ5b07FtrY5nCbX9f4o6uJ5OOyAh/Mu8DXjdbcY9bePQ/vgrPyHDXKhWW3tHiWh44FLB65bx6fV
-        M/B6fO1S39thY8a7q0VNasPX8cf0s/uiDfa9/nkrLfBw0jz11JOpInW+gfr7fH2V5valsxmI6DQc
-        DncHpwPbg4fnZQuP+WW9oY/Wl7MFLn1B2pu8p7e3i7o9HPGDUejA4aXd589XvJHcl83YfVRnRu+0
-        Wj41HtYflnMFvQBMNuhQ3RnjdreK3zpLeyPxkh/sGhdvBvXagzXdNRed2bu73fa3XakuXr36p2v0
-        3l4eZmKrdtoMF4eZ+bQVnW1ts5O54qWld0i92fBDDytCxsrDkT8AU7UwcFUvdHUAI+YtmMypyHro
-        mZGj0L/lNe6gCRP5ITQAAU2ggA+sYoAwn2rkpSUNEyBDWRJ2ZXFFZE87AP3K3ocV36saEJgWruia
-        QU5uVkiAhUF5zlg/mRP7WHPIMq5uecBUxPbXbA8lWVkFYaXGf23c0BEuUcmCgYaNoyLcsFNRUQMB
-        DQfQMoAiNm82lAlLSuR0Rw0egFK71UllshFCSPLeNftFrXzQiaWKUMbYawb2iS/wfI7DwIzFnEMS
-        mzlW4jEpEDiaAZAi5jgMynGIFVV0dXXf4fIwBAxV/vNnXj/DM1SRY7dT5MTI9Oa7keMauLKHvlvB
-        R0BKghcCmSuyMiUX4KNv5oDYNN3pwzSnQ82VGxIniG+7CP2PW4mqjIY1ZbJakvVzvESQUfE1AIpB
-        588RYzg3Tg9nIRadpVDIvD+h0LMulqtef7IkUxXgjBVvfYFDE3i4AjUMclR6LM9X/X3szShKFfkh
-        k2GLhHFemgByOUByMVEKg5znc9kpAbF0lO0g0OjG+2uS5tIRFcTb7JOO4Xo5AggYgaUP6xAG6llz
-        QkCjIg/IhoVZCDm+Z5K8FNrElClI5fFE41jOhHRqw9EQYn8on7iGhqMN5DAmp8mwKKfTkB4kbkjo
-        dHFpL0KREYltVJukcbYCF1syAaOGh1ETzRQpzJfx7kxpWya6Py09CJMXsIwSn2WguaRQ5kj0hFy2
-        LpcYLbpeyMwcGz0PpOJYf+WRimZWRqT/I71bRmW3AC3ibaT3i+q6GgBSOaKSFifAuyKZRCBQoeYd
-        gEpqDxuz+wn/XREkfKx0wkNICpfICyRFZgTKDbFBnHyPACkszWihMprREDCI45DIqLeERr3BF9iJ
-        kNKv5J/rmiSgyaK8JEiMmeLkcn2pyQtqDGueScLMBTG9yktVQVoK7W81/hvP/4sXvkUr3Vdg85Yt
-        QMcIaxDf2EQUiDE6JHCdv9MkTUFs1uo/bJK6KPyUSepVUfgVkzATxKmH+mOUx+ed7qg/l7kczCix
-        GV40TALpUnkgvYsHfkOVCTkOjNob+M9EidqL/rZMpTkcJBIyYrhDvNzPEkkeZAyyPRwixbHOqZxB
-        CYEWGS4Zx7UEWW4QdRlxYk70aJWhv8MAAcchSyFc2GP/do/f23uEj1Z5nLsz9wH4Ki2CjoatqPAo
-        jbgEp0OZJOMD/VnlvwqRKAVkLtM/akgl9YYE9h4pni9zBSDKhVG5AWaaBNlQdrUPFYaeR8xK718Q
-        iWvcoLJLcuYdXhmVPUDabhMExG9C0uFEvhTv5x7OyCEpteR9m6MlCCVEZ/Chq3kGe+7doHLUe9Ga
-        2BXmlfpyInMplCR4UklxxFZtV+FZAS7jMjr6cXrc0+PQh3IRk7/zCii0/7/c9xca/ri3Ys1Lpzfu
-        zxfr/ni8kLmcgJFo76KR9hmSiFsTH0MJjVUe1j/8UqCWHleFZ1XhIrJkuAYmSZatqID8/cmyRWrC
-        TyTL1k2y/F70RmET+L7Dmrr4/ktYFEyO5UaFOHbZ3PCvcnDrR3Nw7G10d9VOu0O8mQFMgtSzlfv+
-        UQYpK0t+1HlJhmON4xtTySD5NraLcR39Ty+u9bXGV2Yv5DGeQlR6PLouaWiEdi2u7XmMrpeFa9T2
-        qnp03nj16IAlKM+J1uAKSHa06E5IW/MeApQmf89PIWDSRrtMkWn2z1mgO5x3x/1o2yVBgUq7sICc
-        pmJY0HBAUYFZ494Dvfwyp+PSg+IWLPByj4t7sHz/JX7zBL/79r55dP9oXmEv1v9fVuSS7zfJ1yD2
-        2eDmK1EB/6lPSlz6rYj77rfV/wL0itPlnRUAAA==
+        H4sIAAAAAAAAA7VYyZLjuBG9+ysUfbAPNoukdrU5nFBpX6u0V9WFQZGQxBK3BkBtv+M/mS+bJMFd
+        6nDN2NPR0S28fAkgE4nMBKVfL5ZZOCFMDMf+5Zv4JHwrIFtzdMPe//Jttexy9W+/yn+TKHZME10V
+        VdcVB+sIKxgRz6SyRLyt7liqYSseAdggylbVZduR+McSScNXlzrK1nS0o6wpHDe22sfbTDBXl/N1
+        ui1Otu8XpVquNUpCuddqKmu3fTIWM0Ep960uV+K61mvx9nle20ur1x+dVldadtXGqGu9za7TzRs5
+        rPakqJ97t52Kim9vLp1jo/w5bPSGVXyero7Hz/VqPbF3tepae7f37Te8vRjT99riIHLcu8Rn9if5
+        BrsOIcbWRPIVEYnPILFjqHNEtnwscpyr7MSpOuAm1159c/tofpRPDeNo3arcZK4Ue2VrPDA+26vn
+        klHpNo79yqpLtEHfKO039f60d6k/f9Y+ei+1ZpWup5etdjo7xUF1cFONSdeudpz5uWq02h1U6b18
+        cKhWQXPto9ecNV8uw8pb9b360TZfRr39boJHItczyeewoi7qPZMunsuN5eaErJfS+cNur9uXxbEr
+        OvWP1+mF03u9kdG0lQVavDg/Xt/2k2lf0LT3zbtqvsIaaHVy1WXnBz4YN3E2G4/dbt/5bI6OSuM8
+        Wxc31mg02mNr7xHN3d0WgtgaC2/CDp3cCdGGePeyGU1uE+f4Vrlqp6Y5La0RKlaHlZqzLe+wu629
+        zvvtoT4f7l4nYlGbc3uvsz4Mt7XGrDOYkV191tIbV22vDIRmabyyrJv+YY2sd2zU7Z597g6E9har
+        S2WpnxrXFa0Ntd1uNhReUWPXFvptm+O4D4nPHlZ8diygNcezqSwmrDTsxwHSFYMiS7E9a4uwz7wH
+        ozllaevZuh8g7P/8Gg/QiEkcD2sIQB3J6EIViggVYo20NKehI6LJnQtF2FbNwhLUCs+qBpbqhTv9
+        gBvpU4eqJkxpbQ0b6XKp8ZTwc7K8CqFyWXiq3NEJzVFhQVel2kEW79ixKKtBkEpdbGhILlXuNpQI
+        c0pg3UHFeySX73VimaR5GEOauya/mEf3WxcSQAZKGDtVow6cuyCkOCGYsMJAqBerKVYUHTHgmqqG
+        iFxMcUIoxQEvKuRqbR2TT8MYhaj823/S+gmeoLIUhJgsRU5mJ9/yg1SjhR12rAI9IKgAtockPstK
+        lCxED46eAgLXtF6eX1I6zF2pIQRBcNpZ6H/cil9VVKrK09US1k/xIkFCpVcXyRqbP0UM4NQ4Ns4g
+        4U3MXYUk+iMKs7XZXo2XMFEGTDjBxps6VMkCoaqtq1hPkZlZtqM4uyCaiZ8W0sNQRg24wmlpBEj5
+        C5K6E7lrkIp8PrESgaf9zIaRyrbe2UBKi0dMwJIKNAjX8wFhFBLY5jWDhpfEdGzdsTnvCM6KQSYP
+        qONAHgpDZVMlJPyP8VVMobymgFDI/AjCwt9Vy/13oQUe9fytpMQSdBdBq8GmDQp1FvLdBV5QjpCc
+        /ZX4wGER4rcxIS9Si5HMZAkvP5+u2hp6PCkzJyJkwIQT2PGsQrTS0NB2ToFZyidb4CMn+geKQ7cH
+        h5AGYnGgv7KhXumFETR40J0l1PBUsAHxBc3dyUBnxUVQK/yCFaS8hyIJ7hxSsGrvkQKVJhwHky0P
+        3r8KIlShBXKhREICLBQFEdJiQmFsj2oQ2DuCqFyq+kvl0YRGkAahBLehXCvWKuUsOxIy+hX+WJau
+        y/6iQkMQQ2aMw0k79aogKgEMFxSuloUCOic0OEFcio3vJeG7IPxTEL/7Kz1WCOfN+4CN4eZjeueV
+        Cj0UJur1/+mParFcKwlf9kdFqPwhf1Tg75/xR2h/kGtYOPqJe95sjTpziU/BISVww0SlUAnOhWdo
+        Vmz0D1KYgjnY72VwYdlZLCNF5jP229Dl6qAbSWAU4iYEuiPDdCr1c0YaDBlQBQ4yD8qcxdbltsG6
+        HOHseF3Ob8P4SD9QCdXBQuoR2TRO8fQhFBFYYeKjcVB/iGG5fmcSJPNIj1Um9ttzCTJN2CmhGRM7
+        9ybCr0lfSOP8gzn2yFFYgTRValAPfF6B8lxsVEWxVJP4GJUgm+/ZT054EgU44UoVOpUElvhksoNK
+        FChMkA92JHj2ZQA/m/p1CYpnlEbDoWSpFwV7tg1HweJGLIINd6hkQdZ9wMujko2gF9eRC/EG1SGI
+        yWA/j/CQ7GGw2bFTtAhhBN8GB1t+Gmbbv0Mlv0ljxbMlzgvl5VTiYygqEVByqc9WjpYshJU6j0vk
+        4ARZdcfMCZbLYdJPngaZN8GXHgOZV0DwOn+U8R8JpKA9Y2stmu1xZ77YdMbjhcSnBCEpmH6hQgeO
+        4Q5vIBRJRAtLWdiC/Omrn3uPZV5imWNKUuwG6VCVxL8iATcaYvnrCVi8L0g/y2T+lXIdxww7wyA2
+        cph/0UzD8mt7EM6p4X/J6+KX61wQiWx3XFN4hUgPgVBClJOR+lCSBxkryYYssCHlhd3nOlRJIOn+
+        3mfvvP8vO7jaU0kovE7g9R5DTHo4WBb0SGKDFcc0xtZLrrLfOytb317W3oM8B6U5/hp8BklM888E
+        bs4PD5G4GthODCGddet5isTKQcoDrcG8Ne74284JMlTW2LlgTUEzsGairELojUev/Pzzno1zr5J7
+        MMNLvVAewdLj5/zdO/7hA/7u5f7VzBI+e/+ajMlHH3eiT0Xhd4a7T0gZ/A99b+LjD0n8T7+9/g6I
+        1+BKvRUAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2023']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:23 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2059']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:51 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <make_reservation><describe_trolley /><self_print_mode>html</self_print_mode><user_id>credit-testuser</user_id><trolley_token>s2--LPeb6RR_25wMPZ2GkaQi6W7AEeLqlioMgvhVZmqCVPvpJIbg535Eo6A3YlTuFovVsugUOiWe5nmiAEW6bK8vFjpBqS9U2NTyM_JLZ3khR-cQx6kQEPEbtv7VkjKzR6O29aXgjNyWfh2b2vIIAeBvZpoacQZSKEYGIkglUoBXsmrd-7ZG81AnewArW7hHUJenD03w4fku5P0mUS389rQLxOzCMaFfDEvY8StIN6jD_jd_s_RXrbqRWy8RkwAXF2sjIIIZglAr9FBJT7tL0T45bKWwviewE18fd0nb9YS4kIK0FKulrIw9E0vytX8mMXLmG_PcDjUTH5BWxilyeDpeNXsg-ZcL9C-tVATkX808opZ5wnPrb3BiOZ6SAPqmYYEYC842yn4zmcDVMBP273jXISgPdHY2lY3XZ</trolley_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsUDfEXxcUCHyqYlLXHoXFHrOkiCFhc3j34smOD16W2zX2VOT-TnkryAjJ8N15iPw8qeHlWzsKzFfY</crypto_block></make_reservation>'
+    body: !!binary |
+      PG1ha2VfcmVzZXJ2YXRpb24+PHNlbGZfcHJpbnRfbW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+
+      PGNyeXB0b19ibG9jaz5jXy0tTG1Ea3pRMGxVeHd5TmIyTWJZeF82NDc5MzA0R0NBX1ZwRHZpU1Ew
+      XzRIbUYtMy1GbVAyemp3Vm5UbUdIS3ZVeXQ0cGE5S0ZtWFF5TldYc2hVZ3MyZHdHemZhZTJYWHB0
+      UnJpNGpKOUdKNnJ3TlVra2pWVVZNbmY3NlZjWW5nRFhyYnhpTlk3U2gxLS1ZPC9jcnlwdG9fYmxv
+      Y2s+PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjxkZXNjcmliZV90cm9sbGV5IC8+PHVzZXJfaWQ+ZGVt
+      by1jcmVkaXQ8L3VzZXJfaWQ+PHRyb2xsZXlfdG9rZW4+azItLXBfZjFOYUktTXlHOFd6WkFaNHY5
+      aWttejYtTVJfMkc0bUxJaWpEVUIzaTVGOWtINVVGc2NJSGkzZ1c4SE5HeDhCajdaR083QTZ0Vk54
+      YmN2d28ySTZJemFpTUZuNkVvUnc2aUNERWU1R09aLWU3NWVSY1pHQVFBT3hKNVg2WTZaRGxPS0dn
+      Zk1ySzEtR2xzako1YVM4R2x0U0I0OVRXdmVtTzN3Wm5EVkR4U2tGMW84WlBOeC1kR0dLaUFuX1Nl
+      U09vcVBYZ01OSDBjY1lXWWFsUDVlUmVVdnBhVEVxcmhpejFRUUxMcEZIb2pBS2tfOXdRVjJXbUtL
+      S2dybWd1c2NwZnpTMDFDTDBYMGZldnBNc2NKcmZPV0tNek1va1g1eWN2QWxOM1ZlZTI2SjU3b2I0
+      ZnJwYjdQUkhESmRSSmZQTTEyY1ItZ3VFVmhKYjc5UUVJUXNmOFFDZDl5Y2dfSTBBM0xVbW16ZFpt
+      S21Zcmk4bkdud0ZJMERicmFUX1Rkdjl5VXQ3SmNmZlFKMFBlOWZEMEhEbi0tLVo8L3Ryb2xsZXlf
+      dG9rZW4+PC9tYWtlX3Jlc2VydmF0aW9uPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['783']
+      Content-Length: ['766']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA71dW3fquJJ+n1/h6Zc5s+awgQC59OJwBhwgJOGSQG68eAlb2ALbcmQJYt7nl8zD
-        rPM3pv/YSLYJl2SLLfVZ0w87uCSX5FJVfVUl2V3/+0fgGytIYoTDv/1W/lH6zYChjR0Uun/77WnS
-        KVz+9vfGv9QDsIQWgTEkK0B5V/Gb+bRRj9nMwQFAocV4o4ViawacRgLjevH7prpNkohia+Zje9l4
-        qhUKk4fhfBO2nhPwOFlY8eIGm6wcDlu0RO3rxKOX1T4aLoF1hQumW+1E3stLxawNl2t7cp7EnbN1
-        3NvEbu18fhu+M2y6D/3mS78bvvhWuTaPH169G9shZrcSvZ6B58pDezS8v/PveovHm4vJ9CokbgdX
-        3FZ3cl1iydm7Gfj2R7V02TbP3kbVW89bDpr3o5vnVrPTdObjy44Hwd18PW8uXiu3Q+txRJ0rr5rQ
-        mvPytLiYkI9qt7pshvHb2U1v5NfunVnJDDxcXUeDypiOoV9KLkavzvlTbXR1Va2t3jtlvAji14fa
-        8nJwYdeixfnHxKlNh5tHf+qx4WTpwEmH3LSsFX5ZRYP2ZrNyk9akO12E5dYlYuByGrVenYLZChhs
-        hvO3alzwcWEwDtdnUfn6yev6ZmGcWOPOaHi7GjxONqVKEj70PrpXo1KlfesGz5ez9lm0KbTKN09D
-        q7vpFdrItFaXqBZcBtU265NWhz0vI1pl5Wgwh3cDBBPm386c0frphVSHt5V+fwRg4bJwPWWtKd4M
-        SqASVJdB9eoh7NoW+GAPK8uZ9vov6ydnE86XLkEf2PXst/7wZnbpDz5Wi1YZvD1788KEND8e1rfW
-        xOw9RGFp0nqDHc8cXcLR2CzcPF6g0ujFO3+fd2pX7iPZ4NGsc/3QnT14H9WXxGpW33tPtWrc7F2Y
-        7X5p0ZqcvXTeB+HCX/btmVdbTJpx7fbMTIZ8xncrumiNpvXigU7WKQFhDOxUz5HTmJZKpUJJ/FO5
-        uHgsdDvNq3rxqE89QCGjMLZ8OKdWZh/cVmDjvPSD31kv/qydD4Z9HyYWxUsYNuJKoQBe37ojB7Tu
-        m2X2aj5ebsLnu4/CzZtZuCs9La3lcjm+LJcKw6fnvmWB59dX8zzpLXtvJYb75353PULrxWIFulP7
-        bNp+XV7fsWlU6gahi17ezM7D2aI7IO3C4zq63sC3N9D1KhMrWrl99gQ+EIbzfq/9tHm7Mf3R9Xn1
-        olu5te7h9fV7uA7mvdnMvbh7Wr4GZGpfjKtsVejUWG2wdGZVdBuHJQJNNjxH/fbYHCJcmr2U3i4W
-        uD25A132UFmWTD6qc+PeobEXd3AJjGH5rdJ+KCyvJu93ZsWpLdajG6d/9lheWGU0fbxi0Rktjd5r
-        79c0WPR90my3C6xZGJfCGhxtWlfnY9CLW+HDsLW0B5ZVGPUL5avNaBXd+oVRp3dB4LMbWZOIPE57
-        ZDoOyLx8nsyryfWlOXvpDiq1q6h0F/mjTeUWnNnN1Qu6KA+eotL1vD39iJ6Tcnt+T+zR9cPNwmLN
-        c9opDZsunliv18na8tsgpM/rIDRv6HVUgNNeCLoWXdDpCL981LrldTIasAR+xO/mEnRcN5jfdAZX
-        F7d4yC4jx4Ht6RBdv1s340GhUJgKrdpXhk/dwMThDtTGLKSN8q7XPnnbt1GfsdDx4fbv8b3fULc9
-        Y8yIDTnRgQ34QS2urrT0ecd+69EdDoztxoT3NsZJTGEwhQQbc0wMHBZsAh1EjRmw+RM5hkswi455
-        pvdveVJMgc+HCWYohE7j7OrHbg5Hbce3xLRRKf2ofeke06OufMAIUNtrlL/0/mw6vCOGgEYE2bBx
-        dv5lQrvGo5v403mAuLBR+XrPZ1vdZoRwzE12vzIpuzMuqUPSrsec+x5MGmXhW46Ju14hC2aQNC7P
-        zvd65cRdr8gHNowbZ3t9ctJeHy5FK06CGfaL+2QCc2rjf/97//4dfUdt1FO1a9S3Qs5W3hSKa1Nj
-        TnBgUA/ycCRksF487LW7KYDUw84eIRWNOWwN9+7JxLV3yZUgXe1D0p+cighxAAWNwdOEj7/Xb9uw
-        60qTCDbsjP9ex5S8d/35cCjOrfPIFHbav+2SPet48nTdHkw4qwPyrlc69TFlDgypQQCFe12zxwqx
-        heepNsfCVexf5m0UcTPeb90S6scGsmcTOQeOkm8v5RLHToGXyOGDUoB8oWTYFxiatuW/63Pmpz/y
-        W7aXdR5FcuiknDOFjrVCcN0IMWf5lVwneJ1xqBfzn+lUuF/7yIRTFIQIcFlgwn8X9+dUzGd9ZMN7
-        ZlvcLRHkasL/AAJBJvU2H3N3lTWkMm7zUDtZe5DAvEPu+5DLImsFfAYzk94n1G1Ec/v3cehwp8qW
-        XFCfxKw9ZXSftueNGWvbB3Gc/8n6c70GVExgj5a3Z578sD1jwwWchvIZuzS+PyQJ2XLZWEuOQfkI
-        xVSKW6JIFfKu2zs/KQf8dv2+YblETvw92+xB8vYD2q5L+iwdECA/2euUPWFxN25xKzSxvCQXcyr0
-        fcJnc3r/U4i46hl3PHHiWc+ua74KBHFT4ToqVNOKIIc9gcep9/62qc7dB8+4QOhCiwNnfp2vD/ur
-        Ub6kntFkLuOoe1Yqc/++65D1ZdTmFjqPIUfFczHQMXXXLYY2Vxxu1tWLcq1aKx303jZm3RP+XxA4
-        3BvxQUuX5cu85yedLy6+PC+VrZQMQof7iACm3Quly0L5clK++r1S+r1U+o9S+Xcx0vc35HyPJZBd
-        xxQQ+kUmZ2UujCb3Ov4/UyTn5bPzSvWXRVI9KyuJpFo4K+uIJBdB6noyfRQg9Ng079qP9eIeOe+S
-        iqEPKDektdHigVcI/y02BvxxiIjNyL9ub8rklf3mPvO819m2CA+a/fK5luOdI9kn5j349CiLGz5a
-        fbbnpG2HDCGL2+sUCGMURCJESlFle18GkdlvFsWQI4GPYnowx/bXOf5s7oJ+97RPL37D24XYyhDc
-        BxQJ1GzU0vjh87LOnbGb/SyUfpRF0yehXtzd74HY4mDJDXsep1h1QBC+UEANdD6dYH5ZD8CHRVgY
-        crFm618+E4nkMVWknt/1O6bWQwgFwHHAo4yHZ0KX0vl8R887M5JWe/a6bSlZB/EMmAQg5DifTv8L
-        tS4CxwwTzfKjUZ0M6sVP0tbBcySlore1DBqlPHo4ptdjD6fucZ49TlZiOqTVf5LCHOQu2knLQbaS
-        BoZ55NW8vm8/jl/a9/fjenGvIe+UBV6Ax/6EW9wL17F42y1Hnjx+0DJUjjrBNqTnnmf/sn6wEDtn
-        +AId7iwvBID8853lBccEBWd58cVZ/sx6hdlEGPt5RJqu/xFNGJOPAgHE26hwe3nKB1/8qg9OtS2b
-        XaF51eTanBPylphHnzGa+bmGHhOzXjvnlykv93B54Pic37Ij1b/a9qFdi3+zhbv4USkZo369uCNl
-        rZ4XBDygKV9VUmzfp2Xj7cxVxOzWTDxvOrp4wCPSfh8xRvGAsnu0NNgm8J3B+NP5h/iTBJ0syD7u
-        Us+8/54EzN6jed8W0z5qOOiaRWERfxrDRsT24eENuTS+qy4clxWy66Ns6CvxoN9eZvQduf59GeFL
-        /eDbwsGXisGv+pU83f7/84rFbfFJp4S6LWvldZIv5a4DulJtrPhZHJvz7I4jVNoaF7coBpIgDZcA
-        cXZQd0BNO8YW5AmKbwHH4clmvEO844a8N3DF/QTOoSh/7MD2aws3IDhHvpiazSN6HPC5Z9GDDUJL
-        iD0b7POqng8lgi5o4RA2eqErCDhbF+OecvP60unwNrrGItkz+pDLx2gx5IttH55b8N+UQrLmynvE
-        RNzClXQdNm5AwGcZc+/qCQ3llCwfSnZJaHa5iwBezo3L6/t9/D+RYK0xWVqRJ2ZeOisZlXLlwrio
-        ljhm7LXUPS6u73vttdQPV4jgOP5PlIvsh41/iMGPFrH400XhPoY/t6g0ZPNFcJcsHj0UcKRZY5OL
-        ihBwnC4Wj5kdc4W/kos2CZgZ7QCJYk+sPMRcPvG564Ewjc+UObsnREKRy4DBwcRoATJjjrp40IkR
-        XK7rvjpbX87W5wCI1LkGcq6EeyENrviUCLCGAN5PrRwP2znkqTMmJ2Qg/CUK1fnGcr7cpPlsQ2MM
-        AqzOnMqZM1GPVOfKTnMFvgbf9QkRs5k6zw8pzz/+yxdG3IvFH3UHtJFPeAPJDKCFuv/Zf85vGLdw
-        zO0tdT83kGygi1camjebyQfhjg04WFkoMzmctEDo+oD/9JQZyxGlBX0XsS9lzZNc5SDSYmTJZWt0
-        QIyVWctRpMV8F2iY38w7IWCPAKSucnJA4nLgsS1S5ro4sWahxkzlGDfmD08FLFPvj3/4MEiU+cvR
-        rsUjKw3An4Vyrly8EBnXgLA4Bj5Q12M5mrawj1YauiaH0xYOASLwr8ZYyLzNRH6MWJx6pjFQ99Yz
-        Oci2CNggX5mpHGG5vYAAqLs5ObS2PKYRd85WJ8TNVpDmaKXMW46uLUzjNdBAkeSEtfhCpZW5ypGV
-        c0UbqMrUlqOqyZ9e3a5tW84U2zjWjS9sOZRewwDbothtG48wYjOf/8Bzw8Q8clYeSg6DIgc3YSji
-        OqM5zyLS7ZjKQ8lhMZ2+8ZcRxJEvysrbYf5deRw5To7XiPIATceUbDlWCmH1VpgkfClATJW5y3dx
-        06XAeKmtVHL4ND3kq1uWHDJNwLMYjJXdoS3HTD5VdX9ly3HSxL4osqqzlSOXiTk0Go8aeactT7ZM
-        jZzIlqOMCSJoPEPiqKuBHGJMRsAf/wPUfZM8hzM9gmLKIVwTGG05gplJpAFgthzAzA20PW0P6sgz
-        oS4UWyXKca8jj9WvF2iGGVVOARy5O7uGYQDIUpmr3ONc4wCFGtbmyL2D8L1b1voA6JwoG/gu1EgL
-        oTwQaduMZ/NEmatc1doxxRqlPygPAdpuEinDJpTD/YvYzyOijuYB9Wo2lLv3NkGUQHWu8sxkHGnk
-        8VCel7Sph3CkvmJzecjTQaGO653LXU4HLZTdzfx09NQB/vLPlP3mct+TDgEdKPY0eBpMxdaGMZwb
-        fWQTHMJYQ/invVIHEAy1H0iu3R0iNt5VmbrybKsLZuoBoStPiLoE6qRw7ik4xcRVXzRXnlF1xLaq
-        Z3QZ0ki6Xbn/7DLu6WKoHAG4chfa9XSmKnccXTTjOSUFysDkytMYrgpQyyW5cuPuAp3swJUnMlwJ
-        QnX0cKMTTIEDfcwidcuVF/3a70wcR0fANzQnLnc3Yuk03M0JLOWhK7e2zJTT+qTwmhl1zC/XiBuj
-        pvt05ZDLF4LCAKjvZbry1I/zVa4Su/IMLVvPQgvF8f4m3y/yludRXZZouA9PDuc3OHSNO/6PMt/T
-        GH4DAXFSVenbPOoPga8dMXhy++dPIU6tqrM9UXQgGFB1Z+XJ1fkGIPUk0JOr8g0LXUCU8QrJw4Ge
-        OOSjE28heUDQI1AHWZAcsXoxAVB5cwPJ9ZjrKxQ14b76XgSS6ywXroZgTweyLfGuScx9seAfGkMb
-        8n8nkHAy1tAQOZT1yP55kV9kKTc6zlJd1HLs6tl6+ia34x4FvrI8F3LLuIVEI+xcyHX4FgRAo5Sz
-        kOvaLSaO+kot5DHXLYjUeS7lMr2DYaL88Et5gnCXEDfZ6JyMW8pTBJOHx1jDMSzlWcIdImgG1GFn
-        eWJfAgeYqJ9wWco9Y3YA4Q5Rmm2ED+AKqY8hV7S0ELnb/vuyWSbqDXdYoyS1lHu3P89fHoDesTVA
-        yqW/5YkKPkgCDiKasdtSXq29Axuw9HRMyZcXSO6Bumb68iNd93AGQvWqiy+vLGf6fs9sdbP35WZ/
-        j6DtURjGFKoXQn155jAmyLgH4VJ9znILuUczneq9Lw8B7mGMqae8c+bLQ4B7RD2mcyDYl4fz9+wD
-        chxgRDkt8+Vbk/eAahxi8uXuga+YOsAGcuPtc1yxbeX1CuSW1udJqAZTeZYkoGTfrfex7+CVukDk
-        UQyfOjdk6BL16cvrqJn36QNC1V1EII+S+sABLoht9eJkII+S0jdaAIk94Pu6sBT8wj4HJgEkxhtz
-        MR9jdbjKwIaOztZdIM9i+8BXjtICeZTWT4DYIlbmKo/S+uKYkcYh9UCeVnC5qlfOgtPB3gAT6on9
-        y744MhwCbbWRJ8SZHaF3plx/DeSw2AeMZ/A6WBPIkVE4lhgSApSjxkAOjn2xLaHMUw6MmRSQ+nGS
-        QI6LfK4OWqm/QRXIo3HOFqzVzVl+XKcPP5AGiMkxXMw00aj0BfLgvo83Yr9HwxxCeXwwAAHS2EcK
-        5fHBAK4NE/h6jj2UA/gAuVDZB4dy7OZObY79pea5rVCO3umENcQgT0kGiIcDwGXqfOW4OYDCvWu5
-        9FCOSFzIa6BckwvlkDSAEVCuVYdyiBhw56gMnaHc4Q6QhunKfYIwsikEOhqL5YHOMFAvIkRyPzPi
-        oUKgrKuR3BWMoPo6Rb90GmKE/URrxyaS+4IRiBgwxMrp7VhH8nh+5CEfRRHnrGy8kTyMH4Gl1gvM
-        kdzbcDlrqG8kV98sExshHozBbNtUAKevXm+K5JH7CFEbIKLOVu5+RgwSisUZbeXgJJKHqCMOyTEP
-        q5U9USSPUEc8J2Cuuh+O5FEfn656ChPJ47NRBprKMPQud28PQOPkEJF7t8c//sFCpK61RA7DjzjQ
-        yX7IiWMtkGiEkUQOmo8sjsXea36IUUcWcg17XHP3oDzrWK4LY8AclH5QQl0gsbxunh0V8nGAtXcR
-        4hM1dJjYHvR9dQCJ5dW9MXP4Sv5loPz2VCy3kvGaK4eyXsRymB6j0AURJsqOMj7xqleKTDfQh+oH
-        kGJ5PjD28Urn4xex/OTzeAX82fb40S0QZZ8E6ivfia0Q/gw8zlB/hhMvYotIABj3EKsjX3wq1MgK
-        YaEyVMcn9m5FjVodUWO57x9z369RaozlAcuYcQGAQF22JyAl8xhjdY8hj1bGABsTHGSh4YhP3Ubq
-        R1NjeR2s7Rtj4K90XnSJ5VWrcbbLAAjV8Hry2ChFl0RUdbPPIem+VhTL89bxWrw8rxH2Uzl0ielP
-        GFlmhx1MgP7EC89UDmamB9Rn/0uJ51gcBBbl9e1JM6SOxFQObhOs/lY2PbWPBPRWVA4+E7BAemkn
-        PbEphZdQI7egcpxpg5gaExSo2zw9cQiYa7X4spWWJOQ4M+EphkaZg544P4lDV52nHGWEENSP9FE5
-        Fky4+0cOyMKbCZ4BDdOQI8GEiS/TKzOV5y0TgNYaqiD3y8J/5l/D29+gnYBwo5MwMnmW9LQUHwdS
-        xl0m921Prk5C96c+V3+S+ekD/vkA+Rt6fR5NEmPIqJ/wEXURjMmDq8Mh8dzIv++mPIw8pHgiTKfa
-        wuSa+rSZQT1cWMmVMn3bAvuJMYbKmrn6lcNpzzzahPzv9r2f7EVBnXrtSp4WP/P8YcOg+rs+qxPB
-        w97J+GdEXKSdC65Of7vkUEn/5HByHHxGkIbqrzGt5AWsZxAyQJW9//r0N3BegO+jLNLtMMr0z2Gs
-        TyRhOl97TOS6+QYD9dwlOXVIIsGUKhvt5kQpL30tL/vOkDJrud+far2/uZHHBVMUzMBsLRFD8dvv
-        8RZ/9v+s/D94GALE9HIAAA==
+        H4sIAAAAAAAAA7Vd3XbqOpK+n6dgnYuZnjXNxoSQhDM0vcJvEn4DJCS5YQlb2ALbciQZAvfzJHMx
+        q19jzotNyTbhJzliy3u611k7uCSX5FJVfVUl2V3++4fnZlaYcUL9v/2W/2H8lsG+SS3i23/77Wnc
+        zN789vfKv5Q9tMRThjlmKySgq/wduqJS5uHMoh4i/jSExinh0xmyKj4t575vKZtsEwg6nbnUXFa6
+        xWz2+jl8e7ybz4v1IH/ltbOvfdbobtwR70+yr8Hj8+qyFk7CObcub97R4qkk3i7aj2R+9bqeFFE+
+        8OZP8w/PKAR0ej15qTe5M7sYPnebwWQZ3hSM5riL3y9JdZhfh+NWfjQTm0bbuK498fd+gU/IdjHs
+        9vFmEjZCwhqXA/Ny039tzs3nodFvjl3GXwoXRmsRtB+yV+H15NYcvr5cen7DYIvlE7JL/gwtF8b1
+        ePZW59lqdlpdNOb1WW3rjzZ81L5Y9Ffz6SPzWH7Ass7bLDSnedt4rb0+04vG9vFj2+u1wsnj9b0x
+        um4ua0P+WB1tW6LbujVqq9bmPnja0qtpdtAjb42be3vuYzwkfdMYdoett2G9lmXLWe0GbVp3fL5+
+        mG/teS2/aT2ubnvFwiNuvQ/rdPvy8uTWxu+PRrH6Um+/9RG/fB5hv3Mzvah3xAN+EYVp/bm+ylvT
+        jtnJN2mPFZrZrYBncfLbF4v1BujeLYjlY/FlxOaj7lBcLUnhff4yXCzc61bp/mbUcNYl9H7l10Zv
+        2dG2NLy/ot79jfV0nS9t2XWp8FbPMtqyvGHLnzy4vbV38daij/Xl0wptRbZfnVqt19ubYfuxvvAa
+        g9rF4N7lZvd5fNFom8xsLKxt+FgzPqbTYGwHd4/t7VW2tpk8C/uaOZtg6QzR4pov1ri27RfxzX3V
+        K9Hp4IGKi3ZWzP3GB++8orx94beMtlMb0HE+m30r5450sSwY8jkyI/UmVmVsGEbWkP9cX7VvslWj
+        ZpRzJ33KHvFDgfnUxXMxjc0CTARX8sUfcGc592ftMBh1XbyZCrrEfmVZyGYfL/ut+eix2OwXu1Pn
+        zs9emuKm3ZzVXlfbwXzB66Xi2/t2OZx0ttPF6HJRHd76/Ubt+nrysXgY3EztasHcvCz54P361u8N
+        S1X7Laj5007pmdZHyzq5ennZ2pP+Mx+X8r3A4t7b6Hl5N27WHXpVf76o34Fa2w/ZQsg6D63e46Wd
+        L5DFxTxcImMOfM3JXeg/3ZBWtW/0ih/tu8Hr/CVba5ZuN9v3RgfnPyZ1endVyz71aT6ff5xcNPl2
+        snnvXhAkTNswmo6L2aTV7Taui0XjZWxOGhTfDhb5583l7aXTy/J2vXsb3H1U0VP2+v22FBZnbDRE
+        1HZK1/2ayF879/Z79vVmetds+lWbt15KH1Xetrn7Qhv1t2wQXpHl+/vzldXs1MPN+mJdemiYhhA3
+        jYf6cnrZ7FX9l/Xd+9jgz51LVA36Dw3ffRgULPrRsaov82HJtfxuYPmLUvXp4qPYnN1jdHNTXBe6
+        2F+V3kbmqr806oY5eG3M3mvN4t1toT7sLJeXnUX33Vneva2b9cbruH1Vwkv/pruCxWPuuNrzitnA
+        6LPXZ8+dP229gtS9YwX41AfKLHCWJg19Ucnvex2Sd30r5VnoWy7e/T299xvqrienITMxEC1cwR9i
+        CioqjM87DltP7rAwNyuND4GZj9zMGG7LVJEJT2Blvtwf9d3dL6hALrD0ZsTHVqVQ+rHvf9J2egsX
+        lUvjR/FLdy5OusKAAeiaU8l/6f3ZdHwHx0gEjJi4Uih+mdC+8eQmeDoHMRtXLr/e89lWNkPGAEo3
+        +1+xRO1ZAJ7niLTvMQffQlklL33HKXHfyw+9GWaVm4urg14Jcd8rcJGJeeXioE9COugDUpzyjTej
+        bu6QzHBCrfzvfx/ev6fvqZVypGKV8k7I8crXpJKaIjNn1MsIB0OU4Ye4nDvutb/Jw8Kh1gEhEk2t
+        X+0f3BOL6+ASlCBa7WPSL05Fhi5IoErvaQzjH/TbNey7ik2AK2bM/6BjRD64/nw4whNLPDGFvfbv
+        usTPelt/6oyB0RFx3yea+K0FoViGC+RbiFkHnePH8umUziNt5tItHF4mbYKACR+27gjlUwM5sImE
+        A6Bgr1ksQJvEQ2LBoAIRVyoZdSVGRm3J7/I8dKMfyS27yzJEhwCNAjgLbE1XBK+jGPIbcpnRdcyh
+        nEt+RlMBH/YRiycnCQFiCIwGfucO55RLZn1iwwdmm9svEQY1gT+IYRTLvTEp5/ZXcUPsESGC3qwd
+        zHDSIZa8SURi4S71LepnwyWI4pMYt0ddO1F70pjc7CLOkz9xf8QEhy57QtIYKwE0Zv4VecF/Zmqg
+        DqGcykGzlHAUjMdsN5hH0j0gSSmCFKZLQBY5Ui4S1o4iA/2k3+62T8oRs32/U34W8k38PdP4cXYd
+        joj7PtFzVBGYmkgetH5yQ/ykuf0UcjshygVlidijRTgkfDZH9z/5BJQt04YMCPKXfddkVRgB4wCt
+        lMo4DTAAnUTbyF9/21QGhwGpE/JtPAWYTK4jZmMn/GsmDxA6woHA0ntnLow8+PR9l7h3KEywyjnH
+        olK4kkOdUvfdODZBlcCUL68vrouXx713jXH3DfzP8yyrIgc1SkY+6flJh5WmN1dGfhqRwbuAX/Bw
+        1D1rlLJGfpwv/V4wfjeM/zDyv8uRvr8h4Xsqg/ga3BYTX6RSFE6mizb/n/K4uri8Lhg/LY+iUdSS
+        RxH+SyOP5PkjXxOro0Sd4W2t3RiWcwfkpEskhi4SAGPrTBUiLR//G8/04HGYDMRYZtwYjXc3xjKL
+        f4OjvLpv7lqk24x/uaDotALskJA+45CY9AAIcyo5uDnrxeNmZ9G4WZ71P8fNyhgyt7s/uiW5HZ5Q
+        hLziktUn+4S06xCjam53HYEnJ14gw6oIiXb3xbAa/w4DjgE9XMLF0SM2vj4i/OreGYf03Dc8bEyn
+        Mbq7SBARgsyLEFtclK7y+cJ1OfdJLYM3t+OfWeNH3oAVLl5BmLUnl3N7Zg7iU0BV8AdzHoHaEUF6
+        U4lJgPw7N5pclj30MWWh78NSxHqTv5AZ5SlV5qDf9Tulln2MJRICMkp0iHQyms939KRzyKJqz0G3
+        HSXuIJ+BMk+64Xj6X6hlGWHG4FnLDzOX414590naQQRArpC9p0uvYiRhxim9zB0aedV5/DjRcCe0
+        8p/kNUcJzU9lMkcpTFS/+s7jf9dQjmLLeKzRbb3TGI4mjU5nVM4dNCSdIvYjBOkDAxuegCryXbcE
+        ypIQJLXpA5R5u8wA/PvhZflomfYudoItQKX8P8MBl0r5y593wPmvgPRnnkyaVECpm4S1kW6c0KSh
+        ucST2L4LLXeXZ/x6/qdxLtLEeHbZW2MAmp4QkhYOISwnMzfR3lNi3GvvDWPFBpeXRJ/PyS17Uvmr
+        3R/bvPw3XrjrHwUjM+iWc3tS3Oo4ngcxUr4Ug+MhLR5vb8oy8J/O5PPGuQm0n5AO+8gxckeU/aNF
+        ETvD7yHmn2jg008StuJI/bRLOYaDAwnU7oe1TkNO+6ThqGsc2AXwNBmTMNPFxzck0viuRHFam4iv
+        T1Kqr8Sjfgfp1Xfk8ve1iC9FiG+rD1/KDj/rWZKc/Z/jMXO7ylSamuqu5pUUVr7Uwo7oWoWz3Gfl
+        bA7pICBV1MpzOzRDGy8KtyCL3kPeETXqyKcYUh13iiwLslP+2fWUnnRGtryd4TmW5RJ80P20BWwF
+        z4krZ2aGXFAPph4HESbyp9giInYcn1flZCgZr+Ep9WXue0QSa5qTmrP2c0mas8ntMTl3NjNaU7ac
+        Bk7M2YEJfV4cPapMs/907mB14GdlAh/zJnifkZ1MAFnK1OwWkmTG0GlOljtldsoV/0zCd8vQLNPw
+        CAQ4kYz1hpirJz63HeRH0Yw2Z/uMSASxQ5QB9wrWyGahpS8ecmYEO4R11Wfrqtm6AAlEn6un5srA
+        VlNwpedEQFMI4P3cykGQCyCgz5idkYF0K8TX58vVfMGkYbZ+ZoQ8qs9cqJmHssynzzU8zxW5Kfiu
+        z4g4nOnz/FDy/OO/XGnE91z+0XdAW/WEt5jNEFno+5/D5/yGcZVysLfI/dxhtsU2XaXQvNlMPQg4
+        NmRRbaHM1HBSRb7tIvjpaDNWI0oVuzYJv9QOz3JVg0g1ZEuQbaaJONVmrUaRaujaKIX5zZwzAnYY
+        IvoqpwYkkANEgESb6+LMmvkpZqrGuBE8vAySmXD++IeLvY02fzXaVSGySgH4M1/NFcSLSaaOWMg5
+        cpG+HqvRtEpdskqha2o4rVIfEYb/mhlJmTdCmTGSkEeeaYT0vfVMDbJVhrbE1WaqRliwF+QhfTen
+        htaqE6aIO2erM+IOV1gkaKXNW42uVSr4GqVAkc0Za3GlSmtzVSMrcCVbrMvUVKNqDZ5e365NU82U
+        mpSnjS9MNZTWsUdNWRo2M0MchDMXftB5pkYhctYeSg2DYwdnatiXcV3mdh5HpLsxtYdSw2I0/cxf
+        BpgGriy17ob5d+1x1Dg5WhMBAVoaUzLVWCmFdb+ibANLgbjQ5q7eKo2WgtJlaqVSw2fNIa6+Zakh
+        s4Ygi6FU2x2aasyEqer7K1ONkzXqyrKjPls1ctUoQGNmmCLvNNXJVi1FTmSqUaaGApx5xszSVwM1
+        xNRChv74H6Tvm9Q5XM1hhAuA8JTAaKoRrLYJUgCYqQaw2habTmoPaqkzoRaWmwfaca+ljtXrCzKj
+        odBOASy1O6tj30Nsqc1V7XHq1CN+Cmuz1N5B+t4d6/QAaJ0pG7g2TpEWYnUg0jBDyOaZNle1qjW4
+        oClKf1gdAjTsTaANm1gN9xO5w8VkHc1B+tVsrHbvDUYEw/pc1ZnJKEiRx2N1XtIQDqGB/orN1SFP
+        k/hpXO9c7XKaZKHtbubno6cmcpe/Uvabq31PNAS2sNzTgDRYyK2NTH+e6RKTUR/zFMI/75WaiFGc
+        +oHU2t1k8ZE/Paa2OttqoZl+QGirE6IWw2lSOPscnFJm6y+arc6omnL30cm0QpIi6bbV/rMVgqfj
+        WDsCsNUutOWkmaracbTIDHJKgbSByVanMaAKOJVLstXG3UJpsgNbnciAEvj66GEHZ5giC7s0DPQt
+        V130a7yH8pQ3QW4m5cTV7kYuXQp3cwZLIXQFa4tNOapPSq8ZU0dwuSZgjCndp62GXFgIgT2kv5dp
+        q1M/4KtdJbbVGVq8ntkq4fxwk+8neavzqFa4SeE+HDWc31HfzrThH22+5zH8DiNmRarSNSHq95Gb
+        OmJw1PYPTyHPeOqzPVN0YBQJfWflqNX5DhH9JNBRq/Jd6NuIaeMVUYcD9/L1jjTxFlEHBPcMp0EW
+        okase84Q1t7cIGo9Bn3Fsibc1d+LIGqdBeGmEOz5QLYqX+jg4Islfz/TNzH8O8YMyDSFhqih7J4d
+        nhf5SZZqowOW+qJWY9e9mU7f1HZ8L5CrLc+F2jIeMEsRdi7UOvyAPJSilLNQ69oDZZb+Si3UMdcD
+        CvR5LtUybWN/o/3wS3WC0N4we7NNczJuqU4RahAe0xSOYanOEtqEkRnSh53lmX0J6lGmf8JlqfaM
+        8QGENhEi3gjv4RXRH0OtaFEhcr/992WzTNYb2jRFSWqp9m6/zl8dgLbDNSLapb/lmQo+2ngAIilj
+        t6W6WttGW7R00piSqy6QdJC+ZrrqI10dPEO+ftXFVVeWY33vhKa+2btqs+8QbDoC+1xg/UKoq84c
+        RoxkOshf6s9ZbSEdMktTvXfVIUAHcyoc7Z0zVx0CdIhwwjQHgl11ON8JP7AnX1fUTstc9dZkB4kU
+        h5hctXuAFdMHWE9tvF3AFdPUXi9PbWldSEJTMFVnSRJKDt16l7oWXekLRB3FwNTBkLHN9KevrqPG
+        3qeLmNB3EZ46SuoiC9mIm/rFSU8dJUmRw4y5g1w3LSx5P7HPQZmHWeY1tCmMsTpeZWRiK83WnafO
+        YrvI1Y7SPHWU1t0guUWszVUdpXXlMaMUh9Q9dVoBctWvnHnng70eZcKR+5ddeWTYR6nVRp0Qx3ZE
+        3kPt+qunhsUuCiGDT4M1nhoZpWPhmDGkHTV6anDsym0JbZ5qYIylQPSPk3hqXIS5WmSl/waVp47G
+        gS1a65uz+rhOF3+QFCCmxnA5002KSp+nDu67dCv3e1KYg6+OD3rIIyn2kXx1fNDD60wNuekcu68G
+        8B6xsbYP9tXYDU5tTt1lynNbvhq9owmnEIM6JekRCAeQHerzVeNmD0v3nsql+2pEAiGvkXZNzldD
+        Ug8HSLtW7ashogfOURs6fbXD7ZEUpqv2CdLI3jBKo7FUHej0Pf0iQqD2MwMIFTxtXQ3UrmCA9dcp
+        +KnTEAPqblLt2ARqXzBAQYgycuXS7VgH6nh+4BCXBAFw1jbeQB3GD9Ay1QvMgdrbgJxTqG+gVt84
+        ExsQCMZwvG0qgdPVrzcF6sh9QISJCNNnq3Y/gxAzQeUZbe3gJFCHqAOAZA5htbYnCtQR6gBygtDW
+        98OBOuqD6eqnMIE6PhvEoKkNQ+9q9/aIUpwcYmrvNvzjH6FP9LWWqWF4SL002Q87c6wFsxRhJFOD
+        5jDkXO69JocY08hCrWHDtfxqpi5TrtaFEQotEn1QQl8gXF03j48KudSjqXcR+JkaOt6YDnZdfQDh
+        6ureKLRgJf/S0357iqutZLQG5dDWC66G6RHxbRRQpu0o+ZlXvSJkusMu1j+AxNX5wMilqzQfv+Dq
+        k8+jFXJnu+NHD0iWfTY4vfKd2QqBZ4A4Q/8ZzryILSMBlOlgqo98/FyoERfCfG2o5mf2bmWNWh9R
+        udr3j8D3pyg1cnXAMgpBAMjTl+0ZSIk9xkjfY6ijlRGimTH14tBwAFM3if7RVK6ugzXczAi5qzQv
+        unB11WoU7zIgJlJ4PXVsFKHLRlZ1488hpX2tiKvz1tFavjyfIuwXauiS0x+HbBkfdqgh8gsvPAs1
+        mNUcpD/7n0o8R/IgsCyv706aEX0kFmpwG1P9t7LFuX0klG5F1eAzRguSLu0UZzal6BKnyC2EGmca
+        iIvMmHj6Ni/OHAIGrZZftkolCTXOjCHFSFHmEGfOT1Lf1uepRhkpBP0jfUKNBWNw/8RCcXgzpjOU
+        wjTUSDAOIYLS1zR13jJGZJ1CFdR+WfrP5Gt4hxu0Y+Rv0ySMoTpLelrKjwNp426o9m1PdpqE7pe+
+        CX+W+fkD/skAyRt6XYgmWaYfCncDI6ZFsFAdXB0PSeeZ5Ptu2sOoQ4onFqaptoRqTX3aznA6XFip
+        lTJ624K6m8wIa2vm6mcOpz1DtInh7+69n/hFwTT12pU6LX6G/GEbYv13fVZngoeDk/HPhNkkdS64
+        Ov/tkmMl/cXh1Dj4TLDw9V9jWqkLWM/ID5HQ9v7r89/AmSDXJXGk2wxFmP4cxvpMEpbma48btW6+
+        Yk8/d9mcOySxoUJoG+32TCkvei0v/s6QNmu1339L9f7mVh0XvBFvhmZrhRhy336PN/dn/w+P/weo
+        OJYdInIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5659']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:23 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['5593']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:52 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <purchase_reservation><crypto_block>U5--TQOfznBVyaRTj_sjHoCu1nOBt0tcDyht84MiOka_9o-Cg4FphWW3C5OkwcT6ysF2wsIzsg56fJnquoCgQMAWMGnWl_15fsQXhHcdrCG3pX2aV3QEPOLKlKIjRH7TZ9nrgFo3gBGTD0uy2qCmlcx408EC2YP4JhhkNALPHVBAFAdfS8FheaKfwfAjX3JO_RPtd9h4yt5dWUj7Trx4G4kAnsY2HIPl5Ldb0Cmho4wpN3StSel0y7PXd6U5P9945vqF1ojmsXQ5k8N7c5pj6xTd5ZOzRlZhuOTkdeTFrHB_voWvpNEzzvgyBTGZjn1B8iua8ZpBXd-CBmueAnfY4s-lo-NSnw2p1DUhGlC-Sy_SFPOJvNRTz03ynQIxG9P03EJgmV8bE2pz-B1HUO_GzI-EiC_v8i5m8m4EuMrBFuVkpt4u1pNfeKNieyulJbdPwUWr4OJ3MMPae-8-DZuBZozN0a3m4km49QnGc_axuQv_dZIMWwUdznfkgrixoghcYMOHb8lNxvjB1aYVhf-TrAxQwJ_TCIQpn0TBYeFhCP8ePSC-HR7i0PWh6qfF59gRrzoPbFDQGbQhx4Wy_A4qIU54sAI7CEM0jBT2WFqNnjlkMcbh5jTAs5J2CyOMPaKvtjBPZ</crypto_block><customer_data><town>Test
-      Town</town><first_name>Test</first_name><last_name>User</last_name><country_code>GB</country_code><title>Mr</title><work_phone>01234567890</work_phone><email_address>test@test.com</email_address><county>County</county><address_line_one>1
-      Test Lane</address_line_one><postcode>AB12 3CD</postcode><home_phone>01234567890</home_phone><user_can_use_data
-      /></customer_data><user_id>credit-testuser</user_id></purchase_reservation>'
+    body: !!binary |
+      PHB1cmNoYXNlX3Jlc2VydmF0aW9uPjx1c2VyX2lkPmRlbW8tY3JlZGl0PC91c2VyX2lkPjxjdXN0
+      b21lcl9kYXRhPjxjb3VudHk+Q291bnR5PC9jb3VudHk+PGFkZHJlc3NfbGluZV9vbmU+MSBUZXN0
+      IExhbmU8L2FkZHJlc3NfbGluZV9vbmU+PGVtYWlsX2FkZHJlc3M+dGVzdEB0ZXN0LmNvbTwvZW1h
+      aWxfYWRkcmVzcz48cG9zdGNvZGU+QUIxMiAzQ0Q8L3Bvc3Rjb2RlPjxmaXJzdF9uYW1lPlRlc3Q8
+      L2ZpcnN0X25hbWU+PHRvd24+VGVzdCBUb3duPC90b3duPjx1c2VyX2Nhbl91c2VfZGF0YSAvPjx0
+      aXRsZT5NcjwvdGl0bGU+PHdvcmtfcGhvbmU+MDEyMzQ1Njc4OTA8L3dvcmtfcGhvbmU+PGxhc3Rf
+      bmFtZT5Vc2VyPC9sYXN0X25hbWU+PGhvbWVfcGhvbmU+MDEyMzQ1Njc4OTA8L2hvbWVfcGhvbmU+
+      PGNvdW50cnlfY29kZT5HQjwvY291bnRyeV9jb2RlPjwvY3VzdG9tZXJfZGF0YT48Y3J5cHRvX2Js
+      b2NrPk01LS03VnVaUUhmZjVEcDE2bUstWU9yRU15bFNzT1ctWXBRVnY0Q3VXdWZzZDQ4cWFqVTl0
+      WjJLUWlmNll3VzVhMXBtZlVmeG0wM3BvXzdXWERGc2hiMlJWTUZwV2t1ODMwRlRNZXE0aUJSMXd1
+      VEcxU2J0eUVLMDdDVXNxTzNzV2l6alJNT2V5V3VFdWlyRTRQYzR5T1lGZmNWUjBPRlRscnNYMzIw
+      R2pwS0otNnU3V0FjUllYNG1uRTByamtVYWc5bmJha2owN1RiWkRzLUItX0JqRWZEYkN6blN5c1NL
+      MmpPdmZfUXJtcjFQci1oWmJ1Y18xZzBZQ1lWbzJFelF4ek5OR3VXUTdJMFM3RmtDUnNRQlN6R3RN
+      R0EwQ3ZHeUlwVXpvNl8tUE5pWkU4SWdmbmVlUmlPYzBSTVJHWlJEQy1ya2JDOGF5R0hzZndKZnpn
+      ZkMxeUdRdkFONTNRZUdxUkRvelhYVWxDVHFRMDVCWERLWk9hczRWU2VuTDhfMkRMdEplWHQzX0RW
+      RHYxZF9MY0wxRm9OcjNGLXp0X0JqaDF6WGRyTlBhSWwzdGtRNVhTcmZTTVJ0NmtpM3FmWFJqamw3
+      RzlJOFNFaHc5YXE2bkNTWi1TejlSSTZvbUk4ZFU3MTl6cjc5M1pELXJvR2RtUkduV0psTndtMlpH
+      b1FEa1V2YXp0LU9CX2RHWUE4UktRRGptRVBDMlBJbHNjTVZUMkVLY3JjRWpkenVRQzB4X19wVGdw
+      SFFLejYtQ3lXVnRnN3JoeXBraFJhajdzandlQ3pPNWU4SUJtOW9fUEpvdDJLLXRmbkV4c0xZYTFn
+      Mm5HMEtoQ1BvVDEtLVo8L2NyeXB0b19ibG9jaz48cHV6emxlZD55ZXM8L3B1enpsZWQ+PC9wdXJj
+      aGFzZV9yZXNlcnZhdGlvbj4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1186']
+      Content-Length: ['1157']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA91Z23riuhW+71PQuelF69jmzHze3iUEEgiQhEOY5MafsWVw8CmSzCGvs9+kT9Yl
-        S8Y2kOnMdH+96FwE6V+/ZGlpnaTRft/7XmmLMHHD4Lcv6pXypYQCK7TdYPXbl/msJzW//K7/RYti
-        bK1NggyMCMJbkwKdtWOP6hqJl3bom25gxCA0XGIsTVs/IKLJl0UaxaHnoYOuLePA9lD6a4TYBpYV
-        xgHVVU2+gKZMEsKKEIA20tGeGhQRqhxH5KUnI2xELH0G7NL0QCjyXxEOS06IS2EgWRjZLi0tTWuD
-        Aru0wmEcnc6ZjE/npCE1PfiMv3QDZOvl1lW2hhPZ6RBC9YpyVTujE3pChQ9GJrXWunrGPoqKIwgy
-        aYRdC+nl+tmCMuHJoOSE8QrplfMxR5lmxRiDgRyyFtfyagmaKkIZwzEtGmJdVZQcR4AZK4j9JcJ6
-        s1zPsQSYsSLPtBDRyzmOgHIc0KJBDv4y9OQ8jJFA9X/9kR+f4Rmqa4nZgZa4NRg5F3AQoyD9cT7p
-        3LWnXUmtNnttiVns52QtPS1uQh3mARYtOTj0S3SNwAmDGGlykZUNctwAToIeIqRbfGiOmxNmI3xE
-        16GdA5JT6TxcP+RG8pPKdcH+EkMrQv/l4lkYMKmpj+cz+H6Olwoy6ic75HuTzzfnEhEYTrwwc7yU
-        wvc6nc1vuuMZTFWAM1ay9CmNbRTQEjYpylH5toLQCJ3EkQiLUvmukFEXzCAvTQHt1Ddz7ihmcG39
-        ZaEqLU2GFvTgo9R0PWbfoWcAlshEW3NiL2mIIWlXg0gL4ZnCzBTZxtZFOz0IYcpzWMPhjs+gyaKZ
-        LAVC6p4rR2ZAZIIuQgxtOb8mWaz6JHzkIoacHRECM4EfEyOTa70L38x6XJDouAsp6bBbg+sIggi7
-        7iqOjK3pxYhHkzygWS4VoccLAxviebwBRR1BLk8mGiZyIeRTW55JiPjhfLBrk7IF5DAh50mkKOfT
-        gIKTdMenS3JgEWK6Bd0YG0h/4gtyosUUZOlUUNORR6QwX8a7MOXGtcnlaflGhLyAZZRkLz3Td71D
-        jsR3KGfflVOlsePFQs2J0vPAUZyMnwcumF7pHgoMqAwyqjgF7IKrgI0y0zQiBBmXlQJJ4rgo0iB8
-        QJQ1gxUyIPCKvjif+B8ltUnXpXa8iiHhlxUVUktG4NyYWuChDkGQkOvsQ6doRiPIAsMBt6421Fq1
-        phTYqZDTD/DP922IRvBRpak2BfOIw+GGzbqiGglsQs6gro8SuqQ0JbU5U1tfK8pXRfm7on5lX7o8
-        QMx7qgHeJ9TE9EwnZRWU0Yao4/2ZKqmr5Xql+sMqqZbVn1JJVSqrv6ISoYIk9HB7ZElo0u7cdyea
-        nIMFJVHDyKTgSLvSNdR8AfobKY1hO5jldvzXdBDXF29DzKz3e6mERVDe8sDKwyyQ5EHBgOXRmOie
-        uz3KBZQSeIaU036SCInrR6w6S7JKOo6nSN6OI4IgE3guoYU1ds/X+NnaGX4/z+PyhblXKDR4Bvfg
-        UsCypl5L6odjV4NgvOJNSblSmegIaHI2HsolA5IlOLZDklxVAFgsZKkG2ccgKLqab+4NHAcBqJWf
-        v1oG0zhDNR9i5gXeKaoFCLEEBwmPxlAZMltK1nMJF+QYJzeiHC1FOIHtIcS+yerAZPlnqMZqVp4T
-        O+qkVJ2NNfkIpQEeMillbGPj64qoHk5xjazDJDw6fDv8GlbEtE9uT4Vr0y/flwoXpaQwFJVX+2bY
-        nUwX3eFwqsk5gSDxwsuEawcGj1uAjZGUJjKPqB9+yVEh6/jpbQIiT76rFQ4iC4YLZEOwbLAE8ucH
-        ywbkhJ8Ilo2zYPmZ9zK3icLQExVpcv4nGHMmz/VZIk6rwrT7n2Jw40djcGJtfHVSu9UGaxaAkBCo
-        Pom79ISFnoKclQU/brwQ4UTh+CyGZJB27ttFv2Z/+cE1ripK6XGkyRnEpeu170NBo7YqSW7PY/x7
-        mbuymt1Ysv0mX2cbPIHyHPYNuYBkW0uKbYzeY0SOwT8IjxCyeZF9StF49M9poNOfdIZdtuwTQYHK
-        q7AIdlOyXGx5qDhAaOPSw8bpiwbvn9yGzsECL3czugRrl18wzp4uLr5ZnD1WJG9OsF7fJSQJxqaf
-        XOPQ3vJi9sQFNwfKI+lFScp3g8/4RYmWfcv4/38o+d5ei9sE9tlR/GjMF68w+QfI5NExKQB81+A5
-        KA1jeQiuMxZsl6QvkbwDfno61f8uG8rpe+el7bDCwjW9dCtp94e3AfUu3KjAJG201z3f91dr/Ia9
-        aLUKiA8m5UBAzFM0Cl0CxsWOEALzK8Q8SWF/Ko3GRLrttVvgU0VO+nJriPfB41PtRfzIPnnXvQQf
-        UWZEhIY+O3XTtjGrl5ERBhDTS4nmh2bAXgUKoiLTYMVn8B2+IORG0V0on/Q5iaErllsxcuTjXfaz
-        a+wP34X5Aj67DIvlJd2D3kl+hDT9REoqCtORdgRxMIo8F7TI7CnfZ0Lmjtyg0g5DdyH27JTPOxry
-        TdczmGJ05hf/ZH+uLLbYnERzXAyRJDAhzzKda3IOyAnF8k4p6arXcOpGtGYHqqjlSrVWbzRb4Ik5
-        XHNBZeAWRM6ax4PyzPSbc9gSu4Mc13BsppovEtIVHEvu9rVaLlU6N/kqPG0J8jklnYXEjuPu5bRx
-        XB/ciMD5R5hlXNbigBh1hNNZaLjjqirNoMXS206gOTXmZOk4OLjNJS3mcBaaUx9LnZGGELZ0UpWk
-        pdE3v/Vmz2+t6yleLD3lNlzF5PV11FvO2x/m+rZr7d7w5tDpzybPtlFuL9eO+7apTm7NQfWmH4S2
-        /7B8m7Wane1hPH24e3QWw8NTu1P/sHrmjfMaN9FssgkGqBn7s2D24t/u/c2gv1hsD7fGy7i1Gred
-        5W70YH77dmsZtQdv2n93nU6we9tQuz5+b7yO0ageRNW7Q+wYC7uy2YzrtYq3R9flx6ClPPhKjHsf
-        cU3aqvPHbuej7Por924xDVfKI9n700O/EdFe2DH87uPd+mNpjYzG4On+ZVC36GzbH+KXCaKPde95
-        tK+vh+66fN2dvBPpfb2o2/fGcNWcPO3Kh+E33Gq9DKKR8XD/+Gw9tcqtfYRuAnR7eGvebquN3fTg
-        GN7i48ExD7vrRaW1jmtv98OHznap+G4XVe9rd/OV87QOZ4tVW4rWc+np7XZSaQTNVtCuPRjt99l9
-        H0tr3Fn2x6OyPSXLlTd6Xtzum/PBCpv1vt1uVpYzG0/vu9PJs0sq5ffyc/9lYD0rdOvuK6ugHb/c
-        dV7fw+Y34w650na43mx2JpGGnev65jBvSnNyqA2ab7tB773nduhoOpnOjENUfor8zZuxClvL7QJt
-        bWuw8+cdCBmtwVT1Gh/rJRncvVY3H967arpk4n+MJefbey04TO9fnmbOjdvsNCTpNYv23MB+Lid8
-        7/8d/w3H0fkrvBwAAA==
+        H4sIAAAAAAAAA+1Z2XbjuBF9z1fo9EPykMgktVodDidaW7YlL1osWy88FAmKtLjIBKilfyd/ki9L
+        YaG4SO5xTzIvOZnTxwJu3QKBQqEKhVF/PfheaYci7IbBL1+UK/lLCQVmaLnB+pcv89mgfP3lV+1P
+        6jaOTMfASI8QRtHOIECn7dgjmorjlRX6hhvoMQh1F+srw9KCUJUuS1QShZ6Hjpq6igPLQ8mvHkYW
+        sMwwDoimqNIFNGHiECaEALSQhg5EJwgT+aSRlRY0LIRNrX8gKAoMrzQDtVLHMDcosEpn+oyb6JOQ
+        GB4M6a/cAFlatXWV8guyogomWk2+qp/RMSlQ4YNbg5iOppyxT6K8BkYG2UauibRq/WxCqbCgxDYz
+        WiOtdq5zkqlmHEXgC8e0xS26Xm1VKQ+lDNswSRhpiixnOAJMWUHsr1CkXVcaGZYAU9bWM0yEtUqG
+        I6AMB6yo46O/Cj0pC0dIoNq//pnVT/EU1VTmYmAl7gl6xtttRClIe5xPusP2tF/uXzfbZeqcH3PV
+        ZLO4B3Wps5ukZEehXyIOguMWxEiV8qxUyXbBNXVy3CLN5KoZbkaYaviIOKGVAdimdB86DxlNvlGZ
+        Lrgf87M89B9Onp54gxja/XwG38/wEkFK/WCFfG3S+eJcLGJA4RCm5y6h8LW2e/PRDAbKgSmHTbxt
+        QQQrYWIElhFZGTJfVhDqoc3OEaYBKdsVMuKCG2SlCaAWj2bmNIoRXEu7H9SrIIMW9OCjxHA96t6h
+        pwPGZKKt2rHHGkIl6aoQVCEQExiZIEvfuWjPQu8FWI3CPR9BlUSTTQWi54GbR6LA1ogMOK7QlrJz
+        ksSsC9EjEzCkdIsQuAn8GBEyuN37C1VKe1zAYzEkn+PegaMjCNzypktEbPHCwAqDcrwBU5xALmfU
+        EZMLoVD2DIzFD+cbEcFASQEh5E4AwtKfDX/791IX3CGmU8mIqYVZDuPDHhFm1s1A1IpgBX0DOY1+
+        SWLGShCaHwUvUTshucFSXnE8y4C4cnlQvpyEkANTDltHx4CjRsRCewUFvlIpnYKUGJFuaCTMzjYh
+        C5zETH8euOBspTu4PEDaT6liVyIXDgd4JXVGfYsgxdI8zzLFRZEKAQPiqhGskQ6hVvTZYDMn/ltJ
+        geQ9RVuCaN4oVWQFsklK4eyYmHAqbYyIVm3QTxXRlIaRCa4ER7nWrDTrtTw7EXL6Ef7zfcvS6Efl
+        lqwI5gmHnQ6vG7KiMxiiC8QFHzF6WW6VZWWmtL5W5a+y/FdZ+Uq/dFlBjFu0Ae9D2IrImVXqxCmN
+        jeN/0x6NSq1ZlT9tj7pc/yl71OHf77GHWD+LNdwdadaZtLt3/YkqZWBBYWYYGwTS2L7UgTtegP6C
+        S/ewnIgm86g0609niSK3GW9DoGzcDBIJDZu85YGjhxoMZxAaM7KgYEAKczQJlMs+/255xb5bxuXg
+        9N0yvb1KiT5TEeqwQhJjzXN3p+EFlBB4VpWSPkue2PW39ELHMlGix9Mqb8dbjCB7eC4muSX2z5cI
+        rfFQzuLShTHWKNR5dvegNCAx2LwOd4tKq6Eo1aYqnVAVovmaN8vylSLDDtcbcMFLYVVKB4N7lQ5Z
+        FeKBjVlSywE0mtKcBJk/CaOiq/rGQY/iIICt4H6jVGANZ6jqQ9S9wCuiaoAQzYSQGWl2YD7J5nMJ
+        F+Q4YkVShpYgnEDXEEY+DcN8+meoSu+2PHl2lUmpNrtXpROUpAhIuYSy9Y2vyeKaUcRV7IQsqtp8
+        OexzBUz9oKLKlVKfqqFyxRMr+y5F/EsCld0t+bem7d6oP5ku+qPRVJUyAkFiw08NKFwiOMMLcEWc
+        0EQqE1eQ333011HIEqnvuxizfTN8djVEB9OLaYGsQx2sVa9qEGYvihIFN8iitSulflLIi9T0a/r/
+        fvX1o7Xml0mDwtluwFXDT2YN+TfbVXPHKE2BC2TBrUH5IxJkq6XUPp8glfMLw0eZhoa8bRh6ouxg
+        Z7eA0UDouT69eyVX/6T7G3lX+fQ9hEUKPrtyW36ESCQAIcFQYmB35YnoUgQ5K81WPPBAShLVwbNQ
+        SSH1PC7nYzL9yzeueVWVS49jVUohLnUc34c7rNLil5csxr+XhlpamOkrul5eO4K8AGU59BtSDkmX
+        xiqqCL3HCJ+ydRCeIGTxSqpIUXm6zligezPpjvp02gVBjsov3ltYTcl0I9NDeQVhjUuPV8VXK94v
+        lLznYI6XKX8vwerlV6qz56mL71JnD1IsZ/xmQGZZ8CficZb//3D8yXB8thWfzcripS37nszekNnl
+        zXd1M0KWS5IwloWgmjVhuSIEJh04p8Wh/pibjJS8VV+aOr0AuoaXTDvpfnrKUM9AwQzuZ6GD5rvI
+        icKN7Ye+4wdb36kacLxyFJVAF4Mj0e2CIDyD+FaW6Z9m4+663JG79PzkOcmruy7ee0/P7BfxE7vw
+        Jn8JPqHUYTAJfbrDhmVFtBZCehhA/ObGHRkBfebJifJMnZYKwQ/4gpDRIvtQKvQ5iaJrmkcjZEun
+        p4qPXik+/dTBJ/DRW4eYHusetS77EdLkEwkpL0w0rS3EvO3Wc8GK1J+yfSqkR487VNKh6D6MPCvh
+        846KfMP1dGoYjZ6Bf9A/VyadbEai2m4EUSMwIKdSm6tSBsgIxfSKlGTWDuy6vnXohspKpVqrN5rX
+        LXDCDK66YDI4FlhKm6eN8ozkm3NYEq0YT3M4NRPL5wnJDE6lUbujVErVbi9bLSUtQT6nJKPg2Lbd
+        g5Q0TvOD+hUO/zii2ZW2OCC0TnAyCgn33FSlGbRoKtsLNGPGjCzRg43bXLJiBqdhODljyWEkIYQs
+        DdfKZc94qa/uUcOp9I+ud9Oy8DF2lv148uBc3+9iZzPu2fb9cvUS1w91z6uWByNHGYavk/ao6j8c
+        lrbz7g0MffHSrIa9xtJtTB/qZF+x27E81HsN4xWHvXX74Tl0H3pV33u5m34fdfFN2awsLPu133+a
+        uN9aZHPdGK+UyWv9XXbn0+BwcKeWuzHG8cDaLPBojO8ny3tvrd+OHlc9R58sH/xg2EbDun3b6z29
+        EmUyRMPB7LjevSm1re4PzcrkbeQS/OxvtzrqLJePT0uz8mb2Ht93d5vKft8zq/vO7fXs/X48fxma
+        E7Lrz67v2pNyp+U8tYZxez2/v+k2bubOsfkSeZv97vF10O4+bxbtwL7ty6OK+aCPVuRRj+8X8sPT
+        +7fNrK33zc3jk/42HjxX1ouB3XqJn8bR06Lqdn0d3Xx3o7eWsl6s+uNGq1HrXjd7140dGt/d+RWE
+        5/3ZbtKp6YfF+N3sVPT30XQwD77fErIbRM2XCVmjqm8s54T48tIfHIz3m/q6Fnwb9vxl59YMJoPY
+        ru2CxWEy/mYqg7f2d1D33o/PI8V4akxGD02j/Xx8rC0UO+73nrxvqF93j+3l1nwxpuGNN6nbb3u7
+        dhy83XYOjtw+yrfdnt7ftFsHe+5OtvHsxsOL57A7v/tefl+Up9azt/Bv3Zf6XXkftQaV8jKN9tzB
+        fi4n/Oh/Gf8bugqX1nceAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2578']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:23 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2639']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:52 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <transaction_info><describe_external_sale_page /><describe_trolley /><user_id>credit-testuser</user_id><describe_customer
-      /><user_passwd>testing123</user_passwd><transaction_id>Z000-0000-377R-GFA9</transaction_id></transaction_info>'
+    body: !!binary |
+      PHRyYW5zYWN0aW9uX2luZm8+PHVzZXJfcGFzc3dkPmRlbW9wYXNzPC91c2VyX3Bhc3N3ZD48ZGVz
+      Y3JpYmVfdHJvbGxleSAvPjxwdXp6bGVkPnllczwvcHV6emxlZD48ZGVzY3JpYmVfY3VzdG9tZXIg
+      Lz48ZGVzY3JpYmVfZXh0ZXJuYWxfc2FsZV9wYWdlIC8+PHVzZXJfaWQ+ZGVtby1jcmVkaXQ8L3Vz
+      ZXJfaWQ+PHRyYW5zYWN0aW9uX2lkPlQwMDAtMDAwMC03Nks4LUIwQzA8L3RyYW5zYWN0aW9uX2lk
+      PjwvdHJhbnNhY3Rpb25faW5mbz4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['271']
+      Content-Length: ['248']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1ZzXLjuBG+5ymYueSwkUlKsiRPYbmr0cjJ1nhmp2w5U5kLiyIhiTFJMABoW8+T
-        N8mTpfFHgBTleGe39pCKDxbw9Ye/RqO7AaIfnsvCe8SU5aT6/k14EbzxcJWSLK/237+531yPFm9+
-        iP6AOE0qlqQcWHFe7UhMMWsKHiHWbDNSJnkVNwzTOGfxNsmiI2bIHxahtGGclJhGKMkyGhd5hWNS
-        4Sj0Nphx7yapMPK7oi4zLhKeVy/wNcFpxZ+I36srkkD3uOKwnh2UU9JUnB6j+yrnOPM+gBZgCcg3
-        uCHEoCEcNQ+tRAGtWE3gTC9merJ6jFbyR0vNEIbUFZqWWR2zpq6LHLRYEeS7dSEU+lZ7YCoCfSK0
-        yAxfVRCG/SlioZiIgzZ/FP8uUjFZR4J2OWU8rpISR0LnyHcAR6in16eYWR9g1+P6IDY0CMeT6eVs
-        vrgKkO/gKAeV5UnBfFtsN6pIzJj3sCTk27oVGc13CWYGNWFcbtTyXTj2Jqv3yG+hVqjJpxTTC2t2
-        u/zZN4V2fjznBY4+wsCqpADdqoVNL5w8KVV5GyiBUNQl6qjRkZl2sHEPQ1p0cDCX9ozhZ45plRQx
-        S2DsGoxdarLaN1CEw8B4hCuhKhdBJXRz3BXkKU4PSVXhQtl3SnGW85EwkkZq+AwP1Q0FgGE49GQx
-        C8I4SziOkyqLeQ77NQ7C2SiYjsbBJgzfhldvx9OvoOeXG9lOlUVvk/QBg3BPSVNHnD2NUphRF4XD
-        VHFxvGUVVp7hXQJ+Kz45x4MCRDForrV7byXX733WE/GUmVkSYhymXIoBM8xSmtecUGEo/Aj2APMH
-        T6XKwm/Gsujrcq8u1ghF5TmzU80bgaM2pRaKSwJqY+B6fFED8PH1+zD5KtbzUpu2y//vgrsLXa24
-        4VLMpmGR2aYMjvOpFFqQosDg/rdNlYmpqd+Y0AyGkPqIQlDsKWqYjMAIWKkMTn0sZhm0LVxpr4VQ
-        ktLs3ZGB4r5iSrwdoR6pRmrFnt5PT25gv0/Z3vTJCU+EFyi3EGezaHx1YefQk/WbgOOZBBeXJ3TG
-        e1QYsE54eojCE3Yr6rZgOOE1zVMw+dnJhKyw10juGN3jaHLappVBPkMppExHW1Ja3m9r4YhdyDJ2
-        sP2ERmEQOBwNWlbVlFswp8V45rA0aFl1kaSYRWOHoyGHA1qM2bHcksJ3YYo1Gv37X257i1s0QtLs
-        7JlvPQ8kT1hQcPT5/nb11+XdehROF9fLUWhdwQAZmd1SJrQSJyDl3o6S0uMHDGlp1WDhFFyWbbTL
-        RVzjxxoCk2rqcB2hbVFifiCZA8hdWf387menpdoppwr2Jw2tC/3KyYvkOOFJ9Ol+A+M7PCOw1DMr
-        VGvzTxeXM+0YeqfQHjxDUWu929y/X3/aQFcd2LLk1O94k4FL9Sj4VoeqllWRmOzkQWLCS7lVLeM5
-        mIErNQDqn03nOOoewMH+/UsYXCFfuNo8g0E5JKfCvkkh3K+U6TLaNYUs6CamiuD+AU6aQ8+QlMeP
-        OX6SufAAjCgkNLIH8OuqKKcCLvVZKUeEB1wnoAsZWXx3Tr6edc99OB7Dt1uEwUzgJ4HopbS+hjFt
-        TQmkjtdwSTs+HbCIXhZF23zf1PFjUjRYeRMXQGnOtespSJWBP5dXlhZUctnRjZRroeo6hfyZ6R/F
-        B7tOuJiAg2m5CiJdueoGFCwvgao7eSvpQkK3oJv4AcKfHsGXWjSgCMWaalq2SKc/yxvo8iHP2HC3
-        aiFa3sEsRa7lOinz4uiQ1Ap9O65vlPa6e6Jsf+6aqHeBwjUoBRsVphnXGCKuSAVk4BgUIZmvQYoB
-        2Tw4Xl3X+9P82QsX/OAtmz1cETyRAII5tgTFbXgKJ3THMATkmRioj1oaw5DbZXCsp/PwcnoZdNhG
-        qOhH+CvLLJNZZ7AIF5rZ4uilJHUxChcbyFAnwdsg+C4I34qRzmSo/qAGVB3yLcpPdDIOQRlL8DrF
-        b6mSWTieTaavVsl0HP4ilUDeHn6LSrQKpOtR9iiC0O1y9WF9C/d+C2uKVMPHhMNBevLeQc5X4T8x
-        7xMsh4rYTv9oGil9qTL4zNlP10YiPKgqFWDlxDoSF9QMnREX+WMrN0myrqkI6Zu6DIQsL2uRncmo
-        YtqpEKnKTc0wRAJ1v3XmuD6d47m5C/zDvYv7A33vMYlVBBc3dhE1o0uZP7RVBM54r4qj4CIUohZA
-        vm0P6VIMwRIO9o7JWNUBhC8UoQZnrRPUVVQmzzFtqgrUqvY/HINpnKCoBJ85wOujqMJYBDgIeBxu
-        T9K25HyGcE1uIDbC/cahGUQRxBoILRORB8rpn6D2tWa9Cm+96eaT+1qj/ThEUi7Y8UMZBTp76OOI
-        HYh0jzu1HPU42cXQmdtT59r0zfelzkVJJoY681q+v1nf3n1Z39zcId8RaJJKvBK4dlA4cV/Axpih
-        6cij84dvOqgQdUpzmwDP41ZRZyOsM/yCM3CWcxFAfntnOYeY8Auc5fzEWZ47veLY1IQUOiOV+9/D
-        xGEq8lIEYpMVmup/88Hz1/pgaW1qdqPl1RKsWQNawiD7ZPm20BbaBxXLOj9lvODhdOL4N93EQkiM
-        qzZmfjEJvM8fxRukgZT0cChLSFjCq4mM3S6m+rPHUeTk8VasR72hgrwHuRwxht9B7NRlMk3xPxvM
-        WudekRYSbyRDFKS8u7PC1U+3q5u1mHZP0KGqLKuG1XhpTtMCdxtobQw9XPRfLFS9d9s5BTs85+Yz
-        BKPhF4qTp4nBN4mTxwj5IAXzLXPGpLNNSnlNw89p0YiPOnAz4MpTDkoMP6/O8bsSZMeK//cfQl5a
-        a3eZkX4bdLfitT5dv7I4DybqU5sM8GUeqxhj3JQLwXUlheUy8/1NVZwn4var3e8W7Xzznjm0HJE4
-        5ElhlmKqr14G5LNwYwKTzPBzVJRluT/Qf9Ci3u8rVoJJ7eD+7lK6nzGz6Cv4vFEg/k3m89vRX66X
-        V93XWeGc9ctsrN//2qfYQbxl995th+AWjXqDOt9X/wP7KddKoB0AAA==
+        H4sIAAAAAAAAA+1ZzXLkthG+5ylYe0gOCUVyfiUFpiONZsuuldZb0ihblQsLQ2I0LJEEDYCS5nny
+        JnmyNP5IkEPJWifOIeU9rIjur/HTaHzdwKDvX8rCeyKM57T67kN0En7wSJXSLK8evvtwv/non374
+        Pv4DEgxXHKcCUEle7WjCCG8KESPebDNa4rxKGk5YkvNki7O4oigY16C04YKWhMUIZxlLirwiCa1I
+        HHkbwoV3jSuCgr6qj0wKLPLqDbwBOFbimQaDtgZJ6QOpBCxnB98pbSrBDvF9lQuSeZ/ACbAEFFi5
+        BSTgIBI3j61GC1q1nsArvdjpqeYhXqk/RmuHsKC+0lpmdcKbui5y8KL0tNuWSunv+EC40qiGlD5T
+        VmQWrxuIwP4UiXRMLMCbf5P/naRyso4G7XLGRVLhksTS5yhwBI7STG8IsbPew64n9V5uaBhNprP5
+        Ynl6FqLAkaMcXJbjggfdZ7tRBbZj3sOSUNC1O5X1fB9gZ1BTLtRGXVxGE2+6ukJBK2qVBnwMsb3w
+        ZrfLXwL70c5P5KIg8Q0MrL+0wFi1YtuLoM/aVd4GvkAp20rquNHRWTvYuMcxLzpyCJf2jJEXQViF
+        i4RjGLuGYFeerB4a+ITDwEVMKukqV4JK6OawK+hzku5xVZFCx3dGSuqnjGQ5bPArGFQ3DAScwIGn
+        p4swSjIsSIKrLBE57NUkjBZ+OPfD2SZanofL8/nkH+Djt426TnU0b3H6SED5wGhTq2kBKZmF6vlp
+        FQr6SDhcAKuMFjyRkR0GGkuOzvWoAkkOm2z10TLfiBEYVIXhFcyj4sCUkiW9lZqHp0OxAyEuYGml
+        nERGeMryWlAmg0kcIGYgnkjmC7yFAbREEmyiP9X/mY93O99MT5Fs4gLbJpAOUDSnPtAbYXlqoH24
+        9CaMrfk56++vFTqbo53PAAWbw4HcAtkC4dO37fbbNm2Xv+/1/36v+753s75cS8NjGwwZ0NKxFixo
+        URBIY9umyuTQ+m9CWQZDKA/HEWzVsdQiOYURiN4EYK9EpqSwtXC1Awvp4nht+E4XB5c6Irwje4W1
+        9oIKGUu03EJtkMXTs5MOP9ANTYAsZ+HJ/AjOxQAKA9ZYpPs4OkK3qr4FJ1jUsJkkns6PJtQpB0Zq
+        d9gDiWfHNq0OajDGoMo7dF/aow/bWiYPV9QhdrDVlMVRGDoYI+xQVVNuIXROJwsHZYQdqi5wSng8
+        cTBG5GDAiwk/lFtaBK6YESON//VP176Td9IYqRDrWKTlMij4iISQ+Mv97eqHi7u1vz5dXvhRxyMj
+        WGQ3S0fQSgZ7Krwdo6Un9gQK6aohklFcVGe0yyVriUNN4lSbOlhH2VmUROxp5gjUpqx+uvzJsdQb
+        5TQh/FSc9UX/4eRlPY8Fjj/fb2B8B2cVHfSVFeq1BceLy7nhgMEh7M6dhei1XlzdX2+go56ww6iJ
+        X2RAmh7wUpVhljlgvayKJnSnzhGXhOQ2jU7kEAau1grQ8Gg6p9H0AFz6+eN8CjrJqnkGgwqop2V4
+        00IyrdKZb7RrCvVhTGxTpiDgYwE9wz0iecrJsyrfR8SIQR2megAK159qKsCeL9o9Mu2QGkPCUiko
+        cOcUmFkP2MMhjKDbIgJhAn8wpDnt9/VXuH+1La3QXAzXysPzHo6OAWjPp7kw3FLQKqOVr+5RrVDr
+        FfRa6Y3SGENRz80fjcdMQAJ1BEapgwCU3h9xWf/VW0E4NHIqjlp6WN1Qdbc21zsi6UXwQvIIOU2O
+        FChnWYlMrAZnzVpJr7MON+wvw8Ar452aotsAesIOo9ZxieGoCbPQq4GBXmnQTSGwTnzfZVbZv3aX
+        NbvC4K6WQlTKYExqAilW5nmVKUZVSJV8UD/AlQOo1rRVZ5t98xcvguR9R2ooniBveLKKhBBsIRrd
+        iBRO5Y4TEU8XcqihtINxAsVgBkd5tpws57M+2io1/AD/yjLLVOkanoWRQbZy9Fale+aH0SY6O5+G
+        52H45zA6lyO9UuYGoz7QbaAtJo68Mhd77wYf/pv+WExmy2n4bn/Mw/k3+QMq//mv8YdZv+IaHY4y
+        69xerD6tb1HgiA1EueEGC0hjz94l1HgV+RP3PsNymEzmzNus7zbWUPtMfwNRLn78aDWSNvVXAYFO
+        Y+gOC8kZrtAgIIXt4wCM/VKP62/VuD73q3ZcX1avgbVXJsbcFMxF/tR2b2to09JZNbBtlTx5Xtay
+        oFOZyNrptKq/m5oTyB76Gu8scX28RPi6+SF05cFIHw+EJjq7ywcI0YDP51BbTM4WUTRdypcDI0XA
+        5g/60w9PohB2eL6AAq8To6DrDOqqBLIq8MGOq6TWE0g2lTkJMr+lUdNEJX5JWFNVsBU6bqIJrOFI
+        ikpg3RHcUIoqQmQmhMwos4OKSTWfMbkBN/rW58CsRAPkGigrJQ3r6R9Ju5eo9Sq69Wabz+5LlMkF
+        kHKFRCePZRyaMmMoR3xPFavu9HLUcAMZeuVG1btKvesO1bs8qTvjGOOPKZCqLfVYdxdX1+vbu6/r
+        6+s7FDgKA1Ld32G4uDA4w18hFLmFmVRmSpBfffQfGFWJtCxzztW+4VKVhuQlLRr59J08YWDRkxnQ
+        7KjKGuSVK52dRPPWoK9C3WjJ///t66219pcpSeFoN6DUKO2sIf+6TdQ7Rl0K/EoyqBqi3yJBnp1F
+        s/cnyOi4YHgt00jKqyktzLVDnd2BTBJhkZey9rKlv23+Qt6N3l2HKKbQs/Mvwi/AREZgNByuGDzf
+        FoZdhkKN6rKVJh5ISeZ28Hdj0omQHFdvzPJkGnpfbuTbuBVp7X5fllCjRme6OHFlur+OSuXFK9nK
+        9ei7IegHIhcjxwh6km7q6sbEyM8N4W02rmgrkm9eYxCk07GzwtWPt6vrtZz2QNGD6sK6htV4ac7S
+        gvQNjDfGHqeGr1K6PbjSHgt7OOd6OyZG469QR89Po+9ORw9OKif8IuGqLPcNfOvif6fbd9Lt0Va8
+        N+ualzTnVUz/AqyKszI3j/GWplwR3FZTWK6hONtwflhof0z+TSqVwL5Fj01dFng5Luy0bfPdU4b7
+        ClyIIfwy8hKXOdkz+rgrabkvq7rcTzEcrx6k/0t6Fm+A3/xQ/rdcfDr1L8NV2H9Zl0RsXtUT857b
+        PqOPylv04M19TNxK48Ggzk/8/wbfT/TQIyAAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2263']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:24 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2365']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:07:53 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/ReviewTests.test_date_is_datetime_date.yaml
+++ b/tests/interface_objects/cassettes/ReviewTests.test_date_is_datetime_date.yaml
@@ -1,137 +1,114 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF92aWRlb19pZnJhbWUgLz48
+      cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNj
+      YXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21l
+      ZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9m
+      b3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlh
+      PnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVx
+      dWVzdF9tZWRpYT48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHJlcXVlc3RfcmV2aWV3cyAvPjxyZXF1
+      ZXN0X2N1c3RvbV9maWVsZHMgLz48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxtaW1lX3RleHRfdHlw
+      ZT5odG1sPC9taW1lX3RleHRfdHlwZT48cmVxdWVzdF9tZXRhX2NvbXBvbmVudHMgLz48cmVxdWVz
+      dF9leHRyYV9pbmZvIC8+PHJlcXVlc3Rfc291cmNlX2luZm8gLz48cmVxdWVzdF9jb3N0X3Jhbmdl
+      IC8+PC9ldmVudF9zZWFyY2g+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['759']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+077XbbuLH/8xTI3nM27aklkhKpj0TV1nacNF9Oaiubtn94QBIUGZOAQoCWta/T
+        P32Oe1/szgCkRMqyLSebnnQ3OUxCDgaYDwwGA8xo8tNVnpFLVshU8D//4HTtHwjjoYhSPv/zD+9n
+        zzqjH36aPpiwS8aVLxktwsQvmCwzNZ3IMohETlPul5IVfir9gEZTLibW7pZJWKwWSvhBJsKLaeh3
+        OoNOID9+ePsxO5sXrCOfBi/Pxm+PwniUvBpcfTo/jZ+r0/N3R++CgZPZq8M0WDybzdVR8Cn4RzgY
+        HZfe66N3NHl//u5s7B/Lv//8zyv5izwvnw5mvYXb48EiOFu+/NvRy5OX/7x67q6OL5KkR9N4nPUj
+        L14FyRvvb96b08xeHLmdf0ysFn+TKJWK8pBJnxbMv6RZaoTbBTcKmk4AQn1QH5uefJhYmy/TEDEZ
+        Tk9A26tlwgpWIWjoJEzVyuBmgkeCd8oLYGgNNO0a9bVurxqrzhmVsvrP4NNCSUDZAKpGjX8IjeRH
+        mi+e/E9/9IQcw2yWyE4DZQJzpifQDL1iMFobNKms4YKtNDULpn0DQeOo8Opua0hrsA3e9ngRKnn3
+        oEakGqEF3OBoOY5oljFlhCVPtzoYSa0NC1atSCGVX1A+h/FyegUj50HKWTT1el17YrVAGgGYVIsi
+        DdnUHdYYG5hBKUEMWsCQ3hpjDZrkqNd6yJ6jMZogjbAZ0RnVGE0qWp31kP01xoYKF76ElZ0xVNZv
+        U8RPJeUKV4ZYKPBpMJl6hfo1fOpMrC3INkbvToz+nRjunRjenRiD6xjWdfH0HPphWRTguAGlfjPL
+        YR4swKpboA1GTEMliqlj2w2cCrjB4mUesGI66g0aWBVwg7XIKLhE1N02qIGDNidXeSAyqwkGN2qg
+        0//9V7P/Bj6xtsW0brDl7/P/O5n/5qSHouSqqOTTG2cTsG7W/v49TxWLyCuwHYhRNqjVTlqkKg0h
+        xLlM2dJfsCLEfd1oaGfTJKKKGT58xqPqWw82S8oD4khFztlCMdQX6dkOaHGDYrBLFfoijiVT0/4A
+        SW1DN2iShbD9y6njDntDz21j140GfQV/8jwCXwtE7bHtVJhrOOzMYjSwHV+DKY98leZMo3fsccd2
+        Zs74cd9+bNt/sp3HSGl3h2rcbR2Yb4iVCnVNK55KyBu6+jX1Mei5w769tz4827uXPjx4Pkcflfwm
+        gNbmePp+dnx2ePzq5GxiNcAVilbDG6pUwpbkSJQFZ48kOQVxChpegAnNTs5ndUejM/MOUejgxbO6
+        ZR2T+imPxfTHTD2J0ssf5+oJvi7w5RoRqUrOYVmQRSGiMkT/QkTcoP2QFAwiRS5JymHq7BFRgpzT
+        KGMFdP/AskyShF7iEEEhLhgnEH2RQFzBMDHs39A9FEUkSVQWiATBliIriO+QOPTuiFLBC5WCd5FN
+        S/P5YM3xLEkliZlU6SUjCmJnRRBQAhHgExtVQSOW0+IChFllDMHLVB2QBVWJkASmiIDMVEE0QTOS
+        03kadlsCxiLLxFKS44wWFNj6qJWzInEhckJJkDF6QY6TAs4AOZUEgnkCXDwtuk8LIeUj8rZYJJTT
+        OTsAQoUo5wn0kkma50yLDFroyAuq8H0JxsmKDJnSjAnkjcgFCxUNS2CAhABfIU8XKMn5kjGVMuyw
+        Uz1vM9BLQeiSFlFnmZq5BBNJ5xzAhxxUwFfkA7RqejMImdILcSkvViBoXoZJJxOX4BolTBIjdVyG
+        CkyITH/5JcPxwgQaxbygi2RF5iVoiSsGs5GAGm4x24c4UxTUyGRyQLJ00ZE5NMCIBzDjhbYZEBHn
+        L0XDg9nZaDmGc9JOidsEwfaARpikDKUIBLANaw/GSEMtMEgEsxCmMLYsQ9iapJENDSdFW+BUWxaH
+        EasjsUSm9KFAG0ygTxOyS17Xlqs7v8vAlX2AodB+P2gLz8EOYeIKPaVnYgWdT2kl2ExbIFgILAeW
+        Iq9qKQjOXorzhNNnTBWGlqBula3QOAJcP5eI39CFfqtW9gOtmMTF96dlocnpdgN6sMsJHJLnIotS
+        PPHqZak7kQ7hAg5NgMRyxFJC6IHMF4ETKkzbrSia7wPysQQ9oQqKdJ4oQnPcbPVEg6PcQ4wPCTiR
+        Y8rJC+DzpzuF4Sscl6xECSZ2wR6SQ6mZJWAYCo/cj6RejmJJwMV092MA1kIkgIH53QzMrrlDNB8w
+        Tske7kOLqupUPn4iyQseZmXEojup6hsFleASQsk528tCngsBPkCQV1ws76IAPgOdyUPyBqYDfD8S
+        hCnEKdX/yj3onZepouA/yTNYFcdJmkUQyd1F+LzEdaKtCMwfPZv26WhRFFYXy2GHA4PFJbQvH8d4
+        CZBlxtDfiSwNVzdwcSpgwcUlRBAEWGZX4C9hRwcLuqRppkWhsYIVu9CnT1nZc01yvRPj/lvtxehB
+        xdTsQKxGMMAKI2dRSiEMpTq8hygZti01jZzllbvse2WQR+lVN8xEGcGOxFWXMzWxNM4k5RDvgL7w
+        RL0ANwUxUJFNE6UW8rFl3TqEJeH0zCKrwQOEu2IBQa417sMT2m4Q21HPZXE/sj02ilnsBnQ4tMdR
+        bLt9l1GnH3Y/LuYQFO3kY8IphEa4d0kQDoTX3xPcmKe/Knk94uTbUMVORchysQDnKH3kp7oubULa
+        CNV12RZsYrXM5Vu1nSGDx3ZH4cDz4uE4ciizHdcZh+Oe27NHAyeKHW8QjPrxHrYDYd2nku1vOfcm
+        /hUt5968/AYs5wv05WtMqzeGZ+gybzQcDyksurEz9HrBsB/R/timbBCPYjpg7mjQu9t88BYRPC3e
+        SvB9behz+fh6lvS5HO1hT9et5RszqC9agR6Dx7bduOcFHqXBIHb7vTAassGoPw7Aebu9aES92BkG
+        e9jSJzj47O+J7k37K3qie/PyO/VE7Er5ikllW3+SK6lY7m8gKEgGZ7U9DKXCvNNU9if3FWxjf+K/
+        ezcSj+GhFCI+iAPd4TDs2/1oOApCz7GHYWgPPTeKR+6AhqO7rUMVKYL8GA71ezuTe3PwFZ3JvXn5
+        DTiTb9B8RHm3g/luPt+G+Xx57GczeHqeF7nxeBBEdi+gdBjEUa8Hf0MajO1wFA9CFvXd/W1I8L09
+        0Oey8dWD4ntz9FvYzb5cbSEAaC9yvdGYjsbuyPYcF04UEBmGLBzR8ag38Hq9kW2P+/vbk1qKe9rT
+        vdn46vZ0b47+w/ZkFDt48ayTmzxIJ9B5kI7s8HXipYNhnFX3NzqrqvkUVaWcZjr4aIFqhDKIqKJW
+        /a0wpddMMhpA3bpaQLyboui+SoG0WqNhS4VVLjDR52epVK3E5cmOxGU0ffNXuwm3dowxZwLTr6AU
+        vNJVZcSmntP1euOB4/SHE2sNnWAiwLx27K5jD2zHG/QAYQ2eWJvBEip9LjDLH0u9p7QAWNOG9wks
+        WhezVZ+6DqoweVSTDXZ6VSlUC6ormXbgbUMneJvvR2xBC6zR05lmzc8ueIVcZXEaaDXEIKAMosjx
+        Htywfw06wUoNU8Z47JwRd3YKy60GTUwFhKxftDZ0nWf1jXS3QBWqT0uViGI6SxiZgXhAu91Q4wUi
+        Wk2PKcccEyaN85zp1K3JiC0J45hafbjurvHrzo1ag5IdEGeoEnIqLtcVGN66W6PwoAlpVgp4juMM
+        2x02BQMVNKN8PmV8jaW/60ZRpJhZzNAbWGsoTq6h7Nhd2yaHb9a9N00t5CTJcymxFEUXOexo2qCr
+        jE3f8zyVEtMUDxvY2DLBmgS/0NdhWIbU/KxRb5zc2t5vmV3MypLDLFsUTN4+w5jxqhJyDzEtSoBl
+        1mG8I8P/+zdnmADVOXqaHeicTyv5DI0mgx6XVbNUolhVnXiKFQdcVTl/IVmdIup2ScpDcP0p6KZL
+        XjzCGgVGgnKFGTTjumSVu63tjc5pyvVQ+u1Ou8Mal94I7O6wnGPyCgzJvY/VufaoN/pvtDpYs48U
+        mTN1bYnex/astYupqn/rmmv/Ip/aWPW5Az7BmdJuzLhOs4+2YRMJO2TITMXN+pID0BrgGsdUa18p
+        VuikPSCSI9xSwQg2PYzGGh8+VorAQDxO53v1bnWoR2L8U5kWKZM+y2maTc21jPwLqAkXleiGoot1
+        bjeg18OgzwYboFFUTDH/ysjQOyA/p1jhl1KsWwjBQWKmeonZ4HNVMKYOyBHLYixwOJo5PeI9+/ua
+        TnO8mkZ1Y2Qqp2uVrnu0WusuStdKhVPMBIMf0dl5VBBuvUTwbNV9AM4AGwpGzBYAOtSbvymMoHxF
+        wMmwfAEAJdYZWJKilkyxjlm81e0VWaZmlYcm+1uVtWC9BowPjqK75rhmDiy1KEPcXKMqhxs2Mseg
+        CswcV1HvjpxyHf1e0qxkFtYr7urd2JkRu67aaHWefmvFGrostdR1bmv252A/EA/6F1wsK2GaBQY3
+        CHSfuoIN1TYt2NgL4zU0ibfV5w0Uvxe9fS96+1709l9e9LZxBZvFjz8QwVNTxBTsgLJy2doHvDNN
+        pGoi2AQHnVsc7ZEQFyRYkb6NIRwMnWmxGkekapNxbPKyBE47+FbFeijEAnTDgXsYBynHYCzgV9bx
+        5C5Rdgsgq6opHwj7YVU1Vcm1s6LqBom+oJBqw+INzCxhGSC/plytYu6mYrYb+Lu9hm3DwjatZcK4
+        Dx7DT/25WJNuFg3etJd+fq1gk5sWdf2rPj8SW8w0CghvYGa/usEW3SYh61qo0jidtX/EsKthAoFV
+        yUxUdwYHJTgmwzZ8qKFIPSiIpV3QC4neUJmq0jXU/B6xBXr/CnjdDFoR0NH1+eHT1ydn5x9OXr8+
+        r5FM2G3edUDdVkaNZmJt867FnJ0d/nzyukW59XEKvgrjyve45cxhY+LRY9gS5iwjfzgFFwNa5DD5
+        nP3x7jHOYFE+1r8agX0St72tIdBZ6aFvGYuQWYnoLIawqtShleEG790w8NAOWw+uwzBBI9xo9ckX
+        oQgwJ9NzRV6KhFcRe5dsTxt6Ue1w6mBO+3z8rIoPCQ2QA7AJkjP4hvBELHmrT7fWuzGpyzRiYHBx
+        YQy48eVvbrRb4IThMNM+XrjsatjCxovu5XLZhRWpyoDBESff7qfvwlsgcweKVzuR9dx5uTj56/P0
+        lwt3q6O59myBrmeNbmm+pWt1X3sbQrs3HMh97Tfqa/T1dfWW8HdKdX2kGyj9WnR2UlmmESjXxdvL
+        HfA2sL7CXV/ltn9R/v+e+0Ywjj4AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:32 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3898']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:41 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_extra_info /><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_video_iframe
-      /><request_reviews /><request_cost_range /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><request_source_info
-      /><mime_text_type>html</mime_text_type></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['903']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1b63LbNhb+n6dAujPtj9oiKVG3hlXXtZ1sNmmS2s5ms384IAmKjEhCBkAr6uvs
-        m+yT7TkASZGSfMsm07TrjCYmDz6cO248pPfTxzwjV0zIlBc/fuP07G8IK0IepcX8x2/eXjw9nHzz
-        0+yRx65YoXzJqAgTXzBZZmrmyTKIeE7Twi8lE34q/YBGszWTnrW/yQvFeqm4H2Q8XMze+oeHV4tl
-        PF0cT5dvh6+Dw7ngceSoZ6vw1Zv3HwYslB8GJ++d0YdfF6/t9++Kk6v84kUijwZL/+Pby/HZy6fr
-        k3B4eBY58ejFZVy+f345P3oqX58Vq/UltS+c0WtX+Cf54OXz01/Xl+L0w+Vkmon+m+fFdHCyWM2z
-        957V0cmLUqloETLpU8H8K5ql0azgnrWPbrwy84BCffAZm52+86zNnWmImAxnp+Di9SphglUATfWC
-        dF4ukVvJZo5te1ab4IWpWhtOGS8iXhyWC1C3IZp2zeilbq8aDeswo1JWfwxeJYwqVKBFq9p1l4tu
-        u2EDkdNhNOx0bLskr0qKBVvXEiyI/4aIaVJB654NpcNvg9vDcpFGcj9bY0jV3qFtINqWpzRPs3UL
-        ZCy0NnKt2mlcKl/QYg48AgbXOiA+j2MmIKqB5FmpmC/pFQyTmTPoQeS2qV5cZhnokQdpwaLZsI+g
-        Ls1AwCa1FGnIZu64wWyIFagEu6kAhYYbTEPztGYbxoMpgraIFWjDeTDcoFryKkLD3G2hNhKXTISQ
-        /HTeGNwfetYuFVJ6x4E5/bita4ekAab/g88/yee7DtSULTW6NAPpqtAleTmO+to2xyDapAoA8b4m
-        bO4douZMbo9aC3N91Ow7RM1x7xK1NuqGqNl3jVr/mqhteQ/vt5Xo0gykq0CX5BXcl8A+Y9J/mNYe
-        prU/tM8fprWHaa0Sf1nSQuFuly8VHF1g06b35H5NnzmetUXZRvRvRQxuRbi3Ioa3Ika7CGvXPD1v
-        +2EpBJzPAFJfma3uPFjC7rVD2iBiGiouzAFjm7hBFWUeQHgm/VELVRE3qGVG4RCEvtsmtTAYbLnO
-        A55ZbTIcnAx19p9/t/tv6J61babiS18nxcOU+UlT5o7/rGs2BA8D6mFAPQyoTxlQ7VEU8rJQokoY
-        /bimTWia9ZOHt0WqWEReAN+I5xto9fxGpCoNfcGuUrbyK02qlNvb5EUUwmXCzYqouq+e7JQHxJmo
-        hByV81Iq0rcdSMoNwGBLFaJRkqnZYISCtqkbmGQhLyIJq/fYGbpDu4OuGw18Df/yPIpmKNSeOJMK
-        2dC9VPLJyHZ8TaZF5Ks0Zxp+aE8OncmFM/1hYP9g29/bzg8oaX+Hiu+2B8y9VFSoHZ/0HXDGEYQz
-        +5wuGTn90cC9s0vcvnMvl7iHfedTXFK5wDzK1fn46u3F8dnR8YvTM89qkSuIdsMvVKmErcjPvBQF
-        +06SV2COoOGCicd1J+Mvc51Gs9Hzp3VL85DUT4uYz77N1JMovfp2rp50+X5L8+WTvwymTySRqiwK
-        GBJkKXhUhjhZEx63xRLBFHSSJC0gavaEKE7OaZQx0WLzjmWZJIketSQQfMEKQrOMBPwjsIth/AKb
-        kItIkqgUCMoo5MKa0TYXCVwOeanggkpe9NCAQBALLXjUublIUkliOBOmV4woAfMPQQJMbKg9NipB
-        I5ZTsQAT1xlD8ipVB2RJVcIlgZgR87AzDWlGcjpPw17H7JhnGV9JcpxRQVtKftAuXJNY8JxQEmSM
-        LshxIlKpcirJKSgE2pyI3ongUjYdyWuxTGgBk9sBCBa8nCfQWyZpnjPtEPDRoVxQhdcryF4mMlRS
-        K8pRVyKXLFQ0LEEhEgJ9jTou0LLzFWMqZdjhBqe9zsBbgtAVFdHhKjVxh2xK5wWQjwpwTLEm76BV
-        S72A2Tpd8Cu5WLfMz8swOcz4FUylEgLKSL1EoHsTItPffsuQb5hAI58LukzWZF6CDwvFIFYJOOfa
-        bGz7H2JIwclMJgckS5eHMocG4HwA2SF0noHhGOUUkxZiuIlBTAW7wQ9d8ZC1IClMUoY2BRyMgIEL
-        nNJQuwHsgwiFKUiQZQg7BWksxSRLMW8KqrOwAI5VZUeiavrhtk6uAEYCU7JHXtY5rzu/ySh4G1hh
-        xr/TYyOHnIWgCh3uM76Gzq9oZV5VLzjAgcRS1FWtOMGYphg9DKpJa2AtwfkqW2PiBDjyrhCvPWJV
-        E8Ij7ZLExet3CYzWY1qQ5+QZ/0mjTMOj1gxyVKxxjiNrXkI4FuwxOZIk4xAGcJ/CUksrjpjYfEVg
-        CPdukgrZc8JvlIqXS7y4qCed7+rJBl0MAZTsse67rOH7ZVHVUu95EWZlxKLrpOrykUowx9Dcgt3g
-        vGecw1Dh5EXBV9ewgxGFQ+0x+QX8DLMocicqnSfK/C+vZX5eporCDEOeQk4cJ2kWwbbyGinnJSbH
-        B9xvQMxxkOtJDzOJQkqxHNYFyCTMmz1CmyUEF45qEcFxzDd1rDaxQuQsSilsnqje5cNmGaZWNdPU
-        HoyfBWQ9jJUw6YW449KNXlrA6gy64t5yCeMCVmyRzRKllvIHy9rf15KwcWSR1ZIK2zK+hM2YNR3A
-        L7TdILajvsviQWQP2SRmsRvQ8dieRrHtDlxGnUHY+7Ccw9q9VwGvoLCC4wwqwRwwV997uFzMPqt4
-        zdH7nX2w1wOyXC5h3pA+KqLLsF1KFyDr0nOH5lmdzPh60mTM4Ge7k3A0HMbjaeRQZjuuMw2nfbdv
-        T0ZOFDvDUTAZxHdIE9hXXJbs7klyb+FfIknurcT/X5IMGfxs2437w2BIaTCK3UE/jMZsNBlMAxhI
-        bj+a0GHsjIPbk0Rewq7n7jlyb9lfIkfurcTXkCORs/rorgbDMsij9GMvzHgZwe68UL2CqdtTBRx1
-        I4d9/mIfla/g+GFb38u1VCz3NxQ0JIM92R0ypELemiN3F3d7UnxBW++QDLuh/mPPGPEUfpTCQgvL
-        rzsehwN7EI0nQTh07HEY2uOhG8UTd0TDye35AIdRJPkxbNfvPG/cW4MvMW/cW4mvYd74M2QKnIAe
-        MuXPuMJU/vI10poO4RdMw8Cl00lMx8HQcQPXHbn2dEztyTgOgnEwdpwwpHdPHjgM3jV3PlWNL7Ac
-        /Y8afRVr1O+eT/0h/OzRMJqGo4j2w9Fo7AymcD8eUzdy3cFoOgqd4TQa3COfVCLufib6VEW+eEbd
-        W6OvIqP+BGuZWvGHpewzLmVSUVXKWaY3kx1SDSiDiCpq1fcKyzbtepIh1K3rJZxYUlTdN15qYNhS
-        ocolFnH8LJWqU6M63VOjuq52BfQXb9t0aw/vOeNYfQNrM6pSVUZsNnR6Q89qbj18Om0uD+2eg00N
-        wbM2/RMq/YJjYTeW2v8dAr5Fj/VtFjWvz1e3+lU3Ycpnpv7n9Ku33TpU/XrVHtw21cPnzH7EllQo
-        TBOsJWp99tErcCl0eaAFqykGgDZwkeOnFEb9HaqHbzuYrymOnTPiXryCwVKTPFP0lvWF9ob+xKS6
-        R7lbpArq01IlXOBnDuQCzAPZ3YYaF/BoPTumRcGVrhHmOdO1OVPGWBFWYK3scdNd4+vOrQJzyQ6I
-        M1YJecWvGL71gTXmYdOtVWpuU9q14aHjOONuh02JuKJmtJjPWNGg9H3dyEWK5aAMB7bVUDG4RvKw
-        15+SN780nTctHWyS5LmUM2fcn2KRfE/TBq4yNntb5KmUWCd43EJji4dFaF/ooiK+ydO+raHNxeZL
-        kPrrG3+Rm7cB99A9DI7OJJO9Zlrq0jwJxxOA01jh+x8UX4JiOU2zWVhKxXMmdCkvZPKvoJFgUnKY
-        c3v4Ise1PWueOj+bBxFNh+pLFHNjEgPaybl+cEH+xQRvoMbxrRsfS7rAoYjT+c3dOsiaBSsuy1Sk
-        97Zxu1/NLy3A9qIq//kx/Tj73nUhqQfEGYzHrtNvOOwi9/NYJrDl73Lp29dwMdiaT8bDirO9T4FN
-        c7eDYWLvk9YG1J1w3gEijSIxw9IXI+PhAflHim96pRQLpiEMciz/rbDqdq5gv6kOyM8si7Gy+vOF
-        0yfDp/9sZLT51TKqR1jm06M6f5oenda6i9JveIQzLMLBTKcLnpgduHwQXmTr3iOY5bBBMGKmMZoR
-        vWaZiiwt1oQqYLwEguJkqd+Egg5gYi7NmwRmwqsep5FVii9PMCzzh2BuVV3HQjHwh2TqNRrXysFQ
-        F2WIC0RUFfHQbIZm6D3Vkbmrd1jmm7emvHrGJQuwLHkEWuNM+lxioU/x4oCYr902RVb9uh9+MGc1
-        EuYQDtgt+IuCryp57bpoR6iFi28HD/O1MDORhr2ubnd6bXD4RhiumxFTMGJkZbCGvzFNpGoi2ARL
-        HWb1DsP9bGRVdPWhox9WRdeK+96C7A7fazisEqpQiCk+VxyvK03vMN3uvUpY4UN++Kk/5w2zdiV/
-        D4tOF/2BpB/xLQ6tqvw12XK3YvwmT7YEWTupqpPOjNN9xf/7ZOdWVbvFuZKiV4jzo5OXp2fn705f
-        vjyvQWbpMNd6bejaWMPMsmGum9estGhScSWaLXl+To7Im5dHx6cdn2w6eldpBLvQNBbGya07f3O8
-        65AThrX72QA3NvsattB4+FutVr01zBxlwMyRcBfS7WUOX7iFiqxnzt+Xp397lv62cLc6mgNVh7R7
-        krmh+Yau1RnnJkC3N2y3fJ3b9TGzOdRtGX+rVbucrpH0ueTslbJKI3CuXi330LvE+nTUnJK6X43/
-        F5UfhalyPgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3543']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:33 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/ReviewTests.test_review_is_user_review.yaml
+++ b/tests/interface_objects/cassettes/ReviewTests.test_review_is_user_review.yaml
@@ -1,137 +1,114 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF92aWRlb19pZnJhbWUgLz48
+      cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNj
+      YXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21l
+      ZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9m
+      b3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlh
+      PnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVx
+      dWVzdF9tZWRpYT48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHJlcXVlc3RfcmV2aWV3cyAvPjxyZXF1
+      ZXN0X2N1c3RvbV9maWVsZHMgLz48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxtaW1lX3RleHRfdHlw
+      ZT5odG1sPC9taW1lX3RleHRfdHlwZT48cmVxdWVzdF9tZXRhX2NvbXBvbmVudHMgLz48cmVxdWVz
+      dF9leHRyYV9pbmZvIC8+PHJlcXVlc3Rfc291cmNlX2luZm8gLz48cmVxdWVzdF9jb3N0X3Jhbmdl
+      IC8+PC9ldmVudF9zZWFyY2g+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['759']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+077XbbuLH/8xTI3nM27aklkhKpj0TV1nacNF9Oaiubtn94QBIUGZOAQoCWta/T
+        P32Oe1/szgCkRMqyLSebnnQ3OUxCDgaYDwwGA8xo8tNVnpFLVshU8D//4HTtHwjjoYhSPv/zD+9n
+        zzqjH36aPpiwS8aVLxktwsQvmCwzNZ3IMohETlPul5IVfir9gEZTLibW7pZJWKwWSvhBJsKLaeh3
+        OoNOID9+ePsxO5sXrCOfBi/Pxm+PwniUvBpcfTo/jZ+r0/N3R++CgZPZq8M0WDybzdVR8Cn4RzgY
+        HZfe66N3NHl//u5s7B/Lv//8zyv5izwvnw5mvYXb48EiOFu+/NvRy5OX/7x67q6OL5KkR9N4nPUj
+        L14FyRvvb96b08xeHLmdf0ysFn+TKJWK8pBJnxbMv6RZaoTbBTcKmk4AQn1QH5uefJhYmy/TEDEZ
+        Tk9A26tlwgpWIWjoJEzVyuBmgkeCd8oLYGgNNO0a9bVurxqrzhmVsvrP4NNCSUDZAKpGjX8IjeRH
+        mi+e/E9/9IQcw2yWyE4DZQJzpifQDL1iMFobNKms4YKtNDULpn0DQeOo8Opua0hrsA3e9ngRKnn3
+        oEakGqEF3OBoOY5oljFlhCVPtzoYSa0NC1atSCGVX1A+h/FyegUj50HKWTT1el17YrVAGgGYVIsi
+        DdnUHdYYG5hBKUEMWsCQ3hpjDZrkqNd6yJ6jMZogjbAZ0RnVGE0qWp31kP01xoYKF76ElZ0xVNZv
+        U8RPJeUKV4ZYKPBpMJl6hfo1fOpMrC3INkbvToz+nRjunRjenRiD6xjWdfH0HPphWRTguAGlfjPL
+        YR4swKpboA1GTEMliqlj2w2cCrjB4mUesGI66g0aWBVwg7XIKLhE1N02qIGDNidXeSAyqwkGN2qg
+        0//9V7P/Bj6xtsW0brDl7/P/O5n/5qSHouSqqOTTG2cTsG7W/v49TxWLyCuwHYhRNqjVTlqkKg0h
+        xLlM2dJfsCLEfd1oaGfTJKKKGT58xqPqWw82S8oD4khFztlCMdQX6dkOaHGDYrBLFfoijiVT0/4A
+        SW1DN2iShbD9y6njDntDz21j140GfQV/8jwCXwtE7bHtVJhrOOzMYjSwHV+DKY98leZMo3fsccd2
+        Zs74cd9+bNt/sp3HSGl3h2rcbR2Yb4iVCnVNK55KyBu6+jX1Mei5w769tz4827uXPjx4Pkcflfwm
+        gNbmePp+dnx2ePzq5GxiNcAVilbDG6pUwpbkSJQFZ48kOQVxChpegAnNTs5ndUejM/MOUejgxbO6
+        ZR2T+imPxfTHTD2J0ssf5+oJvi7w5RoRqUrOYVmQRSGiMkT/QkTcoP2QFAwiRS5JymHq7BFRgpzT
+        KGMFdP/AskyShF7iEEEhLhgnEH2RQFzBMDHs39A9FEUkSVQWiATBliIriO+QOPTuiFLBC5WCd5FN
+        S/P5YM3xLEkliZlU6SUjCmJnRRBQAhHgExtVQSOW0+IChFllDMHLVB2QBVWJkASmiIDMVEE0QTOS
+        03kadlsCxiLLxFKS44wWFNj6qJWzInEhckJJkDF6QY6TAs4AOZUEgnkCXDwtuk8LIeUj8rZYJJTT
+        OTsAQoUo5wn0kkma50yLDFroyAuq8H0JxsmKDJnSjAnkjcgFCxUNS2CAhABfIU8XKMn5kjGVMuyw
+        Uz1vM9BLQeiSFlFnmZq5BBNJ5xzAhxxUwFfkA7RqejMImdILcSkvViBoXoZJJxOX4BolTBIjdVyG
+        CkyITH/5JcPxwgQaxbygi2RF5iVoiSsGs5GAGm4x24c4UxTUyGRyQLJ00ZE5NMCIBzDjhbYZEBHn
+        L0XDg9nZaDmGc9JOidsEwfaARpikDKUIBLANaw/GSEMtMEgEsxCmMLYsQ9iapJENDSdFW+BUWxaH
+        EasjsUSm9KFAG0ygTxOyS17Xlqs7v8vAlX2AodB+P2gLz8EOYeIKPaVnYgWdT2kl2ExbIFgILAeW
+        Iq9qKQjOXorzhNNnTBWGlqBula3QOAJcP5eI39CFfqtW9gOtmMTF96dlocnpdgN6sMsJHJLnIotS
+        PPHqZak7kQ7hAg5NgMRyxFJC6IHMF4ETKkzbrSia7wPysQQ9oQqKdJ4oQnPcbPVEg6PcQ4wPCTiR
+        Y8rJC+DzpzuF4Sscl6xECSZ2wR6SQ6mZJWAYCo/cj6RejmJJwMV092MA1kIkgIH53QzMrrlDNB8w
+        Tske7kOLqupUPn4iyQseZmXEojup6hsFleASQsk528tCngsBPkCQV1ws76IAPgOdyUPyBqYDfD8S
+        hCnEKdX/yj3onZepouA/yTNYFcdJmkUQyd1F+LzEdaKtCMwfPZv26WhRFFYXy2GHA4PFJbQvH8d4
+        CZBlxtDfiSwNVzdwcSpgwcUlRBAEWGZX4C9hRwcLuqRppkWhsYIVu9CnT1nZc01yvRPj/lvtxehB
+        xdTsQKxGMMAKI2dRSiEMpTq8hygZti01jZzllbvse2WQR+lVN8xEGcGOxFWXMzWxNM4k5RDvgL7w
+        RL0ANwUxUJFNE6UW8rFl3TqEJeH0zCKrwQOEu2IBQa417sMT2m4Q21HPZXE/sj02ilnsBnQ4tMdR
+        bLt9l1GnH3Y/LuYQFO3kY8IphEa4d0kQDoTX3xPcmKe/Knk94uTbUMVORchysQDnKH3kp7oubULa
+        CNV12RZsYrXM5Vu1nSGDx3ZH4cDz4uE4ciizHdcZh+Oe27NHAyeKHW8QjPrxHrYDYd2nku1vOfcm
+        /hUt5968/AYs5wv05WtMqzeGZ+gybzQcDyksurEz9HrBsB/R/timbBCPYjpg7mjQu9t88BYRPC3e
+        SvB9behz+fh6lvS5HO1hT9et5RszqC9agR6Dx7bduOcFHqXBIHb7vTAassGoPw7Aebu9aES92BkG
+        e9jSJzj47O+J7k37K3qie/PyO/VE7Er5ikllW3+SK6lY7m8gKEgGZ7U9DKXCvNNU9if3FWxjf+K/
+        ezcSj+GhFCI+iAPd4TDs2/1oOApCz7GHYWgPPTeKR+6AhqO7rUMVKYL8GA71ezuTe3PwFZ3JvXn5
+        DTiTb9B8RHm3g/luPt+G+Xx57GczeHqeF7nxeBBEdi+gdBjEUa8Hf0MajO1wFA9CFvXd/W1I8L09
+        0Oey8dWD4ntz9FvYzb5cbSEAaC9yvdGYjsbuyPYcF04UEBmGLBzR8ag38Hq9kW2P+/vbk1qKe9rT
+        vdn46vZ0b47+w/ZkFDt48ayTmzxIJ9B5kI7s8HXipYNhnFX3NzqrqvkUVaWcZjr4aIFqhDKIqKJW
+        /a0wpddMMhpA3bpaQLyboui+SoG0WqNhS4VVLjDR52epVK3E5cmOxGU0ffNXuwm3dowxZwLTr6AU
+        vNJVZcSmntP1euOB4/SHE2sNnWAiwLx27K5jD2zHG/QAYQ2eWJvBEip9LjDLH0u9p7QAWNOG9wks
+        WhezVZ+6DqoweVSTDXZ6VSlUC6ormXbgbUMneJvvR2xBC6zR05lmzc8ueIVcZXEaaDXEIKAMosjx
+        Htywfw06wUoNU8Z47JwRd3YKy60GTUwFhKxftDZ0nWf1jXS3QBWqT0uViGI6SxiZgXhAu91Q4wUi
+        Wk2PKcccEyaN85zp1K3JiC0J45hafbjurvHrzo1ag5IdEGeoEnIqLtcVGN66W6PwoAlpVgp4juMM
+        2x02BQMVNKN8PmV8jaW/60ZRpJhZzNAbWGsoTq6h7Nhd2yaHb9a9N00t5CTJcymxFEUXOexo2qCr
+        jE3f8zyVEtMUDxvY2DLBmgS/0NdhWIbU/KxRb5zc2t5vmV3MypLDLFsUTN4+w5jxqhJyDzEtSoBl
+        1mG8I8P/+zdnmADVOXqaHeicTyv5DI0mgx6XVbNUolhVnXiKFQdcVTl/IVmdIup2ScpDcP0p6KZL
+        XjzCGgVGgnKFGTTjumSVu63tjc5pyvVQ+u1Ou8Mal94I7O6wnGPyCgzJvY/VufaoN/pvtDpYs48U
+        mTN1bYnex/astYupqn/rmmv/Ip/aWPW5Az7BmdJuzLhOs4+2YRMJO2TITMXN+pID0BrgGsdUa18p
+        VuikPSCSI9xSwQg2PYzGGh8+VorAQDxO53v1bnWoR2L8U5kWKZM+y2maTc21jPwLqAkXleiGoot1
+        bjeg18OgzwYboFFUTDH/ysjQOyA/p1jhl1KsWwjBQWKmeonZ4HNVMKYOyBHLYixwOJo5PeI9+/ua
+        TnO8mkZ1Y2Qqp2uVrnu0WusuStdKhVPMBIMf0dl5VBBuvUTwbNV9AM4AGwpGzBYAOtSbvymMoHxF
+        wMmwfAEAJdYZWJKilkyxjlm81e0VWaZmlYcm+1uVtWC9BowPjqK75rhmDiy1KEPcXKMqhxs2Mseg
+        CswcV1HvjpxyHf1e0qxkFtYr7urd2JkRu67aaHWefmvFGrostdR1bmv252A/EA/6F1wsK2GaBQY3
+        CHSfuoIN1TYt2NgL4zU0ibfV5w0Uvxe9fS96+1709l9e9LZxBZvFjz8QwVNTxBTsgLJy2doHvDNN
+        pGoi2AQHnVsc7ZEQFyRYkb6NIRwMnWmxGkekapNxbPKyBE47+FbFeijEAnTDgXsYBynHYCzgV9bx
+        5C5Rdgsgq6opHwj7YVU1Vcm1s6LqBom+oJBqw+INzCxhGSC/plytYu6mYrYb+Lu9hm3DwjatZcK4
+        Dx7DT/25WJNuFg3etJd+fq1gk5sWdf2rPj8SW8w0CghvYGa/usEW3SYh61qo0jidtX/EsKthAoFV
+        yUxUdwYHJTgmwzZ8qKFIPSiIpV3QC4neUJmq0jXU/B6xBXr/CnjdDFoR0NH1+eHT1ydn5x9OXr8+
+        r5FM2G3edUDdVkaNZmJt867FnJ0d/nzyukW59XEKvgrjyve45cxhY+LRY9gS5iwjfzgFFwNa5DD5
+        nP3x7jHOYFE+1r8agX0St72tIdBZ6aFvGYuQWYnoLIawqtShleEG790w8NAOWw+uwzBBI9xo9ckX
+        oQgwJ9NzRV6KhFcRe5dsTxt6Ue1w6mBO+3z8rIoPCQ2QA7AJkjP4hvBELHmrT7fWuzGpyzRiYHBx
+        YQy48eVvbrRb4IThMNM+XrjsatjCxovu5XLZhRWpyoDBESff7qfvwlsgcweKVzuR9dx5uTj56/P0
+        lwt3q6O59myBrmeNbmm+pWt1X3sbQrs3HMh97Tfqa/T1dfWW8HdKdX2kGyj9WnR2UlmmESjXxdvL
+        HfA2sL7CXV/ltn9R/v+e+0Ywjj4AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:33 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3898']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:42 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_extra_info /><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_video_iframe
-      /><request_reviews /><request_cost_range /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><request_source_info
-      /><mime_text_type>html</mime_text_type></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['903']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1b63LbNhb+n6dAujPtj9oiKVG3hlXXtZ1sNmmS2s5ms384IAmKjEhCBkAr6uvs
-        m+yT7TkASZGSfMsm07TrjCYmDz6cO248pPfTxzwjV0zIlBc/fuP07G8IK0IepcX8x2/eXjw9nHzz
-        0+yRx65YoXzJqAgTXzBZZmrmyTKIeE7Twi8lE34q/YBGszWTnrW/yQvFeqm4H2Q8XMze+oeHV4tl
-        PF0cT5dvh6+Dw7ngceSoZ6vw1Zv3HwYslB8GJ++d0YdfF6/t9++Kk6v84kUijwZL/+Pby/HZy6fr
-        k3B4eBY58ejFZVy+f345P3oqX58Vq/UltS+c0WtX+Cf54OXz01/Xl+L0w+Vkmon+m+fFdHCyWM2z
-        957V0cmLUqloETLpU8H8K5ql0azgnrWPbrwy84BCffAZm52+86zNnWmImAxnp+Di9SphglUATfWC
-        dF4ukVvJZo5te1ab4IWpWhtOGS8iXhyWC1C3IZp2zeilbq8aDeswo1JWfwxeJYwqVKBFq9p1l4tu
-        u2EDkdNhNOx0bLskr0qKBVvXEiyI/4aIaVJB654NpcNvg9vDcpFGcj9bY0jV3qFtINqWpzRPs3UL
-        ZCy0NnKt2mlcKl/QYg48AgbXOiA+j2MmIKqB5FmpmC/pFQyTmTPoQeS2qV5cZhnokQdpwaLZsI+g
-        Ls1AwCa1FGnIZu64wWyIFagEu6kAhYYbTEPztGYbxoMpgraIFWjDeTDcoFryKkLD3G2hNhKXTISQ
-        /HTeGNwfetYuFVJ6x4E5/bita4ekAab/g88/yee7DtSULTW6NAPpqtAleTmO+to2xyDapAoA8b4m
-        bO4douZMbo9aC3N91Ow7RM1x7xK1NuqGqNl3jVr/mqhteQ/vt5Xo0gykq0CX5BXcl8A+Y9J/mNYe
-        prU/tM8fprWHaa0Sf1nSQuFuly8VHF1g06b35H5NnzmetUXZRvRvRQxuRbi3Ioa3Ika7CGvXPD1v
-        +2EpBJzPAFJfma3uPFjC7rVD2iBiGiouzAFjm7hBFWUeQHgm/VELVRE3qGVG4RCEvtsmtTAYbLnO
-        A55ZbTIcnAx19p9/t/tv6J61babiS18nxcOU+UlT5o7/rGs2BA8D6mFAPQyoTxlQ7VEU8rJQokoY
-        /bimTWia9ZOHt0WqWEReAN+I5xto9fxGpCoNfcGuUrbyK02qlNvb5EUUwmXCzYqouq+e7JQHxJmo
-        hByV81Iq0rcdSMoNwGBLFaJRkqnZYISCtqkbmGQhLyIJq/fYGbpDu4OuGw18Df/yPIpmKNSeOJMK
-        2dC9VPLJyHZ8TaZF5Ks0Zxp+aE8OncmFM/1hYP9g29/bzg8oaX+Hiu+2B8y9VFSoHZ/0HXDGEYQz
-        +5wuGTn90cC9s0vcvnMvl7iHfedTXFK5wDzK1fn46u3F8dnR8YvTM89qkSuIdsMvVKmErcjPvBQF
-        +06SV2COoOGCicd1J+Mvc51Gs9Hzp3VL85DUT4uYz77N1JMovfp2rp50+X5L8+WTvwymTySRqiwK
-        GBJkKXhUhjhZEx63xRLBFHSSJC0gavaEKE7OaZQx0WLzjmWZJIketSQQfMEKQrOMBPwjsIth/AKb
-        kItIkqgUCMoo5MKa0TYXCVwOeanggkpe9NCAQBALLXjUublIUkliOBOmV4woAfMPQQJMbKg9NipB
-        I5ZTsQAT1xlD8ipVB2RJVcIlgZgR87AzDWlGcjpPw17H7JhnGV9JcpxRQVtKftAuXJNY8JxQEmSM
-        LshxIlKpcirJKSgE2pyI3ongUjYdyWuxTGgBk9sBCBa8nCfQWyZpnjPtEPDRoVxQhdcryF4mMlRS
-        K8pRVyKXLFQ0LEEhEgJ9jTou0LLzFWMqZdjhBqe9zsBbgtAVFdHhKjVxh2xK5wWQjwpwTLEm76BV
-        S72A2Tpd8Cu5WLfMz8swOcz4FUylEgLKSL1EoHsTItPffsuQb5hAI58LukzWZF6CDwvFIFYJOOfa
-        bGz7H2JIwclMJgckS5eHMocG4HwA2SF0noHhGOUUkxZiuIlBTAW7wQ9d8ZC1IClMUoY2BRyMgIEL
-        nNJQuwHsgwiFKUiQZQg7BWksxSRLMW8KqrOwAI5VZUeiavrhtk6uAEYCU7JHXtY5rzu/ySh4G1hh
-        xr/TYyOHnIWgCh3uM76Gzq9oZV5VLzjAgcRS1FWtOMGYphg9DKpJa2AtwfkqW2PiBDjyrhCvPWJV
-        E8Ij7ZLExet3CYzWY1qQ5+QZ/0mjTMOj1gxyVKxxjiNrXkI4FuwxOZIk4xAGcJ/CUksrjpjYfEVg
-        CPdukgrZc8JvlIqXS7y4qCed7+rJBl0MAZTsse67rOH7ZVHVUu95EWZlxKLrpOrykUowx9Dcgt3g
-        vGecw1Dh5EXBV9ewgxGFQ+0x+QX8DLMocicqnSfK/C+vZX5eporCDEOeQk4cJ2kWwbbyGinnJSbH
-        B9xvQMxxkOtJDzOJQkqxHNYFyCTMmz1CmyUEF45qEcFxzDd1rDaxQuQsSilsnqje5cNmGaZWNdPU
-        HoyfBWQ9jJUw6YW449KNXlrA6gy64t5yCeMCVmyRzRKllvIHy9rf15KwcWSR1ZIK2zK+hM2YNR3A
-        L7TdILajvsviQWQP2SRmsRvQ8dieRrHtDlxGnUHY+7Ccw9q9VwGvoLCC4wwqwRwwV997uFzMPqt4
-        zdH7nX2w1wOyXC5h3pA+KqLLsF1KFyDr0nOH5lmdzPh60mTM4Ge7k3A0HMbjaeRQZjuuMw2nfbdv
-        T0ZOFDvDUTAZxHdIE9hXXJbs7klyb+FfIknurcT/X5IMGfxs2437w2BIaTCK3UE/jMZsNBlMAxhI
-        bj+a0GHsjIPbk0Rewq7n7jlyb9lfIkfurcTXkCORs/rorgbDMsij9GMvzHgZwe68UL2CqdtTBRx1
-        I4d9/mIfla/g+GFb38u1VCz3NxQ0JIM92R0ypELemiN3F3d7UnxBW++QDLuh/mPPGPEUfpTCQgvL
-        rzsehwN7EI0nQTh07HEY2uOhG8UTd0TDye35AIdRJPkxbNfvPG/cW4MvMW/cW4mvYd74M2QKnIAe
-        MuXPuMJU/vI10poO4RdMw8Cl00lMx8HQcQPXHbn2dEztyTgOgnEwdpwwpHdPHjgM3jV3PlWNL7Ac
-        /Y8afRVr1O+eT/0h/OzRMJqGo4j2w9Fo7AymcD8eUzdy3cFoOgqd4TQa3COfVCLufib6VEW+eEbd
-        W6OvIqP+BGuZWvGHpewzLmVSUVXKWaY3kx1SDSiDiCpq1fcKyzbtepIh1K3rJZxYUlTdN15qYNhS
-        ocolFnH8LJWqU6M63VOjuq52BfQXb9t0aw/vOeNYfQNrM6pSVUZsNnR6Q89qbj18Om0uD+2eg00N
-        wbM2/RMq/YJjYTeW2v8dAr5Fj/VtFjWvz1e3+lU3Ycpnpv7n9Ku33TpU/XrVHtw21cPnzH7EllQo
-        TBOsJWp99tErcCl0eaAFqykGgDZwkeOnFEb9HaqHbzuYrymOnTPiXryCwVKTPFP0lvWF9ob+xKS6
-        R7lbpArq01IlXOBnDuQCzAPZ3YYaF/BoPTumRcGVrhHmOdO1OVPGWBFWYK3scdNd4+vOrQJzyQ6I
-        M1YJecWvGL71gTXmYdOtVWpuU9q14aHjOONuh02JuKJmtJjPWNGg9H3dyEWK5aAMB7bVUDG4RvKw
-        15+SN780nTctHWyS5LmUM2fcn2KRfE/TBq4yNntb5KmUWCd43EJji4dFaF/ooiK+ydO+raHNxeZL
-        kPrrG3+Rm7cB99A9DI7OJJO9Zlrq0jwJxxOA01jh+x8UX4JiOU2zWVhKxXMmdCkvZPKvoJFgUnKY
-        c3v4Ise1PWueOj+bBxFNh+pLFHNjEgPaybl+cEH+xQRvoMbxrRsfS7rAoYjT+c3dOsiaBSsuy1Sk
-        97Zxu1/NLy3A9qIq//kx/Tj73nUhqQfEGYzHrtNvOOwi9/NYJrDl73Lp29dwMdiaT8bDirO9T4FN
-        c7eDYWLvk9YG1J1w3gEijSIxw9IXI+PhAflHim96pRQLpiEMciz/rbDqdq5gv6kOyM8si7Gy+vOF
-        0yfDp/9sZLT51TKqR1jm06M6f5oenda6i9JveIQzLMLBTKcLnpgduHwQXmTr3iOY5bBBMGKmMZoR
-        vWaZiiwt1oQqYLwEguJkqd+Egg5gYi7NmwRmwqsep5FVii9PMCzzh2BuVV3HQjHwh2TqNRrXysFQ
-        F2WIC0RUFfHQbIZm6D3Vkbmrd1jmm7emvHrGJQuwLHkEWuNM+lxioU/x4oCYr902RVb9uh9+MGc1
-        EuYQDtgt+IuCryp57bpoR6iFi28HD/O1MDORhr2ubnd6bXD4RhiumxFTMGJkZbCGvzFNpGoi2ARL
-        HWb1DsP9bGRVdPWhox9WRdeK+96C7A7fazisEqpQiCk+VxyvK03vMN3uvUpY4UN++Kk/5w2zdiV/
-        D4tOF/2BpB/xLQ6tqvw12XK3YvwmT7YEWTupqpPOjNN9xf/7ZOdWVbvFuZKiV4jzo5OXp2fn705f
-        vjyvQWbpMNd6bejaWMPMsmGum9estGhScSWaLXl+To7Im5dHx6cdn2w6eldpBLvQNBbGya07f3O8
-        65AThrX72QA3NvsattB4+FutVr01zBxlwMyRcBfS7WUOX7iFiqxnzt+Xp397lv62cLc6mgNVh7R7
-        krmh+Yau1RnnJkC3N2y3fJ3b9TGzOdRtGX+rVbucrpH0ueTslbJKI3CuXi330LvE+nTUnJK6X43/
-        F5UfhalyPgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3543']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:33 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/ReviewTests.test_review_string_properties.yaml
+++ b/tests/interface_objects/cassettes/ReviewTests.test_review_string_properties.yaml
@@ -1,137 +1,114 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF92aWRlb19pZnJhbWUgLz48
+      cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNj
+      YXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21l
+      ZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9m
+      b3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlh
+      PnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVx
+      dWVzdF9tZWRpYT48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHJlcXVlc3RfcmV2aWV3cyAvPjxyZXF1
+      ZXN0X2N1c3RvbV9maWVsZHMgLz48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxtaW1lX3RleHRfdHlw
+      ZT5odG1sPC9taW1lX3RleHRfdHlwZT48cmVxdWVzdF9tZXRhX2NvbXBvbmVudHMgLz48cmVxdWVz
+      dF9leHRyYV9pbmZvIC8+PHJlcXVlc3Rfc291cmNlX2luZm8gLz48cmVxdWVzdF9jb3N0X3Jhbmdl
+      IC8+PC9ldmVudF9zZWFyY2g+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['759']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+077XbbuLH/8xTI3nM27aklkhKpj0TV1nacNF9Oaiubtn94QBIUGZOAQoCWta/T
+        P32Oe1/szgCkRMqyLSebnnQ3OUxCDgaYDwwGA8xo8tNVnpFLVshU8D//4HTtHwjjoYhSPv/zD+9n
+        zzqjH36aPpiwS8aVLxktwsQvmCwzNZ3IMohETlPul5IVfir9gEZTLibW7pZJWKwWSvhBJsKLaeh3
+        OoNOID9+ePsxO5sXrCOfBi/Pxm+PwniUvBpcfTo/jZ+r0/N3R++CgZPZq8M0WDybzdVR8Cn4RzgY
+        HZfe66N3NHl//u5s7B/Lv//8zyv5izwvnw5mvYXb48EiOFu+/NvRy5OX/7x67q6OL5KkR9N4nPUj
+        L14FyRvvb96b08xeHLmdf0ysFn+TKJWK8pBJnxbMv6RZaoTbBTcKmk4AQn1QH5uefJhYmy/TEDEZ
+        Tk9A26tlwgpWIWjoJEzVyuBmgkeCd8oLYGgNNO0a9bVurxqrzhmVsvrP4NNCSUDZAKpGjX8IjeRH
+        mi+e/E9/9IQcw2yWyE4DZQJzpifQDL1iMFobNKms4YKtNDULpn0DQeOo8Opua0hrsA3e9ngRKnn3
+        oEakGqEF3OBoOY5oljFlhCVPtzoYSa0NC1atSCGVX1A+h/FyegUj50HKWTT1el17YrVAGgGYVIsi
+        DdnUHdYYG5hBKUEMWsCQ3hpjDZrkqNd6yJ6jMZogjbAZ0RnVGE0qWp31kP01xoYKF76ElZ0xVNZv
+        U8RPJeUKV4ZYKPBpMJl6hfo1fOpMrC3INkbvToz+nRjunRjenRiD6xjWdfH0HPphWRTguAGlfjPL
+        YR4swKpboA1GTEMliqlj2w2cCrjB4mUesGI66g0aWBVwg7XIKLhE1N02qIGDNidXeSAyqwkGN2qg
+        0//9V7P/Bj6xtsW0brDl7/P/O5n/5qSHouSqqOTTG2cTsG7W/v49TxWLyCuwHYhRNqjVTlqkKg0h
+        xLlM2dJfsCLEfd1oaGfTJKKKGT58xqPqWw82S8oD4khFztlCMdQX6dkOaHGDYrBLFfoijiVT0/4A
+        SW1DN2iShbD9y6njDntDz21j140GfQV/8jwCXwtE7bHtVJhrOOzMYjSwHV+DKY98leZMo3fsccd2
+        Zs74cd9+bNt/sp3HSGl3h2rcbR2Yb4iVCnVNK55KyBu6+jX1Mei5w769tz4827uXPjx4Pkcflfwm
+        gNbmePp+dnx2ePzq5GxiNcAVilbDG6pUwpbkSJQFZ48kOQVxChpegAnNTs5ndUejM/MOUejgxbO6
+        ZR2T+imPxfTHTD2J0ssf5+oJvi7w5RoRqUrOYVmQRSGiMkT/QkTcoP2QFAwiRS5JymHq7BFRgpzT
+        KGMFdP/AskyShF7iEEEhLhgnEH2RQFzBMDHs39A9FEUkSVQWiATBliIriO+QOPTuiFLBC5WCd5FN
+        S/P5YM3xLEkliZlU6SUjCmJnRRBQAhHgExtVQSOW0+IChFllDMHLVB2QBVWJkASmiIDMVEE0QTOS
+        03kadlsCxiLLxFKS44wWFNj6qJWzInEhckJJkDF6QY6TAs4AOZUEgnkCXDwtuk8LIeUj8rZYJJTT
+        OTsAQoUo5wn0kkma50yLDFroyAuq8H0JxsmKDJnSjAnkjcgFCxUNS2CAhABfIU8XKMn5kjGVMuyw
+        Uz1vM9BLQeiSFlFnmZq5BBNJ5xzAhxxUwFfkA7RqejMImdILcSkvViBoXoZJJxOX4BolTBIjdVyG
+        CkyITH/5JcPxwgQaxbygi2RF5iVoiSsGs5GAGm4x24c4UxTUyGRyQLJ00ZE5NMCIBzDjhbYZEBHn
+        L0XDg9nZaDmGc9JOidsEwfaARpikDKUIBLANaw/GSEMtMEgEsxCmMLYsQ9iapJENDSdFW+BUWxaH
+        EasjsUSm9KFAG0ygTxOyS17Xlqs7v8vAlX2AodB+P2gLz8EOYeIKPaVnYgWdT2kl2ExbIFgILAeW
+        Iq9qKQjOXorzhNNnTBWGlqBula3QOAJcP5eI39CFfqtW9gOtmMTF96dlocnpdgN6sMsJHJLnIotS
+        PPHqZak7kQ7hAg5NgMRyxFJC6IHMF4ETKkzbrSia7wPysQQ9oQqKdJ4oQnPcbPVEg6PcQ4wPCTiR
+        Y8rJC+DzpzuF4Sscl6xECSZ2wR6SQ6mZJWAYCo/cj6RejmJJwMV092MA1kIkgIH53QzMrrlDNB8w
+        Tske7kOLqupUPn4iyQseZmXEojup6hsFleASQsk528tCngsBPkCQV1ws76IAPgOdyUPyBqYDfD8S
+        hCnEKdX/yj3onZepouA/yTNYFcdJmkUQyd1F+LzEdaKtCMwfPZv26WhRFFYXy2GHA4PFJbQvH8d4
+        CZBlxtDfiSwNVzdwcSpgwcUlRBAEWGZX4C9hRwcLuqRppkWhsYIVu9CnT1nZc01yvRPj/lvtxehB
+        xdTsQKxGMMAKI2dRSiEMpTq8hygZti01jZzllbvse2WQR+lVN8xEGcGOxFWXMzWxNM4k5RDvgL7w
+        RL0ANwUxUJFNE6UW8rFl3TqEJeH0zCKrwQOEu2IBQa417sMT2m4Q21HPZXE/sj02ilnsBnQ4tMdR
+        bLt9l1GnH3Y/LuYQFO3kY8IphEa4d0kQDoTX3xPcmKe/Knk94uTbUMVORchysQDnKH3kp7oubULa
+        CNV12RZsYrXM5Vu1nSGDx3ZH4cDz4uE4ciizHdcZh+Oe27NHAyeKHW8QjPrxHrYDYd2nku1vOfcm
+        /hUt5968/AYs5wv05WtMqzeGZ+gybzQcDyksurEz9HrBsB/R/timbBCPYjpg7mjQu9t88BYRPC3e
+        SvB9behz+fh6lvS5HO1hT9et5RszqC9agR6Dx7bduOcFHqXBIHb7vTAassGoPw7Aebu9aES92BkG
+        e9jSJzj47O+J7k37K3qie/PyO/VE7Er5ikllW3+SK6lY7m8gKEgGZ7U9DKXCvNNU9if3FWxjf+K/
+        ezcSj+GhFCI+iAPd4TDs2/1oOApCz7GHYWgPPTeKR+6AhqO7rUMVKYL8GA71ezuTe3PwFZ3JvXn5
+        DTiTb9B8RHm3g/luPt+G+Xx57GczeHqeF7nxeBBEdi+gdBjEUa8Hf0MajO1wFA9CFvXd/W1I8L09
+        0Oey8dWD4ntz9FvYzb5cbSEAaC9yvdGYjsbuyPYcF04UEBmGLBzR8ag38Hq9kW2P+/vbk1qKe9rT
+        vdn46vZ0b47+w/ZkFDt48ayTmzxIJ9B5kI7s8HXipYNhnFX3NzqrqvkUVaWcZjr4aIFqhDKIqKJW
+        /a0wpddMMhpA3bpaQLyboui+SoG0WqNhS4VVLjDR52epVK3E5cmOxGU0ffNXuwm3dowxZwLTr6AU
+        vNJVZcSmntP1euOB4/SHE2sNnWAiwLx27K5jD2zHG/QAYQ2eWJvBEip9LjDLH0u9p7QAWNOG9wks
+        WhezVZ+6DqoweVSTDXZ6VSlUC6ormXbgbUMneJvvR2xBC6zR05lmzc8ueIVcZXEaaDXEIKAMosjx
+        Htywfw06wUoNU8Z47JwRd3YKy60GTUwFhKxftDZ0nWf1jXS3QBWqT0uViGI6SxiZgXhAu91Q4wUi
+        Wk2PKcccEyaN85zp1K3JiC0J45hafbjurvHrzo1ag5IdEGeoEnIqLtcVGN66W6PwoAlpVgp4juMM
+        2x02BQMVNKN8PmV8jaW/60ZRpJhZzNAbWGsoTq6h7Nhd2yaHb9a9N00t5CTJcymxFEUXOexo2qCr
+        jE3f8zyVEtMUDxvY2DLBmgS/0NdhWIbU/KxRb5zc2t5vmV3MypLDLFsUTN4+w5jxqhJyDzEtSoBl
+        1mG8I8P/+zdnmADVOXqaHeicTyv5DI0mgx6XVbNUolhVnXiKFQdcVTl/IVmdIup2ScpDcP0p6KZL
+        XjzCGgVGgnKFGTTjumSVu63tjc5pyvVQ+u1Ou8Mal94I7O6wnGPyCgzJvY/VufaoN/pvtDpYs48U
+        mTN1bYnex/astYupqn/rmmv/Ip/aWPW5Az7BmdJuzLhOs4+2YRMJO2TITMXN+pID0BrgGsdUa18p
+        VuikPSCSI9xSwQg2PYzGGh8+VorAQDxO53v1bnWoR2L8U5kWKZM+y2maTc21jPwLqAkXleiGoot1
+        bjeg18OgzwYboFFUTDH/ysjQOyA/p1jhl1KsWwjBQWKmeonZ4HNVMKYOyBHLYixwOJo5PeI9+/ua
+        TnO8mkZ1Y2Qqp2uVrnu0WusuStdKhVPMBIMf0dl5VBBuvUTwbNV9AM4AGwpGzBYAOtSbvymMoHxF
+        wMmwfAEAJdYZWJKilkyxjlm81e0VWaZmlYcm+1uVtWC9BowPjqK75rhmDiy1KEPcXKMqhxs2Mseg
+        CswcV1HvjpxyHf1e0qxkFtYr7urd2JkRu67aaHWefmvFGrostdR1bmv252A/EA/6F1wsK2GaBQY3
+        CHSfuoIN1TYt2NgL4zU0ibfV5w0Uvxe9fS96+1709l9e9LZxBZvFjz8QwVNTxBTsgLJy2doHvDNN
+        pGoi2AQHnVsc7ZEQFyRYkb6NIRwMnWmxGkekapNxbPKyBE47+FbFeijEAnTDgXsYBynHYCzgV9bx
+        5C5Rdgsgq6opHwj7YVU1Vcm1s6LqBom+oJBqw+INzCxhGSC/plytYu6mYrYb+Lu9hm3DwjatZcK4
+        Dx7DT/25WJNuFg3etJd+fq1gk5sWdf2rPj8SW8w0CghvYGa/usEW3SYh61qo0jidtX/EsKthAoFV
+        yUxUdwYHJTgmwzZ8qKFIPSiIpV3QC4neUJmq0jXU/B6xBXr/CnjdDFoR0NH1+eHT1ydn5x9OXr8+
+        r5FM2G3edUDdVkaNZmJt867FnJ0d/nzyukW59XEKvgrjyve45cxhY+LRY9gS5iwjfzgFFwNa5DD5
+        nP3x7jHOYFE+1r8agX0St72tIdBZ6aFvGYuQWYnoLIawqtShleEG790w8NAOWw+uwzBBI9xo9ckX
+        oQgwJ9NzRV6KhFcRe5dsTxt6Ue1w6mBO+3z8rIoPCQ2QA7AJkjP4hvBELHmrT7fWuzGpyzRiYHBx
+        YQy48eVvbrRb4IThMNM+XrjsatjCxovu5XLZhRWpyoDBESff7qfvwlsgcweKVzuR9dx5uTj56/P0
+        lwt3q6O59myBrmeNbmm+pWt1X3sbQrs3HMh97Tfqa/T1dfWW8HdKdX2kGyj9WnR2UlmmESjXxdvL
+        HfA2sL7CXV/ltn9R/v+e+0Ywjj4AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:34 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3898']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:42 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_extra_info /><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_video_iframe
-      /><request_reviews /><request_cost_range /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><request_source_info
-      /><mime_text_type>html</mime_text_type></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['903']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1b63LbNhb+n6dAujPtj9oiKVG3hlXXtZ1sNmmS2s5ms384IAmKjEhCBkAr6uvs
-        m+yT7TkASZGSfMsm07TrjCYmDz6cO248pPfTxzwjV0zIlBc/fuP07G8IK0IepcX8x2/eXjw9nHzz
-        0+yRx65YoXzJqAgTXzBZZmrmyTKIeE7Twi8lE34q/YBGszWTnrW/yQvFeqm4H2Q8XMze+oeHV4tl
-        PF0cT5dvh6+Dw7ngceSoZ6vw1Zv3HwYslB8GJ++d0YdfF6/t9++Kk6v84kUijwZL/+Pby/HZy6fr
-        k3B4eBY58ejFZVy+f345P3oqX58Vq/UltS+c0WtX+Cf54OXz01/Xl+L0w+Vkmon+m+fFdHCyWM2z
-        957V0cmLUqloETLpU8H8K5ql0azgnrWPbrwy84BCffAZm52+86zNnWmImAxnp+Di9SphglUATfWC
-        dF4ukVvJZo5te1ab4IWpWhtOGS8iXhyWC1C3IZp2zeilbq8aDeswo1JWfwxeJYwqVKBFq9p1l4tu
-        u2EDkdNhNOx0bLskr0qKBVvXEiyI/4aIaVJB654NpcNvg9vDcpFGcj9bY0jV3qFtINqWpzRPs3UL
-        ZCy0NnKt2mlcKl/QYg48AgbXOiA+j2MmIKqB5FmpmC/pFQyTmTPoQeS2qV5cZhnokQdpwaLZsI+g
-        Ls1AwCa1FGnIZu64wWyIFagEu6kAhYYbTEPztGYbxoMpgraIFWjDeTDcoFryKkLD3G2hNhKXTISQ
-        /HTeGNwfetYuFVJ6x4E5/bita4ekAab/g88/yee7DtSULTW6NAPpqtAleTmO+to2xyDapAoA8b4m
-        bO4douZMbo9aC3N91Ow7RM1x7xK1NuqGqNl3jVr/mqhteQ/vt5Xo0gykq0CX5BXcl8A+Y9J/mNYe
-        prU/tM8fprWHaa0Sf1nSQuFuly8VHF1g06b35H5NnzmetUXZRvRvRQxuRbi3Ioa3Ika7CGvXPD1v
-        +2EpBJzPAFJfma3uPFjC7rVD2iBiGiouzAFjm7hBFWUeQHgm/VELVRE3qGVG4RCEvtsmtTAYbLnO
-        A55ZbTIcnAx19p9/t/tv6J61babiS18nxcOU+UlT5o7/rGs2BA8D6mFAPQyoTxlQ7VEU8rJQokoY
-        /bimTWia9ZOHt0WqWEReAN+I5xto9fxGpCoNfcGuUrbyK02qlNvb5EUUwmXCzYqouq+e7JQHxJmo
-        hByV81Iq0rcdSMoNwGBLFaJRkqnZYISCtqkbmGQhLyIJq/fYGbpDu4OuGw18Df/yPIpmKNSeOJMK
-        2dC9VPLJyHZ8TaZF5Ks0Zxp+aE8OncmFM/1hYP9g29/bzg8oaX+Hiu+2B8y9VFSoHZ/0HXDGEYQz
-        +5wuGTn90cC9s0vcvnMvl7iHfedTXFK5wDzK1fn46u3F8dnR8YvTM89qkSuIdsMvVKmErcjPvBQF
-        +06SV2COoOGCicd1J+Mvc51Gs9Hzp3VL85DUT4uYz77N1JMovfp2rp50+X5L8+WTvwymTySRqiwK
-        GBJkKXhUhjhZEx63xRLBFHSSJC0gavaEKE7OaZQx0WLzjmWZJIketSQQfMEKQrOMBPwjsIth/AKb
-        kItIkqgUCMoo5MKa0TYXCVwOeanggkpe9NCAQBALLXjUublIUkliOBOmV4woAfMPQQJMbKg9NipB
-        I5ZTsQAT1xlD8ipVB2RJVcIlgZgR87AzDWlGcjpPw17H7JhnGV9JcpxRQVtKftAuXJNY8JxQEmSM
-        LshxIlKpcirJKSgE2pyI3ongUjYdyWuxTGgBk9sBCBa8nCfQWyZpnjPtEPDRoVxQhdcryF4mMlRS
-        K8pRVyKXLFQ0LEEhEgJ9jTou0LLzFWMqZdjhBqe9zsBbgtAVFdHhKjVxh2xK5wWQjwpwTLEm76BV
-        S72A2Tpd8Cu5WLfMz8swOcz4FUylEgLKSL1EoHsTItPffsuQb5hAI58LukzWZF6CDwvFIFYJOOfa
-        bGz7H2JIwclMJgckS5eHMocG4HwA2SF0noHhGOUUkxZiuIlBTAW7wQ9d8ZC1IClMUoY2BRyMgIEL
-        nNJQuwHsgwiFKUiQZQg7BWksxSRLMW8KqrOwAI5VZUeiavrhtk6uAEYCU7JHXtY5rzu/ySh4G1hh
-        xr/TYyOHnIWgCh3uM76Gzq9oZV5VLzjAgcRS1FWtOMGYphg9DKpJa2AtwfkqW2PiBDjyrhCvPWJV
-        E8Ij7ZLExet3CYzWY1qQ5+QZ/0mjTMOj1gxyVKxxjiNrXkI4FuwxOZIk4xAGcJ/CUksrjpjYfEVg
-        CPdukgrZc8JvlIqXS7y4qCed7+rJBl0MAZTsse67rOH7ZVHVUu95EWZlxKLrpOrykUowx9Dcgt3g
-        vGecw1Dh5EXBV9ewgxGFQ+0x+QX8DLMocicqnSfK/C+vZX5eporCDEOeQk4cJ2kWwbbyGinnJSbH
-        B9xvQMxxkOtJDzOJQkqxHNYFyCTMmz1CmyUEF45qEcFxzDd1rDaxQuQsSilsnqje5cNmGaZWNdPU
-        HoyfBWQ9jJUw6YW449KNXlrA6gy64t5yCeMCVmyRzRKllvIHy9rf15KwcWSR1ZIK2zK+hM2YNR3A
-        L7TdILajvsviQWQP2SRmsRvQ8dieRrHtDlxGnUHY+7Ccw9q9VwGvoLCC4wwqwRwwV997uFzMPqt4
-        zdH7nX2w1wOyXC5h3pA+KqLLsF1KFyDr0nOH5lmdzPh60mTM4Ge7k3A0HMbjaeRQZjuuMw2nfbdv
-        T0ZOFDvDUTAZxHdIE9hXXJbs7klyb+FfIknurcT/X5IMGfxs2437w2BIaTCK3UE/jMZsNBlMAxhI
-        bj+a0GHsjIPbk0Rewq7n7jlyb9lfIkfurcTXkCORs/rorgbDMsij9GMvzHgZwe68UL2CqdtTBRx1
-        I4d9/mIfla/g+GFb38u1VCz3NxQ0JIM92R0ypELemiN3F3d7UnxBW++QDLuh/mPPGPEUfpTCQgvL
-        rzsehwN7EI0nQTh07HEY2uOhG8UTd0TDye35AIdRJPkxbNfvPG/cW4MvMW/cW4mvYd74M2QKnIAe
-        MuXPuMJU/vI10poO4RdMw8Cl00lMx8HQcQPXHbn2dEztyTgOgnEwdpwwpHdPHjgM3jV3PlWNL7Ac
-        /Y8afRVr1O+eT/0h/OzRMJqGo4j2w9Fo7AymcD8eUzdy3cFoOgqd4TQa3COfVCLufib6VEW+eEbd
-        W6OvIqP+BGuZWvGHpewzLmVSUVXKWaY3kx1SDSiDiCpq1fcKyzbtepIh1K3rJZxYUlTdN15qYNhS
-        ocolFnH8LJWqU6M63VOjuq52BfQXb9t0aw/vOeNYfQNrM6pSVUZsNnR6Q89qbj18Om0uD+2eg00N
-        wbM2/RMq/YJjYTeW2v8dAr5Fj/VtFjWvz1e3+lU3Ycpnpv7n9Ku33TpU/XrVHtw21cPnzH7EllQo
-        TBOsJWp99tErcCl0eaAFqykGgDZwkeOnFEb9HaqHbzuYrymOnTPiXryCwVKTPFP0lvWF9ob+xKS6
-        R7lbpArq01IlXOBnDuQCzAPZ3YYaF/BoPTumRcGVrhHmOdO1OVPGWBFWYK3scdNd4+vOrQJzyQ6I
-        M1YJecWvGL71gTXmYdOtVWpuU9q14aHjOONuh02JuKJmtJjPWNGg9H3dyEWK5aAMB7bVUDG4RvKw
-        15+SN780nTctHWyS5LmUM2fcn2KRfE/TBq4yNntb5KmUWCd43EJji4dFaF/ooiK+ydO+raHNxeZL
-        kPrrG3+Rm7cB99A9DI7OJJO9Zlrq0jwJxxOA01jh+x8UX4JiOU2zWVhKxXMmdCkvZPKvoJFgUnKY
-        c3v4Ise1PWueOj+bBxFNh+pLFHNjEgPaybl+cEH+xQRvoMbxrRsfS7rAoYjT+c3dOsiaBSsuy1Sk
-        97Zxu1/NLy3A9qIq//kx/Tj73nUhqQfEGYzHrtNvOOwi9/NYJrDl73Lp29dwMdiaT8bDirO9T4FN
-        c7eDYWLvk9YG1J1w3gEijSIxw9IXI+PhAflHim96pRQLpiEMciz/rbDqdq5gv6kOyM8si7Gy+vOF
-        0yfDp/9sZLT51TKqR1jm06M6f5oenda6i9JveIQzLMLBTKcLnpgduHwQXmTr3iOY5bBBMGKmMZoR
-        vWaZiiwt1oQqYLwEguJkqd+Egg5gYi7NmwRmwqsep5FVii9PMCzzh2BuVV3HQjHwh2TqNRrXysFQ
-        F2WIC0RUFfHQbIZm6D3Vkbmrd1jmm7emvHrGJQuwLHkEWuNM+lxioU/x4oCYr902RVb9uh9+MGc1
-        EuYQDtgt+IuCryp57bpoR6iFi28HD/O1MDORhr2ubnd6bXD4RhiumxFTMGJkZbCGvzFNpGoi2ARL
-        HWb1DsP9bGRVdPWhox9WRdeK+96C7A7fazisEqpQiCk+VxyvK03vMN3uvUpY4UN++Kk/5w2zdiV/
-        D4tOF/2BpB/xLQ6tqvw12XK3YvwmT7YEWTupqpPOjNN9xf/7ZOdWVbvFuZKiV4jzo5OXp2fn705f
-        vjyvQWbpMNd6bejaWMPMsmGum9estGhScSWaLXl+To7Im5dHx6cdn2w6eldpBLvQNBbGya07f3O8
-        65AThrX72QA3NvsattB4+FutVr01zBxlwMyRcBfS7WUOX7iFiqxnzt+Xp397lv62cLc6mgNVh7R7
-        krmh+Yau1RnnJkC3N2y3fJ3b9TGzOdRtGX+rVbucrpH0ueTslbJKI3CuXi330LvE+nTUnJK6X43/
-        F5UfhalyPgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3543']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:34 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/ReviewTests.test_time_is_datetime_time.yaml
+++ b/tests/interface_objects/cassettes/ReviewTests.test_time_is_datetime_time.yaml
@@ -1,137 +1,114 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF92aWRlb19pZnJhbWUgLz48
+      cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNj
+      YXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21l
+      ZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9m
+      b3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlh
+      PnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVx
+      dWVzdF9tZWRpYT48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHJlcXVlc3RfcmV2aWV3cyAvPjxyZXF1
+      ZXN0X2N1c3RvbV9maWVsZHMgLz48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxtaW1lX3RleHRfdHlw
+      ZT5odG1sPC9taW1lX3RleHRfdHlwZT48cmVxdWVzdF9tZXRhX2NvbXBvbmVudHMgLz48cmVxdWVz
+      dF9leHRyYV9pbmZvIC8+PHJlcXVlc3Rfc291cmNlX2luZm8gLz48cmVxdWVzdF9jb3N0X3Jhbmdl
+      IC8+PC9ldmVudF9zZWFyY2g+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['759']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+077XbbuLH/8xTI3nM27aklkhKpj0TV1nacNF9Oaiubtn94QBIUGZOAQoCWta/T
+        P32Oe1/szgCkRMqyLSebnnQ3OUxCDgaYDwwGA8xo8tNVnpFLVshU8D//4HTtHwjjoYhSPv/zD+9n
+        zzqjH36aPpiwS8aVLxktwsQvmCwzNZ3IMohETlPul5IVfir9gEZTLibW7pZJWKwWSvhBJsKLaeh3
+        OoNOID9+ePsxO5sXrCOfBi/Pxm+PwniUvBpcfTo/jZ+r0/N3R++CgZPZq8M0WDybzdVR8Cn4RzgY
+        HZfe66N3NHl//u5s7B/Lv//8zyv5izwvnw5mvYXb48EiOFu+/NvRy5OX/7x67q6OL5KkR9N4nPUj
+        L14FyRvvb96b08xeHLmdf0ysFn+TKJWK8pBJnxbMv6RZaoTbBTcKmk4AQn1QH5uefJhYmy/TEDEZ
+        Tk9A26tlwgpWIWjoJEzVyuBmgkeCd8oLYGgNNO0a9bVurxqrzhmVsvrP4NNCSUDZAKpGjX8IjeRH
+        mi+e/E9/9IQcw2yWyE4DZQJzpifQDL1iMFobNKms4YKtNDULpn0DQeOo8Opua0hrsA3e9ngRKnn3
+        oEakGqEF3OBoOY5oljFlhCVPtzoYSa0NC1atSCGVX1A+h/FyegUj50HKWTT1el17YrVAGgGYVIsi
+        DdnUHdYYG5hBKUEMWsCQ3hpjDZrkqNd6yJ6jMZogjbAZ0RnVGE0qWp31kP01xoYKF76ElZ0xVNZv
+        U8RPJeUKV4ZYKPBpMJl6hfo1fOpMrC3INkbvToz+nRjunRjenRiD6xjWdfH0HPphWRTguAGlfjPL
+        YR4swKpboA1GTEMliqlj2w2cCrjB4mUesGI66g0aWBVwg7XIKLhE1N02qIGDNidXeSAyqwkGN2qg
+        0//9V7P/Bj6xtsW0brDl7/P/O5n/5qSHouSqqOTTG2cTsG7W/v49TxWLyCuwHYhRNqjVTlqkKg0h
+        xLlM2dJfsCLEfd1oaGfTJKKKGT58xqPqWw82S8oD4khFztlCMdQX6dkOaHGDYrBLFfoijiVT0/4A
+        SW1DN2iShbD9y6njDntDz21j140GfQV/8jwCXwtE7bHtVJhrOOzMYjSwHV+DKY98leZMo3fsccd2
+        Zs74cd9+bNt/sp3HSGl3h2rcbR2Yb4iVCnVNK55KyBu6+jX1Mei5w769tz4827uXPjx4Pkcflfwm
+        gNbmePp+dnx2ePzq5GxiNcAVilbDG6pUwpbkSJQFZ48kOQVxChpegAnNTs5ndUejM/MOUejgxbO6
+        ZR2T+imPxfTHTD2J0ssf5+oJvi7w5RoRqUrOYVmQRSGiMkT/QkTcoP2QFAwiRS5JymHq7BFRgpzT
+        KGMFdP/AskyShF7iEEEhLhgnEH2RQFzBMDHs39A9FEUkSVQWiATBliIriO+QOPTuiFLBC5WCd5FN
+        S/P5YM3xLEkliZlU6SUjCmJnRRBQAhHgExtVQSOW0+IChFllDMHLVB2QBVWJkASmiIDMVEE0QTOS
+        03kadlsCxiLLxFKS44wWFNj6qJWzInEhckJJkDF6QY6TAs4AOZUEgnkCXDwtuk8LIeUj8rZYJJTT
+        OTsAQoUo5wn0kkma50yLDFroyAuq8H0JxsmKDJnSjAnkjcgFCxUNS2CAhABfIU8XKMn5kjGVMuyw
+        Uz1vM9BLQeiSFlFnmZq5BBNJ5xzAhxxUwFfkA7RqejMImdILcSkvViBoXoZJJxOX4BolTBIjdVyG
+        CkyITH/5JcPxwgQaxbygi2RF5iVoiSsGs5GAGm4x24c4UxTUyGRyQLJ00ZE5NMCIBzDjhbYZEBHn
+        L0XDg9nZaDmGc9JOidsEwfaARpikDKUIBLANaw/GSEMtMEgEsxCmMLYsQ9iapJENDSdFW+BUWxaH
+        EasjsUSm9KFAG0ygTxOyS17Xlqs7v8vAlX2AodB+P2gLz8EOYeIKPaVnYgWdT2kl2ExbIFgILAeW
+        Iq9qKQjOXorzhNNnTBWGlqBula3QOAJcP5eI39CFfqtW9gOtmMTF96dlocnpdgN6sMsJHJLnIotS
+        PPHqZak7kQ7hAg5NgMRyxFJC6IHMF4ETKkzbrSia7wPysQQ9oQqKdJ4oQnPcbPVEg6PcQ4wPCTiR
+        Y8rJC+DzpzuF4Sscl6xECSZ2wR6SQ6mZJWAYCo/cj6RejmJJwMV092MA1kIkgIH53QzMrrlDNB8w
+        Tske7kOLqupUPn4iyQseZmXEojup6hsFleASQsk528tCngsBPkCQV1ws76IAPgOdyUPyBqYDfD8S
+        hCnEKdX/yj3onZepouA/yTNYFcdJmkUQyd1F+LzEdaKtCMwfPZv26WhRFFYXy2GHA4PFJbQvH8d4
+        CZBlxtDfiSwNVzdwcSpgwcUlRBAEWGZX4C9hRwcLuqRppkWhsYIVu9CnT1nZc01yvRPj/lvtxehB
+        xdTsQKxGMMAKI2dRSiEMpTq8hygZti01jZzllbvse2WQR+lVN8xEGcGOxFWXMzWxNM4k5RDvgL7w
+        RL0ANwUxUJFNE6UW8rFl3TqEJeH0zCKrwQOEu2IBQa417sMT2m4Q21HPZXE/sj02ilnsBnQ4tMdR
+        bLt9l1GnH3Y/LuYQFO3kY8IphEa4d0kQDoTX3xPcmKe/Knk94uTbUMVORchysQDnKH3kp7oubULa
+        CNV12RZsYrXM5Vu1nSGDx3ZH4cDz4uE4ciizHdcZh+Oe27NHAyeKHW8QjPrxHrYDYd2nku1vOfcm
+        /hUt5968/AYs5wv05WtMqzeGZ+gybzQcDyksurEz9HrBsB/R/timbBCPYjpg7mjQu9t88BYRPC3e
+        SvB9behz+fh6lvS5HO1hT9et5RszqC9agR6Dx7bduOcFHqXBIHb7vTAassGoPw7Aebu9aES92BkG
+        e9jSJzj47O+J7k37K3qie/PyO/VE7Er5ikllW3+SK6lY7m8gKEgGZ7U9DKXCvNNU9if3FWxjf+K/
+        ezcSj+GhFCI+iAPd4TDs2/1oOApCz7GHYWgPPTeKR+6AhqO7rUMVKYL8GA71ezuTe3PwFZ3JvXn5
+        DTiTb9B8RHm3g/luPt+G+Xx57GczeHqeF7nxeBBEdi+gdBjEUa8Hf0MajO1wFA9CFvXd/W1I8L09
+        0Oey8dWD4ntz9FvYzb5cbSEAaC9yvdGYjsbuyPYcF04UEBmGLBzR8ag38Hq9kW2P+/vbk1qKe9rT
+        vdn46vZ0b47+w/ZkFDt48ayTmzxIJ9B5kI7s8HXipYNhnFX3NzqrqvkUVaWcZjr4aIFqhDKIqKJW
+        /a0wpddMMhpA3bpaQLyboui+SoG0WqNhS4VVLjDR52epVK3E5cmOxGU0ffNXuwm3dowxZwLTr6AU
+        vNJVZcSmntP1euOB4/SHE2sNnWAiwLx27K5jD2zHG/QAYQ2eWJvBEip9LjDLH0u9p7QAWNOG9wks
+        WhezVZ+6DqoweVSTDXZ6VSlUC6ormXbgbUMneJvvR2xBC6zR05lmzc8ueIVcZXEaaDXEIKAMosjx
+        Htywfw06wUoNU8Z47JwRd3YKy60GTUwFhKxftDZ0nWf1jXS3QBWqT0uViGI6SxiZgXhAu91Q4wUi
+        Wk2PKcccEyaN85zp1K3JiC0J45hafbjurvHrzo1ag5IdEGeoEnIqLtcVGN66W6PwoAlpVgp4juMM
+        2x02BQMVNKN8PmV8jaW/60ZRpJhZzNAbWGsoTq6h7Nhd2yaHb9a9N00t5CTJcymxFEUXOexo2qCr
+        jE3f8zyVEtMUDxvY2DLBmgS/0NdhWIbU/KxRb5zc2t5vmV3MypLDLFsUTN4+w5jxqhJyDzEtSoBl
+        1mG8I8P/+zdnmADVOXqaHeicTyv5DI0mgx6XVbNUolhVnXiKFQdcVTl/IVmdIup2ScpDcP0p6KZL
+        XjzCGgVGgnKFGTTjumSVu63tjc5pyvVQ+u1Ou8Mal94I7O6wnGPyCgzJvY/VufaoN/pvtDpYs48U
+        mTN1bYnex/astYupqn/rmmv/Ip/aWPW5Az7BmdJuzLhOs4+2YRMJO2TITMXN+pID0BrgGsdUa18p
+        VuikPSCSI9xSwQg2PYzGGh8+VorAQDxO53v1bnWoR2L8U5kWKZM+y2maTc21jPwLqAkXleiGoot1
+        bjeg18OgzwYboFFUTDH/ysjQOyA/p1jhl1KsWwjBQWKmeonZ4HNVMKYOyBHLYixwOJo5PeI9+/ua
+        TnO8mkZ1Y2Qqp2uVrnu0WusuStdKhVPMBIMf0dl5VBBuvUTwbNV9AM4AGwpGzBYAOtSbvymMoHxF
+        wMmwfAEAJdYZWJKilkyxjlm81e0VWaZmlYcm+1uVtWC9BowPjqK75rhmDiy1KEPcXKMqhxs2Mseg
+        CswcV1HvjpxyHf1e0qxkFtYr7urd2JkRu67aaHWefmvFGrostdR1bmv252A/EA/6F1wsK2GaBQY3
+        CHSfuoIN1TYt2NgL4zU0ibfV5w0Uvxe9fS96+1709l9e9LZxBZvFjz8QwVNTxBTsgLJy2doHvDNN
+        pGoi2AQHnVsc7ZEQFyRYkb6NIRwMnWmxGkekapNxbPKyBE47+FbFeijEAnTDgXsYBynHYCzgV9bx
+        5C5Rdgsgq6opHwj7YVU1Vcm1s6LqBom+oJBqw+INzCxhGSC/plytYu6mYrYb+Lu9hm3DwjatZcK4
+        Dx7DT/25WJNuFg3etJd+fq1gk5sWdf2rPj8SW8w0CghvYGa/usEW3SYh61qo0jidtX/EsKthAoFV
+        yUxUdwYHJTgmwzZ8qKFIPSiIpV3QC4neUJmq0jXU/B6xBXr/CnjdDFoR0NH1+eHT1ydn5x9OXr8+
+        r5FM2G3edUDdVkaNZmJt867FnJ0d/nzyukW59XEKvgrjyve45cxhY+LRY9gS5iwjfzgFFwNa5DD5
+        nP3x7jHOYFE+1r8agX0St72tIdBZ6aFvGYuQWYnoLIawqtShleEG790w8NAOWw+uwzBBI9xo9ckX
+        oQgwJ9NzRV6KhFcRe5dsTxt6Ue1w6mBO+3z8rIoPCQ2QA7AJkjP4hvBELHmrT7fWuzGpyzRiYHBx
+        YQy48eVvbrRb4IThMNM+XrjsatjCxovu5XLZhRWpyoDBESff7qfvwlsgcweKVzuR9dx5uTj56/P0
+        lwt3q6O59myBrmeNbmm+pWt1X3sbQrs3HMh97Tfqa/T1dfWW8HdKdX2kGyj9WnR2UlmmESjXxdvL
+        HfA2sL7CXV/ltn9R/v+e+0Ywjj4AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:34 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3898']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:43 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_extra_info /><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_video_iframe
-      /><request_reviews /><request_cost_range /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><request_source_info
-      /><mime_text_type>html</mime_text_type></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['903']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1b63LbNhb+n6dAujPtj9oiKVG3hlXXtZ1sNmmS2s5ms384IAmKjEhCBkAr6uvs
-        m+yT7TkASZGSfMsm07TrjCYmDz6cO248pPfTxzwjV0zIlBc/fuP07G8IK0IepcX8x2/eXjw9nHzz
-        0+yRx65YoXzJqAgTXzBZZmrmyTKIeE7Twi8lE34q/YBGszWTnrW/yQvFeqm4H2Q8XMze+oeHV4tl
-        PF0cT5dvh6+Dw7ngceSoZ6vw1Zv3HwYslB8GJ++d0YdfF6/t9++Kk6v84kUijwZL/+Pby/HZy6fr
-        k3B4eBY58ejFZVy+f345P3oqX58Vq/UltS+c0WtX+Cf54OXz01/Xl+L0w+Vkmon+m+fFdHCyWM2z
-        957V0cmLUqloETLpU8H8K5ql0azgnrWPbrwy84BCffAZm52+86zNnWmImAxnp+Di9SphglUATfWC
-        dF4ukVvJZo5te1ab4IWpWhtOGS8iXhyWC1C3IZp2zeilbq8aDeswo1JWfwxeJYwqVKBFq9p1l4tu
-        u2EDkdNhNOx0bLskr0qKBVvXEiyI/4aIaVJB654NpcNvg9vDcpFGcj9bY0jV3qFtINqWpzRPs3UL
-        ZCy0NnKt2mlcKl/QYg48AgbXOiA+j2MmIKqB5FmpmC/pFQyTmTPoQeS2qV5cZhnokQdpwaLZsI+g
-        Ls1AwCa1FGnIZu64wWyIFagEu6kAhYYbTEPztGYbxoMpgraIFWjDeTDcoFryKkLD3G2hNhKXTISQ
-        /HTeGNwfetYuFVJ6x4E5/bita4ekAab/g88/yee7DtSULTW6NAPpqtAleTmO+to2xyDapAoA8b4m
-        bO4douZMbo9aC3N91Ow7RM1x7xK1NuqGqNl3jVr/mqhteQ/vt5Xo0gykq0CX5BXcl8A+Y9J/mNYe
-        prU/tM8fprWHaa0Sf1nSQuFuly8VHF1g06b35H5NnzmetUXZRvRvRQxuRbi3Ioa3Ika7CGvXPD1v
-        +2EpBJzPAFJfma3uPFjC7rVD2iBiGiouzAFjm7hBFWUeQHgm/VELVRE3qGVG4RCEvtsmtTAYbLnO
-        A55ZbTIcnAx19p9/t/tv6J61babiS18nxcOU+UlT5o7/rGs2BA8D6mFAPQyoTxlQ7VEU8rJQokoY
-        /bimTWia9ZOHt0WqWEReAN+I5xto9fxGpCoNfcGuUrbyK02qlNvb5EUUwmXCzYqouq+e7JQHxJmo
-        hByV81Iq0rcdSMoNwGBLFaJRkqnZYISCtqkbmGQhLyIJq/fYGbpDu4OuGw18Df/yPIpmKNSeOJMK
-        2dC9VPLJyHZ8TaZF5Ks0Zxp+aE8OncmFM/1hYP9g29/bzg8oaX+Hiu+2B8y9VFSoHZ/0HXDGEYQz
-        +5wuGTn90cC9s0vcvnMvl7iHfedTXFK5wDzK1fn46u3F8dnR8YvTM89qkSuIdsMvVKmErcjPvBQF
-        +06SV2COoOGCicd1J+Mvc51Gs9Hzp3VL85DUT4uYz77N1JMovfp2rp50+X5L8+WTvwymTySRqiwK
-        GBJkKXhUhjhZEx63xRLBFHSSJC0gavaEKE7OaZQx0WLzjmWZJIketSQQfMEKQrOMBPwjsIth/AKb
-        kItIkqgUCMoo5MKa0TYXCVwOeanggkpe9NCAQBALLXjUublIUkliOBOmV4woAfMPQQJMbKg9NipB
-        I5ZTsQAT1xlD8ipVB2RJVcIlgZgR87AzDWlGcjpPw17H7JhnGV9JcpxRQVtKftAuXJNY8JxQEmSM
-        LshxIlKpcirJKSgE2pyI3ongUjYdyWuxTGgBk9sBCBa8nCfQWyZpnjPtEPDRoVxQhdcryF4mMlRS
-        K8pRVyKXLFQ0LEEhEgJ9jTou0LLzFWMqZdjhBqe9zsBbgtAVFdHhKjVxh2xK5wWQjwpwTLEm76BV
-        S72A2Tpd8Cu5WLfMz8swOcz4FUylEgLKSL1EoHsTItPffsuQb5hAI58LukzWZF6CDwvFIFYJOOfa
-        bGz7H2JIwclMJgckS5eHMocG4HwA2SF0noHhGOUUkxZiuIlBTAW7wQ9d8ZC1IClMUoY2BRyMgIEL
-        nNJQuwHsgwiFKUiQZQg7BWksxSRLMW8KqrOwAI5VZUeiavrhtk6uAEYCU7JHXtY5rzu/ySh4G1hh
-        xr/TYyOHnIWgCh3uM76Gzq9oZV5VLzjAgcRS1FWtOMGYphg9DKpJa2AtwfkqW2PiBDjyrhCvPWJV
-        E8Ij7ZLExet3CYzWY1qQ5+QZ/0mjTMOj1gxyVKxxjiNrXkI4FuwxOZIk4xAGcJ/CUksrjpjYfEVg
-        CPdukgrZc8JvlIqXS7y4qCed7+rJBl0MAZTsse67rOH7ZVHVUu95EWZlxKLrpOrykUowx9Dcgt3g
-        vGecw1Dh5EXBV9ewgxGFQ+0x+QX8DLMocicqnSfK/C+vZX5eporCDEOeQk4cJ2kWwbbyGinnJSbH
-        B9xvQMxxkOtJDzOJQkqxHNYFyCTMmz1CmyUEF45qEcFxzDd1rDaxQuQsSilsnqje5cNmGaZWNdPU
-        HoyfBWQ9jJUw6YW449KNXlrA6gy64t5yCeMCVmyRzRKllvIHy9rf15KwcWSR1ZIK2zK+hM2YNR3A
-        L7TdILajvsviQWQP2SRmsRvQ8dieRrHtDlxGnUHY+7Ccw9q9VwGvoLCC4wwqwRwwV997uFzMPqt4
-        zdH7nX2w1wOyXC5h3pA+KqLLsF1KFyDr0nOH5lmdzPh60mTM4Ge7k3A0HMbjaeRQZjuuMw2nfbdv
-        T0ZOFDvDUTAZxHdIE9hXXJbs7klyb+FfIknurcT/X5IMGfxs2437w2BIaTCK3UE/jMZsNBlMAxhI
-        bj+a0GHsjIPbk0Rewq7n7jlyb9lfIkfurcTXkCORs/rorgbDMsij9GMvzHgZwe68UL2CqdtTBRx1
-        I4d9/mIfla/g+GFb38u1VCz3NxQ0JIM92R0ypELemiN3F3d7UnxBW++QDLuh/mPPGPEUfpTCQgvL
-        rzsehwN7EI0nQTh07HEY2uOhG8UTd0TDye35AIdRJPkxbNfvPG/cW4MvMW/cW4mvYd74M2QKnIAe
-        MuXPuMJU/vI10poO4RdMw8Cl00lMx8HQcQPXHbn2dEztyTgOgnEwdpwwpHdPHjgM3jV3PlWNL7Ac
-        /Y8afRVr1O+eT/0h/OzRMJqGo4j2w9Fo7AymcD8eUzdy3cFoOgqd4TQa3COfVCLufib6VEW+eEbd
-        W6OvIqP+BGuZWvGHpewzLmVSUVXKWaY3kx1SDSiDiCpq1fcKyzbtepIh1K3rJZxYUlTdN15qYNhS
-        ocolFnH8LJWqU6M63VOjuq52BfQXb9t0aw/vOeNYfQNrM6pSVUZsNnR6Q89qbj18Om0uD+2eg00N
-        wbM2/RMq/YJjYTeW2v8dAr5Fj/VtFjWvz1e3+lU3Ycpnpv7n9Ku33TpU/XrVHtw21cPnzH7EllQo
-        TBOsJWp99tErcCl0eaAFqykGgDZwkeOnFEb9HaqHbzuYrymOnTPiXryCwVKTPFP0lvWF9ob+xKS6
-        R7lbpArq01IlXOBnDuQCzAPZ3YYaF/BoPTumRcGVrhHmOdO1OVPGWBFWYK3scdNd4+vOrQJzyQ6I
-        M1YJecWvGL71gTXmYdOtVWpuU9q14aHjOONuh02JuKJmtJjPWNGg9H3dyEWK5aAMB7bVUDG4RvKw
-        15+SN780nTctHWyS5LmUM2fcn2KRfE/TBq4yNntb5KmUWCd43EJji4dFaF/ooiK+ydO+raHNxeZL
-        kPrrG3+Rm7cB99A9DI7OJJO9Zlrq0jwJxxOA01jh+x8UX4JiOU2zWVhKxXMmdCkvZPKvoJFgUnKY
-        c3v4Ise1PWueOj+bBxFNh+pLFHNjEgPaybl+cEH+xQRvoMbxrRsfS7rAoYjT+c3dOsiaBSsuy1Sk
-        97Zxu1/NLy3A9qIq//kx/Tj73nUhqQfEGYzHrtNvOOwi9/NYJrDl73Lp29dwMdiaT8bDirO9T4FN
-        c7eDYWLvk9YG1J1w3gEijSIxw9IXI+PhAflHim96pRQLpiEMciz/rbDqdq5gv6kOyM8si7Gy+vOF
-        0yfDp/9sZLT51TKqR1jm06M6f5oenda6i9JveIQzLMLBTKcLnpgduHwQXmTr3iOY5bBBMGKmMZoR
-        vWaZiiwt1oQqYLwEguJkqd+Egg5gYi7NmwRmwqsep5FVii9PMCzzh2BuVV3HQjHwh2TqNRrXysFQ
-        F2WIC0RUFfHQbIZm6D3Vkbmrd1jmm7emvHrGJQuwLHkEWuNM+lxioU/x4oCYr902RVb9uh9+MGc1
-        EuYQDtgt+IuCryp57bpoR6iFi28HD/O1MDORhr2ubnd6bXD4RhiumxFTMGJkZbCGvzFNpGoi2ARL
-        HWb1DsP9bGRVdPWhox9WRdeK+96C7A7fazisEqpQiCk+VxyvK03vMN3uvUpY4UN++Kk/5w2zdiV/
-        D4tOF/2BpB/xLQ6tqvw12XK3YvwmT7YEWTupqpPOjNN9xf/7ZOdWVbvFuZKiV4jzo5OXp2fn705f
-        vjyvQWbpMNd6bejaWMPMsmGum9estGhScSWaLXl+To7Im5dHx6cdn2w6eldpBLvQNBbGya07f3O8
-        65AThrX72QA3NvsattB4+FutVr01zBxlwMyRcBfS7WUOX7iFiqxnzt+Xp397lv62cLc6mgNVh7R7
-        krmh+Yau1RnnJkC3N2y3fJ3b9TGzOdRtGX+rVbucrpH0ueTslbJKI3CuXi330LvE+nTUnJK6X43/
-        F5UfhalyPgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3543']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:34 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/TicketTypeConcessionTests.test_blanket_discount_only.yaml
+++ b/tests/interface_objects/cassettes/TicketTypeConcessionTests.test_blanket_discount_only.yaml
@@ -1,411 +1,347 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:53 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:31 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:54 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:31 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:54 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:32 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGNyeXB0b19ibG9jaz5FMC0tRXhJNTJKUkNxLWdMRHN2eDR3blVa
+      elpTV1NZRHFxZXZKRkd2bDRwb0NpdkNxVVVmdlVMQVhnOWJwOVhnNi1jY0s1THRRSlN2Um1MZXZl
+      eGUxMzBpNXo1UWdFV3puMVdtRTJ5WHdnVnhkTm85U21KZmNlWHlZN0tNTnQ4enV5Vkp3OWFSWE9T
+      ajV5Rk5wLTB3QWR2MktCSHZwaDZjRnFST2NyejktNGxEaHV4MlhIYUFtMUY0U2JuZEoybXF3a1Jn
+      WjwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bm9fb2ZfdGlja2V0cz4xPC9u
+      b19vZl90aWNrZXRzPjxiYW5kX3Rva2VuPi0xLS1RMW16UTBaV0tTZWNaazl6NFdQN1pCSi1GazFR
+      bGpSTGVIODl4djlzQ1llOGJFZXYxM2hoRkhheXlfNllkVWJIQUd5d0VSNlNSeW5ZLUJlWGhUd3Ey
+      YWQtYzVoQXc4WmhLcEpubTNONjJLZnpNM3B5QnNtUC1Dd0NVSVktY2dzV3F2S1kxcS1CUUFfQ1N3
+      SmE4SFJjdGZ2WlFpSktYN3JGZGNGTHlwQzZjQ29DWGdPaF9vc3ZXY295UU1MWjd1SWlpYk9Sa1ly
+      NFV2dEl3el8xbWhvVzNQVVdmRGVnUzJzWkpzV0RpcU56bXJkZ243Tlg4cjlfZmFaRGhPSDdjOUpi
+      WjwvYmFuZF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkZXNwYXRjaF90b2tlbj5jXy0t
+      RnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJYaWgtWnkyeFNwU09EZEhh
+      SHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5OC1zaExzUlpJRW45TEJX
+      M1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tlbj48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['449']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS0HvDihIg7XFxZDKMgoBCj+Tv9Jf1kHg4Je
+        O4fKzLeqlauS2GfHCeLEOWcHJvPHxbYqEfADw3V+/0R8xj9VgKO6muEcfv+0EgdY89Mf7b8xmhGo
+        buhAyfUgYgaSD4LQgm0mCBXNtWXDkcIA+JIRSIqstR2Xqb62MCACDpon+0CW0DqgzW6YajHKDBoI
+        1DaLXis+68AHOSFFGdWAcca1XEdzHSw0mWoBZvaUOkntuTGfbMlBkP+V8WUfBohSALkx5XeQsfJ3
+        2fb+Xemh7YbJq5TMDNpUusPMbQyQp0eICYDsq7pkgjhdqYriUiBJ9HLebdodeXBW8J79abKjgtdO
+        s+3cCA9gwUn30ZUtC8B8o/2nCdlOq8UrVG9BTBLCz8OeHkIZuJvT+SvHgECrjFFaoaQoqPmp+AY0
+        VJRTkQHOkgd8NckRAscR8aWJ0WQIJF92DkACjpaPU2eiHv6rQgSwsgQeBLYC/AqJE3WmWlAydghV
+        yd3vAwDbVD1Z6hktaAFQUSoFbYJukI0a/ci+GTN6jP6zbU1rJ4viLZzImXccnbTbrOOElMKyo0nQ
+        sEFKx/AWhhMi0fqNwn/D8X/ixG/JSq8n5H6fY5CNA4iS40NUalCvTOX4Z8ajTtINCv/meNTw2nfF
+        o4b+/Jl45PtPe02WjvxK7Amd3pgVmGoJzilpGKYyhDo4V7pu6DvgH0GFR9vxZdVEKSSyS/E2MYtZ
+        9mxo7fpwcLMYt/4mWSjR3TZyJ8OkZ5TBnOHJUG9X0WTMztbFlHRdLMCc+7oYBAGs3uanU/LpaIcw
+        DNqWEd3d59CNgNqvDOXqbQxjD7QDw/YsgAKGnMPbvNSSs0IvAJaF3jSAD1tkP24RPU05vIxXX/g4
+        ADc5KLnNWDI0YIhiXiM+18hWnSCoBlO9owzq5ofsEcM/Ezg64VqdRIQ7zFQLZ7ocSI6b9IN9kKrN
+        A5B0U9QRUce5t9F8yNjyRfJDx0FHkeUNQaI9fEAZG3XdF7xnlHEA0FBGeCjfkDqkOZm+zys8J4e+
+        nGhoiXZDMkKyB9e3kzacvf4HlPHcAGbi2SOECi3yTPUO3SQCSTZM2JJpt/HP+F0jyjgT6G7aVffZ
+        dtLlnjAmQHmJ6KlzcEH5gnIycVeCb5xMty8Q+I5sVURErHSTRHa0SjEjq5/0UvCq478yMCixwnyt
+        Zac/YYXlhp1Mlky1ZMhJqfulrFnARzW8QakY3Gi5lOVXkIeIFt1wAzQkIMSv6JWtFkF/e68kPmrH
+        /2s6SfZ7rmulaZ7fHZ6wpCYsw05kOM280vArLZj4ZklKkyZ7O6yDz1FS5kBuCaTICAzFyhPtGcxY
+        RePKchB1p/yiuM6nFBDzsUQfyzP5f3Zwjc8UXplPmWoBZVZdt210nSFamY6VsWy9e46ofuxBV1Is
+        VzXbUwrDvHkNEtSBlVXalIXudWeTuhutBMPhuVlgkuo4UubOUbCgNrqQvd4RP9dbR77FLk5S5F35
+        2DT7K8FuGrQ+6jkreFUipdk5cUNLBc3x3pZ74tjXvL1lDYQmO5KPVmO6dq3RwWxQxHKCNa5DsS/W
+        pS0fen2bVcXTGIZDSu1btBoC1rBFZ4L7RmdPc7EAIHccWoK4PMCVt2GbEmsv+krUeANrsyX68/gw
+        P+v6ecguW+bUtg+z/uy9f9VDq7GmG5sWL0Flya3mZ3eh0YOr1j8tsV204eaDbp/g5pG55jcTjDxv
+        V9Pu+0ggllA4jKlOIOG0wq5rltPz9my0cFW18cZe6xam6ZFKBRNtAPvyXMPm516NdJeu4hIgNiPB
+        Hg1mKuQ9TtqO3ll8Rtgrj+pq/JEfnrjxmxWc1V7EwcF+KncGrLAJ3wMruA58F9DcdQ4243ptSvOD
+        3di3CfXisFAzzoPl5djvw+OkT485stsYyjVX0YQ3BXawXXLXLJ0vo1iyg1RSKj59HCtOS+e1pfhG
+        SuuqTaHqfUQYNfR99HUVF09ZGh8UD63+ABWMvaxC189vw09gwXLC5KrbbpL1EisHC5ZnySoI2mSJ
+        k0MlDhISKYhtxbWqZRipWIa2//uf8vwCL9AiGMFDXNCNAH8IS3JFQLLt7qViAo0U7wm6+0Dfh0rg
+        WiFqO4EcoTrPpO0ZRB8ftmI4qLdRrcR+HxYvk0a5019NxNILZaG/D7NvQA19+VUSzdRkXyuRcz34
+        yu7uQ+giHWyrOIadTKzVXY/jCx5zw8b727pPDh1BdLX94rR78whpEZIUy5HN96CGMm0VXTWcvcwI
+        +mw1WHuwhz2ObACbr8VU1xodD1YwkMddthlxTTpyur6+UehtxxjESmfKc9vOarzAj9aJXkP7PD5z
+        /MzpT8QemG0Wi94+gkGzZfqboOGdotp+PhiMdmezNbXOHe1AKFdlI7sxPFIm5UbWdGlSfJeXVq7W
+        s2EX7weqUbP2FuYd9dF4PN4u+ucBuSsFIdt1KQrJZbMcpez2iVQAKSfK1VyasgFKDSd7lJ4O9IWh
+        RE4Uz/MN1LOp2iO7sJTp6Fqiy/4BtOkn9t1QYmeXZ+m1/wcjk9WfJEeyYcmJwiFF/4Ax+SVHPhQ5
+        nQrPE8ikTiUlkdsseRHrCSpzkvSsPiCFsvryGU1woHEI3TDIbwgEuo6/NKR06ELZemKWMeY56KVQ
+        PwW4FNYXwXwMYbWo/D/dA0jiSz2gxw0n/a/0gJ5uWFoF3dLBj9Y/hup/MrPtKdcbqoPpZLVRjAO2
+        ssfieL2bAKTbI3vcXGMY2Y+3w51CBCJ+4PZCPzk6QG8miq0vunWjX9eIix7hsqGe4vCs26ap2dtA
+        wSSIBHl42I07kWVKFKcvWuxA1nbS25BerhoT1msK727Ei+PT6r0xmVDXQcvvXqh+h++1LrPNynwb
+        rsH1elI9aYdhX61l4gdqOTuYb61lovldtUx9by0/+/+rlu9BeVnL1JdqOZv3C2r5i3q+FFd9lv+a
+        oi+TnxMc+FPq2UT17GPxebJddlnWqznX/ZD2uzzRiHrWfOny5mEyn7iR8z7ZHvsX8chpR65Xj+Z2
+        NI15DzojxdKN6I2bDa2Q3bwfV+pKEt6l3tCGbOOkHK52d79Vh6fNsYOu9cLaP8lig641u9dQsE7u
+        uaY3LouDyHbZCF3FLd7t4cPl2TwbyKUn7bueQY5YZbicjI6NWcemPPYwmR2c4/xiYS3K655W5D6O
+        pyuBvtRngIhtasg1AqMJTD7e94Y0JvC0EPaImo3PZuTX+wH5I/3gu7SdrP/afvDs/69+cA/K9/eD
+        bN7P7wfUF7V91pl/rRcAx3D9impA4wqcn9IS6qglDEyKmxgcTte6Y0ne4wK7D4TgeMbttdUYGWK0
+        ah6W0LlsKa+3vhr+vjmCO6G31UdGf2SbMqV350rY6h54rTkX45ALdV912bXWXEN/esa242406ZHH
+        eG1uZ4Sxj5quxQn8pkZOehoei9KFvC75GPi7S3PhHWcCCXbXGqmfSJ2iRKsf8EJwUtXjEA99bo6j
+        b3TaOknfIPfUj1zdv0vuyV8s98/+/yrve1D+RHl/We7vj0H2W2VRkrprJD8/3H+x/GAp5dvTvz3/
+        D1lRoYe8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:54 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:32 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['1148']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:55 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/TicketTypeConcessionTests.test_ticket_concessions.yaml
+++ b/tests/interface_objects/cassettes/TicketTypeConcessionTests.test_ticket_concessions.yaml
@@ -1,411 +1,347 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:55 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:33 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:55 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:33 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:56 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:33 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGNyeXB0b19ibG9jaz5FMC0tRXhJNTJKUkNxLWdMRHN2eDR3blVa
+      elpTV1NZRHFxZXZKRkd2bDRwb0NpdkNxVVVmdlVMQVhnOWJwOVhnNi1jY0s1THRRSlN2Um1MZXZl
+      eGUxMzBpNXo1UWdFV3puMVdtRTJ5WHdnVnhkTm85U21KZmNlWHlZN0tNTnQ4enV5Vkp3OWFSWE9T
+      ajV5Rk5wLTB3QWR2MktCSHZwaDZjRnFST2NyejktNGxEaHV4MlhIYUFtMUY0U2JuZEoybXF3a1Jn
+      WjwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bm9fb2ZfdGlja2V0cz4xPC9u
+      b19vZl90aWNrZXRzPjxiYW5kX3Rva2VuPi0xLS1RMW16UTBaV0tTZWNaazl6NFdQN1pCSi1GazFR
+      bGpSTGVIODl4djlzQ1llOGJFZXYxM2hoRkhheXlfNllkVWJIQUd5d0VSNlNSeW5ZLUJlWGhUd3Ey
+      YWQtYzVoQXc4WmhLcEpubTNONjJLZnpNM3B5QnNtUC1Dd0NVSVktY2dzV3F2S1kxcS1CUUFfQ1N3
+      SmE4SFJjdGZ2WlFpSktYN3JGZGNGTHlwQzZjQ29DWGdPaF9vc3ZXY295UU1MWjd1SWlpYk9Sa1ly
+      NFV2dEl3el8xbWhvVzNQVVdmRGVnUzJzWkpzV0RpcU56bXJkZ243Tlg4cjlfZmFaRGhPSDdjOUpi
+      WjwvYmFuZF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkZXNwYXRjaF90b2tlbj5jXy0t
+      RnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJYaWgtWnkyeFNwU09EZEhh
+      SHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5OC1zaExzUlpJRW45TEJX
+      M1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tlbj48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['449']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS0HvDihIg7XFxZDKMgoBCj+Tv9Jf1kHg4Je
+        O4fKzLeqlauS2GfHCeLEOWcHJvPHxbYqEfADw3V+/0R8xj9VgKO6muEcfv+0EgdY89Mf7b8xmhGo
+        buhAyfUgYgaSD4LQgm0mCBXNtWXDkcIA+JIRSIqstR2Xqb62MCACDpon+0CW0DqgzW6YajHKDBoI
+        1DaLXis+68AHOSFFGdWAcca1XEdzHSw0mWoBZvaUOkntuTGfbMlBkP+V8WUfBohSALkx5XeQsfJ3
+        2fb+Xemh7YbJq5TMDNpUusPMbQyQp0eICYDsq7pkgjhdqYriUiBJ9HLebdodeXBW8J79abKjgtdO
+        s+3cCA9gwUn30ZUtC8B8o/2nCdlOq8UrVG9BTBLCz8OeHkIZuJvT+SvHgECrjFFaoaQoqPmp+AY0
+        VJRTkQHOkgd8NckRAscR8aWJ0WQIJF92DkACjpaPU2eiHv6rQgSwsgQeBLYC/AqJE3WmWlAydghV
+        yd3vAwDbVD1Z6hktaAFQUSoFbYJukI0a/ci+GTN6jP6zbU1rJ4viLZzImXccnbTbrOOElMKyo0nQ
+        sEFKx/AWhhMi0fqNwn/D8X/ixG/JSq8n5H6fY5CNA4iS40NUalCvTOX4Z8ajTtINCv/meNTw2nfF
+        o4b+/Jl45PtPe02WjvxK7Amd3pgVmGoJzilpGKYyhDo4V7pu6DvgH0GFR9vxZdVEKSSyS/E2MYtZ
+        9mxo7fpwcLMYt/4mWSjR3TZyJ8OkZ5TBnOHJUG9X0WTMztbFlHRdLMCc+7oYBAGs3uanU/LpaIcw
+        DNqWEd3d59CNgNqvDOXqbQxjD7QDw/YsgAKGnMPbvNSSs0IvAJaF3jSAD1tkP24RPU05vIxXX/g4
+        ADc5KLnNWDI0YIhiXiM+18hWnSCoBlO9owzq5ofsEcM/Ezg64VqdRIQ7zFQLZ7ocSI6b9IN9kKrN
+        A5B0U9QRUce5t9F8yNjyRfJDx0FHkeUNQaI9fEAZG3XdF7xnlHEA0FBGeCjfkDqkOZm+zys8J4e+
+        nGhoiXZDMkKyB9e3kzacvf4HlPHcAGbi2SOECi3yTPUO3SQCSTZM2JJpt/HP+F0jyjgT6G7aVffZ
+        dtLlnjAmQHmJ6KlzcEH5gnIycVeCb5xMty8Q+I5sVURErHSTRHa0SjEjq5/0UvCq478yMCixwnyt
+        Zac/YYXlhp1Mlky1ZMhJqfulrFnARzW8QakY3Gi5lOVXkIeIFt1wAzQkIMSv6JWtFkF/e68kPmrH
+        /2s6SfZ7rmulaZ7fHZ6wpCYsw05kOM280vArLZj4ZklKkyZ7O6yDz1FS5kBuCaTICAzFyhPtGcxY
+        RePKchB1p/yiuM6nFBDzsUQfyzP5f3Zwjc8UXplPmWoBZVZdt210nSFamY6VsWy9e46ofuxBV1Is
+        VzXbUwrDvHkNEtSBlVXalIXudWeTuhutBMPhuVlgkuo4UubOUbCgNrqQvd4RP9dbR77FLk5S5F35
+        2DT7K8FuGrQ+6jkreFUipdk5cUNLBc3x3pZ74tjXvL1lDYQmO5KPVmO6dq3RwWxQxHKCNa5DsS/W
+        pS0fen2bVcXTGIZDSu1btBoC1rBFZ4L7RmdPc7EAIHccWoK4PMCVt2GbEmsv+krUeANrsyX68/gw
+        P+v6ecguW+bUtg+z/uy9f9VDq7GmG5sWL0Flya3mZ3eh0YOr1j8tsV204eaDbp/g5pG55jcTjDxv
+        V9Pu+0ggllA4jKlOIOG0wq5rltPz9my0cFW18cZe6xam6ZFKBRNtAPvyXMPm516NdJeu4hIgNiPB
+        Hg1mKuQ9TtqO3ll8Rtgrj+pq/JEfnrjxmxWc1V7EwcF+KncGrLAJ3wMruA58F9DcdQ4243ptSvOD
+        3di3CfXisFAzzoPl5djvw+OkT485stsYyjVX0YQ3BXawXXLXLJ0vo1iyg1RSKj59HCtOS+e1pfhG
+        SuuqTaHqfUQYNfR99HUVF09ZGh8UD63+ABWMvaxC189vw09gwXLC5KrbbpL1EisHC5ZnySoI2mSJ
+        k0MlDhISKYhtxbWqZRipWIa2//uf8vwCL9AiGMFDXNCNAH8IS3JFQLLt7qViAo0U7wm6+0Dfh0rg
+        WiFqO4EcoTrPpO0ZRB8ftmI4qLdRrcR+HxYvk0a5019NxNILZaG/D7NvQA19+VUSzdRkXyuRcz34
+        yu7uQ+giHWyrOIadTKzVXY/jCx5zw8b727pPDh1BdLX94rR78whpEZIUy5HN96CGMm0VXTWcvcwI
+        +mw1WHuwhz2ObACbr8VU1xodD1YwkMddthlxTTpyur6+UehtxxjESmfKc9vOarzAj9aJXkP7PD5z
+        /MzpT8QemG0Wi94+gkGzZfqboOGdotp+PhiMdmezNbXOHe1AKFdlI7sxPFIm5UbWdGlSfJeXVq7W
+        s2EX7weqUbP2FuYd9dF4PN4u+ucBuSsFIdt1KQrJZbMcpez2iVQAKSfK1VyasgFKDSd7lJ4O9IWh
+        RE4Uz/MN1LOp2iO7sJTp6Fqiy/4BtOkn9t1QYmeXZ+m1/wcjk9WfJEeyYcmJwiFF/4Ax+SVHPhQ5
+        nQrPE8ikTiUlkdsseRHrCSpzkvSsPiCFsvryGU1woHEI3TDIbwgEuo6/NKR06ELZemKWMeY56KVQ
+        PwW4FNYXwXwMYbWo/D/dA0jiSz2gxw0n/a/0gJ5uWFoF3dLBj9Y/hup/MrPtKdcbqoPpZLVRjAO2
+        ssfieL2bAKTbI3vcXGMY2Y+3w51CBCJ+4PZCPzk6QG8miq0vunWjX9eIix7hsqGe4vCs26ap2dtA
+        wSSIBHl42I07kWVKFKcvWuxA1nbS25BerhoT1msK727Ei+PT6r0xmVDXQcvvXqh+h++1LrPNynwb
+        rsH1elI9aYdhX61l4gdqOTuYb61lovldtUx9by0/+/+rlu9BeVnL1JdqOZv3C2r5i3q+FFd9lv+a
+        oi+TnxMc+FPq2UT17GPxebJddlnWqznX/ZD2uzzRiHrWfOny5mEyn7iR8z7ZHvsX8chpR65Xj+Z2
+        NI15DzojxdKN6I2bDa2Q3bwfV+pKEt6l3tCGbOOkHK52d79Vh6fNsYOu9cLaP8lig641u9dQsE7u
+        uaY3LouDyHbZCF3FLd7t4cPl2TwbyKUn7bueQY5YZbicjI6NWcemPPYwmR2c4/xiYS3K655W5D6O
+        pyuBvtRngIhtasg1AqMJTD7e94Y0JvC0EPaImo3PZuTX+wH5I/3gu7SdrP/afvDs/69+cA/K9/eD
+        bN7P7wfUF7V91pl/rRcAx3D9impA4wqcn9IS6qglDEyKmxgcTte6Y0ne4wK7D4TgeMbttdUYGWK0
+        ah6W0LlsKa+3vhr+vjmCO6G31UdGf2SbMqV350rY6h54rTkX45ALdV912bXWXEN/esa242406ZHH
+        eG1uZ4Sxj5quxQn8pkZOehoei9KFvC75GPi7S3PhHWcCCXbXGqmfSJ2iRKsf8EJwUtXjEA99bo6j
+        b3TaOknfIPfUj1zdv0vuyV8s98/+/yrve1D+RHl/We7vj0H2W2VRkrprJD8/3H+x/GAp5dvTvz3/
+        D1lRoYe8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:56 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:34 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['1148']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:56 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/TicketTypeTests.test_bool_properties.yaml
+++ b/tests/interface_objects/cassettes/TicketTypeTests.test_bool_properties.yaml
@@ -1,329 +1,258 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:44 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:18 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:44 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:18 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjxhZGRfdXNlcl9jb21taXNzaW9uIC8+PGNyeXB0b19ibG9j
+      az4tMC0tNi1ic2pXT2psUmdQd2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21O
+      ZS1MMmQzUWdEcXl0N1BxWjBrNkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85
+      MXVfUzBlcnFjbVFXdjhiVmV1S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BI
+      cDVlZTM1LVk8L2NyeXB0b19ibG9jaz48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHVzZXJfaWQ+ZGVt
+      bzwvdXNlcl9pZD48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBz
+      RGxGbWwyRUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHNlbGZfcHJp
+      bnRfbW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PC9hdmFpbGFiaWxpdHlfb3B0aW9ucz4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['452']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA+1b2XKryJZ9769Q1EMP0Y3FKES1rm5ongANSELSC4EgEUhMYhT6nf6T/rJOBlmD
+        7WP73OOquh2uqKiClSuTzJ0799obi9rfT5ZZioDnG479t9+wJ/S3ErAVRzXs3d9+W8y7SPW3v9f/
+        pSZHsmHKW8M0gkRy3ACyfckDfmgG9ZofblXHkg1bCn3gSYYvbWW1bju18usttWMo28HNSPVaJJuG
+        Kl3wOlYrPyCPDPxdBvEug3yXQb3LqLxklF8uT/ESN3Ckrekoh3oHRZDOaUDhw1nriOzYth+dyNhe
+        bM4bQRTW7eMRRMNuLzJJ12kZUeu4WGjRgm2sdszWZVa7CqIoI4oNpkMhmlksiMAJYARqUGdquuuI
+        ZxsTrQ6erOLd8qTyDiNYQ00Bq2RNjzg+qJ7DZDmMGXm2Ggt7KunyLoLGDTXCR81+5OoVpXucjRXv
+        zCCk2dbDE77qyw0L65LC1laHuHWMD7Pdpla+W1MNzsKGriB7QJag+4B6R6yVr3d5gwp8pd6B3pbE
+        OvBAQcjQmpIaLOOajq06NhIe4DOewbw9o7JZe9FYdDZl3y/+l/NlL/Ah5QoUjRm/ARtL/ypb7n+X
+        WtCDw3QqN8016KeZ0+bDJgCOdA/VfCB7ii4dQJI9qQxd/YqkB6LgXbo9I3eDXXmP46myrYDXB82X
+        cyHcgVdOto6mbJogKBbafuiQr7R8nUL5YkQntAOvMHu2CbfAc3PWf2EbAVBLIxgt4Dm/Uotd8YzA
+        UGCYiAwQSy7wlNRHMBRNnee1ppoqB0DyZHsHJGCrxX022FwP/6uE+UFJAG4ArC3wSjiKwdN3peTs
+        MFAkR9N8ENSJSvqoR/RK84ECXcmvYySN0xR5z7405vQE/mNZqlpPH4oyKFYwn3G40061gmJSBsu2
+        KgWGBTI6gjIIis0x5ncC/R1F/xPFfk+f9HqHYtxHG+T3fgCd44VVqEAvcXLyK+1RwUmaQD9sDwql
+        PmUPCv77M/Yo1p/Fmtwd+cW8NWu0Rp1ZrXwDF5TMDJwcBDqIS00n9Gzwb36Jh8vxZOUAXWjeEeaX
+        jrnN8mtDrVcG3UsLvCtwEzq6U4fDyUEaM27BguHKgV4vw86IlT8X2WbPRXzEfn4uEgA/KF/6Z12K
+        7nCFQejXTSN6Hr6ALgSoqHIgly/3QeKCum9YrgmgweDgwaVf1lKwQtcHpgln6gd3S+y8XCK84vro
+        LV5+ZYwdcNKNkus1U4ZSF0KbU9gThTMVDCPoWvkZrcFovssvEfQJQ+EOUxUo3le4Vr4Opsu+ZDtp
+        PND8LIG4A9JoCiMijDjPYbS4rVnySfJC24ZbkfsNhsM1vEBrFoy6r/Ae0ZoNgAo9woX+BtUh88ls
+        Pq/hBTn05FTtb2gXJCeka3A8Kw3D+fRfoDXX8YNcPFvYrETO+Vr5GbpIhArtn7Klg1VHn9BnjbjF
+        a77uZFFVy5eTPe4Bq/nQLyE9GxycoL9An0yHu4EvnFy3TwHwbNkszSGx1Ewd2VZL1x75+cnyvNci
+        /msNNehYYfEsodFmOzNB7LCsAHOqa0NByoYXZNUEHjzDInRF/0IrpKxIQe4seo2GIlChgGBfESsZ
+        BiM/Hiuxl9rxVtBJvd91HDNz8yJ3eMDSM2EaVirDmefd3L4TgrEPS1LmNPnskAY6gU5ZAEWLL0WG
+        b2zNwtEewZx1DVy5D8LoVCSKy6LLFaq9PKL3xzP9b75x9BOBliZcrXyF8lZdtyyYzmBMrmO3WP68
+        Zx9RQs+DNU9yvcpnsdu6MFG5g64MTVYCxyuSmQfwyrLDNFOpV/HKDasAryzXlBXgpyXNI3TDgXFA
+        8hNr65jlWxgGoRyt/+//3Pa/4le0flfGpXZK9aIQCtcz4CHeymnKIW99xwyhD/hyBI2ex5lHsLbN
+        PMSBYaCOYAgyxazzFN2IIwEomwNzJsUJvWkOke4Bm5r7GQv6VeYUMX5rDarbDogwQte7fTlJpMpa
+        XWz7jV4Sd2YVYZbYa6QJVvo8PuKyiiiU3oirG33kDm2L4Cv4SDtzhJs0fWuCtOLWYrBGlJ0vHqPR
+        GjsizWlDagnxUK72Z0qgRZupMRytaK+rKl02cVsVpeW0VruxLjl+JCpOMuXYDR0ODGM7nh3WHrmI
+        gkF8ljBLd0RishC1NtgJuL8Z+mLbOPJny1N3Ns2vqh4DN3zT1sd9WmGGW1gS3VgE5snW1rDhMSSY
+        1HrPt7Wd52T5umUZvp/Jg2ylabMETooZpoW3FMlBnXyqVqHRX2u6dDDsW5R6qlLPHe6batenSf//
+        vf21tZZfWh1GKBjV4dSKsJnf1GzYL7uUHnbwlYYbchqNsyNUJ6h79rXllg4lU5e9HYD7fM9+brhh
+        Fwf19fHvGmu5uaXioMPoC/fiBVYrBFjeXY94FhQfwJugkHtEA7IeoFtOGn7Ld8g16ntyDDvYgbEL
+        ndAv1AuDqeKrDRk9cALZfGDeYrVHo9+Y+sHAN2Z9xZj3JswylXfPZx4TP348b/nfp/PhdL4weflW
+        jv4hafJRBNnPVz2y2zqhNG6T6HCja0m/0nMGnTh0Fy0Q6w0a2283PjFlKA5TV+sqNjGZdTi2Q/qM
+        CL1uhByOxmRqCxVijnMiNe1ZR2fgKkr/UKEwZU0x7SZDaex03jvaY7zCgI3o8wl+xlnR78xhNR2p
+        FXYrMEDdEBjHc/Se8TWLnh3HU5xje4x/rsjmwus3Ma3qToxTb8JulHCGcrM9YvPjuNITzw2vSSxl
+        py2G2Arj+y0klgVcdyOqhRqaweoy5/ieRQ/AWK0mwxaU5DclibyXJHCSswLyklKqdb5LMFB+0hyv
+        uKtc7uApD2Agyd4UmWkWmDGL65oWmtlFMcDlNo22Hqwb4E7C1FRKq4BL3H2Eax6sU7IR4InPL7OD
+        DguUU17el1MAlmAydHB4Xb6d06vzq7w+v8qfML/yg63vbiUZHhUPyGb27DeaPp5A4NQnEwjsO0J9
+        Sf5Afip/QL84f0D/vPyh+YvzB+aj6QPz4+wB/cnsAf3OHv4CZ/MLswcOZg/A2Snkkl1405HnnjlJ
+        XM+Z5QF4jNxvuhzDiewcxfqYaghLZVGNzTkaLI5SbPXnqIsJh8pQ2fEtgXI3XWV86nj0kYq5fmsu
+        bDAebPZ4a4dsrZG41nhCbe/HrEo3iC3e01pyrA259hC65Z40VoeeQUph6JLt5ToGY5LZxYfGfjFW
+        EK6xROY9jUPWyCAOhuGB5jWzepIaM4XcHxK6D9Z4pE+sltt8MyPAf65IJZ4qxKf8mHwivovULxEZ
+        /FNFKv7FRerj+H+kyLR+dZGKf7hIxX8oM/hPFqn4d5H6VzidP5aZm5ephRsOZi2287xvN2+3b5H8
+        z+gudOuSYniKCe47XF5oX5E8clckBOG1BoqrVrWxm047vWrPOy1VK5Bpsh05vFnZzQb7GVidJ72D
+        YmqLyAyUbYUaHavOobdCVj3NW5ggtk5khYmx1VqXjyeMl7aNeR8/K3xlvFvfT6WQjPLdW+Nf9wr5
+        AJVW8BXWr+7Gcssht4nUxx1raC3M2FpxPg/Om3AoJ+pSHveGe9aiw2PCUdXt4gxHZbqOqo4nlKbx
+        jN01z8pkBoReizlsxRkfTpqi6HHCXMUnY0kWnWmsOGsrmHHz2ZQeNM11oiHmmZAMMBCbcsBXHbZi
+        7D1j3kUH8bm5Ykczb8xr85UWLVcJ6rlyV5U7I/+ono/7E8k4ze3SmPZO4YGP/cPCaXf9qhohRneC
+        cCLdR8YiETclMdRCBEyE5pmfNt5W4vdr8ylOodfaHN5hb9bmGfNF7ZsP8I/UvtNfVJtnc39tftif
+        ML8/rjYnPhmXYZ71HZe/JGv6VGmOY5/KmohPZ03Yn5c1/fJX+78sa8LezJqIH2ZN2HfW9Bc4nV9Y
+        nKc/pKVWjLqcnyZbotljhLChVK3FbjVfKLrnyAq3odVEiIcUtprQXiucBgLlWDPmHFT1QYTvhtNm
+        shjoDW7EOiMEHU+k7VHfLIZjIKCd5BzvFjzr9OYjf3d28ROFIcZ6XyVwddYVeZFlm8B0ONuvxslp
+        GgdM2JkPewJ5mgWqbThM2AAaZ/XU8fxYQRcgqFJ0f4QePa8VVcaTjr08LqX1m2kA9lMFOf7Zgpx4
+        wr4L8q+RFuwz0oJVv1ZaHsd/R1qIv/JbX+KjykL8UFhyk3xeWPJ+38LylxaWF1W3MG9kvyz8QDku
+        QHdJf134kUIcgYW4nliUiEwlyyAScjNRNkduuumNGSYJRkGzS3bQaV/HRlNN1ZSlMbAP3Lgzspvh
+        UW3i2FrxyBU+145jXIjUFZVgcaQQpAW17Y8twNNX3SuBGij9RLGmNgelrKEYXUlr8PxZ2B/OHG6E
+        Ai4gU/M8mPLD0YmIeJLuDcJ5b1NpV7uDVY+cLgODR3fBVq56Dr8X7Jm854nhWkSnK2HO+PP1IJ6q
+        qz0bHsaNdofqrxp+WEmCAUkMT44ZJWHfpSvLczxfRjS3thzLjTYt0cF2du+8nTUXZ9f0aWqICEOn
+        x81QVOhRPZvV+pM5O3Y5xGOHqGeFvCO9WWBT+E8pa+Xpc39NpZ+q32f3K3Q137+P6ipJf0pXH1+L
+        v6urj+P/M5ds6UuXjwnrhfmGsuZGeVVZqR8pa97vW1n/uZS12WBbY379IWltyib0ruTjL7lnHMJE
+        MnEgdz4iwMPQOVVhZSWb7nzhM7NWlZzrwoYjOmQV7Tv8lB+1HLbvjVW+2g6czmgVTzC34sm2tWuc
+        j52mpQe7BrPqNRHnpMZeX/+IxpbvfzatyLZkAjmCdoROY4Lih/kv4RpcmCsHin79EPQZsUCgO+oN
+        kP/NYNwc18r32C3FD+pYqkP30JWRWbLlmCZQgpLmOVYp0EEp+0riplPxxcPltogK2bdU4+YN79Jw
+        pebmUeC+dJPhsq1V20mnrXPrRUVbmwengfWw8561I3UZ6/SIHR623srQkU2CnwRXGLfVvtw/q4nc
+        2yOu11dJekRHWmvWXYVcZxgu9rNR0+/Z4uxo9QOmivg66882g47NsE2REJcjn5ggSDy0p/2xdHaT
+        TZgsjEaaJz3M8GbG6Q4quUVuafnGvr0dr+/PZJx+L/bD/SHe3Z8JxEr/vhgVH2YOPGDCg1VybDP5
+        jw/tEpzFB3bJh7vUI0FMN04HgmRpNokX8504Wc9Z83hS5+hsmzB9ASH7rDmkm2suRjRFEjv0Ku62
+        21hvyDb5xPfU6QD1sLHSYKgDLQWDTrV1ZDV646si6S6XcnNqOZLoKPuJQY4Jhzwhcfc0Gu6s7rjh
+        Vnrm0DQT5oxHvfC0Ac2+YtPboec1+W5H5E/v7lwa3F5sG5RGywjSl/7596YGuH62+vD9qgF++P1q
+        YfvHD1fLj4P9yq9ir4OXX13IS6e8Is9xpPyjD/L/Dx1R2NzVPwAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:44 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['4029']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:20 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><add_user_commission /><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['472']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:44 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/TicketTypeTests.test_example_seats.yaml
+++ b/tests/interface_objects/cassettes/TicketTypeTests.test_example_seats.yaml
@@ -1,329 +1,258 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:45 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:20 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:45 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:21 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjxhZGRfdXNlcl9jb21taXNzaW9uIC8+PGNyeXB0b19ibG9j
+      az4tMC0tNi1ic2pXT2psUmdQd2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21O
+      ZS1MMmQzUWdEcXl0N1BxWjBrNkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85
+      MXVfUzBlcnFjbVFXdjhiVmV1S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BI
+      cDVlZTM1LVk8L2NyeXB0b19ibG9jaz48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHVzZXJfaWQ+ZGVt
+      bzwvdXNlcl9pZD48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBz
+      RGxGbWwyRUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHNlbGZfcHJp
+      bnRfbW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PC9hdmFpbGFiaWxpdHlfb3B0aW9ucz4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['452']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA+1b2XKryJZ9769Q1EMP0Y3FKES1rm5ongANSELSC4EgEUhMYhT6nf6T/rJOBlmD
+        7WP73OOquh2uqKiClSuTzJ0799obi9rfT5ZZioDnG479t9+wJ/S3ErAVRzXs3d9+W8y7SPW3v9f/
+        pSZHsmHKW8M0gkRy3ACyfckDfmgG9ZofblXHkg1bCn3gSYYvbWW1bju18usttWMo28HNSPVaJJuG
+        Kl3wOlYrPyCPDPxdBvEug3yXQb3LqLxklF8uT/ESN3Ckrekoh3oHRZDOaUDhw1nriOzYth+dyNhe
+        bM4bQRTW7eMRRMNuLzJJ12kZUeu4WGjRgm2sdszWZVa7CqIoI4oNpkMhmlksiMAJYARqUGdquuuI
+        ZxsTrQ6erOLd8qTyDiNYQ00Bq2RNjzg+qJ7DZDmMGXm2Ggt7KunyLoLGDTXCR81+5OoVpXucjRXv
+        zCCk2dbDE77qyw0L65LC1laHuHWMD7Pdpla+W1MNzsKGriB7QJag+4B6R6yVr3d5gwp8pd6B3pbE
+        OvBAQcjQmpIaLOOajq06NhIe4DOewbw9o7JZe9FYdDZl3y/+l/NlL/Ah5QoUjRm/ARtL/ypb7n+X
+        WtCDw3QqN8016KeZ0+bDJgCOdA/VfCB7ii4dQJI9qQxd/YqkB6LgXbo9I3eDXXmP46myrYDXB82X
+        cyHcgVdOto6mbJogKBbafuiQr7R8nUL5YkQntAOvMHu2CbfAc3PWf2EbAVBLIxgt4Dm/Uotd8YzA
+        UGCYiAwQSy7wlNRHMBRNnee1ppoqB0DyZHsHJGCrxX022FwP/6uE+UFJAG4ArC3wSjiKwdN3peTs
+        MFAkR9N8ENSJSvqoR/RK84ECXcmvYySN0xR5z7405vQE/mNZqlpPH4oyKFYwn3G40061gmJSBsu2
+        KgWGBTI6gjIIis0x5ncC/R1F/xPFfk+f9HqHYtxHG+T3fgCd44VVqEAvcXLyK+1RwUmaQD9sDwql
+        PmUPCv77M/Yo1p/Fmtwd+cW8NWu0Rp1ZrXwDF5TMDJwcBDqIS00n9Gzwb36Jh8vxZOUAXWjeEeaX
+        jrnN8mtDrVcG3UsLvCtwEzq6U4fDyUEaM27BguHKgV4vw86IlT8X2WbPRXzEfn4uEgA/KF/6Z12K
+        7nCFQejXTSN6Hr6ALgSoqHIgly/3QeKCum9YrgmgweDgwaVf1lKwQtcHpgln6gd3S+y8XCK84vro
+        LV5+ZYwdcNKNkus1U4ZSF0KbU9gThTMVDCPoWvkZrcFovssvEfQJQ+EOUxUo3le4Vr4Opsu+ZDtp
+        PND8LIG4A9JoCiMijDjPYbS4rVnySfJC24ZbkfsNhsM1vEBrFoy6r/Ae0ZoNgAo9woX+BtUh88ls
+        Pq/hBTn05FTtb2gXJCeka3A8Kw3D+fRfoDXX8YNcPFvYrETO+Vr5GbpIhArtn7Klg1VHn9BnjbjF
+        a77uZFFVy5eTPe4Bq/nQLyE9GxycoL9An0yHu4EvnFy3TwHwbNkszSGx1Ewd2VZL1x75+cnyvNci
+        /msNNehYYfEsodFmOzNB7LCsAHOqa0NByoYXZNUEHjzDInRF/0IrpKxIQe4seo2GIlChgGBfESsZ
+        BiM/Hiuxl9rxVtBJvd91HDNz8yJ3eMDSM2EaVirDmefd3L4TgrEPS1LmNPnskAY6gU5ZAEWLL0WG
+        b2zNwtEewZx1DVy5D8LoVCSKy6LLFaq9PKL3xzP9b75x9BOBliZcrXyF8lZdtyyYzmBMrmO3WP68
+        Zx9RQs+DNU9yvcpnsdu6MFG5g64MTVYCxyuSmQfwyrLDNFOpV/HKDasAryzXlBXgpyXNI3TDgXFA
+        8hNr65jlWxgGoRyt/+//3Pa/4le0flfGpXZK9aIQCtcz4CHeymnKIW99xwyhD/hyBI2ex5lHsLbN
+        PMSBYaCOYAgyxazzFN2IIwEomwNzJsUJvWkOke4Bm5r7GQv6VeYUMX5rDarbDogwQte7fTlJpMpa
+        XWz7jV4Sd2YVYZbYa6QJVvo8PuKyiiiU3oirG33kDm2L4Cv4SDtzhJs0fWuCtOLWYrBGlJ0vHqPR
+        GjsizWlDagnxUK72Z0qgRZupMRytaK+rKl02cVsVpeW0VruxLjl+JCpOMuXYDR0ODGM7nh3WHrmI
+        gkF8ljBLd0RishC1NtgJuL8Z+mLbOPJny1N3Ns2vqh4DN3zT1sd9WmGGW1gS3VgE5snW1rDhMSSY
+        1HrPt7Wd52T5umUZvp/Jg2ylabMETooZpoW3FMlBnXyqVqHRX2u6dDDsW5R6qlLPHe6batenSf//
+        vf21tZZfWh1GKBjV4dSKsJnf1GzYL7uUHnbwlYYbchqNsyNUJ6h79rXllg4lU5e9HYD7fM9+brhh
+        Fwf19fHvGmu5uaXioMPoC/fiBVYrBFjeXY94FhQfwJugkHtEA7IeoFtOGn7Ld8g16ntyDDvYgbEL
+        ndAv1AuDqeKrDRk9cALZfGDeYrVHo9+Y+sHAN2Z9xZj3JswylXfPZx4TP348b/nfp/PhdL4weflW
+        jv4hafJRBNnPVz2y2zqhNG6T6HCja0m/0nMGnTh0Fy0Q6w0a2283PjFlKA5TV+sqNjGZdTi2Q/qM
+        CL1uhByOxmRqCxVijnMiNe1ZR2fgKkr/UKEwZU0x7SZDaex03jvaY7zCgI3o8wl+xlnR78xhNR2p
+        FXYrMEDdEBjHc/Se8TWLnh3HU5xje4x/rsjmwus3Ma3qToxTb8JulHCGcrM9YvPjuNITzw2vSSxl
+        py2G2Arj+y0klgVcdyOqhRqaweoy5/ieRQ/AWK0mwxaU5DclibyXJHCSswLyklKqdb5LMFB+0hyv
+        uKtc7uApD2Agyd4UmWkWmDGL65oWmtlFMcDlNo22Hqwb4E7C1FRKq4BL3H2Eax6sU7IR4InPL7OD
+        DguUU17el1MAlmAydHB4Xb6d06vzq7w+v8qfML/yg63vbiUZHhUPyGb27DeaPp5A4NQnEwjsO0J9
+        Sf5Afip/QL84f0D/vPyh+YvzB+aj6QPz4+wB/cnsAf3OHv4CZ/MLswcOZg/A2Snkkl1405HnnjlJ
+        XM+Z5QF4jNxvuhzDiewcxfqYaghLZVGNzTkaLI5SbPXnqIsJh8pQ2fEtgXI3XWV86nj0kYq5fmsu
+        bDAebPZ4a4dsrZG41nhCbe/HrEo3iC3e01pyrA259hC65Z40VoeeQUph6JLt5ToGY5LZxYfGfjFW
+        EK6xROY9jUPWyCAOhuGB5jWzepIaM4XcHxK6D9Z4pE+sltt8MyPAf65IJZ4qxKf8mHwivovULxEZ
+        /FNFKv7FRerj+H+kyLR+dZGKf7hIxX8oM/hPFqn4d5H6VzidP5aZm5ephRsOZi2287xvN2+3b5H8
+        z+gudOuSYniKCe47XF5oX5E8clckBOG1BoqrVrWxm047vWrPOy1VK5Bpsh05vFnZzQb7GVidJ72D
+        YmqLyAyUbYUaHavOobdCVj3NW5ggtk5khYmx1VqXjyeMl7aNeR8/K3xlvFvfT6WQjPLdW+Nf9wr5
+        AJVW8BXWr+7Gcssht4nUxx1raC3M2FpxPg/Om3AoJ+pSHveGe9aiw2PCUdXt4gxHZbqOqo4nlKbx
+        jN01z8pkBoReizlsxRkfTpqi6HHCXMUnY0kWnWmsOGsrmHHz2ZQeNM11oiHmmZAMMBCbcsBXHbZi
+        7D1j3kUH8bm5Ykczb8xr85UWLVcJ6rlyV5U7I/+ono/7E8k4ze3SmPZO4YGP/cPCaXf9qhohRneC
+        cCLdR8YiETclMdRCBEyE5pmfNt5W4vdr8ylOodfaHN5hb9bmGfNF7ZsP8I/UvtNfVJtnc39tftif
+        ML8/rjYnPhmXYZ71HZe/JGv6VGmOY5/KmohPZ03Yn5c1/fJX+78sa8LezJqIH2ZN2HfW9Bc4nV9Y
+        nKc/pKVWjLqcnyZbotljhLChVK3FbjVfKLrnyAq3odVEiIcUtprQXiucBgLlWDPmHFT1QYTvhtNm
+        shjoDW7EOiMEHU+k7VHfLIZjIKCd5BzvFjzr9OYjf3d28ROFIcZ6XyVwddYVeZFlm8B0ONuvxslp
+        GgdM2JkPewJ5mgWqbThM2AAaZ/XU8fxYQRcgqFJ0f4QePa8VVcaTjr08LqX1m2kA9lMFOf7Zgpx4
+        wr4L8q+RFuwz0oJVv1ZaHsd/R1qIv/JbX+KjykL8UFhyk3xeWPJ+38LylxaWF1W3MG9kvyz8QDku
+        QHdJf134kUIcgYW4nliUiEwlyyAScjNRNkduuumNGSYJRkGzS3bQaV/HRlNN1ZSlMbAP3Lgzspvh
+        UW3i2FrxyBU+145jXIjUFZVgcaQQpAW17Y8twNNX3SuBGij9RLGmNgelrKEYXUlr8PxZ2B/OHG6E
+        Ai4gU/M8mPLD0YmIeJLuDcJ5b1NpV7uDVY+cLgODR3fBVq56Dr8X7Jm854nhWkSnK2HO+PP1IJ6q
+        qz0bHsaNdofqrxp+WEmCAUkMT44ZJWHfpSvLczxfRjS3thzLjTYt0cF2du+8nTUXZ9f0aWqICEOn
+        x81QVOhRPZvV+pM5O3Y5xGOHqGeFvCO9WWBT+E8pa+Xpc39NpZ+q32f3K3Q137+P6ipJf0pXH1+L
+        v6urj+P/M5ds6UuXjwnrhfmGsuZGeVVZqR8pa97vW1n/uZS12WBbY379IWltyib0ruTjL7lnHMJE
+        MnEgdz4iwMPQOVVhZSWb7nzhM7NWlZzrwoYjOmQV7Tv8lB+1HLbvjVW+2g6czmgVTzC34sm2tWuc
+        j52mpQe7BrPqNRHnpMZeX/+IxpbvfzatyLZkAjmCdoROY4Lih/kv4RpcmCsHin79EPQZsUCgO+oN
+        kP/NYNwc18r32C3FD+pYqkP30JWRWbLlmCZQgpLmOVYp0EEp+0riplPxxcPltogK2bdU4+YN79Jw
+        pebmUeC+dJPhsq1V20mnrXPrRUVbmwengfWw8561I3UZ6/SIHR623srQkU2CnwRXGLfVvtw/q4nc
+        2yOu11dJekRHWmvWXYVcZxgu9rNR0+/Z4uxo9QOmivg66882g47NsE2REJcjn5ggSDy0p/2xdHaT
+        TZgsjEaaJz3M8GbG6Q4quUVuafnGvr0dr+/PZJx+L/bD/SHe3Z8JxEr/vhgVH2YOPGDCg1VybDP5
+        jw/tEpzFB3bJh7vUI0FMN04HgmRpNokX8504Wc9Z83hS5+hsmzB9ASH7rDmkm2suRjRFEjv0Ku62
+        21hvyDb5xPfU6QD1sLHSYKgDLQWDTrV1ZDV646si6S6XcnNqOZLoKPuJQY4Jhzwhcfc0Gu6s7rjh
+        Vnrm0DQT5oxHvfC0Ac2+YtPboec1+W5H5E/v7lwa3F5sG5RGywjSl/7596YGuH62+vD9qgF++P1q
+        YfvHD1fLj4P9yq9ir4OXX13IS6e8Is9xpPyjD/L/Dx1R2NzVPwAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:45 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['4029']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:23 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><add_user_commission /><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['472']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:46 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/TicketTypeTests.test_float_properties.yaml
+++ b/tests/interface_objects/cassettes/TicketTypeTests.test_float_properties.yaml
@@ -1,329 +1,258 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:46 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:23 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:47 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:24 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjxhZGRfdXNlcl9jb21taXNzaW9uIC8+PGNyeXB0b19ibG9j
+      az4tMC0tNi1ic2pXT2psUmdQd2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21O
+      ZS1MMmQzUWdEcXl0N1BxWjBrNkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85
+      MXVfUzBlcnFjbVFXdjhiVmV1S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BI
+      cDVlZTM1LVk8L2NyeXB0b19ibG9jaz48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHVzZXJfaWQ+ZGVt
+      bzwvdXNlcl9pZD48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBz
+      RGxGbWwyRUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHNlbGZfcHJp
+      bnRfbW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PC9hdmFpbGFiaWxpdHlfb3B0aW9ucz4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['452']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA+1b2XKryJZ9769Q1EMP0Y3FKES1rm5ongANSELSC4EgEUhMYhT6nf6T/rJOBlmD
+        7WP73OOquh2uqKiClSuTzJ0799obi9rfT5ZZioDnG479t9+wJ/S3ErAVRzXs3d9+W8y7SPW3v9f/
+        pSZHsmHKW8M0gkRy3ACyfckDfmgG9ZofblXHkg1bCn3gSYYvbWW1bju18usttWMo28HNSPVaJJuG
+        Kl3wOlYrPyCPDPxdBvEug3yXQb3LqLxklF8uT/ESN3Ckrekoh3oHRZDOaUDhw1nriOzYth+dyNhe
+        bM4bQRTW7eMRRMNuLzJJ12kZUeu4WGjRgm2sdszWZVa7CqIoI4oNpkMhmlksiMAJYARqUGdquuuI
+        ZxsTrQ6erOLd8qTyDiNYQ00Bq2RNjzg+qJ7DZDmMGXm2Ggt7KunyLoLGDTXCR81+5OoVpXucjRXv
+        zCCk2dbDE77qyw0L65LC1laHuHWMD7Pdpla+W1MNzsKGriB7QJag+4B6R6yVr3d5gwp8pd6B3pbE
+        OvBAQcjQmpIaLOOajq06NhIe4DOewbw9o7JZe9FYdDZl3y/+l/NlL/Ah5QoUjRm/ARtL/ypb7n+X
+        WtCDw3QqN8016KeZ0+bDJgCOdA/VfCB7ii4dQJI9qQxd/YqkB6LgXbo9I3eDXXmP46myrYDXB82X
+        cyHcgVdOto6mbJogKBbafuiQr7R8nUL5YkQntAOvMHu2CbfAc3PWf2EbAVBLIxgt4Dm/Uotd8YzA
+        UGCYiAwQSy7wlNRHMBRNnee1ppoqB0DyZHsHJGCrxX022FwP/6uE+UFJAG4ArC3wSjiKwdN3peTs
+        MFAkR9N8ENSJSvqoR/RK84ECXcmvYySN0xR5z7405vQE/mNZqlpPH4oyKFYwn3G40061gmJSBsu2
+        KgWGBTI6gjIIis0x5ncC/R1F/xPFfk+f9HqHYtxHG+T3fgCd44VVqEAvcXLyK+1RwUmaQD9sDwql
+        PmUPCv77M/Yo1p/Fmtwd+cW8NWu0Rp1ZrXwDF5TMDJwcBDqIS00n9Gzwb36Jh8vxZOUAXWjeEeaX
+        jrnN8mtDrVcG3UsLvCtwEzq6U4fDyUEaM27BguHKgV4vw86IlT8X2WbPRXzEfn4uEgA/KF/6Z12K
+        7nCFQejXTSN6Hr6ALgSoqHIgly/3QeKCum9YrgmgweDgwaVf1lKwQtcHpgln6gd3S+y8XCK84vro
+        LV5+ZYwdcNKNkus1U4ZSF0KbU9gThTMVDCPoWvkZrcFovssvEfQJQ+EOUxUo3le4Vr4Opsu+ZDtp
+        PND8LIG4A9JoCiMijDjPYbS4rVnySfJC24ZbkfsNhsM1vEBrFoy6r/Ae0ZoNgAo9woX+BtUh88ls
+        Pq/hBTn05FTtb2gXJCeka3A8Kw3D+fRfoDXX8YNcPFvYrETO+Vr5GbpIhArtn7Klg1VHn9BnjbjF
+        a77uZFFVy5eTPe4Bq/nQLyE9GxycoL9An0yHu4EvnFy3TwHwbNkszSGx1Ewd2VZL1x75+cnyvNci
+        /msNNehYYfEsodFmOzNB7LCsAHOqa0NByoYXZNUEHjzDInRF/0IrpKxIQe4seo2GIlChgGBfESsZ
+        BiM/Hiuxl9rxVtBJvd91HDNz8yJ3eMDSM2EaVirDmefd3L4TgrEPS1LmNPnskAY6gU5ZAEWLL0WG
+        b2zNwtEewZx1DVy5D8LoVCSKy6LLFaq9PKL3xzP9b75x9BOBliZcrXyF8lZdtyyYzmBMrmO3WP68
+        Zx9RQs+DNU9yvcpnsdu6MFG5g64MTVYCxyuSmQfwyrLDNFOpV/HKDasAryzXlBXgpyXNI3TDgXFA
+        8hNr65jlWxgGoRyt/+//3Pa/4le0flfGpXZK9aIQCtcz4CHeymnKIW99xwyhD/hyBI2ex5lHsLbN
+        PMSBYaCOYAgyxazzFN2IIwEomwNzJsUJvWkOke4Bm5r7GQv6VeYUMX5rDarbDogwQte7fTlJpMpa
+        XWz7jV4Sd2YVYZbYa6QJVvo8PuKyiiiU3oirG33kDm2L4Cv4SDtzhJs0fWuCtOLWYrBGlJ0vHqPR
+        GjsizWlDagnxUK72Z0qgRZupMRytaK+rKl02cVsVpeW0VruxLjl+JCpOMuXYDR0ODGM7nh3WHrmI
+        gkF8ljBLd0RishC1NtgJuL8Z+mLbOPJny1N3Ns2vqh4DN3zT1sd9WmGGW1gS3VgE5snW1rDhMSSY
+        1HrPt7Wd52T5umUZvp/Jg2ylabMETooZpoW3FMlBnXyqVqHRX2u6dDDsW5R6qlLPHe6batenSf//
+        vf21tZZfWh1GKBjV4dSKsJnf1GzYL7uUHnbwlYYbchqNsyNUJ6h79rXllg4lU5e9HYD7fM9+brhh
+        Fwf19fHvGmu5uaXioMPoC/fiBVYrBFjeXY94FhQfwJugkHtEA7IeoFtOGn7Ld8g16ntyDDvYgbEL
+        ndAv1AuDqeKrDRk9cALZfGDeYrVHo9+Y+sHAN2Z9xZj3JswylXfPZx4TP348b/nfp/PhdL4weflW
+        jv4hafJRBNnPVz2y2zqhNG6T6HCja0m/0nMGnTh0Fy0Q6w0a2283PjFlKA5TV+sqNjGZdTi2Q/qM
+        CL1uhByOxmRqCxVijnMiNe1ZR2fgKkr/UKEwZU0x7SZDaex03jvaY7zCgI3o8wl+xlnR78xhNR2p
+        FXYrMEDdEBjHc/Se8TWLnh3HU5xje4x/rsjmwus3Ma3qToxTb8JulHCGcrM9YvPjuNITzw2vSSxl
+        py2G2Arj+y0klgVcdyOqhRqaweoy5/ieRQ/AWK0mwxaU5DclibyXJHCSswLyklKqdb5LMFB+0hyv
+        uKtc7uApD2Agyd4UmWkWmDGL65oWmtlFMcDlNo22Hqwb4E7C1FRKq4BL3H2Eax6sU7IR4InPL7OD
+        DguUU17el1MAlmAydHB4Xb6d06vzq7w+v8qfML/yg63vbiUZHhUPyGb27DeaPp5A4NQnEwjsO0J9
+        Sf5Afip/QL84f0D/vPyh+YvzB+aj6QPz4+wB/cnsAf3OHv4CZ/MLswcOZg/A2Snkkl1405HnnjlJ
+        XM+Z5QF4jNxvuhzDiewcxfqYaghLZVGNzTkaLI5SbPXnqIsJh8pQ2fEtgXI3XWV86nj0kYq5fmsu
+        bDAebPZ4a4dsrZG41nhCbe/HrEo3iC3e01pyrA259hC65Z40VoeeQUph6JLt5ToGY5LZxYfGfjFW
+        EK6xROY9jUPWyCAOhuGB5jWzepIaM4XcHxK6D9Z4pE+sltt8MyPAf65IJZ4qxKf8mHwivovULxEZ
+        /FNFKv7FRerj+H+kyLR+dZGKf7hIxX8oM/hPFqn4d5H6VzidP5aZm5ephRsOZi2287xvN2+3b5H8
+        z+gudOuSYniKCe47XF5oX5E8clckBOG1BoqrVrWxm047vWrPOy1VK5Bpsh05vFnZzQb7GVidJ72D
+        YmqLyAyUbYUaHavOobdCVj3NW5ggtk5khYmx1VqXjyeMl7aNeR8/K3xlvFvfT6WQjPLdW+Nf9wr5
+        AJVW8BXWr+7Gcssht4nUxx1raC3M2FpxPg/Om3AoJ+pSHveGe9aiw2PCUdXt4gxHZbqOqo4nlKbx
+        jN01z8pkBoReizlsxRkfTpqi6HHCXMUnY0kWnWmsOGsrmHHz2ZQeNM11oiHmmZAMMBCbcsBXHbZi
+        7D1j3kUH8bm5Ykczb8xr85UWLVcJ6rlyV5U7I/+ono/7E8k4ze3SmPZO4YGP/cPCaXf9qhohRneC
+        cCLdR8YiETclMdRCBEyE5pmfNt5W4vdr8ylOodfaHN5hb9bmGfNF7ZsP8I/UvtNfVJtnc39tftif
+        ML8/rjYnPhmXYZ71HZe/JGv6VGmOY5/KmohPZ03Yn5c1/fJX+78sa8LezJqIH2ZN2HfW9Bc4nV9Y
+        nKc/pKVWjLqcnyZbotljhLChVK3FbjVfKLrnyAq3odVEiIcUtprQXiucBgLlWDPmHFT1QYTvhtNm
+        shjoDW7EOiMEHU+k7VHfLIZjIKCd5BzvFjzr9OYjf3d28ROFIcZ6XyVwddYVeZFlm8B0ONuvxslp
+        GgdM2JkPewJ5mgWqbThM2AAaZ/XU8fxYQRcgqFJ0f4QePa8VVcaTjr08LqX1m2kA9lMFOf7Zgpx4
+        wr4L8q+RFuwz0oJVv1ZaHsd/R1qIv/JbX+KjykL8UFhyk3xeWPJ+38LylxaWF1W3MG9kvyz8QDku
+        QHdJf134kUIcgYW4nliUiEwlyyAScjNRNkduuumNGSYJRkGzS3bQaV/HRlNN1ZSlMbAP3Lgzspvh
+        UW3i2FrxyBU+145jXIjUFZVgcaQQpAW17Y8twNNX3SuBGij9RLGmNgelrKEYXUlr8PxZ2B/OHG6E
+        Ai4gU/M8mPLD0YmIeJLuDcJ5b1NpV7uDVY+cLgODR3fBVq56Dr8X7Jm854nhWkSnK2HO+PP1IJ6q
+        qz0bHsaNdofqrxp+WEmCAUkMT44ZJWHfpSvLczxfRjS3thzLjTYt0cF2du+8nTUXZ9f0aWqICEOn
+        x81QVOhRPZvV+pM5O3Y5xGOHqGeFvCO9WWBT+E8pa+Xpc39NpZ+q32f3K3Q137+P6ipJf0pXH1+L
+        v6urj+P/M5ds6UuXjwnrhfmGsuZGeVVZqR8pa97vW1n/uZS12WBbY379IWltyib0ruTjL7lnHMJE
+        MnEgdz4iwMPQOVVhZSWb7nzhM7NWlZzrwoYjOmQV7Tv8lB+1HLbvjVW+2g6czmgVTzC34sm2tWuc
+        j52mpQe7BrPqNRHnpMZeX/+IxpbvfzatyLZkAjmCdoROY4Lih/kv4RpcmCsHin79EPQZsUCgO+oN
+        kP/NYNwc18r32C3FD+pYqkP30JWRWbLlmCZQgpLmOVYp0EEp+0riplPxxcPltogK2bdU4+YN79Jw
+        pebmUeC+dJPhsq1V20mnrXPrRUVbmwengfWw8561I3UZ6/SIHR623srQkU2CnwRXGLfVvtw/q4nc
+        2yOu11dJekRHWmvWXYVcZxgu9rNR0+/Z4uxo9QOmivg66882g47NsE2REJcjn5ggSDy0p/2xdHaT
+        TZgsjEaaJz3M8GbG6Q4quUVuafnGvr0dr+/PZJx+L/bD/SHe3Z8JxEr/vhgVH2YOPGDCg1VybDP5
+        jw/tEpzFB3bJh7vUI0FMN04HgmRpNokX8504Wc9Z83hS5+hsmzB9ASH7rDmkm2suRjRFEjv0Ku62
+        21hvyDb5xPfU6QD1sLHSYKgDLQWDTrV1ZDV646si6S6XcnNqOZLoKPuJQY4Jhzwhcfc0Gu6s7rjh
+        Vnrm0DQT5oxHvfC0Ac2+YtPboec1+W5H5E/v7lwa3F5sG5RGywjSl/7596YGuH62+vD9qgF++P1q
+        YfvHD1fLj4P9yq9ir4OXX13IS6e8Is9xpPyjD/L/Dx1R2NzVPwAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:47 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['4029']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:25 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><add_user_commission /><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['472']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:47 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/TicketTypeTests.test_int_properties.yaml
+++ b/tests/interface_objects/cassettes/TicketTypeTests.test_int_properties.yaml
@@ -1,329 +1,258 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:48 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:25 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:48 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:26 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjxhZGRfdXNlcl9jb21taXNzaW9uIC8+PGNyeXB0b19ibG9j
+      az4tMC0tNi1ic2pXT2psUmdQd2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21O
+      ZS1MMmQzUWdEcXl0N1BxWjBrNkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85
+      MXVfUzBlcnFjbVFXdjhiVmV1S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BI
+      cDVlZTM1LVk8L2NyeXB0b19ibG9jaz48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHVzZXJfaWQ+ZGVt
+      bzwvdXNlcl9pZD48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBz
+      RGxGbWwyRUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHNlbGZfcHJp
+      bnRfbW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PC9hdmFpbGFiaWxpdHlfb3B0aW9ucz4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['452']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA+1b2XKryJZ9769Q1EMP0Y3FKES1rm5ongANSELSC4EgEUhMYhT6nf6T/rJOBlmD
+        7WP73OOquh2uqKiClSuTzJ0799obi9rfT5ZZioDnG479t9+wJ/S3ErAVRzXs3d9+W8y7SPW3v9f/
+        pSZHsmHKW8M0gkRy3ACyfckDfmgG9ZofblXHkg1bCn3gSYYvbWW1bju18usttWMo28HNSPVaJJuG
+        Kl3wOlYrPyCPDPxdBvEug3yXQb3LqLxklF8uT/ESN3Ckrekoh3oHRZDOaUDhw1nriOzYth+dyNhe
+        bM4bQRTW7eMRRMNuLzJJ12kZUeu4WGjRgm2sdszWZVa7CqIoI4oNpkMhmlksiMAJYARqUGdquuuI
+        ZxsTrQ6erOLd8qTyDiNYQ00Bq2RNjzg+qJ7DZDmMGXm2Ggt7KunyLoLGDTXCR81+5OoVpXucjRXv
+        zCCk2dbDE77qyw0L65LC1laHuHWMD7Pdpla+W1MNzsKGriB7QJag+4B6R6yVr3d5gwp8pd6B3pbE
+        OvBAQcjQmpIaLOOajq06NhIe4DOewbw9o7JZe9FYdDZl3y/+l/NlL/Ah5QoUjRm/ARtL/ypb7n+X
+        WtCDw3QqN8016KeZ0+bDJgCOdA/VfCB7ii4dQJI9qQxd/YqkB6LgXbo9I3eDXXmP46myrYDXB82X
+        cyHcgVdOto6mbJogKBbafuiQr7R8nUL5YkQntAOvMHu2CbfAc3PWf2EbAVBLIxgt4Dm/Uotd8YzA
+        UGCYiAwQSy7wlNRHMBRNnee1ppoqB0DyZHsHJGCrxX022FwP/6uE+UFJAG4ArC3wSjiKwdN3peTs
+        MFAkR9N8ENSJSvqoR/RK84ECXcmvYySN0xR5z7405vQE/mNZqlpPH4oyKFYwn3G40061gmJSBsu2
+        KgWGBTI6gjIIis0x5ncC/R1F/xPFfk+f9HqHYtxHG+T3fgCd44VVqEAvcXLyK+1RwUmaQD9sDwql
+        PmUPCv77M/Yo1p/Fmtwd+cW8NWu0Rp1ZrXwDF5TMDJwcBDqIS00n9Gzwb36Jh8vxZOUAXWjeEeaX
+        jrnN8mtDrVcG3UsLvCtwEzq6U4fDyUEaM27BguHKgV4vw86IlT8X2WbPRXzEfn4uEgA/KF/6Z12K
+        7nCFQejXTSN6Hr6ALgSoqHIgly/3QeKCum9YrgmgweDgwaVf1lKwQtcHpgln6gd3S+y8XCK84vro
+        LV5+ZYwdcNKNkus1U4ZSF0KbU9gThTMVDCPoWvkZrcFovssvEfQJQ+EOUxUo3le4Vr4Opsu+ZDtp
+        PND8LIG4A9JoCiMijDjPYbS4rVnySfJC24ZbkfsNhsM1vEBrFoy6r/Ae0ZoNgAo9woX+BtUh88ls
+        Pq/hBTn05FTtb2gXJCeka3A8Kw3D+fRfoDXX8YNcPFvYrETO+Vr5GbpIhArtn7Klg1VHn9BnjbjF
+        a77uZFFVy5eTPe4Bq/nQLyE9GxycoL9An0yHu4EvnFy3TwHwbNkszSGx1Ewd2VZL1x75+cnyvNci
+        /msNNehYYfEsodFmOzNB7LCsAHOqa0NByoYXZNUEHjzDInRF/0IrpKxIQe4seo2GIlChgGBfESsZ
+        BiM/Hiuxl9rxVtBJvd91HDNz8yJ3eMDSM2EaVirDmefd3L4TgrEPS1LmNPnskAY6gU5ZAEWLL0WG
+        b2zNwtEewZx1DVy5D8LoVCSKy6LLFaq9PKL3xzP9b75x9BOBliZcrXyF8lZdtyyYzmBMrmO3WP68
+        Zx9RQs+DNU9yvcpnsdu6MFG5g64MTVYCxyuSmQfwyrLDNFOpV/HKDasAryzXlBXgpyXNI3TDgXFA
+        8hNr65jlWxgGoRyt/+//3Pa/4le0flfGpXZK9aIQCtcz4CHeymnKIW99xwyhD/hyBI2ex5lHsLbN
+        PMSBYaCOYAgyxazzFN2IIwEomwNzJsUJvWkOke4Bm5r7GQv6VeYUMX5rDarbDogwQte7fTlJpMpa
+        XWz7jV4Sd2YVYZbYa6QJVvo8PuKyiiiU3oirG33kDm2L4Cv4SDtzhJs0fWuCtOLWYrBGlJ0vHqPR
+        GjsizWlDagnxUK72Z0qgRZupMRytaK+rKl02cVsVpeW0VruxLjl+JCpOMuXYDR0ODGM7nh3WHrmI
+        gkF8ljBLd0RishC1NtgJuL8Z+mLbOPJny1N3Ns2vqh4DN3zT1sd9WmGGW1gS3VgE5snW1rDhMSSY
+        1HrPt7Wd52T5umUZvp/Jg2ylabMETooZpoW3FMlBnXyqVqHRX2u6dDDsW5R6qlLPHe6batenSf//
+        vf21tZZfWh1GKBjV4dSKsJnf1GzYL7uUHnbwlYYbchqNsyNUJ6h79rXllg4lU5e9HYD7fM9+brhh
+        Fwf19fHvGmu5uaXioMPoC/fiBVYrBFjeXY94FhQfwJugkHtEA7IeoFtOGn7Ld8g16ntyDDvYgbEL
+        ndAv1AuDqeKrDRk9cALZfGDeYrVHo9+Y+sHAN2Z9xZj3JswylXfPZx4TP348b/nfp/PhdL4weflW
+        jv4hafJRBNnPVz2y2zqhNG6T6HCja0m/0nMGnTh0Fy0Q6w0a2283PjFlKA5TV+sqNjGZdTi2Q/qM
+        CL1uhByOxmRqCxVijnMiNe1ZR2fgKkr/UKEwZU0x7SZDaex03jvaY7zCgI3o8wl+xlnR78xhNR2p
+        FXYrMEDdEBjHc/Se8TWLnh3HU5xje4x/rsjmwus3Ma3qToxTb8JulHCGcrM9YvPjuNITzw2vSSxl
+        py2G2Arj+y0klgVcdyOqhRqaweoy5/ieRQ/AWK0mwxaU5DclibyXJHCSswLyklKqdb5LMFB+0hyv
+        uKtc7uApD2Agyd4UmWkWmDGL65oWmtlFMcDlNo22Hqwb4E7C1FRKq4BL3H2Eax6sU7IR4InPL7OD
+        DguUU17el1MAlmAydHB4Xb6d06vzq7w+v8qfML/yg63vbiUZHhUPyGb27DeaPp5A4NQnEwjsO0J9
+        Sf5Afip/QL84f0D/vPyh+YvzB+aj6QPz4+wB/cnsAf3OHv4CZ/MLswcOZg/A2Snkkl1405HnnjlJ
+        XM+Z5QF4jNxvuhzDiewcxfqYaghLZVGNzTkaLI5SbPXnqIsJh8pQ2fEtgXI3XWV86nj0kYq5fmsu
+        bDAebPZ4a4dsrZG41nhCbe/HrEo3iC3e01pyrA259hC65Z40VoeeQUph6JLt5ToGY5LZxYfGfjFW
+        EK6xROY9jUPWyCAOhuGB5jWzepIaM4XcHxK6D9Z4pE+sltt8MyPAf65IJZ4qxKf8mHwivovULxEZ
+        /FNFKv7FRerj+H+kyLR+dZGKf7hIxX8oM/hPFqn4d5H6VzidP5aZm5ephRsOZi2287xvN2+3b5H8
+        z+gudOuSYniKCe47XF5oX5E8clckBOG1BoqrVrWxm047vWrPOy1VK5Bpsh05vFnZzQb7GVidJ72D
+        YmqLyAyUbYUaHavOobdCVj3NW5ggtk5khYmx1VqXjyeMl7aNeR8/K3xlvFvfT6WQjPLdW+Nf9wr5
+        AJVW8BXWr+7Gcssht4nUxx1raC3M2FpxPg/Om3AoJ+pSHveGe9aiw2PCUdXt4gxHZbqOqo4nlKbx
+        jN01z8pkBoReizlsxRkfTpqi6HHCXMUnY0kWnWmsOGsrmHHz2ZQeNM11oiHmmZAMMBCbcsBXHbZi
+        7D1j3kUH8bm5Ykczb8xr85UWLVcJ6rlyV5U7I/+ono/7E8k4ze3SmPZO4YGP/cPCaXf9qhohRneC
+        cCLdR8YiETclMdRCBEyE5pmfNt5W4vdr8ylOodfaHN5hb9bmGfNF7ZsP8I/UvtNfVJtnc39tftif
+        ML8/rjYnPhmXYZ71HZe/JGv6VGmOY5/KmohPZ03Yn5c1/fJX+78sa8LezJqIH2ZN2HfW9Bc4nV9Y
+        nKc/pKVWjLqcnyZbotljhLChVK3FbjVfKLrnyAq3odVEiIcUtprQXiucBgLlWDPmHFT1QYTvhtNm
+        shjoDW7EOiMEHU+k7VHfLIZjIKCd5BzvFjzr9OYjf3d28ROFIcZ6XyVwddYVeZFlm8B0ONuvxslp
+        GgdM2JkPewJ5mgWqbThM2AAaZ/XU8fxYQRcgqFJ0f4QePa8VVcaTjr08LqX1m2kA9lMFOf7Zgpx4
+        wr4L8q+RFuwz0oJVv1ZaHsd/R1qIv/JbX+KjykL8UFhyk3xeWPJ+38LylxaWF1W3MG9kvyz8QDku
+        QHdJf134kUIcgYW4nliUiEwlyyAScjNRNkduuumNGSYJRkGzS3bQaV/HRlNN1ZSlMbAP3Lgzspvh
+        UW3i2FrxyBU+145jXIjUFZVgcaQQpAW17Y8twNNX3SuBGij9RLGmNgelrKEYXUlr8PxZ2B/OHG6E
+        Ai4gU/M8mPLD0YmIeJLuDcJ5b1NpV7uDVY+cLgODR3fBVq56Dr8X7Jm854nhWkSnK2HO+PP1IJ6q
+        qz0bHsaNdofqrxp+WEmCAUkMT44ZJWHfpSvLczxfRjS3thzLjTYt0cF2du+8nTUXZ9f0aWqICEOn
+        x81QVOhRPZvV+pM5O3Y5xGOHqGeFvCO9WWBT+E8pa+Xpc39NpZ+q32f3K3Q137+P6ipJf0pXH1+L
+        v6urj+P/M5ds6UuXjwnrhfmGsuZGeVVZqR8pa97vW1n/uZS12WBbY379IWltyib0ruTjL7lnHMJE
+        MnEgdz4iwMPQOVVhZSWb7nzhM7NWlZzrwoYjOmQV7Tv8lB+1HLbvjVW+2g6czmgVTzC34sm2tWuc
+        j52mpQe7BrPqNRHnpMZeX/+IxpbvfzatyLZkAjmCdoROY4Lih/kv4RpcmCsHin79EPQZsUCgO+oN
+        kP/NYNwc18r32C3FD+pYqkP30JWRWbLlmCZQgpLmOVYp0EEp+0riplPxxcPltogK2bdU4+YN79Jw
+        pebmUeC+dJPhsq1V20mnrXPrRUVbmwengfWw8561I3UZ6/SIHR623srQkU2CnwRXGLfVvtw/q4nc
+        2yOu11dJekRHWmvWXYVcZxgu9rNR0+/Z4uxo9QOmivg66882g47NsE2REJcjn5ggSDy0p/2xdHaT
+        TZgsjEaaJz3M8GbG6Q4quUVuafnGvr0dr+/PZJx+L/bD/SHe3Z8JxEr/vhgVH2YOPGDCg1VybDP5
+        jw/tEpzFB3bJh7vUI0FMN04HgmRpNokX8504Wc9Z83hS5+hsmzB9ASH7rDmkm2suRjRFEjv0Ku62
+        21hvyDb5xPfU6QD1sLHSYKgDLQWDTrV1ZDV646si6S6XcnNqOZLoKPuJQY4Jhzwhcfc0Gu6s7rjh
+        Vnrm0DQT5oxHvfC0Ac2+YtPboec1+W5H5E/v7lwa3F5sG5RGywjSl/7596YGuH62+vD9qgF++P1q
+        YfvHD1fLj4P9yq9ir4OXX13IS6e8Is9xpPyjD/L/Dx1R2NzVPwAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:48 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['4029']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:26 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><add_user_commission /><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['472']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:49 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/TicketTypeTests.test_quantity_options.yaml
+++ b/tests/interface_objects/cassettes/TicketTypeTests.test_quantity_options.yaml
@@ -1,329 +1,258 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:49 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:27 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:49 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:27 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjxhZGRfdXNlcl9jb21taXNzaW9uIC8+PGNyeXB0b19ibG9j
+      az4tMC0tNi1ic2pXT2psUmdQd2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21O
+      ZS1MMmQzUWdEcXl0N1BxWjBrNkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85
+      MXVfUzBlcnFjbVFXdjhiVmV1S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BI
+      cDVlZTM1LVk8L2NyeXB0b19ibG9jaz48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHVzZXJfaWQ+ZGVt
+      bzwvdXNlcl9pZD48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBz
+      RGxGbWwyRUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHNlbGZfcHJp
+      bnRfbW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PC9hdmFpbGFiaWxpdHlfb3B0aW9ucz4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['452']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA+1b2XKryJZ9769Q1EMP0Y3FKES1rm5ongANSELSC4EgEUhMYhT6nf6T/rJOBlmD
+        7WP73OOquh2uqKiClSuTzJ0799obi9rfT5ZZioDnG479t9+wJ/S3ErAVRzXs3d9+W8y7SPW3v9f/
+        pSZHsmHKW8M0gkRy3ACyfckDfmgG9ZofblXHkg1bCn3gSYYvbWW1bju18usttWMo28HNSPVaJJuG
+        Kl3wOlYrPyCPDPxdBvEug3yXQb3LqLxklF8uT/ESN3Ckrekoh3oHRZDOaUDhw1nriOzYth+dyNhe
+        bM4bQRTW7eMRRMNuLzJJ12kZUeu4WGjRgm2sdszWZVa7CqIoI4oNpkMhmlksiMAJYARqUGdquuuI
+        ZxsTrQ6erOLd8qTyDiNYQ00Bq2RNjzg+qJ7DZDmMGXm2Ggt7KunyLoLGDTXCR81+5OoVpXucjRXv
+        zCCk2dbDE77qyw0L65LC1laHuHWMD7Pdpla+W1MNzsKGriB7QJag+4B6R6yVr3d5gwp8pd6B3pbE
+        OvBAQcjQmpIaLOOajq06NhIe4DOewbw9o7JZe9FYdDZl3y/+l/NlL/Ah5QoUjRm/ARtL/ypb7n+X
+        WtCDw3QqN8016KeZ0+bDJgCOdA/VfCB7ii4dQJI9qQxd/YqkB6LgXbo9I3eDXXmP46myrYDXB82X
+        cyHcgVdOto6mbJogKBbafuiQr7R8nUL5YkQntAOvMHu2CbfAc3PWf2EbAVBLIxgt4Dm/Uotd8YzA
+        UGCYiAwQSy7wlNRHMBRNnee1ppoqB0DyZHsHJGCrxX022FwP/6uE+UFJAG4ArC3wSjiKwdN3peTs
+        MFAkR9N8ENSJSvqoR/RK84ECXcmvYySN0xR5z7405vQE/mNZqlpPH4oyKFYwn3G40061gmJSBsu2
+        KgWGBTI6gjIIis0x5ncC/R1F/xPFfk+f9HqHYtxHG+T3fgCd44VVqEAvcXLyK+1RwUmaQD9sDwql
+        PmUPCv77M/Yo1p/Fmtwd+cW8NWu0Rp1ZrXwDF5TMDJwcBDqIS00n9Gzwb36Jh8vxZOUAXWjeEeaX
+        jrnN8mtDrVcG3UsLvCtwEzq6U4fDyUEaM27BguHKgV4vw86IlT8X2WbPRXzEfn4uEgA/KF/6Z12K
+        7nCFQejXTSN6Hr6ALgSoqHIgly/3QeKCum9YrgmgweDgwaVf1lKwQtcHpgln6gd3S+y8XCK84vro
+        LV5+ZYwdcNKNkus1U4ZSF0KbU9gThTMVDCPoWvkZrcFovssvEfQJQ+EOUxUo3le4Vr4Opsu+ZDtp
+        PND8LIG4A9JoCiMijDjPYbS4rVnySfJC24ZbkfsNhsM1vEBrFoy6r/Ae0ZoNgAo9woX+BtUh88ls
+        Pq/hBTn05FTtb2gXJCeka3A8Kw3D+fRfoDXX8YNcPFvYrETO+Vr5GbpIhArtn7Klg1VHn9BnjbjF
+        a77uZFFVy5eTPe4Bq/nQLyE9GxycoL9An0yHu4EvnFy3TwHwbNkszSGx1Ewd2VZL1x75+cnyvNci
+        /msNNehYYfEsodFmOzNB7LCsAHOqa0NByoYXZNUEHjzDInRF/0IrpKxIQe4seo2GIlChgGBfESsZ
+        BiM/Hiuxl9rxVtBJvd91HDNz8yJ3eMDSM2EaVirDmefd3L4TgrEPS1LmNPnskAY6gU5ZAEWLL0WG
+        b2zNwtEewZx1DVy5D8LoVCSKy6LLFaq9PKL3xzP9b75x9BOBliZcrXyF8lZdtyyYzmBMrmO3WP68
+        Zx9RQs+DNU9yvcpnsdu6MFG5g64MTVYCxyuSmQfwyrLDNFOpV/HKDasAryzXlBXgpyXNI3TDgXFA
+        8hNr65jlWxgGoRyt/+//3Pa/4le0flfGpXZK9aIQCtcz4CHeymnKIW99xwyhD/hyBI2ex5lHsLbN
+        PMSBYaCOYAgyxazzFN2IIwEomwNzJsUJvWkOke4Bm5r7GQv6VeYUMX5rDarbDogwQte7fTlJpMpa
+        XWz7jV4Sd2YVYZbYa6QJVvo8PuKyiiiU3oirG33kDm2L4Cv4SDtzhJs0fWuCtOLWYrBGlJ0vHqPR
+        GjsizWlDagnxUK72Z0qgRZupMRytaK+rKl02cVsVpeW0VruxLjl+JCpOMuXYDR0ODGM7nh3WHrmI
+        gkF8ljBLd0RishC1NtgJuL8Z+mLbOPJny1N3Ns2vqh4DN3zT1sd9WmGGW1gS3VgE5snW1rDhMSSY
+        1HrPt7Wd52T5umUZvp/Jg2ylabMETooZpoW3FMlBnXyqVqHRX2u6dDDsW5R6qlLPHe6batenSf//
+        vf21tZZfWh1GKBjV4dSKsJnf1GzYL7uUHnbwlYYbchqNsyNUJ6h79rXllg4lU5e9HYD7fM9+brhh
+        Fwf19fHvGmu5uaXioMPoC/fiBVYrBFjeXY94FhQfwJugkHtEA7IeoFtOGn7Ld8g16ntyDDvYgbEL
+        ndAv1AuDqeKrDRk9cALZfGDeYrVHo9+Y+sHAN2Z9xZj3JswylXfPZx4TP348b/nfp/PhdL4weflW
+        jv4hafJRBNnPVz2y2zqhNG6T6HCja0m/0nMGnTh0Fy0Q6w0a2283PjFlKA5TV+sqNjGZdTi2Q/qM
+        CL1uhByOxmRqCxVijnMiNe1ZR2fgKkr/UKEwZU0x7SZDaex03jvaY7zCgI3o8wl+xlnR78xhNR2p
+        FXYrMEDdEBjHc/Se8TWLnh3HU5xje4x/rsjmwus3Ma3qToxTb8JulHCGcrM9YvPjuNITzw2vSSxl
+        py2G2Arj+y0klgVcdyOqhRqaweoy5/ieRQ/AWK0mwxaU5DclibyXJHCSswLyklKqdb5LMFB+0hyv
+        uKtc7uApD2Agyd4UmWkWmDGL65oWmtlFMcDlNo22Hqwb4E7C1FRKq4BL3H2Eax6sU7IR4InPL7OD
+        DguUU17el1MAlmAydHB4Xb6d06vzq7w+v8qfML/yg63vbiUZHhUPyGb27DeaPp5A4NQnEwjsO0J9
+        Sf5Afip/QL84f0D/vPyh+YvzB+aj6QPz4+wB/cnsAf3OHv4CZ/MLswcOZg/A2Snkkl1405HnnjlJ
+        XM+Z5QF4jNxvuhzDiewcxfqYaghLZVGNzTkaLI5SbPXnqIsJh8pQ2fEtgXI3XWV86nj0kYq5fmsu
+        bDAebPZ4a4dsrZG41nhCbe/HrEo3iC3e01pyrA259hC65Z40VoeeQUph6JLt5ToGY5LZxYfGfjFW
+        EK6xROY9jUPWyCAOhuGB5jWzepIaM4XcHxK6D9Z4pE+sltt8MyPAf65IJZ4qxKf8mHwivovULxEZ
+        /FNFKv7FRerj+H+kyLR+dZGKf7hIxX8oM/hPFqn4d5H6VzidP5aZm5ephRsOZi2287xvN2+3b5H8
+        z+gudOuSYniKCe47XF5oX5E8clckBOG1BoqrVrWxm047vWrPOy1VK5Bpsh05vFnZzQb7GVidJ72D
+        YmqLyAyUbYUaHavOobdCVj3NW5ggtk5khYmx1VqXjyeMl7aNeR8/K3xlvFvfT6WQjPLdW+Nf9wr5
+        AJVW8BXWr+7Gcssht4nUxx1raC3M2FpxPg/Om3AoJ+pSHveGe9aiw2PCUdXt4gxHZbqOqo4nlKbx
+        jN01z8pkBoReizlsxRkfTpqi6HHCXMUnY0kWnWmsOGsrmHHz2ZQeNM11oiHmmZAMMBCbcsBXHbZi
+        7D1j3kUH8bm5Ykczb8xr85UWLVcJ6rlyV5U7I/+ono/7E8k4ze3SmPZO4YGP/cPCaXf9qhohRneC
+        cCLdR8YiETclMdRCBEyE5pmfNt5W4vdr8ylOodfaHN5hb9bmGfNF7ZsP8I/UvtNfVJtnc39tftif
+        ML8/rjYnPhmXYZ71HZe/JGv6VGmOY5/KmohPZ03Yn5c1/fJX+78sa8LezJqIH2ZN2HfW9Bc4nV9Y
+        nKc/pKVWjLqcnyZbotljhLChVK3FbjVfKLrnyAq3odVEiIcUtprQXiucBgLlWDPmHFT1QYTvhtNm
+        shjoDW7EOiMEHU+k7VHfLIZjIKCd5BzvFjzr9OYjf3d28ROFIcZ6XyVwddYVeZFlm8B0ONuvxslp
+        GgdM2JkPewJ5mgWqbThM2AAaZ/XU8fxYQRcgqFJ0f4QePa8VVcaTjr08LqX1m2kA9lMFOf7Zgpx4
+        wr4L8q+RFuwz0oJVv1ZaHsd/R1qIv/JbX+KjykL8UFhyk3xeWPJ+38LylxaWF1W3MG9kvyz8QDku
+        QHdJf134kUIcgYW4nliUiEwlyyAScjNRNkduuumNGSYJRkGzS3bQaV/HRlNN1ZSlMbAP3Lgzspvh
+        UW3i2FrxyBU+145jXIjUFZVgcaQQpAW17Y8twNNX3SuBGij9RLGmNgelrKEYXUlr8PxZ2B/OHG6E
+        Ai4gU/M8mPLD0YmIeJLuDcJ5b1NpV7uDVY+cLgODR3fBVq56Dr8X7Jm854nhWkSnK2HO+PP1IJ6q
+        qz0bHsaNdofqrxp+WEmCAUkMT44ZJWHfpSvLczxfRjS3thzLjTYt0cF2du+8nTUXZ9f0aWqICEOn
+        x81QVOhRPZvV+pM5O3Y5xGOHqGeFvCO9WWBT+E8pa+Xpc39NpZ+q32f3K3Q137+P6ipJf0pXH1+L
+        v6urj+P/M5ds6UuXjwnrhfmGsuZGeVVZqR8pa97vW1n/uZS12WBbY379IWltyib0ruTjL7lnHMJE
+        MnEgdz4iwMPQOVVhZSWb7nzhM7NWlZzrwoYjOmQV7Tv8lB+1HLbvjVW+2g6czmgVTzC34sm2tWuc
+        j52mpQe7BrPqNRHnpMZeX/+IxpbvfzatyLZkAjmCdoROY4Lih/kv4RpcmCsHin79EPQZsUCgO+oN
+        kP/NYNwc18r32C3FD+pYqkP30JWRWbLlmCZQgpLmOVYp0EEp+0riplPxxcPltogK2bdU4+YN79Jw
+        pebmUeC+dJPhsq1V20mnrXPrRUVbmwengfWw8561I3UZ6/SIHR623srQkU2CnwRXGLfVvtw/q4nc
+        2yOu11dJekRHWmvWXYVcZxgu9rNR0+/Z4uxo9QOmivg66882g47NsE2REJcjn5ggSDy0p/2xdHaT
+        TZgsjEaaJz3M8GbG6Q4quUVuafnGvr0dr+/PZJx+L/bD/SHe3Z8JxEr/vhgVH2YOPGDCg1VybDP5
+        jw/tEpzFB3bJh7vUI0FMN04HgmRpNokX8504Wc9Z83hS5+hsmzB9ASH7rDmkm2suRjRFEjv0Ku62
+        21hvyDb5xPfU6QD1sLHSYKgDLQWDTrV1ZDV646si6S6XcnNqOZLoKPuJQY4Jhzwhcfc0Gu6s7rjh
+        Vnrm0DQT5oxHvfC0Ac2+YtPboec1+W5H5E/v7lwa3F5sG5RGywjSl/7596YGuH62+vD9qgF++P1q
+        YfvHD1fLj4P9yq9ir4OXX13IS6e8Is9xpPyjD/L/Dx1R2NzVPwAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:50 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['4029']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:28 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><add_user_commission /><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['472']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:50 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/TicketTypeTests.test_string_properties.yaml
+++ b/tests/interface_objects/cassettes/TicketTypeTests.test_string_properties.yaml
@@ -1,329 +1,258 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:51 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:28 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:51 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:28 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjxhZGRfdXNlcl9jb21taXNzaW9uIC8+PGNyeXB0b19ibG9j
+      az4tMC0tNi1ic2pXT2psUmdQd2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21O
+      ZS1MMmQzUWdEcXl0N1BxWjBrNkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85
+      MXVfUzBlcnFjbVFXdjhiVmV1S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BI
+      cDVlZTM1LVk8L2NyeXB0b19ibG9jaz48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHVzZXJfaWQ+ZGVt
+      bzwvdXNlcl9pZD48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBz
+      RGxGbWwyRUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHNlbGZfcHJp
+      bnRfbW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PC9hdmFpbGFiaWxpdHlfb3B0aW9ucz4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['452']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA+1b2XKryJZ9769Q1EMP0Y3FKES1rm5ongANSELSC4EgEUhMYhT6nf6T/rJOBlmD
+        7WP73OOquh2uqKiClSuTzJ0799obi9rfT5ZZioDnG479t9+wJ/S3ErAVRzXs3d9+W8y7SPW3v9f/
+        pSZHsmHKW8M0gkRy3ACyfckDfmgG9ZofblXHkg1bCn3gSYYvbWW1bju18usttWMo28HNSPVaJJuG
+        Kl3wOlYrPyCPDPxdBvEug3yXQb3LqLxklF8uT/ESN3Ckrekoh3oHRZDOaUDhw1nriOzYth+dyNhe
+        bM4bQRTW7eMRRMNuLzJJ12kZUeu4WGjRgm2sdszWZVa7CqIoI4oNpkMhmlksiMAJYARqUGdquuuI
+        ZxsTrQ6erOLd8qTyDiNYQ00Bq2RNjzg+qJ7DZDmMGXm2Ggt7KunyLoLGDTXCR81+5OoVpXucjRXv
+        zCCk2dbDE77qyw0L65LC1laHuHWMD7Pdpla+W1MNzsKGriB7QJag+4B6R6yVr3d5gwp8pd6B3pbE
+        OvBAQcjQmpIaLOOajq06NhIe4DOewbw9o7JZe9FYdDZl3y/+l/NlL/Ah5QoUjRm/ARtL/ypb7n+X
+        WtCDw3QqN8016KeZ0+bDJgCOdA/VfCB7ii4dQJI9qQxd/YqkB6LgXbo9I3eDXXmP46myrYDXB82X
+        cyHcgVdOto6mbJogKBbafuiQr7R8nUL5YkQntAOvMHu2CbfAc3PWf2EbAVBLIxgt4Dm/Uotd8YzA
+        UGCYiAwQSy7wlNRHMBRNnee1ppoqB0DyZHsHJGCrxX022FwP/6uE+UFJAG4ArC3wSjiKwdN3peTs
+        MFAkR9N8ENSJSvqoR/RK84ECXcmvYySN0xR5z7405vQE/mNZqlpPH4oyKFYwn3G40061gmJSBsu2
+        KgWGBTI6gjIIis0x5ncC/R1F/xPFfk+f9HqHYtxHG+T3fgCd44VVqEAvcXLyK+1RwUmaQD9sDwql
+        PmUPCv77M/Yo1p/Fmtwd+cW8NWu0Rp1ZrXwDF5TMDJwcBDqIS00n9Gzwb36Jh8vxZOUAXWjeEeaX
+        jrnN8mtDrVcG3UsLvCtwEzq6U4fDyUEaM27BguHKgV4vw86IlT8X2WbPRXzEfn4uEgA/KF/6Z12K
+        7nCFQejXTSN6Hr6ALgSoqHIgly/3QeKCum9YrgmgweDgwaVf1lKwQtcHpgln6gd3S+y8XCK84vro
+        LV5+ZYwdcNKNkus1U4ZSF0KbU9gThTMVDCPoWvkZrcFovssvEfQJQ+EOUxUo3le4Vr4Opsu+ZDtp
+        PND8LIG4A9JoCiMijDjPYbS4rVnySfJC24ZbkfsNhsM1vEBrFoy6r/Ae0ZoNgAo9woX+BtUh88ls
+        Pq/hBTn05FTtb2gXJCeka3A8Kw3D+fRfoDXX8YNcPFvYrETO+Vr5GbpIhArtn7Klg1VHn9BnjbjF
+        a77uZFFVy5eTPe4Bq/nQLyE9GxycoL9An0yHu4EvnFy3TwHwbNkszSGx1Ewd2VZL1x75+cnyvNci
+        /msNNehYYfEsodFmOzNB7LCsAHOqa0NByoYXZNUEHjzDInRF/0IrpKxIQe4seo2GIlChgGBfESsZ
+        BiM/Hiuxl9rxVtBJvd91HDNz8yJ3eMDSM2EaVirDmefd3L4TgrEPS1LmNPnskAY6gU5ZAEWLL0WG
+        b2zNwtEewZx1DVy5D8LoVCSKy6LLFaq9PKL3xzP9b75x9BOBliZcrXyF8lZdtyyYzmBMrmO3WP68
+        Zx9RQs+DNU9yvcpnsdu6MFG5g64MTVYCxyuSmQfwyrLDNFOpV/HKDasAryzXlBXgpyXNI3TDgXFA
+        8hNr65jlWxgGoRyt/+//3Pa/4le0flfGpXZK9aIQCtcz4CHeymnKIW99xwyhD/hyBI2ex5lHsLbN
+        PMSBYaCOYAgyxazzFN2IIwEomwNzJsUJvWkOke4Bm5r7GQv6VeYUMX5rDarbDogwQte7fTlJpMpa
+        XWz7jV4Sd2YVYZbYa6QJVvo8PuKyiiiU3oirG33kDm2L4Cv4SDtzhJs0fWuCtOLWYrBGlJ0vHqPR
+        GjsizWlDagnxUK72Z0qgRZupMRytaK+rKl02cVsVpeW0VruxLjl+JCpOMuXYDR0ODGM7nh3WHrmI
+        gkF8ljBLd0RishC1NtgJuL8Z+mLbOPJny1N3Ns2vqh4DN3zT1sd9WmGGW1gS3VgE5snW1rDhMSSY
+        1HrPt7Wd52T5umUZvp/Jg2ylabMETooZpoW3FMlBnXyqVqHRX2u6dDDsW5R6qlLPHe6batenSf//
+        vf21tZZfWh1GKBjV4dSKsJnf1GzYL7uUHnbwlYYbchqNsyNUJ6h79rXllg4lU5e9HYD7fM9+brhh
+        Fwf19fHvGmu5uaXioMPoC/fiBVYrBFjeXY94FhQfwJugkHtEA7IeoFtOGn7Ld8g16ntyDDvYgbEL
+        ndAv1AuDqeKrDRk9cALZfGDeYrVHo9+Y+sHAN2Z9xZj3JswylXfPZx4TP348b/nfp/PhdL4weflW
+        jv4hafJRBNnPVz2y2zqhNG6T6HCja0m/0nMGnTh0Fy0Q6w0a2283PjFlKA5TV+sqNjGZdTi2Q/qM
+        CL1uhByOxmRqCxVijnMiNe1ZR2fgKkr/UKEwZU0x7SZDaex03jvaY7zCgI3o8wl+xlnR78xhNR2p
+        FXYrMEDdEBjHc/Se8TWLnh3HU5xje4x/rsjmwus3Ma3qToxTb8JulHCGcrM9YvPjuNITzw2vSSxl
+        py2G2Arj+y0klgVcdyOqhRqaweoy5/ieRQ/AWK0mwxaU5DclibyXJHCSswLyklKqdb5LMFB+0hyv
+        uKtc7uApD2Agyd4UmWkWmDGL65oWmtlFMcDlNo22Hqwb4E7C1FRKq4BL3H2Eax6sU7IR4InPL7OD
+        DguUU17el1MAlmAydHB4Xb6d06vzq7w+v8qfML/yg63vbiUZHhUPyGb27DeaPp5A4NQnEwjsO0J9
+        Sf5Afip/QL84f0D/vPyh+YvzB+aj6QPz4+wB/cnsAf3OHv4CZ/MLswcOZg/A2Snkkl1405HnnjlJ
+        XM+Z5QF4jNxvuhzDiewcxfqYaghLZVGNzTkaLI5SbPXnqIsJh8pQ2fEtgXI3XWV86nj0kYq5fmsu
+        bDAebPZ4a4dsrZG41nhCbe/HrEo3iC3e01pyrA259hC65Z40VoeeQUph6JLt5ToGY5LZxYfGfjFW
+        EK6xROY9jUPWyCAOhuGB5jWzepIaM4XcHxK6D9Z4pE+sltt8MyPAf65IJZ4qxKf8mHwivovULxEZ
+        /FNFKv7FRerj+H+kyLR+dZGKf7hIxX8oM/hPFqn4d5H6VzidP5aZm5ephRsOZi2287xvN2+3b5H8
+        z+gudOuSYniKCe47XF5oX5E8clckBOG1BoqrVrWxm047vWrPOy1VK5Bpsh05vFnZzQb7GVidJ72D
+        YmqLyAyUbYUaHavOobdCVj3NW5ggtk5khYmx1VqXjyeMl7aNeR8/K3xlvFvfT6WQjPLdW+Nf9wr5
+        AJVW8BXWr+7Gcssht4nUxx1raC3M2FpxPg/Om3AoJ+pSHveGe9aiw2PCUdXt4gxHZbqOqo4nlKbx
+        jN01z8pkBoReizlsxRkfTpqi6HHCXMUnY0kWnWmsOGsrmHHz2ZQeNM11oiHmmZAMMBCbcsBXHbZi
+        7D1j3kUH8bm5Ykczb8xr85UWLVcJ6rlyV5U7I/+ono/7E8k4ze3SmPZO4YGP/cPCaXf9qhohRneC
+        cCLdR8YiETclMdRCBEyE5pmfNt5W4vdr8ylOodfaHN5hb9bmGfNF7ZsP8I/UvtNfVJtnc39tftif
+        ML8/rjYnPhmXYZ71HZe/JGv6VGmOY5/KmohPZ03Yn5c1/fJX+78sa8LezJqIH2ZN2HfW9Bc4nV9Y
+        nKc/pKVWjLqcnyZbotljhLChVK3FbjVfKLrnyAq3odVEiIcUtprQXiucBgLlWDPmHFT1QYTvhtNm
+        shjoDW7EOiMEHU+k7VHfLIZjIKCd5BzvFjzr9OYjf3d28ROFIcZ6XyVwddYVeZFlm8B0ONuvxslp
+        GgdM2JkPewJ5mgWqbThM2AAaZ/XU8fxYQRcgqFJ0f4QePa8VVcaTjr08LqX1m2kA9lMFOf7Zgpx4
+        wr4L8q+RFuwz0oJVv1ZaHsd/R1qIv/JbX+KjykL8UFhyk3xeWPJ+38LylxaWF1W3MG9kvyz8QDku
+        QHdJf134kUIcgYW4nliUiEwlyyAScjNRNkduuumNGSYJRkGzS3bQaV/HRlNN1ZSlMbAP3Lgzspvh
+        UW3i2FrxyBU+145jXIjUFZVgcaQQpAW17Y8twNNX3SuBGij9RLGmNgelrKEYXUlr8PxZ2B/OHG6E
+        Ai4gU/M8mPLD0YmIeJLuDcJ5b1NpV7uDVY+cLgODR3fBVq56Dr8X7Jm854nhWkSnK2HO+PP1IJ6q
+        qz0bHsaNdofqrxp+WEmCAUkMT44ZJWHfpSvLczxfRjS3thzLjTYt0cF2du+8nTUXZ9f0aWqICEOn
+        x81QVOhRPZvV+pM5O3Y5xGOHqGeFvCO9WWBT+E8pa+Xpc39NpZ+q32f3K3Q137+P6ipJf0pXH1+L
+        v6urj+P/M5ds6UuXjwnrhfmGsuZGeVVZqR8pa97vW1n/uZS12WBbY379IWltyib0ruTjL7lnHMJE
+        MnEgdz4iwMPQOVVhZSWb7nzhM7NWlZzrwoYjOmQV7Tv8lB+1HLbvjVW+2g6czmgVTzC34sm2tWuc
+        j52mpQe7BrPqNRHnpMZeX/+IxpbvfzatyLZkAjmCdoROY4Lih/kv4RpcmCsHin79EPQZsUCgO+oN
+        kP/NYNwc18r32C3FD+pYqkP30JWRWbLlmCZQgpLmOVYp0EEp+0riplPxxcPltogK2bdU4+YN79Jw
+        pebmUeC+dJPhsq1V20mnrXPrRUVbmwengfWw8561I3UZ6/SIHR623srQkU2CnwRXGLfVvtw/q4nc
+        2yOu11dJekRHWmvWXYVcZxgu9rNR0+/Z4uxo9QOmivg66882g47NsE2REJcjn5ggSDy0p/2xdHaT
+        TZgsjEaaJz3M8GbG6Q4quUVuafnGvr0dr+/PZJx+L/bD/SHe3Z8JxEr/vhgVH2YOPGDCg1VybDP5
+        jw/tEpzFB3bJh7vUI0FMN04HgmRpNokX8504Wc9Z83hS5+hsmzB9ASH7rDmkm2suRjRFEjv0Ku62
+        21hvyDb5xPfU6QD1sLHSYKgDLQWDTrV1ZDV646si6S6XcnNqOZLoKPuJQY4Jhzwhcfc0Gu6s7rjh
+        Vnrm0DQT5oxHvfC0Ac2+YtPboec1+W5H5E/v7lwa3F5sG5RGywjSl/7596YGuH62+vD9qgF++P1q
+        YfvHD1fLj4P9yq9ir4OXX13IS6e8Is9xpPyjD/L/Dx1R2NzVPwAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:51 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['4029']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:29 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><add_user_commission /><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['472']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:51 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/TicketTypeTests.test_unicode_properties.yaml
+++ b/tests/interface_objects/cassettes/TicketTypeTests.test_unicode_properties.yaml
@@ -1,329 +1,258 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:52 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:30 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:52 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:30 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjxhZGRfdXNlcl9jb21taXNzaW9uIC8+PGNyeXB0b19ibG9j
+      az4tMC0tNi1ic2pXT2psUmdQd2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21O
+      ZS1MMmQzUWdEcXl0N1BxWjBrNkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85
+      MXVfUzBlcnFjbVFXdjhiVmV1S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BI
+      cDVlZTM1LVk8L2NyeXB0b19ibG9jaz48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHVzZXJfaWQ+ZGVt
+      bzwvdXNlcl9pZD48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBz
+      RGxGbWwyRUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHNlbGZfcHJp
+      bnRfbW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PC9hdmFpbGFiaWxpdHlfb3B0aW9ucz4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['452']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA+1b2XKryJZ9769Q1EMP0Y3FKES1rm5ongANSELSC4EgEUhMYhT6nf6T/rJOBlmD
+        7WP73OOquh2uqKiClSuTzJ0799obi9rfT5ZZioDnG479t9+wJ/S3ErAVRzXs3d9+W8y7SPW3v9f/
+        pSZHsmHKW8M0gkRy3ACyfckDfmgG9ZofblXHkg1bCn3gSYYvbWW1bju18usttWMo28HNSPVaJJuG
+        Kl3wOlYrPyCPDPxdBvEug3yXQb3LqLxklF8uT/ESN3Ckrekoh3oHRZDOaUDhw1nriOzYth+dyNhe
+        bM4bQRTW7eMRRMNuLzJJ12kZUeu4WGjRgm2sdszWZVa7CqIoI4oNpkMhmlksiMAJYARqUGdquuuI
+        ZxsTrQ6erOLd8qTyDiNYQ00Bq2RNjzg+qJ7DZDmMGXm2Ggt7KunyLoLGDTXCR81+5OoVpXucjRXv
+        zCCk2dbDE77qyw0L65LC1laHuHWMD7Pdpla+W1MNzsKGriB7QJag+4B6R6yVr3d5gwp8pd6B3pbE
+        OvBAQcjQmpIaLOOajq06NhIe4DOewbw9o7JZe9FYdDZl3y/+l/NlL/Ah5QoUjRm/ARtL/ypb7n+X
+        WtCDw3QqN8016KeZ0+bDJgCOdA/VfCB7ii4dQJI9qQxd/YqkB6LgXbo9I3eDXXmP46myrYDXB82X
+        cyHcgVdOto6mbJogKBbafuiQr7R8nUL5YkQntAOvMHu2CbfAc3PWf2EbAVBLIxgt4Dm/Uotd8YzA
+        UGCYiAwQSy7wlNRHMBRNnee1ppoqB0DyZHsHJGCrxX022FwP/6uE+UFJAG4ArC3wSjiKwdN3peTs
+        MFAkR9N8ENSJSvqoR/RK84ECXcmvYySN0xR5z7405vQE/mNZqlpPH4oyKFYwn3G40061gmJSBsu2
+        KgWGBTI6gjIIis0x5ncC/R1F/xPFfk+f9HqHYtxHG+T3fgCd44VVqEAvcXLyK+1RwUmaQD9sDwql
+        PmUPCv77M/Yo1p/Fmtwd+cW8NWu0Rp1ZrXwDF5TMDJwcBDqIS00n9Gzwb36Jh8vxZOUAXWjeEeaX
+        jrnN8mtDrVcG3UsLvCtwEzq6U4fDyUEaM27BguHKgV4vw86IlT8X2WbPRXzEfn4uEgA/KF/6Z12K
+        7nCFQejXTSN6Hr6ALgSoqHIgly/3QeKCum9YrgmgweDgwaVf1lKwQtcHpgln6gd3S+y8XCK84vro
+        LV5+ZYwdcNKNkus1U4ZSF0KbU9gThTMVDCPoWvkZrcFovssvEfQJQ+EOUxUo3le4Vr4Opsu+ZDtp
+        PND8LIG4A9JoCiMijDjPYbS4rVnySfJC24ZbkfsNhsM1vEBrFoy6r/Ae0ZoNgAo9woX+BtUh88ls
+        Pq/hBTn05FTtb2gXJCeka3A8Kw3D+fRfoDXX8YNcPFvYrETO+Vr5GbpIhArtn7Klg1VHn9BnjbjF
+        a77uZFFVy5eTPe4Bq/nQLyE9GxycoL9An0yHu4EvnFy3TwHwbNkszSGx1Ewd2VZL1x75+cnyvNci
+        /msNNehYYfEsodFmOzNB7LCsAHOqa0NByoYXZNUEHjzDInRF/0IrpKxIQe4seo2GIlChgGBfESsZ
+        BiM/Hiuxl9rxVtBJvd91HDNz8yJ3eMDSM2EaVirDmefd3L4TgrEPS1LmNPnskAY6gU5ZAEWLL0WG
+        b2zNwtEewZx1DVy5D8LoVCSKy6LLFaq9PKL3xzP9b75x9BOBliZcrXyF8lZdtyyYzmBMrmO3WP68
+        Zx9RQs+DNU9yvcpnsdu6MFG5g64MTVYCxyuSmQfwyrLDNFOpV/HKDasAryzXlBXgpyXNI3TDgXFA
+        8hNr65jlWxgGoRyt/+//3Pa/4le0flfGpXZK9aIQCtcz4CHeymnKIW99xwyhD/hyBI2ex5lHsLbN
+        PMSBYaCOYAgyxazzFN2IIwEomwNzJsUJvWkOke4Bm5r7GQv6VeYUMX5rDarbDogwQte7fTlJpMpa
+        XWz7jV4Sd2YVYZbYa6QJVvo8PuKyiiiU3oirG33kDm2L4Cv4SDtzhJs0fWuCtOLWYrBGlJ0vHqPR
+        GjsizWlDagnxUK72Z0qgRZupMRytaK+rKl02cVsVpeW0VruxLjl+JCpOMuXYDR0ODGM7nh3WHrmI
+        gkF8ljBLd0RishC1NtgJuL8Z+mLbOPJny1N3Ns2vqh4DN3zT1sd9WmGGW1gS3VgE5snW1rDhMSSY
+        1HrPt7Wd52T5umUZvp/Jg2ylabMETooZpoW3FMlBnXyqVqHRX2u6dDDsW5R6qlLPHe6batenSf//
+        vf21tZZfWh1GKBjV4dSKsJnf1GzYL7uUHnbwlYYbchqNsyNUJ6h79rXllg4lU5e9HYD7fM9+brhh
+        Fwf19fHvGmu5uaXioMPoC/fiBVYrBFjeXY94FhQfwJugkHtEA7IeoFtOGn7Ld8g16ntyDDvYgbEL
+        ndAv1AuDqeKrDRk9cALZfGDeYrVHo9+Y+sHAN2Z9xZj3JswylXfPZx4TP348b/nfp/PhdL4weflW
+        jv4hafJRBNnPVz2y2zqhNG6T6HCja0m/0nMGnTh0Fy0Q6w0a2283PjFlKA5TV+sqNjGZdTi2Q/qM
+        CL1uhByOxmRqCxVijnMiNe1ZR2fgKkr/UKEwZU0x7SZDaex03jvaY7zCgI3o8wl+xlnR78xhNR2p
+        FXYrMEDdEBjHc/Se8TWLnh3HU5xje4x/rsjmwus3Ma3qToxTb8JulHCGcrM9YvPjuNITzw2vSSxl
+        py2G2Arj+y0klgVcdyOqhRqaweoy5/ieRQ/AWK0mwxaU5DclibyXJHCSswLyklKqdb5LMFB+0hyv
+        uKtc7uApD2Agyd4UmWkWmDGL65oWmtlFMcDlNo22Hqwb4E7C1FRKq4BL3H2Eax6sU7IR4InPL7OD
+        DguUU17el1MAlmAydHB4Xb6d06vzq7w+v8qfML/yg63vbiUZHhUPyGb27DeaPp5A4NQnEwjsO0J9
+        Sf5Afip/QL84f0D/vPyh+YvzB+aj6QPz4+wB/cnsAf3OHv4CZ/MLswcOZg/A2Snkkl1405HnnjlJ
+        XM+Z5QF4jNxvuhzDiewcxfqYaghLZVGNzTkaLI5SbPXnqIsJh8pQ2fEtgXI3XWV86nj0kYq5fmsu
+        bDAebPZ4a4dsrZG41nhCbe/HrEo3iC3e01pyrA259hC65Z40VoeeQUph6JLt5ToGY5LZxYfGfjFW
+        EK6xROY9jUPWyCAOhuGB5jWzepIaM4XcHxK6D9Z4pE+sltt8MyPAf65IJZ4qxKf8mHwivovULxEZ
+        /FNFKv7FRerj+H+kyLR+dZGKf7hIxX8oM/hPFqn4d5H6VzidP5aZm5ephRsOZi2287xvN2+3b5H8
+        z+gudOuSYniKCe47XF5oX5E8clckBOG1BoqrVrWxm047vWrPOy1VK5Bpsh05vFnZzQb7GVidJ72D
+        YmqLyAyUbYUaHavOobdCVj3NW5ggtk5khYmx1VqXjyeMl7aNeR8/K3xlvFvfT6WQjPLdW+Nf9wr5
+        AJVW8BXWr+7Gcssht4nUxx1raC3M2FpxPg/Om3AoJ+pSHveGe9aiw2PCUdXt4gxHZbqOqo4nlKbx
+        jN01z8pkBoReizlsxRkfTpqi6HHCXMUnY0kWnWmsOGsrmHHz2ZQeNM11oiHmmZAMMBCbcsBXHbZi
+        7D1j3kUH8bm5Ykczb8xr85UWLVcJ6rlyV5U7I/+ono/7E8k4ze3SmPZO4YGP/cPCaXf9qhohRneC
+        cCLdR8YiETclMdRCBEyE5pmfNt5W4vdr8ylOodfaHN5hb9bmGfNF7ZsP8I/UvtNfVJtnc39tftif
+        ML8/rjYnPhmXYZ71HZe/JGv6VGmOY5/KmohPZ03Yn5c1/fJX+78sa8LezJqIH2ZN2HfW9Bc4nV9Y
+        nKc/pKVWjLqcnyZbotljhLChVK3FbjVfKLrnyAq3odVEiIcUtprQXiucBgLlWDPmHFT1QYTvhtNm
+        shjoDW7EOiMEHU+k7VHfLIZjIKCd5BzvFjzr9OYjf3d28ROFIcZ6XyVwddYVeZFlm8B0ONuvxslp
+        GgdM2JkPewJ5mgWqbThM2AAaZ/XU8fxYQRcgqFJ0f4QePa8VVcaTjr08LqX1m2kA9lMFOf7Zgpx4
+        wr4L8q+RFuwz0oJVv1ZaHsd/R1qIv/JbX+KjykL8UFhyk3xeWPJ+38LylxaWF1W3MG9kvyz8QDku
+        QHdJf134kUIcgYW4nliUiEwlyyAScjNRNkduuumNGSYJRkGzS3bQaV/HRlNN1ZSlMbAP3Lgzspvh
+        UW3i2FrxyBU+145jXIjUFZVgcaQQpAW17Y8twNNX3SuBGij9RLGmNgelrKEYXUlr8PxZ2B/OHG6E
+        Ai4gU/M8mPLD0YmIeJLuDcJ5b1NpV7uDVY+cLgODR3fBVq56Dr8X7Jm854nhWkSnK2HO+PP1IJ6q
+        qz0bHsaNdofqrxp+WEmCAUkMT44ZJWHfpSvLczxfRjS3thzLjTYt0cF2du+8nTUXZ9f0aWqICEOn
+        x81QVOhRPZvV+pM5O3Y5xGOHqGeFvCO9WWBT+E8pa+Xpc39NpZ+q32f3K3Q137+P6ipJf0pXH1+L
+        v6urj+P/M5ds6UuXjwnrhfmGsuZGeVVZqR8pa97vW1n/uZS12WBbY379IWltyib0ruTjL7lnHMJE
+        MnEgdz4iwMPQOVVhZSWb7nzhM7NWlZzrwoYjOmQV7Tv8lB+1HLbvjVW+2g6czmgVTzC34sm2tWuc
+        j52mpQe7BrPqNRHnpMZeX/+IxpbvfzatyLZkAjmCdoROY4Lih/kv4RpcmCsHin79EPQZsUCgO+oN
+        kP/NYNwc18r32C3FD+pYqkP30JWRWbLlmCZQgpLmOVYp0EEp+0riplPxxcPltogK2bdU4+YN79Jw
+        pebmUeC+dJPhsq1V20mnrXPrRUVbmwengfWw8561I3UZ6/SIHR623srQkU2CnwRXGLfVvtw/q4nc
+        2yOu11dJekRHWmvWXYVcZxgu9rNR0+/Z4uxo9QOmivg66882g47NsE2REJcjn5ggSDy0p/2xdHaT
+        TZgsjEaaJz3M8GbG6Q4quUVuafnGvr0dr+/PZJx+L/bD/SHe3Z8JxEr/vhgVH2YOPGDCg1VybDP5
+        jw/tEpzFB3bJh7vUI0FMN04HgmRpNokX8504Wc9Z83hS5+hsmzB9ASH7rDmkm2suRjRFEjv0Ku62
+        21hvyDb5xPfU6QD1sLHSYKgDLQWDTrV1ZDV646si6S6XcnNqOZLoKPuJQY4Jhzwhcfc0Gu6s7rjh
+        Vnrm0DQT5oxHvfC0Ac2+YtPboec1+W5H5E/v7lwa3F5sG5RGywjSl/7596YGuH62+vD9qgF++P1q
+        YfvHD1fLj4P9yq9ir4OXX13IS6e8Is9xpPyjD/L/Dx1R2NzVPwAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:53 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['4029']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:30 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><add_user_commission /><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['472']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:53 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/TrolleyTests.test_bundles.yaml
+++ b/tests/interface_objects/cassettes/TrolleyTests.test_bundles.yaml
@@ -1,544 +1,505 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:57 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:34 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:57 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:34 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:57 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:35 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGNyeXB0b19ibG9jaz5FMC0tRXhJNTJKUkNxLWdMRHN2eDR3blVa
+      elpTV1NZRHFxZXZKRkd2bDRwb0NpdkNxVVVmdlVMQVhnOWJwOVhnNi1jY0s1THRRSlN2Um1MZXZl
+      eGUxMzBpNXo1UWdFV3puMVdtRTJ5WHdnVnhkTm85U21KZmNlWHlZN0tNTnQ4enV5Vkp3OWFSWE9T
+      ajV5Rk5wLTB3QWR2MktCSHZwaDZjRnFST2NyejktNGxEaHV4MlhIYUFtMUY0U2JuZEoybXF3a1Jn
+      WjwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bm9fb2ZfdGlja2V0cz4xPC9u
+      b19vZl90aWNrZXRzPjxiYW5kX3Rva2VuPi0xLS1RMW16UTBaV0tTZWNaazl6NFdQN1pCSi1GazFR
+      bGpSTGVIODl4djlzQ1llOGJFZXYxM2hoRkhheXlfNllkVWJIQUd5d0VSNlNSeW5ZLUJlWGhUd3Ey
+      YWQtYzVoQXc4WmhLcEpubTNONjJLZnpNM3B5QnNtUC1Dd0NVSVktY2dzV3F2S1kxcS1CUUFfQ1N3
+      SmE4SFJjdGZ2WlFpSktYN3JGZGNGTHlwQzZjQ29DWGdPaF9vc3ZXY295UU1MWjd1SWlpYk9Sa1ly
+      NFV2dEl3el8xbWhvVzNQVVdmRGVnUzJzWkpzV0RpcU56bXJkZ243Tlg4cjlfZmFaRGhPSDdjOUpi
+      WjwvYmFuZF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkZXNwYXRjaF90b2tlbj5jXy0t
+      RnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJYaWgtWnkyeFNwU09EZEhh
+      SHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5OC1zaExzUlpJRW45TEJX
+      M1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tlbj48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['449']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS0HvDihIg7XFxZDKMgoBCj+Tv9Jf1kHg4Je
+        O4fKzLeqlauS2GfHCeLEOWcHJvPHxbYqEfADw3V+/0R8xj9VgKO6muEcfv+0EgdY89Mf7b8xmhGo
+        buhAyfUgYgaSD4LQgm0mCBXNtWXDkcIA+JIRSIqstR2Xqb62MCACDpon+0CW0DqgzW6YajHKDBoI
+        1DaLXis+68AHOSFFGdWAcca1XEdzHSw0mWoBZvaUOkntuTGfbMlBkP+V8WUfBohSALkx5XeQsfJ3
+        2fb+Xemh7YbJq5TMDNpUusPMbQyQp0eICYDsq7pkgjhdqYriUiBJ9HLebdodeXBW8J79abKjgtdO
+        s+3cCA9gwUn30ZUtC8B8o/2nCdlOq8UrVG9BTBLCz8OeHkIZuJvT+SvHgECrjFFaoaQoqPmp+AY0
+        VJRTkQHOkgd8NckRAscR8aWJ0WQIJF92DkACjpaPU2eiHv6rQgSwsgQeBLYC/AqJE3WmWlAydghV
+        yd3vAwDbVD1Z6hktaAFQUSoFbYJukI0a/ci+GTN6jP6zbU1rJ4viLZzImXccnbTbrOOElMKyo0nQ
+        sEFKx/AWhhMi0fqNwn/D8X/ixG/JSq8n5H6fY5CNA4iS40NUalCvTOX4Z8ajTtINCv/meNTw2nfF
+        o4b+/Jl45PtPe02WjvxK7Amd3pgVmGoJzilpGKYyhDo4V7pu6DvgH0GFR9vxZdVEKSSyS/E2MYtZ
+        9mxo7fpwcLMYt/4mWSjR3TZyJ8OkZ5TBnOHJUG9X0WTMztbFlHRdLMCc+7oYBAGs3uanU/LpaIcw
+        DNqWEd3d59CNgNqvDOXqbQxjD7QDw/YsgAKGnMPbvNSSs0IvAJaF3jSAD1tkP24RPU05vIxXX/g4
+        ADc5KLnNWDI0YIhiXiM+18hWnSCoBlO9owzq5ofsEcM/Ezg64VqdRIQ7zFQLZ7ocSI6b9IN9kKrN
+        A5B0U9QRUce5t9F8yNjyRfJDx0FHkeUNQaI9fEAZG3XdF7xnlHEA0FBGeCjfkDqkOZm+zys8J4e+
+        nGhoiXZDMkKyB9e3kzacvf4HlPHcAGbi2SOECi3yTPUO3SQCSTZM2JJpt/HP+F0jyjgT6G7aVffZ
+        dtLlnjAmQHmJ6KlzcEH5gnIycVeCb5xMty8Q+I5sVURErHSTRHa0SjEjq5/0UvCq478yMCixwnyt
+        Zac/YYXlhp1Mlky1ZMhJqfulrFnARzW8QakY3Gi5lOVXkIeIFt1wAzQkIMSv6JWtFkF/e68kPmrH
+        /2s6SfZ7rmulaZ7fHZ6wpCYsw05kOM280vArLZj4ZklKkyZ7O6yDz1FS5kBuCaTICAzFyhPtGcxY
+        RePKchB1p/yiuM6nFBDzsUQfyzP5f3Zwjc8UXplPmWoBZVZdt210nSFamY6VsWy9e46ofuxBV1Is
+        VzXbUwrDvHkNEtSBlVXalIXudWeTuhutBMPhuVlgkuo4UubOUbCgNrqQvd4RP9dbR77FLk5S5F35
+        2DT7K8FuGrQ+6jkreFUipdk5cUNLBc3x3pZ74tjXvL1lDYQmO5KPVmO6dq3RwWxQxHKCNa5DsS/W
+        pS0fen2bVcXTGIZDSu1btBoC1rBFZ4L7RmdPc7EAIHccWoK4PMCVt2GbEmsv+krUeANrsyX68/gw
+        P+v6ecguW+bUtg+z/uy9f9VDq7GmG5sWL0Flya3mZ3eh0YOr1j8tsV204eaDbp/g5pG55jcTjDxv
+        V9Pu+0ggllA4jKlOIOG0wq5rltPz9my0cFW18cZe6xam6ZFKBRNtAPvyXMPm516NdJeu4hIgNiPB
+        Hg1mKuQ9TtqO3ll8Rtgrj+pq/JEfnrjxmxWc1V7EwcF+KncGrLAJ3wMruA58F9DcdQ4243ptSvOD
+        3di3CfXisFAzzoPl5djvw+OkT485stsYyjVX0YQ3BXawXXLXLJ0vo1iyg1RSKj59HCtOS+e1pfhG
+        SuuqTaHqfUQYNfR99HUVF09ZGh8UD63+ABWMvaxC189vw09gwXLC5KrbbpL1EisHC5ZnySoI2mSJ
+        k0MlDhISKYhtxbWqZRipWIa2//uf8vwCL9AiGMFDXNCNAH8IS3JFQLLt7qViAo0U7wm6+0Dfh0rg
+        WiFqO4EcoTrPpO0ZRB8ftmI4qLdRrcR+HxYvk0a5019NxNILZaG/D7NvQA19+VUSzdRkXyuRcz34
+        yu7uQ+giHWyrOIadTKzVXY/jCx5zw8b727pPDh1BdLX94rR78whpEZIUy5HN96CGMm0VXTWcvcwI
+        +mw1WHuwhz2ObACbr8VU1xodD1YwkMddthlxTTpyur6+UehtxxjESmfKc9vOarzAj9aJXkP7PD5z
+        /MzpT8QemG0Wi94+gkGzZfqboOGdotp+PhiMdmezNbXOHe1AKFdlI7sxPFIm5UbWdGlSfJeXVq7W
+        s2EX7weqUbP2FuYd9dF4PN4u+ucBuSsFIdt1KQrJZbMcpez2iVQAKSfK1VyasgFKDSd7lJ4O9IWh
+        RE4Uz/MN1LOp2iO7sJTp6Fqiy/4BtOkn9t1QYmeXZ+m1/wcjk9WfJEeyYcmJwiFF/4Ax+SVHPhQ5
+        nQrPE8ikTiUlkdsseRHrCSpzkvSsPiCFsvryGU1woHEI3TDIbwgEuo6/NKR06ELZemKWMeY56KVQ
+        PwW4FNYXwXwMYbWo/D/dA0jiSz2gxw0n/a/0gJ5uWFoF3dLBj9Y/hup/MrPtKdcbqoPpZLVRjAO2
+        ssfieL2bAKTbI3vcXGMY2Y+3w51CBCJ+4PZCPzk6QG8miq0vunWjX9eIix7hsqGe4vCs26ap2dtA
+        wSSIBHl42I07kWVKFKcvWuxA1nbS25BerhoT1msK727Ei+PT6r0xmVDXQcvvXqh+h++1LrPNynwb
+        rsH1elI9aYdhX61l4gdqOTuYb61lovldtUx9by0/+/+rlu9BeVnL1JdqOZv3C2r5i3q+FFd9lv+a
+        oi+TnxMc+FPq2UT17GPxebJddlnWqznX/ZD2uzzRiHrWfOny5mEyn7iR8z7ZHvsX8chpR65Xj+Z2
+        NI15DzojxdKN6I2bDa2Q3bwfV+pKEt6l3tCGbOOkHK52d79Vh6fNsYOu9cLaP8lig641u9dQsE7u
+        uaY3LouDyHbZCF3FLd7t4cPl2TwbyKUn7bueQY5YZbicjI6NWcemPPYwmR2c4/xiYS3K655W5D6O
+        pyuBvtRngIhtasg1AqMJTD7e94Y0JvC0EPaImo3PZuTX+wH5I/3gu7SdrP/afvDs/69+cA/K9/eD
+        bN7P7wfUF7V91pl/rRcAx3D9impA4wqcn9IS6qglDEyKmxgcTte6Y0ne4wK7D4TgeMbttdUYGWK0
+        ah6W0LlsKa+3vhr+vjmCO6G31UdGf2SbMqV350rY6h54rTkX45ALdV912bXWXEN/esa242406ZHH
+        eG1uZ4Sxj5quxQn8pkZOehoei9KFvC75GPi7S3PhHWcCCXbXGqmfSJ2iRKsf8EJwUtXjEA99bo6j
+        b3TaOknfIPfUj1zdv0vuyV8s98/+/yrve1D+RHl/We7vj0H2W2VRkrprJD8/3H+x/GAp5dvTvz3/
+        D1lRoYe8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:58 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:35 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkaXNjb3VudF90b2tlbj5jMC0t
+      cWstOUJWS3l4MHlISTdZR1ZEMkluUlRvZGZRcVpHcDFfUXUyM0VIMjhZczVhbmtVdnpkMEV4TzE0
+      d2w3RW1GZnRDSDI3ZW1ONXkzQmxKamdsc0ZhS0JFOHZIODR2bkJyaFdiNFhBaUZ5YkFNTkhYQVVL
+      UTBqbHE0VnRtd0t3SE5PbkRMVENlT1dRUUNmdnRzODlrcldzN3BxdjVmUEZGSlp3azlNbHdBZGcx
+      YnpiV2FveXRqM2szb3ZsTVNrM05CTl9Vb2RDbXRCMERzY2k1bGZsLXBqaEpLS0tYUUR3RjJaPC9k
+      aXNjb3VudF90b2tlbj48cHV6emxlZD55ZXM8L3B1enpsZWQ+PGRlc3BhdGNoX3Rva2VuPmNfLS1G
+      eUpWRGY4RHlFRGhNWVU2Zllsa29BMUcxempMbnZkVndoN0tMSmticlhpaC1aeTJ4U3BTT0RkSGFI
+      emR5YUdqLXBySGQ0N0s3dmZDUkZYdU1FSnVValJLQnNHbldScW1IdDk4LXNoTHNSWklFbjlMQlcz
+      V1ZLczNQLS13Sm5RSE9fenB5WnV5VWlBLVk8L2Rlc3BhdGNoX3Rva2VuPjxjcnlwdG9fYmxvY2s+
+      TTMtLXBQNXQxM2dFYWM0a2FSQnpabTJob3ZVUmluTkhPc2syY0t2YlBualJsdGRKeDJDQ2owdzY5
+      ak45RVFxX3Zwek55a2tEVVJtOGk0aEpDblV0emJ2YjhBcUhJbGNlOEtmbWFDVEtyZHBmbGxGUjhF
+      SmFqbDdNVm9sSmdrNzMxU0wtN3pJVERUNl9YTnVwRG1FY1RxS3R1STNjRGw0Y3VlRWltVG5MMHJp
+      QWY0SHlSZXRIaklsUlRTZ3RVcFdFOF9FbVFEYnY3R2VWazlUclB5Z1B3aGh3SUVTOWtNbW1nT0RP
+      WUR6aHVsN1Y0N1c5Tl90YlNIVVB3b1FkNEZ6ZERxUy1adldIUEZCRDFIUHZrVk5XTC0yd1hVTUJZ
+      SlIxU3RSZ0szQXNfMDRiRVY1bG5DcGZFdlFvY2M3R0V6NmwtZGh2YzNzTGRGdERhUGQtUHdDNTJv
+      U29ibzFleWt2Um1KRk9jdE5wSF9YSllFME8xbVVwM0JkTmpOSXFIS0dsc3djQ3ZIdEZmTWFBRkVS
+      V3VZc2xzekZyb2U0SHpQZVdLNjVNNE5GWktybTFjeG5FdGRpd0ZTeGpERHRqTEQ0S0gyQjdJYTVv
+      YmRSR2J0QS1aPC9jcnlwdG9fYmxvY2s+PC9jcmVhdGVfb3JkZXI+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1148']
+      Content-Length: ['1008']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
+        H4sIAAAAAAAAA7VY2XLjuBV9z1ew+mHmIaG5aO9wOKW9ZVleJFmS/cLiAkm0SEICQC3+nfxJviyX
+        BChSsqbSmSSuLps491wA9+IuQBu/H8NA2iNCfRz99k27U79JKHKx50er3769Tnty/dvv5l8MlyCb
+        IQsTDxGLIBoHzDRo7Hg4tP3IiinAPrUc2zMjbCi3JYYbEwKzn/IvC5ZC5srZGsollDOWtsswMTVV
+        LXAEmLOiOHQQMet6tcASYM7aBraLqKkXOAIqcDBlFj2FDg6UIkyQQM1//qOon+M5CnrktGXYcgLs
+        bkzXkuWq7NCP+dNHMF4RJNOOcz9uPLXcZX09rB53k8dlnz1OnlvPTlUL1FPTd7a96Wr8Uhp674PP
+        jk9XnztGG97sx2uLWCffDwYrHZfr82iP3iZPM2cR9OkMP+/mnfmh5jgvGpr9mPW2sku0T//9hOy5
+        u5r1ds1P0pHfYKfF/Rn8XBneoMis6rL8flRlbRAd2/t5a9hYdtnboq82WAc1SbsfPcz6h9Wu8mPR
+        H9XR8TCddOo7/aU/6O3wptq+Xyx71n21/PBWZq1HN3Le41pVnSH/1B2w8eDw2Qg6u8FLadHc6c1h
+        975B1eWL3w3aeDhh6nTf7ez9Zs/W/U515I7eV/KijJv3R28dbYa91uKw9BalaIlaFW0zGNn68Zmw
+        oFtvfp68NVKX/rv9uWmMYxmTUml3Qp3RyDno88/jev/08sZG+DirnWrTYzir3J9au1Kz9XL/OGnY
+        4Xo/bTmd9kelNNdPVth2lg3NPtgf8vuQ6m5ra+nHwJ8ebH+kq4/DnX2oTiqzUT0s43c3Umn51WrY
+        nWnY1/36y3bufiw+P96qbzPWWw/cx2CNdtFC7i+I68z1Pn43lKLLuf9Nw0N0azN3bcGHa7ZxECCX
+        SUuCQ4mtEaRpFCNDuWTlSiFia+wVgDSR2k+tp4IOT67CkDJTu6tcMAD6L7eS5L/NbPPxdQrrF3iZ
+        IKey0xaZLp+/QEzhwvhsnE9dHEewQxeHjh8hzyw17pLSkA3PFG5rs/P6MIWJLsCck2686UE9kyiz
+        I88mXoHMzYqwhZcWhQpITc1QikMhY767QUVpBhgJbUt8F5mlSrLNfAzlk7hrm6yQWU4l52G+AdNA
+        4Gn4Y0P95Vvvzg0lH3FBus0uVPHTYY0IEgS+eddnoqQGOPJwJMcbcNYZ5PKU+pDKhVAoBzal4g/n
+        24RRoOSAEHI/glD6xQ63f5fa4NE42UpBbEAfSJsCn/aEYKZLKHEXeMHaoFO6kpI6LEOShiN4mdoZ
+        uZgs513P59mRi25Pys3JCBdgzkntaNkQrUwY2rlS4JYq+RaUzInJgRLh9vQQisBZnOq/Rj5DnjSE
+        Lgx9NKeKUyE+xBe04b2PDtYWETeJEd4gb4oML2nexI5WyEKRJ8bpZNN1/DdJo0yaoC1DSbuUdFWD
+        JppTODtmLgT2kiJmlqrJUtdoTqPIhVCCbCjX9FqlfMnOhJx+gp8w9DwzWVRtqJpgnnE4aVyvqpqV
+        wpCgkFohSumy2pBVbao1vpfU76r6V1X7nqx0W0HMe+0DPobMJ+yLVypsLY3s0//SH1W9XCupP+2P
+        ilr5j/xRgX9/xh/C/rTW8HBMCve42R52x4ZSgAUldcPIZtAJDlILxyRCv1LpEcwhNtQ9Ik27k2mm
+        yH3Gv33PrA56mQRGAg8g0LEJ09ksqRlFUDCgC6xNBZTlkK8rO+m6MpWj87oyQ5QpmX6qItTBQhZT
+        M/D35+kFlBF4Y1Kycdp/qB9uAySKeabHOxP/jrcUBQHslLILE7tfTYSv0Q+1iCs35lghbPEGGdjM
+        ZzH4vALtWW9UNa1UM5QzakA1X/FPWb3TVDjhShXutTlsKPlka5ta0JigHixpekG/AJJqmvQlaJ5Z
+        GRVDI7SPFomjCI6Cx42mgw1fUCOEqnuDd40aEUIeRMQW4g26QxqT6X5u4YIcE7AZRwVahnBCYgMm
+        YVKG+fa/oEZypefNs62NpfL00VDOUNYioOWyhG1tQlMVnfoaN+gap1V1yc1Jl7vCDApxCfR0cnSE
+        eIGYTKYrwBmH9+0jQySyA2kKRKmVBHLkSbkGz5/0HXWr4t8SGOn1jK81aXYeuuPJvPvwMDGUgkCQ
+        0uknthcgAjk8h1CkGU20MnEF+dOpD60szJ5iST0qDI2LY8pL7Bx50JW0/0cBbjS08s8XYO1rQ/qj
+        Spak1BbjQNwM09i4wpJEC/ww6e1pOBeG/6auaz/d59JI5LuTm+ozRLoAhIRae5/6TiCi9xrkrLwa
+        8sCGkidunzOhkkPG17y/zPnkNz+42l1JlZ5HhpJDXLpehyHckbQGb45FjK+Xp3Jyd7acxF5+vQf5
+        FVTkJGsoF0huWnImkDm7GNFzN4jwGUIev61fUwzeDgoeaA/G7Ydusu0rwQWVX+y2YI3k+sQN0KWC
+        8AZmdmBdPW2uQEG6epV8BS94hRfKLVhwr18r12hGu3y5XIM/XVnEs1e59b9L/wL2/DbImhIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:58 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1879']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:36 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order><crypto_block>E7--NuwIhns8SF9pSFmOCtayGoPi5orsAykdVtQtCufnKnVXd5ijHtnqR7hewEY9Siu9mKWZXgSi50wUnsm6QPTTn5Ap3rEh2y8qt7LQOigLgEgeiLH4ylijiJOz3cCcGHfmz-mr55XI7fNrF6K5mYhYQ3qn1nCceIO3_pGh-y2ODATK_1unwgfaRcvmf9rRBGVuoIht5KuL4JvyIf1HGwjOVpnEZgHPJm7kxU7hRzZCGSznxEZHloNsR7I2pTbq40t7v2mLo1javANm8iUGKktt-5o16BpnLLteyP0yqrtW48EZlb91SwCaca-PJX0S8BvzKCatNcVD_hETlolGxPekOoYcRxyhOS0oqh4PNL4fG5MfxXXjHxpdCbQvBrDibivFS6vhbjmFeBcQYWikaldIWXGQFooHSH2dWMs_BXrsAz6-j8VMn40F2LZish9H3g6jBjVkrnayZ4NMPTq5FtXcdK_5L7WFk2ASLauJCqJowO_bV8X2sPX_At8097h3QpXw1Kh0OkgxfUXvzDHbFI_bN0XSMiJ0al9y_p-VXab83-6hG9eHDURd6DtENaA6ZdPR1b2kCR_toknr_BpFKcDNzxpBDj9-GWfRRbpiCUM9rPYDDkijx5sFQiucuV4RNL_xRMwwjtm79e8Q_Ffs_Rbj0MXC_rEfuYOIlmhROtFCXJpXG4CNo46bV1NKHU8emAOPjTy5eN5yHKnfgvMsrKq0Ix6-yFmDNxXSz4pazVchj_p8eOwdiIe_aY0Ybh9RJBrav76RZUsxDdWqMKRqoWJyL_--Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>k0--5q_Eg4_-x1Nz1FPUkY_jXomw7H7E1_PjxiUKNYUK3emm0ERjusgvnWUYFQqZHjDGEekx61hC9iIriru1LpexlQdiFWf9oohhZR3m54tmVkLEMIItGP0eGhqQULniBgRbrSIgFusujEyS0Rw91TvO3pqX8rgNeFy0FDAL-H3GFetfBUfLnD1Zi-94KcFBeU0CKwDSXAHtxFWU5WZiFJ-wMeIriNlK_uoAMR58EAI8VqC-Z</discount_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></create_order>'
+    body: !!binary |
+      PHRyb2xsZXlfYWRkX29yZGVyPjxwdXp6bGVkPnllczwvcHV6emxlZD48dXNlcl9pZD5kZW1vPC91
+      c2VyX2lkPjxkZXNjcmliZV90cm9sbGV5IC8+PGNyeXB0b19ibG9jaz5jXy0tNi1ic2pXT2psUmdy
+      ZS1zRGJKUjlPQmNmOGhLNnhxU05mR3ROU1BCUGI2MWwweUFpYnBGVGdSUTNLZFpJekRpc2d6cXRz
+      OWRWSFVCcl95aWlsSWcybzQ4V252ZVlTT1ZiWGxHc1ZvUHFXRFd3N2JiUTFlVkhWRnAtY3Ixemla
+      eWVhV2NnVkZxQXpyRC1ZPC9jcnlwdG9fYmxvY2s+PG9yZGVyX3Rva2VuPjYyLS1aeDAtMUlueEN2
+      V0JLOWZFdFlYRzA5dERlQXJDR25MVkd3Z3E1SFhHTThleHdUU0Q4cTJRR0lGcW9rNkNKWGZGX0o2
+      NExZNHRCTmNuYlp1NzYwVmVpeUVJdFJJd3o5bERxSVEzWEFxMkFLRUo5czBmUWlFbENvS1N0MFR2
+      RUR2aUFGYTJpRDZNY01aZy1YNG9BSnhkaG5rS0ZCWHdmZFgzbmZlQjUxa0lNYTJ4UHJ0bEU4QXp5
+      ZGhlMGZpWmF6azlSdS1vcjMzcXllRE1NYncyV3p4aHZPUVl0TW94Vjd5N1R4bVY1SnlCcTNBQlFK
+      TlM5YW1odlRCYkRDajUzVzJ5X21DYmY5MWF3YWotWktzMmNCcF8yeGxpVHdhaU0yME5LcWF3NlM1
+      Vk04bTRvWmNuMHM0VV85YURUbUcyaThRcFdjalh6alk2WVZ0RmhJY05saGVxblgtR1hyY2JXMkdv
+      Wjwvb3JkZXJfdG9rZW4+PC90cm9sbGV5X2FkZF9vcmRlcj4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1384']
+      Content-Length: ['662']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61Y23arNhB971e456UPLQGM7eCzKF2O7cSJr8eX2M4LC4NsEwMiSPj2O/2TflkH
-        JAw47urpJQ8J2rMljUaaPVK0346eW9qjkDjY//WLfCd9KSHfwrbjb379Mps+CuqX3/QfNCtEJkUG
-        Dm0UGiEikUt1jUQrG3um4xsRAdghxsq09RMimnjbpFlRGMLwp+zLgLmQvlkFmliEMsbatCgOdVmS
-        chwOZiw/8lYo1NVyLcfiYMYKXNNCRC/nOBzKcTChBjl5K+yKeThEHNX/+D3fP8MzFPqFp4BiY+Vi
-        a6fPDEHY74J1fdesB7PqcCVsQry2Zfp0sAaj5buCLPKutJZy7f3bbigt535r7027WzJrrduLozVr
-        dk4fS7e36ODFYycc7pzm49ZS3pUK8YYtuTYvnxfl1+FUmPq78NR4f1EHctUZHdQP1HHnZ9I9P66X
-        4F3eJ41tJsU75OvtsiBUUadq7KMoaLxvvlmbRefQD6aovqh/bCZueSm5i6Bq4f1hJhNSeZ4vHxrC
-        eKYaG2XUi9Tn7nmDwrOhdFxJUfCz8NpvW+et1Gjuh/35Uq2co6qC5s11Y9NYlPeV+5O6eXMx7TkV
-        ggeDtUqXiO4WH294JAzkrdudvewOb/ZqLjUnR1SbnTyzbb9PFuH5MJSGRms4HlvzoHZ8RuOHD2Oz
-        O1bmUX359jIiw261idqCGTwaPeXQDOyPLpooo5qhfHtr7MevU3v89BBNzhNh0XkJXmsR7ftC1OvK
-        C9MJBpFKW8+NoTto9NWn1pM1Wi7HMJJihB0Htu5bf9h7c04P/frD1vJPvaemOnVmw6k5PE4n87ra
-        wXar1Yx6HyevLffnlve6mGxrxxfyGvlWxaOjxWhwdO+FN03Mh5/tha7ZiAQmtbYGfFh6E7susmhp
-        HWKvRLcI8tSPkCYWWVknD9EttnNAkkjN4cMw14clV65JqC7fVQsMgP6jK3H+m9TUB7MpzJ/jpYaM
-        Sk8B0i02fo6YwLn2ZXEOsXDkg4cW9laOj2y9XL+LpSFtXihsrZPprNUeTGGoApyxEtcnNLKRT0sh
-        yFyOypblYwOvDQISSHRZE/NNbqOOtUN5awpoMS0IHQvp5VrsZtYG/QytrRlukK4klkszc0DXEEQa
-        /pggwMzx9lwTsxYzJG62QcZPhy0KEScw51fOJgqMvelGiGloHtAsh3LBdbFvY8iEHYTyAjJ7MlAv
-        sXMjG9pyTUL4H8aHo2HS2IEcxu1Jl2nRzoaB6pCUCjZcUj+KUBxEiI2xQ6d0BjGJZArGpYhT054X
-        pDBexrsx5M6xye1h2UK4vYBllGQtj6bnuKccia1QzOYV06DF2xvyMCdBzwMXc9J/5jsU2aUuFGWo
-        qhmV70LowGmDqrx30MEIUGjFJ4aVy5smzY5reWj6G2Qg3+Ztvj/RLyVZpdtSI9pEhJbKkgwFNSMw
-        bkQtOORrgqiu1OKJrtGMRpAFBwcyo3IvVytVqcBOjYx+gh/PsyGhYVJJlVXOvOCwuVitSbKRwKZv
-        Q5p5KKELkirI6lSuf1Wkr5L0syR/jWe63YGPex0B1ibUDOmnmJRlCEYDEtf9P0NSk8s1pfLdIamU
-        5X8UkopQlv9NSHgIEulh5zHW8XGj2W2PNTEHc0oShr5JIZEOpQcchT76iZQGsJzQBBkMf0w7sXix
-        b8fWa8+PqQVaHHfhlONMSPIgZ4B7NCK66+wvdg6lBFZkxLSd1BLieIGLuDCn/ViVYd9RQJDrwlSE
-        Fnxsf/bxr3yP8e4sj4s3xt4gbLAi6JrUiQuPXk1K8KWpgRhv2Kcg3cmx6QJoYtZ/axID6g0k9pro
-        PtbEAhBrYVxukH0RQd7UPPNohJHvQ1jZ/stlOBqfUM0DzbzBu0Y1HyEbdjeAcxPBfTg+S4k/t3BO
-        jqDUwqMjR0sRRojXgEPP9KFUJu5/QrX4ps5qYlMelyrTgSZeoFTgoZLSmG3sPF3iBfga18gWJ/K4
-        ZsthT5giphE410BPBkdHODqI0Hi4HJxymGyAvTQ5EYq80hsK8YXKkiC5QPEbSqPVa48n83avN9HE
-        nIGT2AXFtF0UQlrN4SCRlMbLC78k/KtshNLipQ+lWB5yTa0Q7Uzx5sgGRbyPq8T/r4j3IPz/QBHv
-        PyniX6VonBsBxi6/uSWbfIXFGeM6Xlxtk3OZa/6d0N5/r9AmR4p5JzTqDTiyHOAWYuwd4qxcfgyv
-        QcbKFI6dUJAxfjt85V0ySPucwMXkjX+zjbu/U6TSqK+JGcSs263nwa1FritJAc9jbL4sJ+O7Lbz2
-        Yb3J7PECr6A8J55DLCDZ0uI9gbvLR4TIReF9fIGQzW7T1xSNSXwuAs3ncbPXjt2+MhSo7KoVwGpK
-        lhNaLip24NHA1HSNq6fHFchJV6+Gz2CBl3tB3II59/o1cY2mtOLL4hr8bl3hz1Lx1r9//gSe8Zbz
-        OxIAAA==
+        H4sIAAAAAAAAA7VY2XLqSBJ9n68g7sPMw4wsiZ07anWwGS+A2TG8KLQUIKONqhK2+J35k/6yTqkk
+        tMCNud0z7XDY0smTVZVZWZlZkn79sq3SGWFius4v38QH4VsJObprmM7+l2/LxSPX/Par/DeJYtey
+        UKCohqG42EBYwYj4FpUl4muGa6umo/gEYJMommrIjivx9yWSjgOPuopmufpR1hWOq3Ma+Vi/fViz
+        PUYc6Wkvs9ZbR981D6/1r9N8vBvQ8XzSmWh10RKCtql5j4v9bFp5NbbPl55J9pcTJS1j9bTsYCUw
+        Tet5X3arzbVzRpv520p7twZk5U5O6976s6FpUxGtnlaPHqdj8WJuA6Su9f3q8dS+4B63kfjc+qTQ
+        YM8lxNQsJAeISHwOuTqGukfkyPUKx1HltKPN4eZY/uQmY/OptqzOp4Y4OiCn2zMGtQDhz4G2Pguz
+        zVzbUkvd4O6upzoz1fQUNDY/4LF9IC+HdqX2YdSmi+eX2X4wtt6f943eevh+mXK1Chl0q4/meXS8
+        LH3zNH45dgJ62jp1vTzcfwUcev7s69MWVha2s3ndHmtvDj4/NbYNQ7QWRlM1zFdaGc0NI/CHh8eX
+        Dlcr94YeFygf/ZZm+ZfutPxWNTRjUz4tuu7r61PD7ArKhbaXA6WL/W6lhbTatvuiiFPRPVU3uvf+
+        Wf0Uh8qL3l8ZDc/ptBtH/VQdjQZ+q+NazY0uBo35YmXsyeSwmfc6fvujgrwGOl0Cd3z0a0652dOV
+        dr1RW5y1lepsyNtw2xla50V3Ig5O5TWtNN87Z63zPL+sZ+vlBW/JadhZdD/Gu7H4rin13mZbFyvT
+        WXnT2I1OC7wZzDa7yevmYz3ZzNr9CapNB8EXXZKn3mbzrgTTL6XpcX2s2YueJ3DcVuLzm3ndWxbw
+        uus7VBZTVhYO4wQZikmRrTi+rSEcMm/BZExZ0nzHCAOI/S/OcQdNmMT1sY4ANJCMvqhCEaHCVSMr
+        LWgYiOhy/4si7KhWaQFqpY6qg6VG6UY/4ib61KWqBUPamukgQ660HlJ+QVZUIVSuCg+1GzqhBSpM
+        6KlUP8jiDfsqymsQpFIPmzqSK7WbBaXCghJYd1DxHsnVW52rTNJ9jCENBukT8+he8yBB5KCUsVN1
+        6sK+C0KGE4MpKw6EZrmeYSXRcQU8S9URkcsZTgxlOOBFhQS25lp8FsYoRuXf/pPVT/EUlaUoxGQp
+        cTLb+W4YpDot7bBrl+gBQYVwfCTxeVaqZCN6cI0MELmm+9Z5y+gwd2VeIQii3c5D/+NSwqqjUlUe
+        Lxcwf4aXCFIqDTwk62z8DDGCM+9X40wSn8TCUUijP6EwW9u95XABA+XAlBMtvG1AFS0RqjqGio0M
+        mZnluIq7i6KZhGkh+xrLqAlHOCtNAKl4QDJnonAMMpHPp1Yi8HSY2TBS2dL7a0hp1zcmYEkFGojg
+        84Awigls8bpJ40NiuY7hOpx/BGddQSaPqMNIHgtjZUslJP7H+CqmUH4zQCxkfgRh6e+q7f271AWP
+        +uFSMmIJuo+oFWHDRoU8D4XuAi8oR0jO4Ux85LAECducmJeoXZHcYCmvOJ6hOjq6PygzJyHkwJQT
+        2dFRIVppbGivoMAs5dMl8IkTww3FsdujTcgCV3Gkv3SgXhmlV2gAoXtLqfGuYBPiC5q/s4k+FQ9B
+        rQgLVpTy7ookOHNIwaqzRwpUmvg9Gmxx8P9VEqEKzZEHJRISYKksiJAWUwpj+1SHwN4RROVKPZyq
+        iKY0gnQIJTgN1Ua5Uavm2YmQ0QP4sW3DkMNJhZYgxswrDjvtNuuCqEQwHFA4WjaK6JzQ4gRxIba+
+        V4TvgvBPQfweznRfIR636AP2Dicf0xuv1OihNFKD/6c/6uVqoyL8tD9qQu0P+aMGv3/GH7H9Ua5h
+        4Rgm7lm7+9qfSXwGjimRG0YqhUrwWepAs+Kgf5DSGMzBYS+DS4v+fJEoMp+xZ9OQ68+PiQTeYtyC
+        QHdlGE6lYc7IgjEDqsBB5kGZs9m8nBbNyxHOuc7LhW0Yn+hHKrE6WEh9Ilvm+Tp8DCUEVpj45D2q
+        P8S0vbAziZJ5oscqE3v2PYIsC1ZKaM7E/q2J8DR6ErI4f2eMPXIVViAtlZrUB5/XoDyXW3VRrDQk
+        /opKkM337JETHkQBdrhWh04lhSU+HeygEgUKE+SDHYmuhTkgzKZhXYLimaTR+FWy1S8F+44DW8Hi
+        RiyDDTeoZEPWvcMropKDoBc3kAfxBtUhisloPffwmOxjsNl1MrQEYYTQBhfbYRpmy79BpbBJY8Wz
+        K85K1cVY4q9QUiKg5NKQrRxtWYgrdRGXyMGNsuqOmRNNV8CkH1wNcneCn7oM5G4B0e39Xsa/J5Ci
+        9ozNNW/3hv3ZfN0fDucSnxHEpGj4uQodOIYzvIZQJAktLmVxC/Knj37hPpa7ieW2KU2xa2RAVRL/
+        igTcaonVn0/A4m1B+lEmC4+U57pW3BlGsVHAwoNmmXZY26Nwzrz+l7wu/nSdiyKRrY5rCxOI9BiI
+        JUQ5m5kPKUWQsdJsyAIbUl7cfa5ilRSSbs99/syHf9nGNR4qQmkygtv7FWLSw8G2oUcSW6w4ZjE2
+        X3qUw95Z0UJ7WXsP8gKU5YRz8DkkNS3cEzg5Jx+RazVw3CuEDNatFykSKwcZD3SfZ91hP1x2QZCj
+        ssbOA2tKuol1C+UVYm/cu+UXr/fsvXAruQVzvMwN5R4s3b/O39zj717gb27uP5tZ4mvvX5Mx+eTj
+        TvKpKP7OcPMJKYf/oe9N/PVDEv/Db7O/A9pPXdzdFQAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1828']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:58 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2085']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:37 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <trolley_add_order><describe_trolley /><user_id>whitelabel-testuser</user_id><order_token>E2--5eH5_vuupAjgQcgXHwMpTe9X9qgSl2Y0lXp5covwU1ss4IWYBA-RU8_g3PLu8IKzgerz_3Hl033oI-VMEczh0ACvOMWY84zu53eWCfAgAX2v47y8gZlotLi4soNNf8tYetkXqZoP-N1hlKUJkwZdbW0CSxe6UymaEdjSXrzwO0O_DORRcWp6xIeRBq_gkx4Wu9YZJPsOK5CeE-apF_L3wCpdqKeS3P6_3QZAvRVTdRGBuSzS-XHJpV6utMn-uLK1XaipNu8tDIAOlNAM8GDGcPYYRpF_3_rHi9pUQMOLZiyBM9BhcnyLGC8TiUOTaOxTSW98HodDDCuLqymE1MWcmVXSh6xJsVunc4mtPXPNxl7-Z</order_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsUDfEXxcUCHyqYlLXHoXFHrOkiCFhc3j34smOD16W2zX2VOT-TnkryAjJ8N15iPw8qeHlWzsKzFfY</crypto_block></trolley_add_order>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['694']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61YyZbiOBbd91fQualFN4HNTB6X6zBGkBAQASYYNj7GEth4DEsGzO/Un/SXtWzJ
-        I2R1ZnXmIgPdd5+GpzdZwh9XyyydoYd0x/79C//EfSlBW3WAbh9//7KSRuX2lz/EfwjYc0wTBrIC
-        gOx4AHqyB5FvYlFA/h44lqLbso8IrCN5rwAxgEioPBYJqhe42JH3pqMa4koul8+Ge+gY/Y67asz3
-        5aPnHACPny/q7G17qkEVnWqDLd88vRtzbru2B2dLmmhoNTgMN1d11X8JPrfmdPPibEYv3tzQ+yNN
-        rZ1qdWTNB3xzXb1tqh9zqSzZhhd0T9/aM76hv13an/DFXN/Q5DY6bIVKbk9CeErXQUjfm5AeJYck
-        1sCOAW2xWS+XdamGlY+2U61hua87DXgz24u1PaqCi2J9PtvX7jV4GV1ul+m5DgdtUJ4fpE7Dfx13
-        WvBtMzPQ+HX8MeeWo8PGOrsjvfF5Ac83/Tg4OtaQO43gDh28+lXvfszWvqoFL9bQ3pd372tzLUNi
-        JSmozdu93v6wQB/c+MOWDbDRpt3XRb87O/Dqdbp7vaKPPexIvU/34jacz8ZAA9Kwf3h2LP0KBsRQ
-        Jv/+8aENXv25Xquqp9bu1IDBYHDqtnby+HZsD/zF1Lm0x3Z9vXr+9N6Pi5GM3qA0WS6MUc/aYvXZ
-        qLfxoXY4ti4zs76a11cvcEXOic6b3vR96kp+Q7+1LEM78/K6Pmmure6u6jRWBuirE9ezTe+0rIE3
-        tf920s6X3nZX7WxXxjoYDYddaXRDw/Gnuw9UHQwnx8GmCYatjS55U74qvbQG0sUdztZcT/12la5b
-        ubpuapfn+rLz3us/j8G3YATWPe/sHSdL3ZSnr+f9rnXrgWALlU79E8tb6CxtY+bOvr2OVz17NBnM
-        p4FR3uh827QMeJPVzRyM7IVuBDO3vz+eaiCAg0bQHu93XvtdW3S0/UwbvzfLO6GSd5DEX2jkqI5v
-        Y5FPWVk49D0IZB1DS7Z9aw+9kHkPxnOKwt63QeiU9G9xjQdozESO76mQgACK8IplDBHmEo2stKAB
-        IFJFibBLywCRPZV20HOKihEpVsQOVkwyl7XXbQjEaucpXaggK6ogLNa4p8YdHeEClSzoKljVRP6O
-        nYjyGggq2PV0FYrV5t2GUmFBiZxOU7wjFGv3OolMUH3PI4k0SH9RUx73Lsk2OShlHBQVO+TCOS7D
-        YWDKYh7QrjYzrNgtEsA1FRUisZrhMCjDIVaUUWDtHbOShT3IUPE/f2b1UzxFRQHAvU52KKuao0fz
-        MyCVUIfRYGngW1ZQ6iseKA2oTKjkSImKbmN49BRMypIMFKxUUpGtWFAE4UypcoQlDBy4d4wIS4bp
-        r3TbUYyEk1BnoRvqh1Gm4tLBc6wSJkc4Q9uHoXaWlSpZEGsOyADRFffnvXlGh157ZkicOfLaPPR/
-        biUsv8Ry4mwlkfUzvFiQUiPjqHT+DDGxWfFwOmKppBDSaRTHFHrWpbQaDGcSmSoHp6xo60vsA2jj
-        Erl2mKHSY9mO7ByiqERhXssOmQzrqgGz0hgQioGeie1COGciuJKeEhJLh6nZgwrd+HBNcnIyooJo
-        m0PSSgUXDXqQEVga1I++K58V04c0urOAoOqYpQLTsYFjl32DmDIBqTyaaBrJmZBOrZoKQuwP5RPX
-        UHC4gQzG5HEgZuV0GtKcRZ0anS7qefJQaERiG9kgNYetUIksGYNhJ8iosWaC5OZLeQ+mNHSAHk9L
-        D8LkOSylRGcZKZZuBhkSPWElXbcSGy28Xo+ZOTJ6FkjEkf7KJuUXlCakMSZNbUplt+DpxNtIU3zW
-        4UV2IamAYf2NEvlDkUAiEMqeYh+hDG3Axux+/H+X+DbWSl3/6JMqW+V4kupTAuX6WCVOfkCQFMhm
-        uFARTWkIqsRxSGTUW3yj3uBy7FhI6QH5Z1mABDRZlGvzbcZMcHK5TrvJ8XIEKzYgYUZyb0gvc+0y
-        35b4ztca95Xj/sXxX8OVHiuweYsWoGOEFQ/f2aTKE2N0SeCav9IkTb7arNV/2CT1Kv9TJqmXq/zf
-        MQkzQZR6qD+GeXzR7U+GC6GSgRklMsOrgkkgXUo90oPZ8DdUmpHjeApJg94/YyVqL/pbB2JzPIol
-        ZMRwk3i5kyaSLMgYZHvYR6KpnxM5g2ICLTKVeBzVEqRbbtgtRYk51qNVhv72XQRNkyyFcG6Pw/s9
-        fm/vIT5ZZfHKg7mP0JFpETRJkxEWHrERleBkKJBkfKQ/y9wTH4oSQKik+pqCZFJvSGAfkGiTPjgH
-        hLkwLDcQJEmQDQVLucqeb9vErPT++SpxjTtUsEjOfMArooINyTcCgC7xG590aqEvRft5hDOyTzus
-        DC1GKCE8g+NZiq2y7+A7VAh7SFoT+/yiVJdmQiWB4gRPKikO2bJhiRwrwEVcQJoTpccDPQ59Qchj
-        wnc+WXLfKn/9kZL7OokaKNahdAfT4WK5Hk6nS6GSETASbVAU0ut7JKzWxJFQTGPlhTUJfysaC597
-        uQ+9nLXTjLeGgGTEVlglfn1GbJHE/xMZsXWXEb8XomFsuI5jss4tuuQCFkaMqVthtY38MjP8X4m2
-        9aOJNnIpurtyt9MlLssAJkHyWc+8/hRBykozHPVQksZYd/jBVFJIuA/gfPCG/9OLaz3VuNLbq1BJ
-        ISrVNMsiXQvfqUUFPIvR9dKYDHtbeR+eN1o9PGABynLCNSo5JD1aeCekd/n0IUoyvO0kEAS0my5S
-        BJriMxbojxf96TDcdkGQo9JWyyWnKam6p5owr8Cs8eg1ofiMQMeFr4Z7MMfLfEE8goXHzwZ37wUP
-        HwruXgh+NK+wz9JfnPoq8bNR/AjFHjLuHqdy+E+9ZFWSJ6rKd5+P/wu8uhIsgBYAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2158']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:59 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/TrolleyTests.test_int_properties.yaml
+++ b/tests/interface_objects/cassettes/TrolleyTests.test_int_properties.yaml
@@ -1,544 +1,505 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:59 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:38 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:19:59 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:39 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjx1c2VyX2lkPmRlbW88L3VzZXJfaWQ+PHNlbGZfcHJpbnRf
+      bW9kZT5odG1sPC9zZWxmX3ByaW50X21vZGU+PGNyeXB0b19ibG9jaz4tMC0tNi1ic2pXT2psUmdQ
+      d2FPVGpVY2xxM2dUMzJHVS1LWXFSWVhmTWZsRVNraEN0ejlFY21OZS1MMmQzUWdEcXl0N1BxWjBr
+      NkZMby1BQXpvck9fZngxcjIxZFZIbkM0Tm95aGhTeDJMX2pKZE85MXVfUzBlcnFjbVFXdjhiVmV1
+      S0pkdUdsN0tnWXByQ2I1b3ZLc2xpRzh4dWpDeTFBclYzNXNTV1BIcDVlZTM1LVk8L2NyeXB0b19i
+      bG9jaz48cGVyZl90b2tlbj5rLS0tNlNZRjlaNjEtZTA5OE14Z292VWV5TU5TWlpwUlBzRGxGbWwy
+      RUs2cmlHa2loX2EwdEw4MjBRZjRnWGVGZzBObVk8L3BlcmZfdG9rZW4+PHB1enpsZWQ+eWVzPC9w
+      dXp6bGVkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:02 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:40 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGNyeXB0b19ibG9jaz5FMC0tRXhJNTJKUkNxLWdMRHN2eDR3blVa
+      elpTV1NZRHFxZXZKRkd2bDRwb0NpdkNxVVVmdlVMQVhnOWJwOVhnNi1jY0s1THRRSlN2Um1MZXZl
+      eGUxMzBpNXo1UWdFV3puMVdtRTJ5WHdnVnhkTm85U21KZmNlWHlZN0tNTnQ4enV5Vkp3OWFSWE9T
+      ajV5Rk5wLTB3QWR2MktCSHZwaDZjRnFST2NyejktNGxEaHV4MlhIYUFtMUY0U2JuZEoybXF3a1Jn
+      WjwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bm9fb2ZfdGlja2V0cz4xPC9u
+      b19vZl90aWNrZXRzPjxiYW5kX3Rva2VuPi0xLS1RMW16UTBaV0tTZWNaazl6NFdQN1pCSi1GazFR
+      bGpSTGVIODl4djlzQ1llOGJFZXYxM2hoRkhheXlfNllkVWJIQUd5d0VSNlNSeW5ZLUJlWGhUd3Ey
+      YWQtYzVoQXc4WmhLcEpubTNONjJLZnpNM3B5QnNtUC1Dd0NVSVktY2dzV3F2S1kxcS1CUUFfQ1N3
+      SmE4SFJjdGZ2WlFpSktYN3JGZGNGTHlwQzZjQ29DWGdPaF9vc3ZXY295UU1MWjd1SWlpYk9Sa1ly
+      NFV2dEl3el8xbWhvVzNQVVdmRGVnUzJzWkpzV0RpcU56bXJkZ243Tlg4cjlfZmFaRGhPSDdjOUpi
+      WjwvYmFuZF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkZXNwYXRjaF90b2tlbj5jXy0t
+      RnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJYaWgtWnkyeFNwU09EZEhh
+      SHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5OC1zaExzUlpJRW45TEJX
+      M1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tlbj48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['449']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS0HvDihIg7XFxZDKMgoBCj+Tv9Jf1kHg4Je
+        O4fKzLeqlauS2GfHCeLEOWcHJvPHxbYqEfADw3V+/0R8xj9VgKO6muEcfv+0EgdY89Mf7b8xmhGo
+        buhAyfUgYgaSD4LQgm0mCBXNtWXDkcIA+JIRSIqstR2Xqb62MCACDpon+0CW0DqgzW6YajHKDBoI
+        1DaLXis+68AHOSFFGdWAcca1XEdzHSw0mWoBZvaUOkntuTGfbMlBkP+V8WUfBohSALkx5XeQsfJ3
+        2fb+Xemh7YbJq5TMDNpUusPMbQyQp0eICYDsq7pkgjhdqYriUiBJ9HLebdodeXBW8J79abKjgtdO
+        s+3cCA9gwUn30ZUtC8B8o/2nCdlOq8UrVG9BTBLCz8OeHkIZuJvT+SvHgECrjFFaoaQoqPmp+AY0
+        VJRTkQHOkgd8NckRAscR8aWJ0WQIJF92DkACjpaPU2eiHv6rQgSwsgQeBLYC/AqJE3WmWlAydghV
+        yd3vAwDbVD1Z6hktaAFQUSoFbYJukI0a/ci+GTN6jP6zbU1rJ4viLZzImXccnbTbrOOElMKyo0nQ
+        sEFKx/AWhhMi0fqNwn/D8X/ixG/JSq8n5H6fY5CNA4iS40NUalCvTOX4Z8ajTtINCv/meNTw2nfF
+        o4b+/Jl45PtPe02WjvxK7Amd3pgVmGoJzilpGKYyhDo4V7pu6DvgH0GFR9vxZdVEKSSyS/E2MYtZ
+        9mxo7fpwcLMYt/4mWSjR3TZyJ8OkZ5TBnOHJUG9X0WTMztbFlHRdLMCc+7oYBAGs3uanU/LpaIcw
+        DNqWEd3d59CNgNqvDOXqbQxjD7QDw/YsgAKGnMPbvNSSs0IvAJaF3jSAD1tkP24RPU05vIxXX/g4
+        ADc5KLnNWDI0YIhiXiM+18hWnSCoBlO9owzq5ofsEcM/Ezg64VqdRIQ7zFQLZ7ocSI6b9IN9kKrN
+        A5B0U9QRUce5t9F8yNjyRfJDx0FHkeUNQaI9fEAZG3XdF7xnlHEA0FBGeCjfkDqkOZm+zys8J4e+
+        nGhoiXZDMkKyB9e3kzacvf4HlPHcAGbi2SOECi3yTPUO3SQCSTZM2JJpt/HP+F0jyjgT6G7aVffZ
+        dtLlnjAmQHmJ6KlzcEH5gnIycVeCb5xMty8Q+I5sVURErHSTRHa0SjEjq5/0UvCq478yMCixwnyt
+        Zac/YYXlhp1Mlky1ZMhJqfulrFnARzW8QakY3Gi5lOVXkIeIFt1wAzQkIMSv6JWtFkF/e68kPmrH
+        /2s6SfZ7rmulaZ7fHZ6wpCYsw05kOM280vArLZj4ZklKkyZ7O6yDz1FS5kBuCaTICAzFyhPtGcxY
+        RePKchB1p/yiuM6nFBDzsUQfyzP5f3Zwjc8UXplPmWoBZVZdt210nSFamY6VsWy9e46ofuxBV1Is
+        VzXbUwrDvHkNEtSBlVXalIXudWeTuhutBMPhuVlgkuo4UubOUbCgNrqQvd4RP9dbR77FLk5S5F35
+        2DT7K8FuGrQ+6jkreFUipdk5cUNLBc3x3pZ74tjXvL1lDYQmO5KPVmO6dq3RwWxQxHKCNa5DsS/W
+        pS0fen2bVcXTGIZDSu1btBoC1rBFZ4L7RmdPc7EAIHccWoK4PMCVt2GbEmsv+krUeANrsyX68/gw
+        P+v6ecguW+bUtg+z/uy9f9VDq7GmG5sWL0Flya3mZ3eh0YOr1j8tsV204eaDbp/g5pG55jcTjDxv
+        V9Pu+0ggllA4jKlOIOG0wq5rltPz9my0cFW18cZe6xam6ZFKBRNtAPvyXMPm516NdJeu4hIgNiPB
+        Hg1mKuQ9TtqO3ll8Rtgrj+pq/JEfnrjxmxWc1V7EwcF+KncGrLAJ3wMruA58F9DcdQ4243ptSvOD
+        3di3CfXisFAzzoPl5djvw+OkT485stsYyjVX0YQ3BXawXXLXLJ0vo1iyg1RSKj59HCtOS+e1pfhG
+        SuuqTaHqfUQYNfR99HUVF09ZGh8UD63+ABWMvaxC189vw09gwXLC5KrbbpL1EisHC5ZnySoI2mSJ
+        k0MlDhISKYhtxbWqZRipWIa2//uf8vwCL9AiGMFDXNCNAH8IS3JFQLLt7qViAo0U7wm6+0Dfh0rg
+        WiFqO4EcoTrPpO0ZRB8ftmI4qLdRrcR+HxYvk0a5019NxNILZaG/D7NvQA19+VUSzdRkXyuRcz34
+        yu7uQ+giHWyrOIadTKzVXY/jCx5zw8b727pPDh1BdLX94rR78whpEZIUy5HN96CGMm0VXTWcvcwI
+        +mw1WHuwhz2ObACbr8VU1xodD1YwkMddthlxTTpyur6+UehtxxjESmfKc9vOarzAj9aJXkP7PD5z
+        /MzpT8QemG0Wi94+gkGzZfqboOGdotp+PhiMdmezNbXOHe1AKFdlI7sxPFIm5UbWdGlSfJeXVq7W
+        s2EX7weqUbP2FuYd9dF4PN4u+ucBuSsFIdt1KQrJZbMcpez2iVQAKSfK1VyasgFKDSd7lJ4O9IWh
+        RE4Uz/MN1LOp2iO7sJTp6Fqiy/4BtOkn9t1QYmeXZ+m1/wcjk9WfJEeyYcmJwiFF/4Ax+SVHPhQ5
+        nQrPE8ikTiUlkdsseRHrCSpzkvSsPiCFsvryGU1woHEI3TDIbwgEuo6/NKR06ELZemKWMeY56KVQ
+        PwW4FNYXwXwMYbWo/D/dA0jiSz2gxw0n/a/0gJ5uWFoF3dLBj9Y/hup/MrPtKdcbqoPpZLVRjAO2
+        ssfieL2bAKTbI3vcXGMY2Y+3w51CBCJ+4PZCPzk6QG8miq0vunWjX9eIix7hsqGe4vCs26ap2dtA
+        wSSIBHl42I07kWVKFKcvWuxA1nbS25BerhoT1msK727Ei+PT6r0xmVDXQcvvXqh+h++1LrPNynwb
+        rsH1elI9aYdhX61l4gdqOTuYb61lovldtUx9by0/+/+rlu9BeVnL1JdqOZv3C2r5i3q+FFd9lv+a
+        oi+TnxMc+FPq2UT17GPxebJddlnWqznX/ZD2uzzRiHrWfOny5mEyn7iR8z7ZHvsX8chpR65Xj+Z2
+        NI15DzojxdKN6I2bDa2Q3bwfV+pKEt6l3tCGbOOkHK52d79Vh6fNsYOu9cLaP8lig641u9dQsE7u
+        uaY3LouDyHbZCF3FLd7t4cPl2TwbyKUn7bueQY5YZbicjI6NWcemPPYwmR2c4/xiYS3K655W5D6O
+        pyuBvtRngIhtasg1AqMJTD7e94Y0JvC0EPaImo3PZuTX+wH5I/3gu7SdrP/afvDs/69+cA/K9/eD
+        bN7P7wfUF7V91pl/rRcAx3D9impA4wqcn9IS6qglDEyKmxgcTte6Y0ne4wK7D4TgeMbttdUYGWK0
+        ah6W0LlsKa+3vhr+vjmCO6G31UdGf2SbMqV350rY6h54rTkX45ALdV912bXWXEN/esa242406ZHH
+        eG1uZ4Sxj5quxQn8pkZOehoei9KFvC75GPi7S3PhHWcCCXbXGqmfSJ2iRKsf8EJwUtXjEA99bo6j
+        b3TaOknfIPfUj1zdv0vuyV8s98/+/yrve1D+RHl/We7vj0H2W2VRkrprJD8/3H+x/GAp5dvTvz3/
+        D1lRoYe8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:02 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:40 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxkaXNjb3VudF90b2tlbj5jMC0t
+      cWstOUJWS3l4MHlISTdZR1ZEMkluUlRvZGZRcVpHcDFfUXUyM0VIMjhZczVhbmtVdnpkMEV4TzE0
+      d2w3RW1GZnRDSDI3ZW1ONXkzQmxKamdsc0ZhS0JFOHZIODR2bkJyaFdiNFhBaUZ5YkFNTkhYQVVL
+      UTBqbHE0VnRtd0t3SE5PbkRMVENlT1dRUUNmdnRzODlrcldzN3BxdjVmUEZGSlp3azlNbHdBZGcx
+      YnpiV2FveXRqM2szb3ZsTVNrM05CTl9Vb2RDbXRCMERzY2k1bGZsLXBqaEpLS0tYUUR3RjJaPC9k
+      aXNjb3VudF90b2tlbj48cHV6emxlZD55ZXM8L3B1enpsZWQ+PGRlc3BhdGNoX3Rva2VuPmNfLS1G
+      eUpWRGY4RHlFRGhNWVU2Zllsa29BMUcxempMbnZkVndoN0tMSmticlhpaC1aeTJ4U3BTT0RkSGFI
+      emR5YUdqLXBySGQ0N0s3dmZDUkZYdU1FSnVValJLQnNHbldScW1IdDk4LXNoTHNSWklFbjlMQlcz
+      V1ZLczNQLS13Sm5RSE9fenB5WnV5VWlBLVk8L2Rlc3BhdGNoX3Rva2VuPjxjcnlwdG9fYmxvY2s+
+      TTMtLXBQNXQxM2dFYWM0a2FSQnpabTJob3ZVUmluTkhPc2syY0t2YlBualJsdGRKeDJDQ2owdzY5
+      ak45RVFxX3Zwek55a2tEVVJtOGk0aEpDblV0emJ2YjhBcUhJbGNlOEtmbWFDVEtyZHBmbGxGUjhF
+      SmFqbDdNVm9sSmdrNzMxU0wtN3pJVERUNl9YTnVwRG1FY1RxS3R1STNjRGw0Y3VlRWltVG5MMHJp
+      QWY0SHlSZXRIaklsUlRTZ3RVcFdFOF9FbVFEYnY3R2VWazlUclB5Z1B3aGh3SUVTOWtNbW1nT0RP
+      WUR6aHVsN1Y0N1c5Tl90YlNIVVB3b1FkNEZ6ZERxUy1adldIUEZCRDFIUHZrVk5XTC0yd1hVTUJZ
+      SlIxU3RSZ0szQXNfMDRiRVY1bG5DcGZFdlFvY2M3R0V6NmwtZGh2YzNzTGRGdERhUGQtUHdDNTJv
+      U29ibzFleWt2Um1KRk9jdE5wSF9YSllFME8xbVVwM0JkTmpOSXFIS0dsc3djQ3ZIdEZmTWFBRkVS
+      V3VZc2xzekZyb2U0SHpQZVdLNjVNNE5GWktybTFjeG5FdGRpd0ZTeGpERHRqTEQ0S0gyQjdJYTVv
+      YmRSR2J0QS1aPC9jcnlwdG9fYmxvY2s+PC9jcmVhdGVfb3JkZXI+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1148']
+      Content-Length: ['1008']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
+        H4sIAAAAAAAAA7VY2XLjuBV9z1ew+mHmIaG5aO9wOKW9ZVleJFmS/cLiAkm0SEICQC3+nfxJviyX
+        BChSsqbSmSSuLps491wA9+IuQBu/H8NA2iNCfRz99k27U79JKHKx50er3769Tnty/dvv5l8MlyCb
+        IQsTDxGLIBoHzDRo7Hg4tP3IiinAPrUc2zMjbCi3JYYbEwKzn/IvC5ZC5srZGsollDOWtsswMTVV
+        LXAEmLOiOHQQMet6tcASYM7aBraLqKkXOAIqcDBlFj2FDg6UIkyQQM1//qOon+M5CnrktGXYcgLs
+        bkzXkuWq7NCP+dNHMF4RJNOOcz9uPLXcZX09rB53k8dlnz1OnlvPTlUL1FPTd7a96Wr8Uhp674PP
+        jk9XnztGG97sx2uLWCffDwYrHZfr82iP3iZPM2cR9OkMP+/mnfmh5jgvGpr9mPW2sku0T//9hOy5
+        u5r1ds1P0pHfYKfF/Rn8XBneoMis6rL8flRlbRAd2/t5a9hYdtnboq82WAc1SbsfPcz6h9Wu8mPR
+        H9XR8TCddOo7/aU/6O3wptq+Xyx71n21/PBWZq1HN3Le41pVnSH/1B2w8eDw2Qg6u8FLadHc6c1h
+        975B1eWL3w3aeDhh6nTf7ez9Zs/W/U515I7eV/KijJv3R28dbYa91uKw9BalaIlaFW0zGNn68Zmw
+        oFtvfp68NVKX/rv9uWmMYxmTUml3Qp3RyDno88/jev/08sZG+DirnWrTYzir3J9au1Kz9XL/OGnY
+        4Xo/bTmd9kelNNdPVth2lg3NPtgf8vuQ6m5ra+nHwJ8ebH+kq4/DnX2oTiqzUT0s43c3Umn51WrY
+        nWnY1/36y3bufiw+P96qbzPWWw/cx2CNdtFC7i+I68z1Pn43lKLLuf9Nw0N0azN3bcGHa7ZxECCX
+        SUuCQ4mtEaRpFCNDuWTlSiFia+wVgDSR2k+tp4IOT67CkDJTu6tcMAD6L7eS5L/NbPPxdQrrF3iZ
+        IKey0xaZLp+/QEzhwvhsnE9dHEewQxeHjh8hzyw17pLSkA3PFG5rs/P6MIWJLsCck2686UE9kyiz
+        I88mXoHMzYqwhZcWhQpITc1QikMhY767QUVpBhgJbUt8F5mlSrLNfAzlk7hrm6yQWU4l52G+AdNA
+        4Gn4Y0P95Vvvzg0lH3FBus0uVPHTYY0IEgS+eddnoqQGOPJwJMcbcNYZ5PKU+pDKhVAoBzal4g/n
+        24RRoOSAEHI/glD6xQ63f5fa4NE42UpBbEAfSJsCn/aEYKZLKHEXeMHaoFO6kpI6LEOShiN4mdoZ
+        uZgs513P59mRi25Pys3JCBdgzkntaNkQrUwY2rlS4JYq+RaUzInJgRLh9vQQisBZnOq/Rj5DnjSE
+        Lgx9NKeKUyE+xBe04b2PDtYWETeJEd4gb4oML2nexI5WyEKRJ8bpZNN1/DdJo0yaoC1DSbuUdFWD
+        JppTODtmLgT2kiJmlqrJUtdoTqPIhVCCbCjX9FqlfMnOhJx+gp8w9DwzWVRtqJpgnnE4aVyvqpqV
+        wpCgkFohSumy2pBVbao1vpfU76r6V1X7nqx0W0HMe+0DPobMJ+yLVypsLY3s0//SH1W9XCupP+2P
+        ilr5j/xRgX9/xh/C/rTW8HBMCve42R52x4ZSgAUldcPIZtAJDlILxyRCv1LpEcwhNtQ9Ik27k2mm
+        yH3Gv33PrA56mQRGAg8g0LEJ09ksqRlFUDCgC6xNBZTlkK8rO+m6MpWj87oyQ5QpmX6qItTBQhZT
+        M/D35+kFlBF4Y1Kycdp/qB9uAySKeabHOxP/jrcUBQHslLILE7tfTYSv0Q+1iCs35lghbPEGGdjM
+        ZzH4vALtWW9UNa1UM5QzakA1X/FPWb3TVDjhShXutTlsKPlka5ta0JigHixpekG/AJJqmvQlaJ5Z
+        GRVDI7SPFomjCI6Cx42mgw1fUCOEqnuDd40aEUIeRMQW4g26QxqT6X5u4YIcE7AZRwVahnBCYgMm
+        YVKG+fa/oEZypefNs62NpfL00VDOUNYioOWyhG1tQlMVnfoaN+gap1V1yc1Jl7vCDApxCfR0cnSE
+        eIGYTKYrwBmH9+0jQySyA2kKRKmVBHLkSbkGz5/0HXWr4t8SGOn1jK81aXYeuuPJvPvwMDGUgkCQ
+        0uknthcgAjk8h1CkGU20MnEF+dOpD60szJ5iST0qDI2LY8pL7Bx50JW0/0cBbjS08s8XYO1rQ/qj
+        Spak1BbjQNwM09i4wpJEC/ww6e1pOBeG/6auaz/d59JI5LuTm+ozRLoAhIRae5/6TiCi9xrkrLwa
+        8sCGkidunzOhkkPG17y/zPnkNz+42l1JlZ5HhpJDXLpehyHckbQGb45FjK+Xp3Jyd7acxF5+vQf5
+        FVTkJGsoF0huWnImkDm7GNFzN4jwGUIev61fUwzeDgoeaA/G7Ydusu0rwQWVX+y2YI3k+sQN0KWC
+        8AZmdmBdPW2uQEG6epV8BS94hRfKLVhwr18r12hGu3y5XIM/XVnEs1e59b9L/wL2/DbImhIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:03 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1879']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:41 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order><crypto_block>E7--NuwIhns8SF9pSFmOCtayGoPi5orsAykdVtQtCufnKnVXd5ijHtnqR7hewEY9Siu9mKWZXgSi50wUnsm6QPTTn5Ap3rEh2y8qt7LQOigLgEgeiLH4ylijiJOz3cCcGHfmz-mr55XI7fNrF6K5mYhYQ3qn1nCceIO3_pGh-y2ODATK_1unwgfaRcvmf9rRBGVuoIht5KuL4JvyIf1HGwjOVpnEZgHPJm7kxU7hRzZCGSznxEZHloNsR7I2pTbq40t7v2mLo1javANm8iUGKktt-5o16BpnLLteyP0yqrtW48EZlb91SwCaca-PJX0S8BvzKCatNcVD_hETlolGxPekOoYcRxyhOS0oqh4PNL4fG5MfxXXjHxpdCbQvBrDibivFS6vhbjmFeBcQYWikaldIWXGQFooHSH2dWMs_BXrsAz6-j8VMn40F2LZish9H3g6jBjVkrnayZ4NMPTq5FtXcdK_5L7WFk2ASLauJCqJowO_bV8X2sPX_At8097h3QpXw1Kh0OkgxfUXvzDHbFI_bN0XSMiJ0al9y_p-VXab83-6hG9eHDURd6DtENaA6ZdPR1b2kCR_toknr_BpFKcDNzxpBDj9-GWfRRbpiCUM9rPYDDkijx5sFQiucuV4RNL_xRMwwjtm79e8Q_Ffs_Rbj0MXC_rEfuYOIlmhROtFCXJpXG4CNo46bV1NKHU8emAOPjTy5eN5yHKnfgvMsrKq0Ix6-yFmDNxXSz4pazVchj_p8eOwdiIe_aY0Ybh9RJBrav76RZUsxDdWqMKRqoWJyL_--Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>k0--5q_Eg4_-x1Nz1FPUkY_jXomw7H7E1_PjxiUKNYUK3emm0ERjusgvnWUYFQqZHjDGEekx61hC9iIriru1LpexlQdiFWf9oohhZR3m54tmVkLEMIItGP0eGhqQULniBgRbrSIgFusujEyS0Rw91TvO3pqX8rgNeFy0FDAL-H3GFetfBUfLnD1Zi-94KcFBeU0CKwDSXAHtxFWU5WZiFJ-wMeIriNlK_uoAMR58EAI8VqC-Z</discount_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></create_order>'
+    body: !!binary |
+      PHRyb2xsZXlfYWRkX29yZGVyPjxwdXp6bGVkPnllczwvcHV6emxlZD48dXNlcl9pZD5kZW1vPC91
+      c2VyX2lkPjxkZXNjcmliZV90cm9sbGV5IC8+PGNyeXB0b19ibG9jaz5jXy0tNi1ic2pXT2psUmdy
+      ZS1zRGJKUjlPQmNmOGhLNnhxU05mR3ROU1BCUGI2MWwweUFpYnBGVGdSUTNLZFpJekRpc2d6cXRz
+      OWRWSFVCcl95aWlsSWcybzQ4V252ZVlTT1ZiWGxHc1ZvUHFXRFd3N2JiUTFlVkhWRnAtY3Ixemla
+      eWVhV2NnVkZxQXpyRC1ZPC9jcnlwdG9fYmxvY2s+PG9yZGVyX3Rva2VuPjYyLS1aeDAtMUlueEN2
+      V0JLOWZFdFlYRzA5dERlQXJDR25MVkd3Z3E1SFhHTThleHdUU0Q4cTJRR0lGcW9rNkNKWGZGX0o2
+      NExZNHRCTmNuYlp1NzYwVmVpeUVJdFJJd3o5bERxSVEzWEFxMkFLRUo5czBmUWlFbENvS1N0MFR2
+      RUR2aUFGYTJpRDZNY01aZy1YNG9BSnhkaG5rS0ZCWHdmZFgzbmZlQjUxa0lNYTJ4UHJ0bEU4QXp5
+      ZGhlMGZpWmF6azlSdS1vcjMzcXllRE1NYncyV3p4aHZPUVl0TW94Vjd5N1R4bVY1SnlCcTNBQlFK
+      TlM5YW1odlRCYkRDajUzVzJ5X21DYmY5MWF3YWotWktzMmNCcF8yeGxpVHdhaU0yME5LcWF3NlM1
+      Vk04bTRvWmNuMHM0VV85YURUbUcyaThRcFdjalh6alk2WVZ0RmhJY05saGVxblgtR1hyY2JXMkdv
+      Wjwvb3JkZXJfdG9rZW4+PC90cm9sbGV5X2FkZF9vcmRlcj4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1384']
+      Content-Length: ['662']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61Y23arNhB971e456UPLQGM7eCzKF2O7cSJr8eX2M4LC4NsEwMiSPj2O/2TflkH
-        JAw47urpJQ8J2rMljUaaPVK0346eW9qjkDjY//WLfCd9KSHfwrbjb379Mps+CuqX3/QfNCtEJkUG
-        Dm0UGiEikUt1jUQrG3um4xsRAdghxsq09RMimnjbpFlRGMLwp+zLgLmQvlkFmliEMsbatCgOdVmS
-        chwOZiw/8lYo1NVyLcfiYMYKXNNCRC/nOBzKcTChBjl5K+yKeThEHNX/+D3fP8MzFPqFp4BiY+Vi
-        a6fPDEHY74J1fdesB7PqcCVsQry2Zfp0sAaj5buCLPKutJZy7f3bbigt535r7027WzJrrduLozVr
-        dk4fS7e36ODFYycc7pzm49ZS3pUK8YYtuTYvnxfl1+FUmPq78NR4f1EHctUZHdQP1HHnZ9I9P66X
-        4F3eJ41tJsU75OvtsiBUUadq7KMoaLxvvlmbRefQD6aovqh/bCZueSm5i6Bq4f1hJhNSeZ4vHxrC
-        eKYaG2XUi9Tn7nmDwrOhdFxJUfCz8NpvW+et1Gjuh/35Uq2co6qC5s11Y9NYlPeV+5O6eXMx7TkV
-        ggeDtUqXiO4WH294JAzkrdudvewOb/ZqLjUnR1SbnTyzbb9PFuH5MJSGRms4HlvzoHZ8RuOHD2Oz
-        O1bmUX359jIiw261idqCGTwaPeXQDOyPLpooo5qhfHtr7MevU3v89BBNzhNh0XkJXmsR7ftC1OvK
-        C9MJBpFKW8+NoTto9NWn1pM1Wi7HMJJihB0Htu5bf9h7c04P/frD1vJPvaemOnVmw6k5PE4n87ra
-        wXar1Yx6HyevLffnlve6mGxrxxfyGvlWxaOjxWhwdO+FN03Mh5/tha7ZiAQmtbYGfFh6E7susmhp
-        HWKvRLcI8tSPkCYWWVknD9EttnNAkkjN4cMw14clV65JqC7fVQsMgP6jK3H+m9TUB7MpzJ/jpYaM
-        Sk8B0i02fo6YwLn2ZXEOsXDkg4cW9laOj2y9XL+LpSFtXihsrZPprNUeTGGoApyxEtcnNLKRT0sh
-        yFyOypblYwOvDQISSHRZE/NNbqOOtUN5awpoMS0IHQvp5VrsZtYG/QytrRlukK4klkszc0DXEEQa
-        /pggwMzx9lwTsxYzJG62QcZPhy0KEScw51fOJgqMvelGiGloHtAsh3LBdbFvY8iEHYTyAjJ7MlAv
-        sXMjG9pyTUL4H8aHo2HS2IEcxu1Jl2nRzoaB6pCUCjZcUj+KUBxEiI2xQ6d0BjGJZArGpYhT054X
-        pDBexrsx5M6xye1h2UK4vYBllGQtj6bnuKccia1QzOYV06DF2xvyMCdBzwMXc9J/5jsU2aUuFGWo
-        qhmV70LowGmDqrx30MEIUGjFJ4aVy5smzY5reWj6G2Qg3+Ztvj/RLyVZpdtSI9pEhJbKkgwFNSMw
-        bkQtOORrgqiu1OKJrtGMRpAFBwcyo3IvVytVqcBOjYx+gh/PsyGhYVJJlVXOvOCwuVitSbKRwKZv
-        Q5p5KKELkirI6lSuf1Wkr5L0syR/jWe63YGPex0B1ibUDOmnmJRlCEYDEtf9P0NSk8s1pfLdIamU
-        5X8UkopQlv9NSHgIEulh5zHW8XGj2W2PNTEHc0oShr5JIZEOpQcchT76iZQGsJzQBBkMf0w7sXix
-        b8fWa8+PqQVaHHfhlONMSPIgZ4B7NCK66+wvdg6lBFZkxLSd1BLieIGLuDCn/ViVYd9RQJDrwlSE
-        Fnxsf/bxr3yP8e4sj4s3xt4gbLAi6JrUiQuPXk1K8KWpgRhv2Kcg3cmx6QJoYtZ/axID6g0k9pro
-        PtbEAhBrYVxukH0RQd7UPPNohJHvQ1jZ/stlOBqfUM0DzbzBu0Y1HyEbdjeAcxPBfTg+S4k/t3BO
-        jqDUwqMjR0sRRojXgEPP9KFUJu5/QrX4ps5qYlMelyrTgSZeoFTgoZLSmG3sPF3iBfga18gWJ/K4
-        ZsthT5giphE410BPBkdHODqI0Hi4HJxymGyAvTQ5EYq80hsK8YXKkiC5QPEbSqPVa48n83avN9HE
-        nIGT2AXFtF0UQlrN4SCRlMbLC78k/KtshNLipQ+lWB5yTa0Q7Uzx5sgGRbyPq8T/r4j3IPz/QBHv
-        PyniX6VonBsBxi6/uSWbfIXFGeM6Xlxtk3OZa/6d0N5/r9AmR4p5JzTqDTiyHOAWYuwd4qxcfgyv
-        QcbKFI6dUJAxfjt85V0ySPucwMXkjX+zjbu/U6TSqK+JGcSs263nwa1FritJAc9jbL4sJ+O7Lbz2
-        Yb3J7PECr6A8J55DLCDZ0uI9gbvLR4TIReF9fIGQzW7T1xSNSXwuAs3ncbPXjt2+MhSo7KoVwGpK
-        lhNaLip24NHA1HSNq6fHFchJV6+Gz2CBl3tB3II59/o1cY2mtOLL4hr8bl3hz1Lx1r9//gSe8Zbz
-        OxIAAA==
+        H4sIAAAAAAAAA7VY2XLqSBJ9n68g7sPMw4wsiZ07anWwGS+A2TG8KLQUIKONqhK2+J35k/6yTqkk
+        tMCNud0z7XDY0smTVZVZWZlZkn79sq3SGWFius4v38QH4VsJObprmM7+l2/LxSPX/Par/DeJYtey
+        UKCohqG42EBYwYj4FpUl4muGa6umo/gEYJMommrIjivx9yWSjgOPuopmufpR1hWOq3Ma+Vi/fViz
+        PUYc6Wkvs9ZbR981D6/1r9N8vBvQ8XzSmWh10RKCtql5j4v9bFp5NbbPl55J9pcTJS1j9bTsYCUw
+        Tet5X3arzbVzRpv520p7twZk5U5O6976s6FpUxGtnlaPHqdj8WJuA6Su9f3q8dS+4B63kfjc+qTQ
+        YM8lxNQsJAeISHwOuTqGukfkyPUKx1HltKPN4eZY/uQmY/OptqzOp4Y4OiCn2zMGtQDhz4G2Pguz
+        zVzbUkvd4O6upzoz1fQUNDY/4LF9IC+HdqX2YdSmi+eX2X4wtt6f943eevh+mXK1Chl0q4/meXS8
+        LH3zNH45dgJ62jp1vTzcfwUcev7s69MWVha2s3ndHmtvDj4/NbYNQ7QWRlM1zFdaGc0NI/CHh8eX
+        Dlcr94YeFygf/ZZm+ZfutPxWNTRjUz4tuu7r61PD7ArKhbaXA6WL/W6lhbTatvuiiFPRPVU3uvf+
+        Wf0Uh8qL3l8ZDc/ptBtH/VQdjQZ+q+NazY0uBo35YmXsyeSwmfc6fvujgrwGOl0Cd3z0a0652dOV
+        dr1RW5y1lepsyNtw2xla50V3Ig5O5TWtNN87Z63zPL+sZ+vlBW/JadhZdD/Gu7H4rin13mZbFyvT
+        WXnT2I1OC7wZzDa7yevmYz3ZzNr9CapNB8EXXZKn3mbzrgTTL6XpcX2s2YueJ3DcVuLzm3ndWxbw
+        uus7VBZTVhYO4wQZikmRrTi+rSEcMm/BZExZ0nzHCAOI/S/OcQdNmMT1sY4ANJCMvqhCEaHCVSMr
+        LWgYiOhy/4si7KhWaQFqpY6qg6VG6UY/4ib61KWqBUPamukgQ660HlJ+QVZUIVSuCg+1GzqhBSpM
+        6KlUP8jiDfsqymsQpFIPmzqSK7WbBaXCghJYd1DxHsnVW52rTNJ9jCENBukT8+he8yBB5KCUsVN1
+        6sK+C0KGE4MpKw6EZrmeYSXRcQU8S9URkcsZTgxlOOBFhQS25lp8FsYoRuXf/pPVT/EUlaUoxGQp
+        cTLb+W4YpDot7bBrl+gBQYVwfCTxeVaqZCN6cI0MELmm+9Z5y+gwd2VeIQii3c5D/+NSwqqjUlUe
+        Lxcwf4aXCFIqDTwk62z8DDGCM+9X40wSn8TCUUijP6EwW9u95XABA+XAlBMtvG1AFS0RqjqGio0M
+        mZnluIq7i6KZhGkh+xrLqAlHOCtNAKl4QDJnonAMMpHPp1Yi8HSY2TBS2dL7a0hp1zcmYEkFGojg
+        84Awigls8bpJ40NiuY7hOpx/BGddQSaPqMNIHgtjZUslJP7H+CqmUH4zQCxkfgRh6e+q7f271AWP
+        +uFSMmIJuo+oFWHDRoU8D4XuAi8oR0jO4Ux85LAECducmJeoXZHcYCmvOJ6hOjq6PygzJyHkwJQT
+        2dFRIVppbGivoMAs5dMl8IkTww3FsdujTcgCV3Gkv3SgXhmlV2gAoXtLqfGuYBPiC5q/s4k+FQ9B
+        rQgLVpTy7ookOHNIwaqzRwpUmvg9Gmxx8P9VEqEKzZEHJRISYKksiJAWUwpj+1SHwN4RROVKPZyq
+        iKY0gnQIJTgN1Ua5Uavm2YmQ0QP4sW3DkMNJhZYgxswrDjvtNuuCqEQwHFA4WjaK6JzQ4gRxIba+
+        V4TvgvBPQfweznRfIR636AP2Dicf0xuv1OihNFKD/6c/6uVqoyL8tD9qQu0P+aMGv3/GH7H9Ua5h
+        4Rgm7lm7+9qfSXwGjimRG0YqhUrwWepAs+Kgf5DSGMzBYS+DS4v+fJEoMp+xZ9OQ68+PiQTeYtyC
+        QHdlGE6lYc7IgjEDqsBB5kGZs9m8nBbNyxHOuc7LhW0Yn+hHKrE6WEh9Ilvm+Tp8DCUEVpj45D2q
+        P8S0vbAziZJ5oscqE3v2PYIsC1ZKaM7E/q2J8DR6ErI4f2eMPXIVViAtlZrUB5/XoDyXW3VRrDQk
+        /opKkM337JETHkQBdrhWh04lhSU+HeygEgUKE+SDHYmuhTkgzKZhXYLimaTR+FWy1S8F+44DW8Hi
+        RiyDDTeoZEPWvcMropKDoBc3kAfxBtUhisloPffwmOxjsNl1MrQEYYTQBhfbYRpmy79BpbBJY8Wz
+        K85K1cVY4q9QUiKg5NKQrRxtWYgrdRGXyMGNsuqOmRNNV8CkH1wNcneCn7oM5G4B0e39Xsa/J5Ci
+        9ozNNW/3hv3ZfN0fDucSnxHEpGj4uQodOIYzvIZQJAktLmVxC/Knj37hPpa7ieW2KU2xa2RAVRL/
+        igTcaonVn0/A4m1B+lEmC4+U57pW3BlGsVHAwoNmmXZY26Nwzrz+l7wu/nSdiyKRrY5rCxOI9BiI
+        JUQ5m5kPKUWQsdJsyAIbUl7cfa5ilRSSbs99/syHf9nGNR4qQmkygtv7FWLSw8G2oUcSW6w4ZjE2
+        X3qUw95Z0UJ7WXsP8gKU5YRz8DkkNS3cEzg5Jx+RazVw3CuEDNatFykSKwcZD3SfZ91hP1x2QZCj
+        ssbOA2tKuol1C+UVYm/cu+UXr/fsvXAruQVzvMwN5R4s3b/O39zj717gb27uP5tZ4mvvX5Mx+eTj
+        TvKpKP7OcPMJKYf/oe9N/PVDEv/Db7O/A9pPXdzdFQAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1828']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:04 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2085']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:41 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <trolley_add_order><describe_trolley /><user_id>whitelabel-testuser</user_id><order_token>E2--5eH5_vuupAjgQcgXHwMpTe9X9qgSl2Y0lXp5covwU1ss4IWYBA-RU8_g3PLu8IKzgerz_3Hl033oI-VMEczh0ACvOMWY84zu53eWCfAgAX2v47y8gZlotLi4soNNf8tYetkXqZoP-N1hlKUJkwZdbW0CSxe6UymaEdjSXrzwO0O_DORRcWp6xIeRBq_gkx4Wu9YZJPsOK5CeE-apF_L3wCpdqKeS3P6_3QZAvRVTdRGBuSzS-XHJpV6utMn-uLK1XaipNu8tDIAOlNAM8GDGcPYYRpF_3_rHi9pUQMOLZiyBM9BhcnyLGC8TiUOTaOxTSW98HodDDCuLqymE1MWcmVXSh6xJsVunc4mtPXPNxl7-Z</order_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsUDfEXxcUCHyqYlLXHoXFHrOkiCFhc3j34smOD16W2zX2VOT-TnkryAjJ8N15iPw8qeHlWzsKzFfY</crypto_block></trolley_add_order>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['694']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61YyZbiOBbd91fQualFN4HNTB6X6zBGkBAQASYYNj7GEth4DEsGzO/Un/SXtWzJ
-        I2R1ZnXmIgPdd5+GpzdZwh9XyyydoYd0x/79C//EfSlBW3WAbh9//7KSRuX2lz/EfwjYc0wTBrIC
-        gOx4AHqyB5FvYlFA/h44lqLbso8IrCN5rwAxgEioPBYJqhe42JH3pqMa4koul8+Ge+gY/Y67asz3
-        5aPnHACPny/q7G17qkEVnWqDLd88vRtzbru2B2dLmmhoNTgMN1d11X8JPrfmdPPibEYv3tzQ+yNN
-        rZ1qdWTNB3xzXb1tqh9zqSzZhhd0T9/aM76hv13an/DFXN/Q5DY6bIVKbk9CeErXQUjfm5AeJYck
-        1sCOAW2xWS+XdamGlY+2U61hua87DXgz24u1PaqCi2J9PtvX7jV4GV1ul+m5DgdtUJ4fpE7Dfx13
-        WvBtMzPQ+HX8MeeWo8PGOrsjvfF5Ac83/Tg4OtaQO43gDh28+lXvfszWvqoFL9bQ3pd372tzLUNi
-        JSmozdu93v6wQB/c+MOWDbDRpt3XRb87O/Dqdbp7vaKPPexIvU/34jacz8ZAA9Kwf3h2LP0KBsRQ
-        Jv/+8aENXv25Xquqp9bu1IDBYHDqtnby+HZsD/zF1Lm0x3Z9vXr+9N6Pi5GM3qA0WS6MUc/aYvXZ
-        qLfxoXY4ti4zs76a11cvcEXOic6b3vR96kp+Q7+1LEM78/K6Pmmure6u6jRWBuirE9ezTe+0rIE3
-        tf920s6X3nZX7WxXxjoYDYddaXRDw/Gnuw9UHQwnx8GmCYatjS55U74qvbQG0sUdztZcT/12la5b
-        ubpuapfn+rLz3us/j8G3YATWPe/sHSdL3ZSnr+f9rnXrgWALlU79E8tb6CxtY+bOvr2OVz17NBnM
-        p4FR3uh827QMeJPVzRyM7IVuBDO3vz+eaiCAg0bQHu93XvtdW3S0/UwbvzfLO6GSd5DEX2jkqI5v
-        Y5FPWVk49D0IZB1DS7Z9aw+9kHkPxnOKwt63QeiU9G9xjQdozESO76mQgACK8IplDBHmEo2stKAB
-        IFJFibBLywCRPZV20HOKihEpVsQOVkwyl7XXbQjEaucpXaggK6ogLNa4p8YdHeEClSzoKljVRP6O
-        nYjyGggq2PV0FYrV5t2GUmFBiZxOU7wjFGv3OolMUH3PI4k0SH9RUx73Lsk2OShlHBQVO+TCOS7D
-        YWDKYh7QrjYzrNgtEsA1FRUisZrhMCjDIVaUUWDtHbOShT3IUPE/f2b1UzxFRQHAvU52KKuao0fz
-        MyCVUIfRYGngW1ZQ6iseKA2oTKjkSImKbmN49BRMypIMFKxUUpGtWFAE4UypcoQlDBy4d4wIS4bp
-        r3TbUYyEk1BnoRvqh1Gm4tLBc6wSJkc4Q9uHoXaWlSpZEGsOyADRFffnvXlGh157ZkicOfLaPPR/
-        biUsv8Ry4mwlkfUzvFiQUiPjqHT+DDGxWfFwOmKppBDSaRTHFHrWpbQaDGcSmSoHp6xo60vsA2jj
-        Erl2mKHSY9mO7ByiqERhXssOmQzrqgGz0hgQioGeie1COGciuJKeEhJLh6nZgwrd+HBNcnIyooJo
-        m0PSSgUXDXqQEVga1I++K58V04c0urOAoOqYpQLTsYFjl32DmDIBqTyaaBrJmZBOrZoKQuwP5RPX
-        UHC4gQzG5HEgZuV0GtKcRZ0anS7qefJQaERiG9kgNYetUIksGYNhJ8iosWaC5OZLeQ+mNHSAHk9L
-        D8LkOSylRGcZKZZuBhkSPWElXbcSGy28Xo+ZOTJ6FkjEkf7KJuUXlCakMSZNbUplt+DpxNtIU3zW
-        4UV2IamAYf2NEvlDkUAiEMqeYh+hDG3Axux+/H+X+DbWSl3/6JMqW+V4kupTAuX6WCVOfkCQFMhm
-        uFARTWkIqsRxSGTUW3yj3uBy7FhI6QH5Z1mABDRZlGvzbcZMcHK5TrvJ8XIEKzYgYUZyb0gvc+0y
-        35b4ztca95Xj/sXxX8OVHiuweYsWoGOEFQ/f2aTKE2N0SeCav9IkTb7arNV/2CT1Kv9TJqmXq/zf
-        MQkzQZR6qD+GeXzR7U+GC6GSgRklMsOrgkkgXUo90oPZ8DdUmpHjeApJg94/YyVqL/pbB2JzPIol
-        ZMRwk3i5kyaSLMgYZHvYR6KpnxM5g2ICLTKVeBzVEqRbbtgtRYk51qNVhv72XQRNkyyFcG6Pw/s9
-        fm/vIT5ZZfHKg7mP0JFpETRJkxEWHrERleBkKJBkfKQ/y9wTH4oSQKik+pqCZFJvSGAfkGiTPjgH
-        hLkwLDcQJEmQDQVLucqeb9vErPT++SpxjTtUsEjOfMArooINyTcCgC7xG590aqEvRft5hDOyTzus
-        DC1GKCE8g+NZiq2y7+A7VAh7SFoT+/yiVJdmQiWB4gRPKikO2bJhiRwrwEVcQJoTpccDPQ59Qchj
-        wnc+WXLfKn/9kZL7OokaKNahdAfT4WK5Hk6nS6GSETASbVAU0ut7JKzWxJFQTGPlhTUJfysaC597
-        uQ+9nLXTjLeGgGTEVlglfn1GbJHE/xMZsXWXEb8XomFsuI5jss4tuuQCFkaMqVthtY38MjP8X4m2
-        9aOJNnIpurtyt9MlLssAJkHyWc+8/hRBykozHPVQksZYd/jBVFJIuA/gfPCG/9OLaz3VuNLbq1BJ
-        ISrVNMsiXQvfqUUFPIvR9dKYDHtbeR+eN1o9PGABynLCNSo5JD1aeCekd/n0IUoyvO0kEAS0my5S
-        BJriMxbojxf96TDcdkGQo9JWyyWnKam6p5owr8Cs8eg1ofiMQMeFr4Z7MMfLfEE8goXHzwZ37wUP
-        HwruXgh+NK+wz9JfnPoq8bNR/AjFHjLuHqdy+E+9ZFWSJ6rKd5+P/wu8uhIsgBYAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2158']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:04 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/TrolleyTests.test_orders.yaml
+++ b/tests/interface_objects/cassettes/TrolleyTests.test_orders.yaml
@@ -1,544 +1,505 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48ZXZlbnRfdG9rZW5fbGlzdD42SUY8L2V2ZW50X3Rva2VuX2xpc3Q+PHJl
+      cXVlc3RfbWVkaWE+c3F1YXJlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPmxhbmRzY2Fw
+      ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X29uZTwvcmVxdWVzdF9tZWRp
+      YT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X3R3bzwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRp
+      YT50cmlwbGV0X3RocmVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZm91
+      cjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X2ZpdmU8L3JlcXVlc3RfbWVk
+      aWE+PHJlcXVlc3RfbWVkaWE+bWFycXVlZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5z
+      ZWF0aW5nX3BsYW48L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+c3VwcGxpZXI8L3JlcXVl
+      c3RfbWVkaWE+PHVzZXJfcGFzc3dkPmRlbW9wYXNzPC91c2VyX3Bhc3N3ZD48dXNlcl9pZD5kZW1v
+      PC91c2VyX2lkPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48cmVxdWVzdF9jdXN0b21fZmllbGRzIC8+
+      PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:04 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:51 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxldmVudF90b2tlbj42SUY8L2V2ZW50X3Rva2VuPjx1c2Vy
+      X2lkPmRlbW88L3VzZXJfaWQ+PHJlcXVlc3RfY29zdF9yYW5nZSAvPjxwdXp6bGVkPnllczwvcHV6
+      emxlZD48bGF0ZXN0X2RhdGU+MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:05 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:52 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+LTAtLTYtYnNqV09qbFJnUHdhT1Rq
+      VWNscTNnVDMyR1UtS1lxUllYZk1mbEVTa2hDdHo5RWNtTmUtTDJkM1FnRHF5dDdQcVowazZGTG8t
+      QUF6b3JPX2Z4MXIyMWRWSG5DNE5veWhoU3gyTF9qSmRPOTF1X1MwZXJxY21RV3Y4YlZldUtKZHVH
+      bDdLZ1lwckNiNW92S3NsaUc4eHVqQ3kxQXJWMzVzU1dQSHA1ZWUzNS1ZPC9jcnlwdG9fYmxvY2s+
+      PHBlcmZfdG9rZW4+ay0tLTZTWUY5WjYxLWUwOThNeGdvdlVleU1OU1pacFJQc0RsRm1sMkVLNnJp
+      R2tpaF9hMHRMODIwUWY0Z1hlRmcwTm1ZPC9wZXJmX3Rva2VuPjxzZWxmX3ByaW50X21vZGU+aHRt
+      bDwvc2VsZl9wcmludF9tb2RlPjxwdXp6bGVkPnllczwvcHV6emxlZD48dXNlcl9pZD5kZW1vPC91
+      c2VyX2lkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:05 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:53 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGJhbmRfdG9rZW4+LTEtLVExbXpRMFpXS1NlY1prOXo0V1A3WkJK
+      LUZrMVFsalJMZUg4OXh2OXNDWWU4YkVldjEzaGhGSGF5eV82WWRVYkhBR3l3RVI2U1J5blktQmVY
+      aFR3cTJhZC1jNWhBdzhaaEtwSm5tM042Mktmek0zcHlCc21QLUN3Q1VJWS1jZ3NXcXZLWTFxLUJR
+      QV9DU3dKYThIUmN0ZnZaUWlKS1g3ckZkY0ZMeXBDNmNDb0NYZ09oX29zdldjb3lRTUxaN3VJaWli
+      T1JrWXI0VXZ0SXd6XzFtaG9XM1BVV2ZEZWdTMnNaSnNXRGlxTnptcmRnbjdOWDhyOV9mYVpEaE9I
+      N2M5SmJaPC9iYW5kX3Rva2VuPjxjcnlwdG9fYmxvY2s+RTAtLUV4STUySlJDcS1nTERzdng0d25V
+      WnpaU1dTWURxcWV2SkZHdmw0cG9DaXZDcVVVZnZVTEFYZzlicDlYZzYtY2NLNUx0UUpTdlJtTGV2
+      ZXhlMTMwaTV6NVFnRVd6bjFXbUUyeVh3Z1Z4ZE5vOVNtSmZjZVh5WTdLTU50OHp1eVZKdzlhUlhP
+      U2o1eUZOcC0wd0FkdjJLQkh2cGg2Y0ZxUk9jcno5LTRsRGh1eDJYSGFBbTFGNFNibmRKMm1xd2tS
+      Z1o8L2NyeXB0b19ibG9jaz48bm9fb2ZfdGlja2V0cz4xPC9ub19vZl90aWNrZXRzPjx1c2VyX2lk
+      PmRlbW88L3VzZXJfaWQ+PGRlc3BhdGNoX3Rva2VuPmNfLS1GeUpWRGY4RHlFRGhNWVU2Zllsa29B
+      MUcxempMbnZkVndoN0tMSmticlhpaC1aeTJ4U3BTT0RkSGFIemR5YUdqLXBySGQ0N0s3dmZDUkZY
+      dU1FSnVValJLQnNHbldScW1IdDk4LXNoTHNSWklFbjlMQlczV1ZLczNQLS13Sm5RSE9fenB5WnV5
+      VWlBLVk8L2Rlc3BhdGNoX3Rva2VuPjxwdXp6bGVkPnllczwvcHV6emxlZD48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['449']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS0HvDihIg7XFxZDKMgoBCj+Tv9Jf1kHg4Je
+        O4fKzLeqlauS2GfHCeLEOWcHJvPHxbYqEfADw3V+/0R8xj9VgKO6muEcfv+0EgdY89Mf7b8xmhGo
+        buhAyfUgYgaSD4LQgm0mCBXNtWXDkcIA+JIRSIqstR2Xqb62MCACDpon+0CW0DqgzW6YajHKDBoI
+        1DaLXis+68AHOSFFGdWAcca1XEdzHSw0mWoBZvaUOkntuTGfbMlBkP+V8WUfBohSALkx5XeQsfJ3
+        2fb+Xemh7YbJq5TMDNpUusPMbQyQp0eICYDsq7pkgjhdqYriUiBJ9HLebdodeXBW8J79abKjgtdO
+        s+3cCA9gwUn30ZUtC8B8o/2nCdlOq8UrVG9BTBLCz8OeHkIZuJvT+SvHgECrjFFaoaQoqPmp+AY0
+        VJRTkQHOkgd8NckRAscR8aWJ0WQIJF92DkACjpaPU2eiHv6rQgSwsgQeBLYC/AqJE3WmWlAydghV
+        yd3vAwDbVD1Z6hktaAFQUSoFbYJukI0a/ci+GTN6jP6zbU1rJ4viLZzImXccnbTbrOOElMKyo0nQ
+        sEFKx/AWhhMi0fqNwn/D8X/ixG/JSq8n5H6fY5CNA4iS40NUalCvTOX4Z8ajTtINCv/meNTw2nfF
+        o4b+/Jl45PtPe02WjvxK7Amd3pgVmGoJzilpGKYyhDo4V7pu6DvgH0GFR9vxZdVEKSSyS/E2MYtZ
+        9mxo7fpwcLMYt/4mWSjR3TZyJ8OkZ5TBnOHJUG9X0WTMztbFlHRdLMCc+7oYBAGs3uanU/LpaIcw
+        DNqWEd3d59CNgNqvDOXqbQxjD7QDw/YsgAKGnMPbvNSSs0IvAJaF3jSAD1tkP24RPU05vIxXX/g4
+        ADc5KLnNWDI0YIhiXiM+18hWnSCoBlO9owzq5ofsEcM/Ezg64VqdRIQ7zFQLZ7ocSI6b9IN9kKrN
+        A5B0U9QRUce5t9F8yNjyRfJDx0FHkeUNQaI9fEAZG3XdF7xnlHEA0FBGeCjfkDqkOZm+zys8J4e+
+        nGhoiXZDMkKyB9e3kzacvf4HlPHcAGbi2SOECi3yTPUO3SQCSTZM2JJpt/HP+F0jyjgT6G7aVffZ
+        dtLlnjAmQHmJ6KlzcEH5gnIycVeCb5xMty8Q+I5sVURErHSTRHa0SjEjq5/0UvCq478yMCixwnyt
+        Zac/YYXlhp1Mlky1ZMhJqfulrFnARzW8QakY3Gi5lOVXkIeIFt1wAzQkIMSv6JWtFkF/e68kPmrH
+        /2s6SfZ7rmulaZ7fHZ6wpCYsw05kOM280vArLZj4ZklKkyZ7O6yDz1FS5kBuCaTICAzFyhPtGcxY
+        RePKchB1p/yiuM6nFBDzsUQfyzP5f3Zwjc8UXplPmWoBZVZdt210nSFamY6VsWy9e46ofuxBV1Is
+        VzXbUwrDvHkNEtSBlVXalIXudWeTuhutBMPhuVlgkuo4UubOUbCgNrqQvd4RP9dbR77FLk5S5F35
+        2DT7K8FuGrQ+6jkreFUipdk5cUNLBc3x3pZ74tjXvL1lDYQmO5KPVmO6dq3RwWxQxHKCNa5DsS/W
+        pS0fen2bVcXTGIZDSu1btBoC1rBFZ4L7RmdPc7EAIHccWoK4PMCVt2GbEmsv+krUeANrsyX68/gw
+        P+v6ecguW+bUtg+z/uy9f9VDq7GmG5sWL0Flya3mZ3eh0YOr1j8tsV204eaDbp/g5pG55jcTjDxv
+        V9Pu+0ggllA4jKlOIOG0wq5rltPz9my0cFW18cZe6xam6ZFKBRNtAPvyXMPm516NdJeu4hIgNiPB
+        Hg1mKuQ9TtqO3ll8Rtgrj+pq/JEfnrjxmxWc1V7EwcF+KncGrLAJ3wMruA58F9DcdQ4243ptSvOD
+        3di3CfXisFAzzoPl5djvw+OkT485stsYyjVX0YQ3BXawXXLXLJ0vo1iyg1RSKj59HCtOS+e1pfhG
+        SuuqTaHqfUQYNfR99HUVF09ZGh8UD63+ABWMvaxC189vw09gwXLC5KrbbpL1EisHC5ZnySoI2mSJ
+        k0MlDhISKYhtxbWqZRipWIa2//uf8vwCL9AiGMFDXNCNAH8IS3JFQLLt7qViAo0U7wm6+0Dfh0rg
+        WiFqO4EcoTrPpO0ZRB8ftmI4qLdRrcR+HxYvk0a5019NxNILZaG/D7NvQA19+VUSzdRkXyuRcz34
+        yu7uQ+giHWyrOIadTKzVXY/jCx5zw8b727pPDh1BdLX94rR78whpEZIUy5HN96CGMm0VXTWcvcwI
+        +mw1WHuwhz2ObACbr8VU1xodD1YwkMddthlxTTpyur6+UehtxxjESmfKc9vOarzAj9aJXkP7PD5z
+        /MzpT8QemG0Wi94+gkGzZfqboOGdotp+PhiMdmezNbXOHe1AKFdlI7sxPFIm5UbWdGlSfJeXVq7W
+        s2EX7weqUbP2FuYd9dF4PN4u+ucBuSsFIdt1KQrJZbMcpez2iVQAKSfK1VyasgFKDSd7lJ4O9IWh
+        RE4Uz/MN1LOp2iO7sJTp6Fqiy/4BtOkn9t1QYmeXZ+m1/wcjk9WfJEeyYcmJwiFF/4Ax+SVHPhQ5
+        nQrPE8ikTiUlkdsseRHrCSpzkvSsPiCFsvryGU1woHEI3TDIbwgEuo6/NKR06ELZemKWMeY56KVQ
+        PwW4FNYXwXwMYbWo/D/dA0jiSz2gxw0n/a/0gJ5uWFoF3dLBj9Y/hup/MrPtKdcbqoPpZLVRjAO2
+        ssfieL2bAKTbI3vcXGMY2Y+3w51CBCJ+4PZCPzk6QG8miq0vunWjX9eIix7hsqGe4vCs26ap2dtA
+        wSSIBHl42I07kWVKFKcvWuxA1nbS25BerhoT1msK727Ei+PT6r0xmVDXQcvvXqh+h++1LrPNynwb
+        rsH1elI9aYdhX61l4gdqOTuYb61lovldtUx9by0/+/+rlu9BeVnL1JdqOZv3C2r5i3q+FFd9lv+a
+        oi+TnxMc+FPq2UT17GPxebJddlnWqznX/ZD2uzzRiHrWfOny5mEyn7iR8z7ZHvsX8chpR65Xj+Z2
+        NI15DzojxdKN6I2bDa2Q3bwfV+pKEt6l3tCGbOOkHK52d79Vh6fNsYOu9cLaP8lig641u9dQsE7u
+        uaY3LouDyHbZCF3FLd7t4cPl2TwbyKUn7bueQY5YZbicjI6NWcemPPYwmR2c4/xiYS3K655W5D6O
+        pyuBvtRngIhtasg1AqMJTD7e94Y0JvC0EPaImo3PZuTX+wH5I/3gu7SdrP/afvDs/69+cA/K9/eD
+        bN7P7wfUF7V91pl/rRcAx3D9impA4wqcn9IS6qglDEyKmxgcTte6Y0ne4wK7D4TgeMbttdUYGWK0
+        ah6W0LlsKa+3vhr+vjmCO6G31UdGf2SbMqV350rY6h54rTkX45ALdV912bXWXEN/esa242406ZHH
+        eG1uZ4Sxj5quxQn8pkZOehoei9KFvC75GPi7S3PhHWcCCXbXGqmfSJ2iRKsf8EJwUtXjEA99bo6j
+        b3TaOknfIPfUj1zdv0vuyV8s98/+/yrve1D+RHl/We7vj0H2W2VRkrprJD8/3H+x/GAp5dvTvz3/
+        D1lRoYe8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:05 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:53 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcj48Y3J5cHRvX2Jsb2NrPk0zLS1wUDV0MTNnRWFjNGthUkJ6Wm0yaG92VVJp
+      bk5IT3NrMmNLdmJQbmpSbHRkSngyQ0NqMHc2OWpOOUVRcV92cHpOeWtrRFVSbThpNGhKQ25VdHpi
+      dmI4QXFISWxjZThLZm1hQ1RLcmRwZmxsRlI4RUphamw3TVZvbEpnazczMVNMLTd6SVREVDZfWE51
+      cERtRWNUcUt0dUkzY0RsNGN1ZUVpbVRuTDByaUFmNEh5UmV0SGpJbFJUU2d0VXBXRThfRW1RRGJ2
+      N0dlVms5VHJQeWdQd2hod0lFUzlrTW1tZ09ET1lEemh1bDdWNDdXOU5fdGJTSFVQd29RZDRGemRE
+      cVMtWnZXSFBGQkQxSFB2a1ZOV0wtMndYVU1CWUpSMVN0UmdLM0FzXzA0YkVWNWxuQ3BmRXZRb2Nj
+      N0dFejZsLWRodmMzc0xkRnREYVBkLVB3QzUyb1NvYm8xZXlrdlJtSkZPY3ROcEhfWEpZRTBPMW1V
+      cDNCZE5qTklxSEtHbHN3Y0N2SHRGZk1hQUZFUld1WXNsc3pGcm9lNEh6UGVXSzY1TTRORlpLcm0x
+      Y3huRXRkaXdGU3hqRER0akxENEtIMkI3SWE1b2JkUkdidEEtWjwvY3J5cHRvX2Jsb2NrPjxkZXNw
+      YXRjaF90b2tlbj5jXy0tRnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJY
+      aWgtWnkyeFNwU09EZEhhSHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5
+      OC1zaExzUlpJRW45TEJXM1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tl
+      bj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxwdXp6bGVkPnllczwvcHV6emxlZD48ZGlzY291bnRf
+      dG9rZW4+YzAtLXFrLTlCVkt5eDB5SEk3WUdWRDJJblJUb2RmUXFaR3AxX1F1MjNFSDI4WXM1YW5r
+      VXZ6ZDBFeE8xNHdsN0VtRmZ0Q0gyN2VtTjV5M0JsSmpnbHNGYUtCRTh2SDg0dm5CcmhXYjRYQWlG
+      eWJBTU5IWEFVS1EwamxxNFZ0bXdLd0hOT25ETFRDZU9XUVFDZnZ0czg5a3JXczdwcXY1ZlBGRkpa
+      d2s5TWx3QWRnMWJ6Yldhb3l0ajNrM292bE1TazNOQk5fVW9kQ210QjBEc2NpNWxmbC1wamhKS0tL
+      WFFEd0YyWjwvZGlzY291bnRfdG9rZW4+PC9jcmVhdGVfb3JkZXI+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1148']
+      Content-Length: ['1008']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
+        H4sIAAAAAAAAA7VY2XLjuBV9z1ew+mHmIaG5aO9wOKW9ZVleJFmS/cLiAkm0SEICQC3+nfxJviyX
+        BChSsqbSmSSuLps491wA9+IuQBu/H8NA2iNCfRz99k27U79JKHKx50er3769Tnty/dvv5l8MlyCb
+        IQsTDxGLIBoHzDRo7Hg4tP3IiinAPrUc2zMjbCi3JYYbEwKzn/IvC5ZC5srZGsollDOWtsswMTVV
+        LXAEmLOiOHQQMet6tcASYM7aBraLqKkXOAIqcDBlFj2FDg6UIkyQQM1//qOon+M5CnrktGXYcgLs
+        bkzXkuWq7NCP+dNHMF4RJNOOcz9uPLXcZX09rB53k8dlnz1OnlvPTlUL1FPTd7a96Wr8Uhp674PP
+        jk9XnztGG97sx2uLWCffDwYrHZfr82iP3iZPM2cR9OkMP+/mnfmh5jgvGpr9mPW2sku0T//9hOy5
+        u5r1ds1P0pHfYKfF/Rn8XBneoMis6rL8flRlbRAd2/t5a9hYdtnboq82WAc1SbsfPcz6h9Wu8mPR
+        H9XR8TCddOo7/aU/6O3wptq+Xyx71n21/PBWZq1HN3Le41pVnSH/1B2w8eDw2Qg6u8FLadHc6c1h
+        975B1eWL3w3aeDhh6nTf7ez9Zs/W/U515I7eV/KijJv3R28dbYa91uKw9BalaIlaFW0zGNn68Zmw
+        oFtvfp68NVKX/rv9uWmMYxmTUml3Qp3RyDno88/jev/08sZG+DirnWrTYzir3J9au1Kz9XL/OGnY
+        4Xo/bTmd9kelNNdPVth2lg3NPtgf8vuQ6m5ra+nHwJ8ebH+kq4/DnX2oTiqzUT0s43c3Umn51WrY
+        nWnY1/36y3bufiw+P96qbzPWWw/cx2CNdtFC7i+I68z1Pn43lKLLuf9Nw0N0azN3bcGHa7ZxECCX
+        SUuCQ4mtEaRpFCNDuWTlSiFia+wVgDSR2k+tp4IOT67CkDJTu6tcMAD6L7eS5L/NbPPxdQrrF3iZ
+        IKey0xaZLp+/QEzhwvhsnE9dHEewQxeHjh8hzyw17pLSkA3PFG5rs/P6MIWJLsCck2686UE9kyiz
+        I88mXoHMzYqwhZcWhQpITc1QikMhY767QUVpBhgJbUt8F5mlSrLNfAzlk7hrm6yQWU4l52G+AdNA
+        4Gn4Y0P95Vvvzg0lH3FBus0uVPHTYY0IEgS+eddnoqQGOPJwJMcbcNYZ5PKU+pDKhVAoBzal4g/n
+        24RRoOSAEHI/glD6xQ63f5fa4NE42UpBbEAfSJsCn/aEYKZLKHEXeMHaoFO6kpI6LEOShiN4mdoZ
+        uZgs513P59mRi25Pys3JCBdgzkntaNkQrUwY2rlS4JYq+RaUzInJgRLh9vQQisBZnOq/Rj5DnjSE
+        Lgx9NKeKUyE+xBe04b2PDtYWETeJEd4gb4oML2nexI5WyEKRJ8bpZNN1/DdJo0yaoC1DSbuUdFWD
+        JppTODtmLgT2kiJmlqrJUtdoTqPIhVCCbCjX9FqlfMnOhJx+gp8w9DwzWVRtqJpgnnE4aVyvqpqV
+        wpCgkFohSumy2pBVbao1vpfU76r6V1X7nqx0W0HMe+0DPobMJ+yLVypsLY3s0//SH1W9XCupP+2P
+        ilr5j/xRgX9/xh/C/rTW8HBMCve42R52x4ZSgAUldcPIZtAJDlILxyRCv1LpEcwhNtQ9Ik27k2mm
+        yH3Gv33PrA56mQRGAg8g0LEJ09ksqRlFUDCgC6xNBZTlkK8rO+m6MpWj87oyQ5QpmX6qItTBQhZT
+        M/D35+kFlBF4Y1Kycdp/qB9uAySKeabHOxP/jrcUBQHslLILE7tfTYSv0Q+1iCs35lghbPEGGdjM
+        ZzH4vALtWW9UNa1UM5QzakA1X/FPWb3TVDjhShXutTlsKPlka5ta0JigHixpekG/AJJqmvQlaJ5Z
+        GRVDI7SPFomjCI6Cx42mgw1fUCOEqnuDd40aEUIeRMQW4g26QxqT6X5u4YIcE7AZRwVahnBCYgMm
+        YVKG+fa/oEZypefNs62NpfL00VDOUNYioOWyhG1tQlMVnfoaN+gap1V1yc1Jl7vCDApxCfR0cnSE
+        eIGYTKYrwBmH9+0jQySyA2kKRKmVBHLkSbkGz5/0HXWr4t8SGOn1jK81aXYeuuPJvPvwMDGUgkCQ
+        0uknthcgAjk8h1CkGU20MnEF+dOpD60szJ5iST0qDI2LY8pL7Bx50JW0/0cBbjS08s8XYO1rQ/qj
+        Spak1BbjQNwM09i4wpJEC/ww6e1pOBeG/6auaz/d59JI5LuTm+ozRLoAhIRae5/6TiCi9xrkrLwa
+        8sCGkidunzOhkkPG17y/zPnkNz+42l1JlZ5HhpJDXLpehyHckbQGb45FjK+Xp3Jyd7acxF5+vQf5
+        FVTkJGsoF0huWnImkDm7GNFzN4jwGUIev61fUwzeDgoeaA/G7Ydusu0rwQWVX+y2YI3k+sQN0KWC
+        8AZmdmBdPW2uQEG6epV8BS94hRfKLVhwr18r12hGu3y5XIM/XVnEs1e59b9L/wL2/DbImhIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:06 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1879']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:53 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order><crypto_block>E7--NuwIhns8SF9pSFmOCtayGoPi5orsAykdVtQtCufnKnVXd5ijHtnqR7hewEY9Siu9mKWZXgSi50wUnsm6QPTTn5Ap3rEh2y8qt7LQOigLgEgeiLH4ylijiJOz3cCcGHfmz-mr55XI7fNrF6K5mYhYQ3qn1nCceIO3_pGh-y2ODATK_1unwgfaRcvmf9rRBGVuoIht5KuL4JvyIf1HGwjOVpnEZgHPJm7kxU7hRzZCGSznxEZHloNsR7I2pTbq40t7v2mLo1javANm8iUGKktt-5o16BpnLLteyP0yqrtW48EZlb91SwCaca-PJX0S8BvzKCatNcVD_hETlolGxPekOoYcRxyhOS0oqh4PNL4fG5MfxXXjHxpdCbQvBrDibivFS6vhbjmFeBcQYWikaldIWXGQFooHSH2dWMs_BXrsAz6-j8VMn40F2LZish9H3g6jBjVkrnayZ4NMPTq5FtXcdK_5L7WFk2ASLauJCqJowO_bV8X2sPX_At8097h3QpXw1Kh0OkgxfUXvzDHbFI_bN0XSMiJ0al9y_p-VXab83-6hG9eHDURd6DtENaA6ZdPR1b2kCR_toknr_BpFKcDNzxpBDj9-GWfRRbpiCUM9rPYDDkijx5sFQiucuV4RNL_xRMwwjtm79e8Q_Ffs_Rbj0MXC_rEfuYOIlmhROtFCXJpXG4CNo46bV1NKHU8emAOPjTy5eN5yHKnfgvMsrKq0Ix6-yFmDNxXSz4pazVchj_p8eOwdiIe_aY0Ybh9RJBrav76RZUsxDdWqMKRqoWJyL_--Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>k0--5q_Eg4_-x1Nz1FPUkY_jXomw7H7E1_PjxiUKNYUK3emm0ERjusgvnWUYFQqZHjDGEekx61hC9iIriru1LpexlQdiFWf9oohhZR3m54tmVkLEMIItGP0eGhqQULniBgRbrSIgFusujEyS0Rw91TvO3pqX8rgNeFy0FDAL-H3GFetfBUfLnD1Zi-94KcFBeU0CKwDSXAHtxFWU5WZiFJ-wMeIriNlK_uoAMR58EAI8VqC-Z</discount_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></create_order>'
+    body: !!binary |
+      PHRyb2xsZXlfYWRkX29yZGVyPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRnUlEzS2RaSXpEaXNnenF0czlkVkhVQnJf
+      eWlpbElnMm80OFdudmVZU09WYlhsR3NWb1BxV0RXdzdiYlExZVZIVkZwLWNyMXppWnllYVdjZ1ZG
+      cUF6ckQtWTwvY3J5cHRvX2Jsb2NrPjxvcmRlcl90b2tlbj42Mi0tWngwLTFJbnhDdldCSzlmRXRZ
+      WEcwOXREZUFyQ0duTFZHd2dxNUhYR004ZXh3VFNEOHEyUUdJRnFvazZDSlhmRl9KNjRMWTR0Qk5j
+      bmJadTc2MFZlaXlFSXRSSXd6OWxEcUlRM1hBcTJBS0VKOXMwZlFpRWxDb0tTdDBUdkVEdmlBRmEy
+      aUQ2TWNNWmctWDRvQUp4ZGhua0tGQlh3ZmRYM25mZUI1MWtJTWEyeFBydGxFOEF6eWRoZTBmaVph
+      ems5UnUtb3IzM3F5ZURNTWJ3Mld6eGh2T1FZdE1veFY3eTdUeG1WNUp5QnEzQUJRSk5TOWFtaHZU
+      QmJEQ2o1M1cyeV9tQ2JmOTFhd2FqLVpLczJjQnBfMnhsaVR3YWlNMjBOS3FhdzZTNVZNOG00b1pj
+      bjBzNFVfOWFEVG1HMmk4UXBXY2pYempZNllWdEZoSWNObGhlcW5YLUdYcmNiVzJHb1o8L29yZGVy
+      X3Rva2VuPjxkZXNjcmliZV90cm9sbGV5IC8+PHVzZXJfaWQ+ZGVtbzwvdXNlcl9pZD48cHV6emxl
+      ZD55ZXM8L3B1enpsZWQ+PC90cm9sbGV5X2FkZF9vcmRlcj4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1384']
+      Content-Length: ['662']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61Y23arNhB971e456UPLQGM7eCzKF2O7cSJr8eX2M4LC4NsEwMiSPj2O/2TflkH
-        JAw47urpJQ8J2rMljUaaPVK0346eW9qjkDjY//WLfCd9KSHfwrbjb379Mps+CuqX3/QfNCtEJkUG
-        Dm0UGiEikUt1jUQrG3um4xsRAdghxsq09RMimnjbpFlRGMLwp+zLgLmQvlkFmliEMsbatCgOdVmS
-        chwOZiw/8lYo1NVyLcfiYMYKXNNCRC/nOBzKcTChBjl5K+yKeThEHNX/+D3fP8MzFPqFp4BiY+Vi
-        a6fPDEHY74J1fdesB7PqcCVsQry2Zfp0sAaj5buCLPKutJZy7f3bbigt535r7027WzJrrduLozVr
-        dk4fS7e36ODFYycc7pzm49ZS3pUK8YYtuTYvnxfl1+FUmPq78NR4f1EHctUZHdQP1HHnZ9I9P66X
-        4F3eJ41tJsU75OvtsiBUUadq7KMoaLxvvlmbRefQD6aovqh/bCZueSm5i6Bq4f1hJhNSeZ4vHxrC
-        eKYaG2XUi9Tn7nmDwrOhdFxJUfCz8NpvW+et1Gjuh/35Uq2co6qC5s11Y9NYlPeV+5O6eXMx7TkV
-        ggeDtUqXiO4WH294JAzkrdudvewOb/ZqLjUnR1SbnTyzbb9PFuH5MJSGRms4HlvzoHZ8RuOHD2Oz
-        O1bmUX359jIiw261idqCGTwaPeXQDOyPLpooo5qhfHtr7MevU3v89BBNzhNh0XkJXmsR7ftC1OvK
-        C9MJBpFKW8+NoTto9NWn1pM1Wi7HMJJihB0Htu5bf9h7c04P/frD1vJPvaemOnVmw6k5PE4n87ra
-        wXar1Yx6HyevLffnlve6mGxrxxfyGvlWxaOjxWhwdO+FN03Mh5/tha7ZiAQmtbYGfFh6E7susmhp
-        HWKvRLcI8tSPkCYWWVknD9EttnNAkkjN4cMw14clV65JqC7fVQsMgP6jK3H+m9TUB7MpzJ/jpYaM
-        Sk8B0i02fo6YwLn2ZXEOsXDkg4cW9laOj2y9XL+LpSFtXihsrZPprNUeTGGoApyxEtcnNLKRT0sh
-        yFyOypblYwOvDQISSHRZE/NNbqOOtUN5awpoMS0IHQvp5VrsZtYG/QytrRlukK4klkszc0DXEEQa
-        /pggwMzx9lwTsxYzJG62QcZPhy0KEScw51fOJgqMvelGiGloHtAsh3LBdbFvY8iEHYTyAjJ7MlAv
-        sXMjG9pyTUL4H8aHo2HS2IEcxu1Jl2nRzoaB6pCUCjZcUj+KUBxEiI2xQ6d0BjGJZArGpYhT054X
-        pDBexrsx5M6xye1h2UK4vYBllGQtj6bnuKccia1QzOYV06DF2xvyMCdBzwMXc9J/5jsU2aUuFGWo
-        qhmV70LowGmDqrx30MEIUGjFJ4aVy5smzY5reWj6G2Qg3+Ztvj/RLyVZpdtSI9pEhJbKkgwFNSMw
-        bkQtOORrgqiu1OKJrtGMRpAFBwcyo3IvVytVqcBOjYx+gh/PsyGhYVJJlVXOvOCwuVitSbKRwKZv
-        Q5p5KKELkirI6lSuf1Wkr5L0syR/jWe63YGPex0B1ibUDOmnmJRlCEYDEtf9P0NSk8s1pfLdIamU
-        5X8UkopQlv9NSHgIEulh5zHW8XGj2W2PNTEHc0oShr5JIZEOpQcchT76iZQGsJzQBBkMf0w7sXix
-        b8fWa8+PqQVaHHfhlONMSPIgZ4B7NCK66+wvdg6lBFZkxLSd1BLieIGLuDCn/ViVYd9RQJDrwlSE
-        Fnxsf/bxr3yP8e4sj4s3xt4gbLAi6JrUiQuPXk1K8KWpgRhv2Kcg3cmx6QJoYtZ/axID6g0k9pro
-        PtbEAhBrYVxukH0RQd7UPPNohJHvQ1jZ/stlOBqfUM0DzbzBu0Y1HyEbdjeAcxPBfTg+S4k/t3BO
-        jqDUwqMjR0sRRojXgEPP9KFUJu5/QrX4ps5qYlMelyrTgSZeoFTgoZLSmG3sPF3iBfga18gWJ/K4
-        ZsthT5giphE410BPBkdHODqI0Hi4HJxymGyAvTQ5EYq80hsK8YXKkiC5QPEbSqPVa48n83avN9HE
-        nIGT2AXFtF0UQlrN4SCRlMbLC78k/KtshNLipQ+lWB5yTa0Q7Uzx5sgGRbyPq8T/r4j3IPz/QBHv
-        PyniX6VonBsBxi6/uSWbfIXFGeM6Xlxtk3OZa/6d0N5/r9AmR4p5JzTqDTiyHOAWYuwd4qxcfgyv
-        QcbKFI6dUJAxfjt85V0ySPucwMXkjX+zjbu/U6TSqK+JGcSs263nwa1FritJAc9jbL4sJ+O7Lbz2
-        Yb3J7PECr6A8J55DLCDZ0uI9gbvLR4TIReF9fIGQzW7T1xSNSXwuAs3ncbPXjt2+MhSo7KoVwGpK
-        lhNaLip24NHA1HSNq6fHFchJV6+Gz2CBl3tB3II59/o1cY2mtOLL4hr8bl3hz1Lx1r9//gSe8Zbz
-        OxIAAA==
+        H4sIAAAAAAAAA7VY2XLqSBJ9n68g7sPMw4wsiZ07anWwGS+A2TG8KLQUIKONqhK2+J35k/6yTqkk
+        tMCNud0z7XDY0smTVZVZWZlZkn79sq3SGWFius4v38QH4VsJObprmM7+l2/LxSPX/Par/DeJYtey
+        UKCohqG42EBYwYj4FpUl4muGa6umo/gEYJMommrIjivx9yWSjgOPuopmufpR1hWOq3Ma+Vi/fViz
+        PUYc6Wkvs9ZbR981D6/1r9N8vBvQ8XzSmWh10RKCtql5j4v9bFp5NbbPl55J9pcTJS1j9bTsYCUw
+        Tet5X3arzbVzRpv520p7twZk5U5O6976s6FpUxGtnlaPHqdj8WJuA6Su9f3q8dS+4B63kfjc+qTQ
+        YM8lxNQsJAeISHwOuTqGukfkyPUKx1HltKPN4eZY/uQmY/OptqzOp4Y4OiCn2zMGtQDhz4G2Pguz
+        zVzbUkvd4O6upzoz1fQUNDY/4LF9IC+HdqX2YdSmi+eX2X4wtt6f943eevh+mXK1Chl0q4/meXS8
+        LH3zNH45dgJ62jp1vTzcfwUcev7s69MWVha2s3ndHmtvDj4/NbYNQ7QWRlM1zFdaGc0NI/CHh8eX
+        Dlcr94YeFygf/ZZm+ZfutPxWNTRjUz4tuu7r61PD7ArKhbaXA6WL/W6lhbTatvuiiFPRPVU3uvf+
+        Wf0Uh8qL3l8ZDc/ptBtH/VQdjQZ+q+NazY0uBo35YmXsyeSwmfc6fvujgrwGOl0Cd3z0a0652dOV
+        dr1RW5y1lepsyNtw2xla50V3Ig5O5TWtNN87Z63zPL+sZ+vlBW/JadhZdD/Gu7H4rin13mZbFyvT
+        WXnT2I1OC7wZzDa7yevmYz3ZzNr9CapNB8EXXZKn3mbzrgTTL6XpcX2s2YueJ3DcVuLzm3ndWxbw
+        uus7VBZTVhYO4wQZikmRrTi+rSEcMm/BZExZ0nzHCAOI/S/OcQdNmMT1sY4ANJCMvqhCEaHCVSMr
+        LWgYiOhy/4si7KhWaQFqpY6qg6VG6UY/4ib61KWqBUPamukgQ660HlJ+QVZUIVSuCg+1GzqhBSpM
+        6KlUP8jiDfsqymsQpFIPmzqSK7WbBaXCghJYd1DxHsnVW52rTNJ9jCENBukT8+he8yBB5KCUsVN1
+        6sK+C0KGE4MpKw6EZrmeYSXRcQU8S9URkcsZTgxlOOBFhQS25lp8FsYoRuXf/pPVT/EUlaUoxGQp
+        cTLb+W4YpDot7bBrl+gBQYVwfCTxeVaqZCN6cI0MELmm+9Z5y+gwd2VeIQii3c5D/+NSwqqjUlUe
+        Lxcwf4aXCFIqDTwk62z8DDGCM+9X40wSn8TCUUijP6EwW9u95XABA+XAlBMtvG1AFS0RqjqGio0M
+        mZnluIq7i6KZhGkh+xrLqAlHOCtNAKl4QDJnonAMMpHPp1Yi8HSY2TBS2dL7a0hp1zcmYEkFGojg
+        84Awigls8bpJ40NiuY7hOpx/BGddQSaPqMNIHgtjZUslJP7H+CqmUH4zQCxkfgRh6e+q7f271AWP
+        +uFSMmIJuo+oFWHDRoU8D4XuAi8oR0jO4Ux85LAECducmJeoXZHcYCmvOJ6hOjq6PygzJyHkwJQT
+        2dFRIVppbGivoMAs5dMl8IkTww3FsdujTcgCV3Gkv3SgXhmlV2gAoXtLqfGuYBPiC5q/s4k+FQ9B
+        rQgLVpTy7ookOHNIwaqzRwpUmvg9Gmxx8P9VEqEKzZEHJRISYKksiJAWUwpj+1SHwN4RROVKPZyq
+        iKY0gnQIJTgN1Ua5Uavm2YmQ0QP4sW3DkMNJhZYgxswrDjvtNuuCqEQwHFA4WjaK6JzQ4gRxIba+
+        V4TvgvBPQfweznRfIR636AP2Dicf0xuv1OihNFKD/6c/6uVqoyL8tD9qQu0P+aMGv3/GH7H9Ua5h
+        4Rgm7lm7+9qfSXwGjimRG0YqhUrwWepAs+Kgf5DSGMzBYS+DS4v+fJEoMp+xZ9OQ68+PiQTeYtyC
+        QHdlGE6lYc7IgjEDqsBB5kGZs9m8nBbNyxHOuc7LhW0Yn+hHKrE6WEh9Ilvm+Tp8DCUEVpj45D2q
+        P8S0vbAziZJ5oscqE3v2PYIsC1ZKaM7E/q2J8DR6ErI4f2eMPXIVViAtlZrUB5/XoDyXW3VRrDQk
+        /opKkM337JETHkQBdrhWh04lhSU+HeygEgUKE+SDHYmuhTkgzKZhXYLimaTR+FWy1S8F+44DW8Hi
+        RiyDDTeoZEPWvcMropKDoBc3kAfxBtUhisloPffwmOxjsNl1MrQEYYTQBhfbYRpmy79BpbBJY8Wz
+        K85K1cVY4q9QUiKg5NKQrRxtWYgrdRGXyMGNsuqOmRNNV8CkH1wNcneCn7oM5G4B0e39Xsa/J5Ci
+        9ozNNW/3hv3ZfN0fDucSnxHEpGj4uQodOIYzvIZQJAktLmVxC/Knj37hPpa7ieW2KU2xa2RAVRL/
+        igTcaonVn0/A4m1B+lEmC4+U57pW3BlGsVHAwoNmmXZY26Nwzrz+l7wu/nSdiyKRrY5rCxOI9BiI
+        JUQ5m5kPKUWQsdJsyAIbUl7cfa5ilRSSbs99/syHf9nGNR4qQmkygtv7FWLSw8G2oUcSW6w4ZjE2
+        X3qUw95Z0UJ7WXsP8gKU5YRz8DkkNS3cEzg5Jx+RazVw3CuEDNatFykSKwcZD3SfZ91hP1x2QZCj
+        ssbOA2tKuol1C+UVYm/cu+UXr/fsvXAruQVzvMwN5R4s3b/O39zj717gb27uP5tZ4mvvX5Mx+eTj
+        TvKpKP7OcPMJKYf/oe9N/PVDEv/Db7O/A9pPXdzdFQAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1828']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:07 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2085']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:54 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <trolley_add_order><describe_trolley /><user_id>whitelabel-testuser</user_id><order_token>E2--5eH5_vuupAjgQcgXHwMpTe9X9qgSl2Y0lXp5covwU1ss4IWYBA-RU8_g3PLu8IKzgerz_3Hl033oI-VMEczh0ACvOMWY84zu53eWCfAgAX2v47y8gZlotLi4soNNf8tYetkXqZoP-N1hlKUJkwZdbW0CSxe6UymaEdjSXrzwO0O_DORRcWp6xIeRBq_gkx4Wu9YZJPsOK5CeE-apF_L3wCpdqKeS3P6_3QZAvRVTdRGBuSzS-XHJpV6utMn-uLK1XaipNu8tDIAOlNAM8GDGcPYYRpF_3_rHi9pUQMOLZiyBM9BhcnyLGC8TiUOTaOxTSW98HodDDCuLqymE1MWcmVXSh6xJsVunc4mtPXPNxl7-Z</order_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsUDfEXxcUCHyqYlLXHoXFHrOkiCFhc3j34smOD16W2zX2VOT-TnkryAjJ8N15iPw8qeHlWzsKzFfY</crypto_block></trolley_add_order>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['694']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61YyZbiOBbd91fQualFN4HNTB6X6zBGkBAQASYYNj7GEth4DEsGzO/Un/SXtWzJ
-        I2R1ZnXmIgPdd5+GpzdZwh9XyyydoYd0x/79C//EfSlBW3WAbh9//7KSRuX2lz/EfwjYc0wTBrIC
-        gOx4AHqyB5FvYlFA/h44lqLbso8IrCN5rwAxgEioPBYJqhe42JH3pqMa4koul8+Ge+gY/Y67asz3
-        5aPnHACPny/q7G17qkEVnWqDLd88vRtzbru2B2dLmmhoNTgMN1d11X8JPrfmdPPibEYv3tzQ+yNN
-        rZ1qdWTNB3xzXb1tqh9zqSzZhhd0T9/aM76hv13an/DFXN/Q5DY6bIVKbk9CeErXQUjfm5AeJYck
-        1sCOAW2xWS+XdamGlY+2U61hua87DXgz24u1PaqCi2J9PtvX7jV4GV1ul+m5DgdtUJ4fpE7Dfx13
-        WvBtMzPQ+HX8MeeWo8PGOrsjvfF5Ac83/Tg4OtaQO43gDh28+lXvfszWvqoFL9bQ3pd372tzLUNi
-        JSmozdu93v6wQB/c+MOWDbDRpt3XRb87O/Dqdbp7vaKPPexIvU/34jacz8ZAA9Kwf3h2LP0KBsRQ
-        Jv/+8aENXv25Xquqp9bu1IDBYHDqtnby+HZsD/zF1Lm0x3Z9vXr+9N6Pi5GM3qA0WS6MUc/aYvXZ
-        qLfxoXY4ti4zs76a11cvcEXOic6b3vR96kp+Q7+1LEM78/K6Pmmure6u6jRWBuirE9ezTe+0rIE3
-        tf920s6X3nZX7WxXxjoYDYddaXRDw/Gnuw9UHQwnx8GmCYatjS55U74qvbQG0sUdztZcT/12la5b
-        ubpuapfn+rLz3us/j8G3YATWPe/sHSdL3ZSnr+f9rnXrgWALlU79E8tb6CxtY+bOvr2OVz17NBnM
-        p4FR3uh827QMeJPVzRyM7IVuBDO3vz+eaiCAg0bQHu93XvtdW3S0/UwbvzfLO6GSd5DEX2jkqI5v
-        Y5FPWVk49D0IZB1DS7Z9aw+9kHkPxnOKwt63QeiU9G9xjQdozESO76mQgACK8IplDBHmEo2stKAB
-        IFJFibBLywCRPZV20HOKihEpVsQOVkwyl7XXbQjEaucpXaggK6ogLNa4p8YdHeEClSzoKljVRP6O
-        nYjyGggq2PV0FYrV5t2GUmFBiZxOU7wjFGv3OolMUH3PI4k0SH9RUx73Lsk2OShlHBQVO+TCOS7D
-        YWDKYh7QrjYzrNgtEsA1FRUisZrhMCjDIVaUUWDtHbOShT3IUPE/f2b1UzxFRQHAvU52KKuao0fz
-        MyCVUIfRYGngW1ZQ6iseKA2oTKjkSImKbmN49BRMypIMFKxUUpGtWFAE4UypcoQlDBy4d4wIS4bp
-        r3TbUYyEk1BnoRvqh1Gm4tLBc6wSJkc4Q9uHoXaWlSpZEGsOyADRFffnvXlGh157ZkicOfLaPPR/
-        biUsv8Ry4mwlkfUzvFiQUiPjqHT+DDGxWfFwOmKppBDSaRTHFHrWpbQaDGcSmSoHp6xo60vsA2jj
-        Erl2mKHSY9mO7ByiqERhXssOmQzrqgGz0hgQioGeie1COGciuJKeEhJLh6nZgwrd+HBNcnIyooJo
-        m0PSSgUXDXqQEVga1I++K58V04c0urOAoOqYpQLTsYFjl32DmDIBqTyaaBrJmZBOrZoKQuwP5RPX
-        UHC4gQzG5HEgZuV0GtKcRZ0anS7qefJQaERiG9kgNYetUIksGYNhJ8iosWaC5OZLeQ+mNHSAHk9L
-        D8LkOSylRGcZKZZuBhkSPWElXbcSGy28Xo+ZOTJ6FkjEkf7KJuUXlCakMSZNbUplt+DpxNtIU3zW
-        4UV2IamAYf2NEvlDkUAiEMqeYh+hDG3Axux+/H+X+DbWSl3/6JMqW+V4kupTAuX6WCVOfkCQFMhm
-        uFARTWkIqsRxSGTUW3yj3uBy7FhI6QH5Z1mABDRZlGvzbcZMcHK5TrvJ8XIEKzYgYUZyb0gvc+0y
-        35b4ztca95Xj/sXxX8OVHiuweYsWoGOEFQ/f2aTKE2N0SeCav9IkTb7arNV/2CT1Kv9TJqmXq/zf
-        MQkzQZR6qD+GeXzR7U+GC6GSgRklMsOrgkkgXUo90oPZ8DdUmpHjeApJg94/YyVqL/pbB2JzPIol
-        ZMRwk3i5kyaSLMgYZHvYR6KpnxM5g2ICLTKVeBzVEqRbbtgtRYk51qNVhv72XQRNkyyFcG6Pw/s9
-        fm/vIT5ZZfHKg7mP0JFpETRJkxEWHrERleBkKJBkfKQ/y9wTH4oSQKik+pqCZFJvSGAfkGiTPjgH
-        hLkwLDcQJEmQDQVLucqeb9vErPT++SpxjTtUsEjOfMArooINyTcCgC7xG590aqEvRft5hDOyTzus
-        DC1GKCE8g+NZiq2y7+A7VAh7SFoT+/yiVJdmQiWB4gRPKikO2bJhiRwrwEVcQJoTpccDPQ59Qchj
-        wnc+WXLfKn/9kZL7OokaKNahdAfT4WK5Hk6nS6GSETASbVAU0ut7JKzWxJFQTGPlhTUJfysaC597
-        uQ+9nLXTjLeGgGTEVlglfn1GbJHE/xMZsXWXEb8XomFsuI5jss4tuuQCFkaMqVthtY38MjP8X4m2
-        9aOJNnIpurtyt9MlLssAJkHyWc+8/hRBykozHPVQksZYd/jBVFJIuA/gfPCG/9OLaz3VuNLbq1BJ
-        ISrVNMsiXQvfqUUFPIvR9dKYDHtbeR+eN1o9PGABynLCNSo5JD1aeCekd/n0IUoyvO0kEAS0my5S
-        BJriMxbojxf96TDcdkGQo9JWyyWnKam6p5owr8Cs8eg1ofiMQMeFr4Z7MMfLfEE8goXHzwZ37wUP
-        HwruXgh+NK+wz9JfnPoq8bNR/AjFHjLuHqdy+E+9ZFWSJ6rKd5+P/wu8uhIsgBYAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2158']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:07 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/TrolleyTests.test_string_properties.yaml
+++ b/tests/interface_objects/cassettes/TrolleyTests.test_string_properties.yaml
@@ -1,544 +1,505 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48ZXZlbnRfdG9rZW5fbGlzdD42SUY8L2V2ZW50X3Rva2VuX2xpc3Q+PHJl
+      cXVlc3RfbWVkaWE+c3F1YXJlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPmxhbmRzY2Fw
+      ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X29uZTwvcmVxdWVzdF9tZWRp
+      YT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X3R3bzwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRp
+      YT50cmlwbGV0X3RocmVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZm91
+      cjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X2ZpdmU8L3JlcXVlc3RfbWVk
+      aWE+PHJlcXVlc3RfbWVkaWE+bWFycXVlZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5z
+      ZWF0aW5nX3BsYW48L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+c3VwcGxpZXI8L3JlcXVl
+      c3RfbWVkaWE+PHVzZXJfcGFzc3dkPmRlbW9wYXNzPC91c2VyX3Bhc3N3ZD48dXNlcl9pZD5kZW1v
+      PC91c2VyX2lkPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48cmVxdWVzdF9jdXN0b21fZmllbGRzIC8+
+      PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:08 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:54 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxldmVudF90b2tlbj42SUY8L2V2ZW50X3Rva2VuPjx1c2Vy
+      X2lkPmRlbW88L3VzZXJfaWQ+PHJlcXVlc3RfY29zdF9yYW5nZSAvPjxwdXp6bGVkPnllczwvcHV6
+      emxlZD48bGF0ZXN0X2RhdGU+MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:08 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:54 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+LTAtLTYtYnNqV09qbFJnUHdhT1Rq
+      VWNscTNnVDMyR1UtS1lxUllYZk1mbEVTa2hDdHo5RWNtTmUtTDJkM1FnRHF5dDdQcVowazZGTG8t
+      QUF6b3JPX2Z4MXIyMWRWSG5DNE5veWhoU3gyTF9qSmRPOTF1X1MwZXJxY21RV3Y4YlZldUtKZHVH
+      bDdLZ1lwckNiNW92S3NsaUc4eHVqQ3kxQXJWMzVzU1dQSHA1ZWUzNS1ZPC9jcnlwdG9fYmxvY2s+
+      PHBlcmZfdG9rZW4+ay0tLTZTWUY5WjYxLWUwOThNeGdvdlVleU1OU1pacFJQc0RsRm1sMkVLNnJp
+      R2tpaF9hMHRMODIwUWY0Z1hlRmcwTm1ZPC9wZXJmX3Rva2VuPjxzZWxmX3ByaW50X21vZGU+aHRt
+      bDwvc2VsZl9wcmludF9tb2RlPjxwdXp6bGVkPnllczwvcHV6emxlZD48dXNlcl9pZD5kZW1vPC91
+      c2VyX2lkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:08 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:55 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGJhbmRfdG9rZW4+LTEtLVExbXpRMFpXS1NlY1prOXo0V1A3WkJK
+      LUZrMVFsalJMZUg4OXh2OXNDWWU4YkVldjEzaGhGSGF5eV82WWRVYkhBR3l3RVI2U1J5blktQmVY
+      aFR3cTJhZC1jNWhBdzhaaEtwSm5tM042Mktmek0zcHlCc21QLUN3Q1VJWS1jZ3NXcXZLWTFxLUJR
+      QV9DU3dKYThIUmN0ZnZaUWlKS1g3ckZkY0ZMeXBDNmNDb0NYZ09oX29zdldjb3lRTUxaN3VJaWli
+      T1JrWXI0VXZ0SXd6XzFtaG9XM1BVV2ZEZWdTMnNaSnNXRGlxTnptcmRnbjdOWDhyOV9mYVpEaE9I
+      N2M5SmJaPC9iYW5kX3Rva2VuPjxjcnlwdG9fYmxvY2s+RTAtLUV4STUySlJDcS1nTERzdng0d25V
+      WnpaU1dTWURxcWV2SkZHdmw0cG9DaXZDcVVVZnZVTEFYZzlicDlYZzYtY2NLNUx0UUpTdlJtTGV2
+      ZXhlMTMwaTV6NVFnRVd6bjFXbUUyeVh3Z1Z4ZE5vOVNtSmZjZVh5WTdLTU50OHp1eVZKdzlhUlhP
+      U2o1eUZOcC0wd0FkdjJLQkh2cGg2Y0ZxUk9jcno5LTRsRGh1eDJYSGFBbTFGNFNibmRKMm1xd2tS
+      Z1o8L2NyeXB0b19ibG9jaz48bm9fb2ZfdGlja2V0cz4xPC9ub19vZl90aWNrZXRzPjx1c2VyX2lk
+      PmRlbW88L3VzZXJfaWQ+PGRlc3BhdGNoX3Rva2VuPmNfLS1GeUpWRGY4RHlFRGhNWVU2Zllsa29B
+      MUcxempMbnZkVndoN0tMSmticlhpaC1aeTJ4U3BTT0RkSGFIemR5YUdqLXBySGQ0N0s3dmZDUkZY
+      dU1FSnVValJLQnNHbldScW1IdDk4LXNoTHNSWklFbjlMQlczV1ZLczNQLS13Sm5RSE9fenB5WnV5
+      VWlBLVk8L2Rlc3BhdGNoX3Rva2VuPjxwdXp6bGVkPnllczwvcHV6emxlZD48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['449']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS0HvDihIg7XFxZDKMgoBCj+Tv9Jf1kHg4Je
+        O4fKzLeqlauS2GfHCeLEOWcHJvPHxbYqEfADw3V+/0R8xj9VgKO6muEcfv+0EgdY89Mf7b8xmhGo
+        buhAyfUgYgaSD4LQgm0mCBXNtWXDkcIA+JIRSIqstR2Xqb62MCACDpon+0CW0DqgzW6YajHKDBoI
+        1DaLXis+68AHOSFFGdWAcca1XEdzHSw0mWoBZvaUOkntuTGfbMlBkP+V8WUfBohSALkx5XeQsfJ3
+        2fb+Xemh7YbJq5TMDNpUusPMbQyQp0eICYDsq7pkgjhdqYriUiBJ9HLebdodeXBW8J79abKjgtdO
+        s+3cCA9gwUn30ZUtC8B8o/2nCdlOq8UrVG9BTBLCz8OeHkIZuJvT+SvHgECrjFFaoaQoqPmp+AY0
+        VJRTkQHOkgd8NckRAscR8aWJ0WQIJF92DkACjpaPU2eiHv6rQgSwsgQeBLYC/AqJE3WmWlAydghV
+        yd3vAwDbVD1Z6hktaAFQUSoFbYJukI0a/ci+GTN6jP6zbU1rJ4viLZzImXccnbTbrOOElMKyo0nQ
+        sEFKx/AWhhMi0fqNwn/D8X/ixG/JSq8n5H6fY5CNA4iS40NUalCvTOX4Z8ajTtINCv/meNTw2nfF
+        o4b+/Jl45PtPe02WjvxK7Amd3pgVmGoJzilpGKYyhDo4V7pu6DvgH0GFR9vxZdVEKSSyS/E2MYtZ
+        9mxo7fpwcLMYt/4mWSjR3TZyJ8OkZ5TBnOHJUG9X0WTMztbFlHRdLMCc+7oYBAGs3uanU/LpaIcw
+        DNqWEd3d59CNgNqvDOXqbQxjD7QDw/YsgAKGnMPbvNSSs0IvAJaF3jSAD1tkP24RPU05vIxXX/g4
+        ADc5KLnNWDI0YIhiXiM+18hWnSCoBlO9owzq5ofsEcM/Ezg64VqdRIQ7zFQLZ7ocSI6b9IN9kKrN
+        A5B0U9QRUce5t9F8yNjyRfJDx0FHkeUNQaI9fEAZG3XdF7xnlHEA0FBGeCjfkDqkOZm+zys8J4e+
+        nGhoiXZDMkKyB9e3kzacvf4HlPHcAGbi2SOECi3yTPUO3SQCSTZM2JJpt/HP+F0jyjgT6G7aVffZ
+        dtLlnjAmQHmJ6KlzcEH5gnIycVeCb5xMty8Q+I5sVURErHSTRHa0SjEjq5/0UvCq478yMCixwnyt
+        Zac/YYXlhp1Mlky1ZMhJqfulrFnARzW8QakY3Gi5lOVXkIeIFt1wAzQkIMSv6JWtFkF/e68kPmrH
+        /2s6SfZ7rmulaZ7fHZ6wpCYsw05kOM280vArLZj4ZklKkyZ7O6yDz1FS5kBuCaTICAzFyhPtGcxY
+        RePKchB1p/yiuM6nFBDzsUQfyzP5f3Zwjc8UXplPmWoBZVZdt210nSFamY6VsWy9e46ofuxBV1Is
+        VzXbUwrDvHkNEtSBlVXalIXudWeTuhutBMPhuVlgkuo4UubOUbCgNrqQvd4RP9dbR77FLk5S5F35
+        2DT7K8FuGrQ+6jkreFUipdk5cUNLBc3x3pZ74tjXvL1lDYQmO5KPVmO6dq3RwWxQxHKCNa5DsS/W
+        pS0fen2bVcXTGIZDSu1btBoC1rBFZ4L7RmdPc7EAIHccWoK4PMCVt2GbEmsv+krUeANrsyX68/gw
+        P+v6ecguW+bUtg+z/uy9f9VDq7GmG5sWL0Flya3mZ3eh0YOr1j8tsV204eaDbp/g5pG55jcTjDxv
+        V9Pu+0ggllA4jKlOIOG0wq5rltPz9my0cFW18cZe6xam6ZFKBRNtAPvyXMPm516NdJeu4hIgNiPB
+        Hg1mKuQ9TtqO3ll8Rtgrj+pq/JEfnrjxmxWc1V7EwcF+KncGrLAJ3wMruA58F9DcdQ4243ptSvOD
+        3di3CfXisFAzzoPl5djvw+OkT485stsYyjVX0YQ3BXawXXLXLJ0vo1iyg1RSKj59HCtOS+e1pfhG
+        SuuqTaHqfUQYNfR99HUVF09ZGh8UD63+ABWMvaxC189vw09gwXLC5KrbbpL1EisHC5ZnySoI2mSJ
+        k0MlDhISKYhtxbWqZRipWIa2//uf8vwCL9AiGMFDXNCNAH8IS3JFQLLt7qViAo0U7wm6+0Dfh0rg
+        WiFqO4EcoTrPpO0ZRB8ftmI4qLdRrcR+HxYvk0a5019NxNILZaG/D7NvQA19+VUSzdRkXyuRcz34
+        yu7uQ+giHWyrOIadTKzVXY/jCx5zw8b727pPDh1BdLX94rR78whpEZIUy5HN96CGMm0VXTWcvcwI
+        +mw1WHuwhz2ObACbr8VU1xodD1YwkMddthlxTTpyur6+UehtxxjESmfKc9vOarzAj9aJXkP7PD5z
+        /MzpT8QemG0Wi94+gkGzZfqboOGdotp+PhiMdmezNbXOHe1AKFdlI7sxPFIm5UbWdGlSfJeXVq7W
+        s2EX7weqUbP2FuYd9dF4PN4u+ucBuSsFIdt1KQrJZbMcpez2iVQAKSfK1VyasgFKDSd7lJ4O9IWh
+        RE4Uz/MN1LOp2iO7sJTp6Fqiy/4BtOkn9t1QYmeXZ+m1/wcjk9WfJEeyYcmJwiFF/4Ax+SVHPhQ5
+        nQrPE8ikTiUlkdsseRHrCSpzkvSsPiCFsvryGU1woHEI3TDIbwgEuo6/NKR06ELZemKWMeY56KVQ
+        PwW4FNYXwXwMYbWo/D/dA0jiSz2gxw0n/a/0gJ5uWFoF3dLBj9Y/hup/MrPtKdcbqoPpZLVRjAO2
+        ssfieL2bAKTbI3vcXGMY2Y+3w51CBCJ+4PZCPzk6QG8miq0vunWjX9eIix7hsqGe4vCs26ap2dtA
+        wSSIBHl42I07kWVKFKcvWuxA1nbS25BerhoT1msK727Ei+PT6r0xmVDXQcvvXqh+h++1LrPNynwb
+        rsH1elI9aYdhX61l4gdqOTuYb61lovldtUx9by0/+/+rlu9BeVnL1JdqOZv3C2r5i3q+FFd9lv+a
+        oi+TnxMc+FPq2UT17GPxebJddlnWqznX/ZD2uzzRiHrWfOny5mEyn7iR8z7ZHvsX8chpR65Xj+Z2
+        NI15DzojxdKN6I2bDa2Q3bwfV+pKEt6l3tCGbOOkHK52d79Vh6fNsYOu9cLaP8lig641u9dQsE7u
+        uaY3LouDyHbZCF3FLd7t4cPl2TwbyKUn7bueQY5YZbicjI6NWcemPPYwmR2c4/xiYS3K655W5D6O
+        pyuBvtRngIhtasg1AqMJTD7e94Y0JvC0EPaImo3PZuTX+wH5I/3gu7SdrP/afvDs/69+cA/K9/eD
+        bN7P7wfUF7V91pl/rRcAx3D9impA4wqcn9IS6qglDEyKmxgcTte6Y0ne4wK7D4TgeMbttdUYGWK0
+        ah6W0LlsKa+3vhr+vjmCO6G31UdGf2SbMqV350rY6h54rTkX45ALdV912bXWXEN/esa242406ZHH
+        eG1uZ4Sxj5quxQn8pkZOehoei9KFvC75GPi7S3PhHWcCCXbXGqmfSJ2iRKsf8EJwUtXjEA99bo6j
+        b3TaOknfIPfUj1zdv0vuyV8s98/+/yrve1D+RHl/We7vj0H2W2VRkrprJD8/3H+x/GAp5dvTvz3/
+        D1lRoYe8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:09 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:55 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcj48Y3J5cHRvX2Jsb2NrPk0zLS1wUDV0MTNnRWFjNGthUkJ6Wm0yaG92VVJp
+      bk5IT3NrMmNLdmJQbmpSbHRkSngyQ0NqMHc2OWpOOUVRcV92cHpOeWtrRFVSbThpNGhKQ25VdHpi
+      dmI4QXFISWxjZThLZm1hQ1RLcmRwZmxsRlI4RUphamw3TVZvbEpnazczMVNMLTd6SVREVDZfWE51
+      cERtRWNUcUt0dUkzY0RsNGN1ZUVpbVRuTDByaUFmNEh5UmV0SGpJbFJUU2d0VXBXRThfRW1RRGJ2
+      N0dlVms5VHJQeWdQd2hod0lFUzlrTW1tZ09ET1lEemh1bDdWNDdXOU5fdGJTSFVQd29RZDRGemRE
+      cVMtWnZXSFBGQkQxSFB2a1ZOV0wtMndYVU1CWUpSMVN0UmdLM0FzXzA0YkVWNWxuQ3BmRXZRb2Nj
+      N0dFejZsLWRodmMzc0xkRnREYVBkLVB3QzUyb1NvYm8xZXlrdlJtSkZPY3ROcEhfWEpZRTBPMW1V
+      cDNCZE5qTklxSEtHbHN3Y0N2SHRGZk1hQUZFUld1WXNsc3pGcm9lNEh6UGVXSzY1TTRORlpLcm0x
+      Y3huRXRkaXdGU3hqRER0akxENEtIMkI3SWE1b2JkUkdidEEtWjwvY3J5cHRvX2Jsb2NrPjxkZXNw
+      YXRjaF90b2tlbj5jXy0tRnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJY
+      aWgtWnkyeFNwU09EZEhhSHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5
+      OC1zaExzUlpJRW45TEJXM1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tl
+      bj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxwdXp6bGVkPnllczwvcHV6emxlZD48ZGlzY291bnRf
+      dG9rZW4+YzAtLXFrLTlCVkt5eDB5SEk3WUdWRDJJblJUb2RmUXFaR3AxX1F1MjNFSDI4WXM1YW5r
+      VXZ6ZDBFeE8xNHdsN0VtRmZ0Q0gyN2VtTjV5M0JsSmpnbHNGYUtCRTh2SDg0dm5CcmhXYjRYQWlG
+      eWJBTU5IWEFVS1EwamxxNFZ0bXdLd0hOT25ETFRDZU9XUVFDZnZ0czg5a3JXczdwcXY1ZlBGRkpa
+      d2s5TWx3QWRnMWJ6Yldhb3l0ajNrM292bE1TazNOQk5fVW9kQ210QjBEc2NpNWxmbC1wamhKS0tL
+      WFFEd0YyWjwvZGlzY291bnRfdG9rZW4+PC9jcmVhdGVfb3JkZXI+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1148']
+      Content-Length: ['1008']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
+        H4sIAAAAAAAAA7VY2XLjuBV9z1ew+mHmIaG5aO9wOKW9ZVleJFmS/cLiAkm0SEICQC3+nfxJviyX
+        BChSsqbSmSSuLps491wA9+IuQBu/H8NA2iNCfRz99k27U79JKHKx50er3769Tnty/dvv5l8MlyCb
+        IQsTDxGLIBoHzDRo7Hg4tP3IiinAPrUc2zMjbCi3JYYbEwKzn/IvC5ZC5srZGsollDOWtsswMTVV
+        LXAEmLOiOHQQMet6tcASYM7aBraLqKkXOAIqcDBlFj2FDg6UIkyQQM1//qOon+M5CnrktGXYcgLs
+        bkzXkuWq7NCP+dNHMF4RJNOOcz9uPLXcZX09rB53k8dlnz1OnlvPTlUL1FPTd7a96Wr8Uhp674PP
+        jk9XnztGG97sx2uLWCffDwYrHZfr82iP3iZPM2cR9OkMP+/mnfmh5jgvGpr9mPW2sku0T//9hOy5
+        u5r1ds1P0pHfYKfF/Rn8XBneoMis6rL8flRlbRAd2/t5a9hYdtnboq82WAc1SbsfPcz6h9Wu8mPR
+        H9XR8TCddOo7/aU/6O3wptq+Xyx71n21/PBWZq1HN3Le41pVnSH/1B2w8eDw2Qg6u8FLadHc6c1h
+        975B1eWL3w3aeDhh6nTf7ez9Zs/W/U515I7eV/KijJv3R28dbYa91uKw9BalaIlaFW0zGNn68Zmw
+        oFtvfp68NVKX/rv9uWmMYxmTUml3Qp3RyDno88/jev/08sZG+DirnWrTYzir3J9au1Kz9XL/OGnY
+        4Xo/bTmd9kelNNdPVth2lg3NPtgf8vuQ6m5ra+nHwJ8ebH+kq4/DnX2oTiqzUT0s43c3Umn51WrY
+        nWnY1/36y3bufiw+P96qbzPWWw/cx2CNdtFC7i+I68z1Pn43lKLLuf9Nw0N0azN3bcGHa7ZxECCX
+        SUuCQ4mtEaRpFCNDuWTlSiFia+wVgDSR2k+tp4IOT67CkDJTu6tcMAD6L7eS5L/NbPPxdQrrF3iZ
+        IKey0xaZLp+/QEzhwvhsnE9dHEewQxeHjh8hzyw17pLSkA3PFG5rs/P6MIWJLsCck2686UE9kyiz
+        I88mXoHMzYqwhZcWhQpITc1QikMhY767QUVpBhgJbUt8F5mlSrLNfAzlk7hrm6yQWU4l52G+AdNA
+        4Gn4Y0P95Vvvzg0lH3FBus0uVPHTYY0IEgS+eddnoqQGOPJwJMcbcNYZ5PKU+pDKhVAoBzal4g/n
+        24RRoOSAEHI/glD6xQ63f5fa4NE42UpBbEAfSJsCn/aEYKZLKHEXeMHaoFO6kpI6LEOShiN4mdoZ
+        uZgs513P59mRi25Pys3JCBdgzkntaNkQrUwY2rlS4JYq+RaUzInJgRLh9vQQisBZnOq/Rj5DnjSE
+        Lgx9NKeKUyE+xBe04b2PDtYWETeJEd4gb4oML2nexI5WyEKRJ8bpZNN1/DdJo0yaoC1DSbuUdFWD
+        JppTODtmLgT2kiJmlqrJUtdoTqPIhVCCbCjX9FqlfMnOhJx+gp8w9DwzWVRtqJpgnnE4aVyvqpqV
+        wpCgkFohSumy2pBVbao1vpfU76r6V1X7nqx0W0HMe+0DPobMJ+yLVypsLY3s0//SH1W9XCupP+2P
+        ilr5j/xRgX9/xh/C/rTW8HBMCve42R52x4ZSgAUldcPIZtAJDlILxyRCv1LpEcwhNtQ9Ik27k2mm
+        yH3Gv33PrA56mQRGAg8g0LEJ09ksqRlFUDCgC6xNBZTlkK8rO+m6MpWj87oyQ5QpmX6qItTBQhZT
+        M/D35+kFlBF4Y1Kycdp/qB9uAySKeabHOxP/jrcUBQHslLILE7tfTYSv0Q+1iCs35lghbPEGGdjM
+        ZzH4vALtWW9UNa1UM5QzakA1X/FPWb3TVDjhShXutTlsKPlka5ta0JigHixpekG/AJJqmvQlaJ5Z
+        GRVDI7SPFomjCI6Cx42mgw1fUCOEqnuDd40aEUIeRMQW4g26QxqT6X5u4YIcE7AZRwVahnBCYgMm
+        YVKG+fa/oEZypefNs62NpfL00VDOUNYioOWyhG1tQlMVnfoaN+gap1V1yc1Jl7vCDApxCfR0cnSE
+        eIGYTKYrwBmH9+0jQySyA2kKRKmVBHLkSbkGz5/0HXWr4t8SGOn1jK81aXYeuuPJvPvwMDGUgkCQ
+        0uknthcgAjk8h1CkGU20MnEF+dOpD60szJ5iST0qDI2LY8pL7Bx50JW0/0cBbjS08s8XYO1rQ/qj
+        Spak1BbjQNwM09i4wpJEC/ww6e1pOBeG/6auaz/d59JI5LuTm+ozRLoAhIRae5/6TiCi9xrkrLwa
+        8sCGkidunzOhkkPG17y/zPnkNz+42l1JlZ5HhpJDXLpehyHckbQGb45FjK+Xp3Jyd7acxF5+vQf5
+        FVTkJGsoF0huWnImkDm7GNFzN4jwGUIev61fUwzeDgoeaA/G7Ydusu0rwQWVX+y2YI3k+sQN0KWC
+        8AZmdmBdPW2uQEG6epV8BS94hRfKLVhwr18r12hGu3y5XIM/XVnEs1e59b9L/wL2/DbImhIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:10 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1879']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:56 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order><crypto_block>E7--NuwIhns8SF9pSFmOCtayGoPi5orsAykdVtQtCufnKnVXd5ijHtnqR7hewEY9Siu9mKWZXgSi50wUnsm6QPTTn5Ap3rEh2y8qt7LQOigLgEgeiLH4ylijiJOz3cCcGHfmz-mr55XI7fNrF6K5mYhYQ3qn1nCceIO3_pGh-y2ODATK_1unwgfaRcvmf9rRBGVuoIht5KuL4JvyIf1HGwjOVpnEZgHPJm7kxU7hRzZCGSznxEZHloNsR7I2pTbq40t7v2mLo1javANm8iUGKktt-5o16BpnLLteyP0yqrtW48EZlb91SwCaca-PJX0S8BvzKCatNcVD_hETlolGxPekOoYcRxyhOS0oqh4PNL4fG5MfxXXjHxpdCbQvBrDibivFS6vhbjmFeBcQYWikaldIWXGQFooHSH2dWMs_BXrsAz6-j8VMn40F2LZish9H3g6jBjVkrnayZ4NMPTq5FtXcdK_5L7WFk2ASLauJCqJowO_bV8X2sPX_At8097h3QpXw1Kh0OkgxfUXvzDHbFI_bN0XSMiJ0al9y_p-VXab83-6hG9eHDURd6DtENaA6ZdPR1b2kCR_toknr_BpFKcDNzxpBDj9-GWfRRbpiCUM9rPYDDkijx5sFQiucuV4RNL_xRMwwjtm79e8Q_Ffs_Rbj0MXC_rEfuYOIlmhROtFCXJpXG4CNo46bV1NKHU8emAOPjTy5eN5yHKnfgvMsrKq0Ix6-yFmDNxXSz4pazVchj_p8eOwdiIe_aY0Ybh9RJBrav76RZUsxDdWqMKRqoWJyL_--Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>k0--5q_Eg4_-x1Nz1FPUkY_jXomw7H7E1_PjxiUKNYUK3emm0ERjusgvnWUYFQqZHjDGEekx61hC9iIriru1LpexlQdiFWf9oohhZR3m54tmVkLEMIItGP0eGhqQULniBgRbrSIgFusujEyS0Rw91TvO3pqX8rgNeFy0FDAL-H3GFetfBUfLnD1Zi-94KcFBeU0CKwDSXAHtxFWU5WZiFJ-wMeIriNlK_uoAMR58EAI8VqC-Z</discount_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></create_order>'
+    body: !!binary |
+      PHRyb2xsZXlfYWRkX29yZGVyPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRnUlEzS2RaSXpEaXNnenF0czlkVkhVQnJf
+      eWlpbElnMm80OFdudmVZU09WYlhsR3NWb1BxV0RXdzdiYlExZVZIVkZwLWNyMXppWnllYVdjZ1ZG
+      cUF6ckQtWTwvY3J5cHRvX2Jsb2NrPjxvcmRlcl90b2tlbj42Mi0tWngwLTFJbnhDdldCSzlmRXRZ
+      WEcwOXREZUFyQ0duTFZHd2dxNUhYR004ZXh3VFNEOHEyUUdJRnFvazZDSlhmRl9KNjRMWTR0Qk5j
+      bmJadTc2MFZlaXlFSXRSSXd6OWxEcUlRM1hBcTJBS0VKOXMwZlFpRWxDb0tTdDBUdkVEdmlBRmEy
+      aUQ2TWNNWmctWDRvQUp4ZGhua0tGQlh3ZmRYM25mZUI1MWtJTWEyeFBydGxFOEF6eWRoZTBmaVph
+      ems5UnUtb3IzM3F5ZURNTWJ3Mld6eGh2T1FZdE1veFY3eTdUeG1WNUp5QnEzQUJRSk5TOWFtaHZU
+      QmJEQ2o1M1cyeV9tQ2JmOTFhd2FqLVpLczJjQnBfMnhsaVR3YWlNMjBOS3FhdzZTNVZNOG00b1pj
+      bjBzNFVfOWFEVG1HMmk4UXBXY2pYempZNllWdEZoSWNObGhlcW5YLUdYcmNiVzJHb1o8L29yZGVy
+      X3Rva2VuPjxkZXNjcmliZV90cm9sbGV5IC8+PHVzZXJfaWQ+ZGVtbzwvdXNlcl9pZD48cHV6emxl
+      ZD55ZXM8L3B1enpsZWQ+PC90cm9sbGV5X2FkZF9vcmRlcj4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1384']
+      Content-Length: ['662']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61Y23arNhB971e456UPLQGM7eCzKF2O7cSJr8eX2M4LC4NsEwMiSPj2O/2TflkH
-        JAw47urpJQ8J2rMljUaaPVK0346eW9qjkDjY//WLfCd9KSHfwrbjb379Mps+CuqX3/QfNCtEJkUG
-        Dm0UGiEikUt1jUQrG3um4xsRAdghxsq09RMimnjbpFlRGMLwp+zLgLmQvlkFmliEMsbatCgOdVmS
-        chwOZiw/8lYo1NVyLcfiYMYKXNNCRC/nOBzKcTChBjl5K+yKeThEHNX/+D3fP8MzFPqFp4BiY+Vi
-        a6fPDEHY74J1fdesB7PqcCVsQry2Zfp0sAaj5buCLPKutJZy7f3bbigt535r7027WzJrrduLozVr
-        dk4fS7e36ODFYycc7pzm49ZS3pUK8YYtuTYvnxfl1+FUmPq78NR4f1EHctUZHdQP1HHnZ9I9P66X
-        4F3eJ41tJsU75OvtsiBUUadq7KMoaLxvvlmbRefQD6aovqh/bCZueSm5i6Bq4f1hJhNSeZ4vHxrC
-        eKYaG2XUi9Tn7nmDwrOhdFxJUfCz8NpvW+et1Gjuh/35Uq2co6qC5s11Y9NYlPeV+5O6eXMx7TkV
-        ggeDtUqXiO4WH294JAzkrdudvewOb/ZqLjUnR1SbnTyzbb9PFuH5MJSGRms4HlvzoHZ8RuOHD2Oz
-        O1bmUX359jIiw261idqCGTwaPeXQDOyPLpooo5qhfHtr7MevU3v89BBNzhNh0XkJXmsR7ftC1OvK
-        C9MJBpFKW8+NoTto9NWn1pM1Wi7HMJJihB0Htu5bf9h7c04P/frD1vJPvaemOnVmw6k5PE4n87ra
-        wXar1Yx6HyevLffnlve6mGxrxxfyGvlWxaOjxWhwdO+FN03Mh5/tha7ZiAQmtbYGfFh6E7susmhp
-        HWKvRLcI8tSPkCYWWVknD9EttnNAkkjN4cMw14clV65JqC7fVQsMgP6jK3H+m9TUB7MpzJ/jpYaM
-        Sk8B0i02fo6YwLn2ZXEOsXDkg4cW9laOj2y9XL+LpSFtXihsrZPprNUeTGGoApyxEtcnNLKRT0sh
-        yFyOypblYwOvDQISSHRZE/NNbqOOtUN5awpoMS0IHQvp5VrsZtYG/QytrRlukK4klkszc0DXEEQa
-        /pggwMzx9lwTsxYzJG62QcZPhy0KEScw51fOJgqMvelGiGloHtAsh3LBdbFvY8iEHYTyAjJ7MlAv
-        sXMjG9pyTUL4H8aHo2HS2IEcxu1Jl2nRzoaB6pCUCjZcUj+KUBxEiI2xQ6d0BjGJZArGpYhT054X
-        pDBexrsx5M6xye1h2UK4vYBllGQtj6bnuKccia1QzOYV06DF2xvyMCdBzwMXc9J/5jsU2aUuFGWo
-        qhmV70LowGmDqrx30MEIUGjFJ4aVy5smzY5reWj6G2Qg3+Ztvj/RLyVZpdtSI9pEhJbKkgwFNSMw
-        bkQtOORrgqiu1OKJrtGMRpAFBwcyo3IvVytVqcBOjYx+gh/PsyGhYVJJlVXOvOCwuVitSbKRwKZv
-        Q5p5KKELkirI6lSuf1Wkr5L0syR/jWe63YGPex0B1ibUDOmnmJRlCEYDEtf9P0NSk8s1pfLdIamU
-        5X8UkopQlv9NSHgIEulh5zHW8XGj2W2PNTEHc0oShr5JIZEOpQcchT76iZQGsJzQBBkMf0w7sXix
-        b8fWa8+PqQVaHHfhlONMSPIgZ4B7NCK66+wvdg6lBFZkxLSd1BLieIGLuDCn/ViVYd9RQJDrwlSE
-        Fnxsf/bxr3yP8e4sj4s3xt4gbLAi6JrUiQuPXk1K8KWpgRhv2Kcg3cmx6QJoYtZ/axID6g0k9pro
-        PtbEAhBrYVxukH0RQd7UPPNohJHvQ1jZ/stlOBqfUM0DzbzBu0Y1HyEbdjeAcxPBfTg+S4k/t3BO
-        jqDUwqMjR0sRRojXgEPP9KFUJu5/QrX4ps5qYlMelyrTgSZeoFTgoZLSmG3sPF3iBfga18gWJ/K4
-        ZsthT5giphE410BPBkdHODqI0Hi4HJxymGyAvTQ5EYq80hsK8YXKkiC5QPEbSqPVa48n83avN9HE
-        nIGT2AXFtF0UQlrN4SCRlMbLC78k/KtshNLipQ+lWB5yTa0Q7Uzx5sgGRbyPq8T/r4j3IPz/QBHv
-        PyniX6VonBsBxi6/uSWbfIXFGeM6Xlxtk3OZa/6d0N5/r9AmR4p5JzTqDTiyHOAWYuwd4qxcfgyv
-        QcbKFI6dUJAxfjt85V0ySPucwMXkjX+zjbu/U6TSqK+JGcSs263nwa1FritJAc9jbL4sJ+O7Lbz2
-        Yb3J7PECr6A8J55DLCDZ0uI9gbvLR4TIReF9fIGQzW7T1xSNSXwuAs3ncbPXjt2+MhSo7KoVwGpK
-        lhNaLip24NHA1HSNq6fHFchJV6+Gz2CBl3tB3II59/o1cY2mtOLL4hr8bl3hz1Lx1r9//gSe8Zbz
-        OxIAAA==
+        H4sIAAAAAAAAA7VY2XLqSBJ9n68g7sPMw4wsiZ07anWwGS+A2TG8KLQUIKONqhK2+J35k/6yTqkk
+        tMCNud0z7XDY0smTVZVZWZlZkn79sq3SGWFius4v38QH4VsJObprmM7+l2/LxSPX/Par/DeJYtey
+        UKCohqG42EBYwYj4FpUl4muGa6umo/gEYJMommrIjivx9yWSjgOPuopmufpR1hWOq3Ma+Vi/fViz
+        PUYc6Wkvs9ZbR981D6/1r9N8vBvQ8XzSmWh10RKCtql5j4v9bFp5NbbPl55J9pcTJS1j9bTsYCUw
+        Tet5X3arzbVzRpv520p7twZk5U5O6976s6FpUxGtnlaPHqdj8WJuA6Su9f3q8dS+4B63kfjc+qTQ
+        YM8lxNQsJAeISHwOuTqGukfkyPUKx1HltKPN4eZY/uQmY/OptqzOp4Y4OiCn2zMGtQDhz4G2Pguz
+        zVzbUkvd4O6upzoz1fQUNDY/4LF9IC+HdqX2YdSmi+eX2X4wtt6f943eevh+mXK1Chl0q4/meXS8
+        LH3zNH45dgJ62jp1vTzcfwUcev7s69MWVha2s3ndHmtvDj4/NbYNQ7QWRlM1zFdaGc0NI/CHh8eX
+        Dlcr94YeFygf/ZZm+ZfutPxWNTRjUz4tuu7r61PD7ArKhbaXA6WL/W6lhbTatvuiiFPRPVU3uvf+
+        Wf0Uh8qL3l8ZDc/ptBtH/VQdjQZ+q+NazY0uBo35YmXsyeSwmfc6fvujgrwGOl0Cd3z0a0652dOV
+        dr1RW5y1lepsyNtw2xla50V3Ig5O5TWtNN87Z63zPL+sZ+vlBW/JadhZdD/Gu7H4rin13mZbFyvT
+        WXnT2I1OC7wZzDa7yevmYz3ZzNr9CapNB8EXXZKn3mbzrgTTL6XpcX2s2YueJ3DcVuLzm3ndWxbw
+        uus7VBZTVhYO4wQZikmRrTi+rSEcMm/BZExZ0nzHCAOI/S/OcQdNmMT1sY4ANJCMvqhCEaHCVSMr
+        LWgYiOhy/4si7KhWaQFqpY6qg6VG6UY/4ib61KWqBUPamukgQ660HlJ+QVZUIVSuCg+1GzqhBSpM
+        6KlUP8jiDfsqymsQpFIPmzqSK7WbBaXCghJYd1DxHsnVW52rTNJ9jCENBukT8+he8yBB5KCUsVN1
+        6sK+C0KGE4MpKw6EZrmeYSXRcQU8S9URkcsZTgxlOOBFhQS25lp8FsYoRuXf/pPVT/EUlaUoxGQp
+        cTLb+W4YpDot7bBrl+gBQYVwfCTxeVaqZCN6cI0MELmm+9Z5y+gwd2VeIQii3c5D/+NSwqqjUlUe
+        Lxcwf4aXCFIqDTwk62z8DDGCM+9X40wSn8TCUUijP6EwW9u95XABA+XAlBMtvG1AFS0RqjqGio0M
+        mZnluIq7i6KZhGkh+xrLqAlHOCtNAKl4QDJnonAMMpHPp1Yi8HSY2TBS2dL7a0hp1zcmYEkFGojg
+        84Awigls8bpJ40NiuY7hOpx/BGddQSaPqMNIHgtjZUslJP7H+CqmUH4zQCxkfgRh6e+q7f271AWP
+        +uFSMmIJuo+oFWHDRoU8D4XuAi8oR0jO4Ux85LAECducmJeoXZHcYCmvOJ6hOjq6PygzJyHkwJQT
+        2dFRIVppbGivoMAs5dMl8IkTww3FsdujTcgCV3Gkv3SgXhmlV2gAoXtLqfGuYBPiC5q/s4k+FQ9B
+        rQgLVpTy7ookOHNIwaqzRwpUmvg9Gmxx8P9VEqEKzZEHJRISYKksiJAWUwpj+1SHwN4RROVKPZyq
+        iKY0gnQIJTgN1Ua5Uavm2YmQ0QP4sW3DkMNJhZYgxswrDjvtNuuCqEQwHFA4WjaK6JzQ4gRxIba+
+        V4TvgvBPQfweznRfIR636AP2Dicf0xuv1OihNFKD/6c/6uVqoyL8tD9qQu0P+aMGv3/GH7H9Ua5h
+        4Rgm7lm7+9qfSXwGjimRG0YqhUrwWepAs+Kgf5DSGMzBYS+DS4v+fJEoMp+xZ9OQ68+PiQTeYtyC
+        QHdlGE6lYc7IgjEDqsBB5kGZs9m8nBbNyxHOuc7LhW0Yn+hHKrE6WEh9Ilvm+Tp8DCUEVpj45D2q
+        P8S0vbAziZJ5oscqE3v2PYIsC1ZKaM7E/q2J8DR6ErI4f2eMPXIVViAtlZrUB5/XoDyXW3VRrDQk
+        /opKkM337JETHkQBdrhWh04lhSU+HeygEgUKE+SDHYmuhTkgzKZhXYLimaTR+FWy1S8F+44DW8Hi
+        RiyDDTeoZEPWvcMropKDoBc3kAfxBtUhisloPffwmOxjsNl1MrQEYYTQBhfbYRpmy79BpbBJY8Wz
+        K85K1cVY4q9QUiKg5NKQrRxtWYgrdRGXyMGNsuqOmRNNV8CkH1wNcneCn7oM5G4B0e39Xsa/J5Ci
+        9ozNNW/3hv3ZfN0fDucSnxHEpGj4uQodOIYzvIZQJAktLmVxC/Knj37hPpa7ieW2KU2xa2RAVRL/
+        igTcaonVn0/A4m1B+lEmC4+U57pW3BlGsVHAwoNmmXZY26Nwzrz+l7wu/nSdiyKRrY5rCxOI9BiI
+        JUQ5m5kPKUWQsdJsyAIbUl7cfa5ilRSSbs99/syHf9nGNR4qQmkygtv7FWLSw8G2oUcSW6w4ZjE2
+        X3qUw95Z0UJ7WXsP8gKU5YRz8DkkNS3cEzg5Jx+RazVw3CuEDNatFykSKwcZD3SfZ91hP1x2QZCj
+        ssbOA2tKuol1C+UVYm/cu+UXr/fsvXAruQVzvMwN5R4s3b/O39zj717gb27uP5tZ4mvvX5Mx+eTj
+        TvKpKP7OcPMJKYf/oe9N/PVDEv/Db7O/A9pPXdzdFQAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1828']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:10 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2085']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:56 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <trolley_add_order><describe_trolley /><user_id>whitelabel-testuser</user_id><order_token>E2--5eH5_vuupAjgQcgXHwMpTe9X9qgSl2Y0lXp5covwU1ss4IWYBA-RU8_g3PLu8IKzgerz_3Hl033oI-VMEczh0ACvOMWY84zu53eWCfAgAX2v47y8gZlotLi4soNNf8tYetkXqZoP-N1hlKUJkwZdbW0CSxe6UymaEdjSXrzwO0O_DORRcWp6xIeRBq_gkx4Wu9YZJPsOK5CeE-apF_L3wCpdqKeS3P6_3QZAvRVTdRGBuSzS-XHJpV6utMn-uLK1XaipNu8tDIAOlNAM8GDGcPYYRpF_3_rHi9pUQMOLZiyBM9BhcnyLGC8TiUOTaOxTSW98HodDDCuLqymE1MWcmVXSh6xJsVunc4mtPXPNxl7-Z</order_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsUDfEXxcUCHyqYlLXHoXFHrOkiCFhc3j34smOD16W2zX2VOT-TnkryAjJ8N15iPw8qeHlWzsKzFfY</crypto_block></trolley_add_order>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['694']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61YyZbiOBbd91fQualFN4HNTB6X6zBGkBAQASYYNj7GEth4DEsGzO/Un/SXtWzJ
-        I2R1ZnXmIgPdd5+GpzdZwh9XyyydoYd0x/79C//EfSlBW3WAbh9//7KSRuX2lz/EfwjYc0wTBrIC
-        gOx4AHqyB5FvYlFA/h44lqLbso8IrCN5rwAxgEioPBYJqhe42JH3pqMa4koul8+Ge+gY/Y67asz3
-        5aPnHACPny/q7G17qkEVnWqDLd88vRtzbru2B2dLmmhoNTgMN1d11X8JPrfmdPPibEYv3tzQ+yNN
-        rZ1qdWTNB3xzXb1tqh9zqSzZhhd0T9/aM76hv13an/DFXN/Q5DY6bIVKbk9CeErXQUjfm5AeJYck
-        1sCOAW2xWS+XdamGlY+2U61hua87DXgz24u1PaqCi2J9PtvX7jV4GV1ul+m5DgdtUJ4fpE7Dfx13
-        WvBtMzPQ+HX8MeeWo8PGOrsjvfF5Ac83/Tg4OtaQO43gDh28+lXvfszWvqoFL9bQ3pd372tzLUNi
-        JSmozdu93v6wQB/c+MOWDbDRpt3XRb87O/Dqdbp7vaKPPexIvU/34jacz8ZAA9Kwf3h2LP0KBsRQ
-        Jv/+8aENXv25Xquqp9bu1IDBYHDqtnby+HZsD/zF1Lm0x3Z9vXr+9N6Pi5GM3qA0WS6MUc/aYvXZ
-        qLfxoXY4ti4zs76a11cvcEXOic6b3vR96kp+Q7+1LEM78/K6Pmmure6u6jRWBuirE9ezTe+0rIE3
-        tf920s6X3nZX7WxXxjoYDYddaXRDw/Gnuw9UHQwnx8GmCYatjS55U74qvbQG0sUdztZcT/12la5b
-        ubpuapfn+rLz3us/j8G3YATWPe/sHSdL3ZSnr+f9rnXrgWALlU79E8tb6CxtY+bOvr2OVz17NBnM
-        p4FR3uh827QMeJPVzRyM7IVuBDO3vz+eaiCAg0bQHu93XvtdW3S0/UwbvzfLO6GSd5DEX2jkqI5v
-        Y5FPWVk49D0IZB1DS7Z9aw+9kHkPxnOKwt63QeiU9G9xjQdozESO76mQgACK8IplDBHmEo2stKAB
-        IFJFibBLywCRPZV20HOKihEpVsQOVkwyl7XXbQjEaucpXaggK6ogLNa4p8YdHeEClSzoKljVRP6O
-        nYjyGggq2PV0FYrV5t2GUmFBiZxOU7wjFGv3OolMUH3PI4k0SH9RUx73Lsk2OShlHBQVO+TCOS7D
-        YWDKYh7QrjYzrNgtEsA1FRUisZrhMCjDIVaUUWDtHbOShT3IUPE/f2b1UzxFRQHAvU52KKuao0fz
-        MyCVUIfRYGngW1ZQ6iseKA2oTKjkSImKbmN49BRMypIMFKxUUpGtWFAE4UypcoQlDBy4d4wIS4bp
-        r3TbUYyEk1BnoRvqh1Gm4tLBc6wSJkc4Q9uHoXaWlSpZEGsOyADRFffnvXlGh157ZkicOfLaPPR/
-        biUsv8Ry4mwlkfUzvFiQUiPjqHT+DDGxWfFwOmKppBDSaRTHFHrWpbQaDGcSmSoHp6xo60vsA2jj
-        Erl2mKHSY9mO7ByiqERhXssOmQzrqgGz0hgQioGeie1COGciuJKeEhJLh6nZgwrd+HBNcnIyooJo
-        m0PSSgUXDXqQEVga1I++K58V04c0urOAoOqYpQLTsYFjl32DmDIBqTyaaBrJmZBOrZoKQuwP5RPX
-        UHC4gQzG5HEgZuV0GtKcRZ0anS7qefJQaERiG9kgNYetUIksGYNhJ8iosWaC5OZLeQ+mNHSAHk9L
-        D8LkOSylRGcZKZZuBhkSPWElXbcSGy28Xo+ZOTJ6FkjEkf7KJuUXlCakMSZNbUplt+DpxNtIU3zW
-        4UV2IamAYf2NEvlDkUAiEMqeYh+hDG3Axux+/H+X+DbWSl3/6JMqW+V4kupTAuX6WCVOfkCQFMhm
-        uFARTWkIqsRxSGTUW3yj3uBy7FhI6QH5Z1mABDRZlGvzbcZMcHK5TrvJ8XIEKzYgYUZyb0gvc+0y
-        35b4ztca95Xj/sXxX8OVHiuweYsWoGOEFQ/f2aTKE2N0SeCav9IkTb7arNV/2CT1Kv9TJqmXq/zf
-        MQkzQZR6qD+GeXzR7U+GC6GSgRklMsOrgkkgXUo90oPZ8DdUmpHjeApJg94/YyVqL/pbB2JzPIol
-        ZMRwk3i5kyaSLMgYZHvYR6KpnxM5g2ICLTKVeBzVEqRbbtgtRYk51qNVhv72XQRNkyyFcG6Pw/s9
-        fm/vIT5ZZfHKg7mP0JFpETRJkxEWHrERleBkKJBkfKQ/y9wTH4oSQKik+pqCZFJvSGAfkGiTPjgH
-        hLkwLDcQJEmQDQVLucqeb9vErPT++SpxjTtUsEjOfMArooINyTcCgC7xG590aqEvRft5hDOyTzus
-        DC1GKCE8g+NZiq2y7+A7VAh7SFoT+/yiVJdmQiWB4gRPKikO2bJhiRwrwEVcQJoTpccDPQ59Qchj
-        wnc+WXLfKn/9kZL7OokaKNahdAfT4WK5Hk6nS6GSETASbVAU0ut7JKzWxJFQTGPlhTUJfysaC597
-        uQ+9nLXTjLeGgGTEVlglfn1GbJHE/xMZsXWXEb8XomFsuI5jss4tuuQCFkaMqVthtY38MjP8X4m2
-        9aOJNnIpurtyt9MlLssAJkHyWc+8/hRBykozHPVQksZYd/jBVFJIuA/gfPCG/9OLaz3VuNLbq1BJ
-        ISrVNMsiXQvfqUUFPIvR9dKYDHtbeR+eN1o9PGABynLCNSo5JD1aeCekd/n0IUoyvO0kEAS0my5S
-        BJriMxbojxf96TDcdkGQo9JWyyWnKam6p5owr8Cs8eg1ofiMQMeFr4Z7MMfLfEE8goXHzwZ37wUP
-        HwruXgh+NK+wz9JfnPoq8bNR/AjFHjLuHqdy+E+9ZFWSJ6rKd5+P/wu8uhIsgBYAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2158']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:10 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/TrolleyTests.test_update.yaml
+++ b/tests/interface_objects/cassettes/TrolleyTests.test_update.yaml
@@ -1,641 +1,613 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48ZXZlbnRfdG9rZW5fbGlzdD42SUY8L2V2ZW50X3Rva2VuX2xpc3Q+PHJl
+      cXVlc3RfbWVkaWE+c3F1YXJlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPmxhbmRzY2Fw
+      ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X29uZTwvcmVxdWVzdF9tZWRp
+      YT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X3R3bzwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRp
+      YT50cmlwbGV0X3RocmVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZm91
+      cjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT50cmlwbGV0X2ZpdmU8L3JlcXVlc3RfbWVk
+      aWE+PHJlcXVlc3RfbWVkaWE+bWFycXVlZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5z
+      ZWF0aW5nX3BsYW48L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+c3VwcGxpZXI8L3JlcXVl
+      c3RfbWVkaWE+PHVzZXJfcGFzc3dkPmRlbW9wYXNzPC91c2VyX3Bhc3N3ZD48dXNlcl9pZD5kZW1v
+      PC91c2VyX2lkPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48cmVxdWVzdF9jdXN0b21fZmllbGRzIC8+
+      PHB1enpsZWQ+eWVzPC9wdXp6bGVkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:11 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:56 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxldmVudF90b2tlbj42SUY8L2V2ZW50X3Rva2VuPjx1c2Vy
+      X2lkPmRlbW88L3VzZXJfaWQ+PHJlcXVlc3RfY29zdF9yYW5nZSAvPjxwdXp6bGVkPnllczwvcHV6
+      emxlZD48bGF0ZXN0X2RhdGU+MjAxNjA1MTE8L2xhdGVzdF9kYXRlPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2c2XLiOhrH7+cpXH1xzsW04wUwuMfHpwhL0mEJYQkNNy5hCzB4w7JZ8jrzJvNk
+        I8s2NoRUOqmkThLc1VXBf/0lWdKHv59IkPT31jSoNXSRblt/feMu2G8UtFRb063ZX98G/Tpd+va3
+        /C9JAx5UPN2Eiu142IoUFyLf8GQJ+RPNNoFuKT6CrqIjZQI02bIl5nSJpLo7x7OViWGrS5lmaVqg
+        J2gxvF0Y3VlnA277i4FqrHKzfo6/GtCN0ao7+jVtTY1abzmveA9iTTXbkG7yWu5uVl3tvGJnNWaX
+        Qr1p0+Xyg+3eKtMt5/Kcdn9tVfJtezef97Z8U1ncaLci5ys9Fror1bwbrkuTe+g3bjT/yig2ZiPH
+        rUwK9rqBDP2qtPUXlR1Xdu9zBdQbdq6dAoS5Aj2SmIP7lywINUWDDnA934VKME9k8Kd0aQ6Q4kB3
+        qljAhEjeQSQxR5rkIzz1oWLoCE8wXEMr+QFcCBS8PlCuDSUmuQoLNIhUuYaXc7eZQxdGBqJKqu7t
+        Qq9hW5pt0f4SD2YvhuXE2iTlUWFU2QAIRT9CPx4YvvuUEBUSfxkXUn8A0/kPVcFR4ge3kiqWcCyQ
+        wAibJfNwKEkIAledK0u4Iz0xOJwSJQi6yBdX2ysHjSW+4/Y0YKnwdKPhcGLDgZh4yDgugWFALxpo
+        9ahCOFImuQUmnkQbeYoLrBluzwRb3LI50S2oyQX+gpWYA4kY8E16jqurUM4XY0eihRYfDwO4uMnC
+        3rGXJDOY17hJniOOtEQMSYtcKXakeyHTGTeZ2zuSXixbCWLXgMFkfc0hrnxgecG7InoKytIaGLqm
+        xLrMScyRcuzgn3XknnXkn3UUnnUIjx3M4+GRNVRU33VxVsCW+FX4dphNHBzVB1LimALVs12ZY9mU
+        JxITl+WbE+jKJV5IuSIxcTkGUPHDkU95IinlCWIO7cyJbTBpGT99Q1X+33/T9RNdYo6HyTwRy9n6
+        n8n6pxddtX3Lc6PxkaSZFvbF5Hk/sHQPalQDxw5mn8QaZVFX93QVo9Nah5sgx6tBTg9n6GRRyF3h
+        3UFLi65JY/25/53ikEf1oOPBYL4onuXwLCaW0O17qmJPpwh6ck4IujpWExuCKk79SObyRb5YyB+6
+        48LQvsP/TFPDz1rcKSuyXOTc6zgz2yWB5Qj6KMDSCD4SO82KNMv1OfFHjv3Bsv9muR9BT6crRO0e
+        z0F4jTyczB/NSsGbUy2we8v5EPh8Mcf+9nwU2MKL5qOA/79mPqLxEzYMw7E96Fe65Uqj1pWYlBxZ
+        yDS0gOfN4Ya6tH3Xgn8iqo2H4wJ1iUOoX+v144rhnIWvdU0WftbjEnwV6QYOdFvGzQEvYLy0GDkc
+        4M1lBlemzbBfekL6pRFt7fulPYg8Jq5PqkTV8Qg9H8mGvt43H0mxAe8ygAeY+NrbOVBGuukYwYYF
+        N+7F9UhJ5PIdBA0jTdjhEGuPh4hfta7ZtM6caGMG7WChgCwZAD9CfTznBe6iwIsCx+WKErNXJUzf
+        s/AlzV5wLF7hgoAfbIksMUljwe4A56JgO4DIvuJACOg34BfMNzH2RpeEmFzfsoLNBIkbjo+g6UAl
+        zHPCd6y+bJ8Tir4LgiySssVKaAjGYLtmgM3h7T9SpeCZHm52KlyXyvfbErOXYqTX8PwHbmVpymzA
+        bCd0Cc3tTbipIsMh3R1pEsJxie2kcbjF8YJjMmguJceecJ+19aBrAYPqYyN1GQSypVFJjfD9Q/a+
+        p574pwokHFh+1FevXG3Wur1hrdns4VydFEQm0nwPaAZ08Xt4iEMRxbZo6xFtGc8OWuKBH4SSCtQ5
+        Dq94Y4GCth5p2d7s8w7x7ML8XNk825ud9/qnF/1TkP9TCE0++rVtI0o+ycfBiRYQnqGbwaaScFTq
+        8s02FASBwrujy+wNRqxIiEqQstaRPjEibDoWQ1eC4SFR2RiG5CVN0znRao2QXlmUN/D6Tm9ou1rP
+        Y+GlgPorNHM31YWnd5YArAWrxDbQoniZHzT70/zsF6zP2LY5inoMW4xaxyQffQh+HxfvJekxzh6i
+        LPk1BgmL4kWOpTotiUmksHQ+N02EV18MVz6thf0lhJoxRsYYWY75ajkmY4zzXv/TjFF39e+U8B6M
+        USiI+RcwhvBBGEN4HWM03pgxJoNfd3q1XKo5znVHHM5qardSofmbm9lwBR4afbba1AclqybeK/le
+        e9rNd4x5pZsxxudLwBljZDnmq+SYjDHOe/1PM0bPt75TpfdgjGKO51/AGKUPwhil1zFG640Zw1/v
+        Nnety/YINN2r+axUzTXd3Q0qKpfXrftOdTIStjtRXe4U2q+PtzciXR4vVhljfMIEnDFGlmO+So7J
+        GOO81/80Y7RszBjiezBGiSv9/l+NFVjxgzCG+DrGaL8xY7BXwzU96XFTfWFt5tu+MSr3c9uce1cY
+        lSqV8ri1Npur9u160F42zMoDPywqc+8uY4zPl4AzxshyzFfJMRljnPf6P/H3GD78TnHse0CGiMnh
+        9yGDYz8GZHDs6yDj9nWQEXydUP5pqYYffJeTmgB1SSEPzCDlABTXIqZnoMT4uZxe/lp077urK9qp
+        GnRXXy2VByG3Whqjun1zXS9qaEyPN9MlKE/8re9a7iCDkk+YsTMoyZLSV0lKGZSc9/qfhpIh1DCU
+        cO8CJSL3gr/g4B5/X+6fgZLf/hreIZR03viTD6E3qotjgaMhK5Za25m9HsBdq90bj51uB1WNumnw
+        tYbg6ldLfa4A1muWePbzQAbz1KkO2XEO2XEOHxSVMhrMaOCr0EBGg+e9/tlxDtlxDtlxDtlxDtlx
+        DtlxDp/9OIcwWr84ujw1yPBpeeogyv8DYFGy/8pSAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:11 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2141']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:57 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160427</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
+    body: !!binary |
+      PGF2YWlsYWJpbGl0eV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+LTAtLTYtYnNqV09qbFJnUHdhT1Rq
+      VWNscTNnVDMyR1UtS1lxUllYZk1mbEVTa2hDdHo5RWNtTmUtTDJkM1FnRHF5dDdQcVowazZGTG8t
+      QUF6b3JPX2Z4MXIyMWRWSG5DNE5veWhoU3gyTF9qSmRPOTF1X1MwZXJxY21RV3Y4YlZldUtKZHVH
+      bDdLZ1lwckNiNW92S3NsaUc4eHVqQ3kxQXJWMzVzU1dQSHA1ZWUzNS1ZPC9jcnlwdG9fYmxvY2s+
+      PHBlcmZfdG9rZW4+ay0tLTZTWUY5WjYxLWUwOThNeGdvdlVleU1OU1pacFJQc0RsRm1sMkVLNnJp
+      R2tpaF9hMHRMODIwUWY0Z1hlRmcwTm1ZPC9wZXJmX3Rva2VuPjxzZWxmX3ByaW50X21vZGU+aHRt
+      bDwvc2VsZl9wcmludF9tb2RlPjxwdXp6bGVkPnllczwvcHV6emxlZD48dXNlcl9pZD5kZW1vPC91
+      c2VyX2lkPjwvYXZhaWxhYmlsaXR5X29wdGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['365']
+      Content-Length: ['429']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1d2XLiSBZ9n69Q10s/TMkggVgq1HRgG28YKLPYZV4UQkqDCi1YKYHx78yfzJdN
-        bkJicRf2uDoo9+3oiEInT6Yyb957pXuEkf7nk+dKcxRiJ/D/+KQc5T9JyLcC2/HHf3wa9M/kyqc/
-        a//SbTNCRuR4yAhmEaFiI0Q4dqOajuORHXim4xsxRqHhYGNk2rUlwnpud5NuhctZFBgjN7CmNWzI
-        cvWhqUTTR+f0xH228OmgqmhPioy8AXpu1Qf1Vt/w3av7G2O5nLaRZt1XlHml/dgc2tXv2vz57ita
-        aNHT6Mm3y8rkfnl28TAdortmcNE6VcvmIn/qFtqNq6Zc7tz4fSe+ihy52B4uK+F4cS4f16czJ3xE
-        k3hg1u9vz4rnt8+LTqP1/K1TGn0/doYzbTTUc2tz1n2EbMNGMzOM4hAZ1Dg1P9Bzu3B9YmJjhsIH
-        wzc9hLllNjA9xsTeHHEdTKyK5shP/zFDZBpkU1Ctcafn0iPeYCNs1RpkD5eLCQqRIDBUHznjeGbM
-        TTdGNSWf13NZQLecaMlHcgPfDnw5npKlrkDezga6Zu2ikQ9tuSbG4h/OjybIjOgEMphoZ1366+18
-        GOIVzEX4cMw665COkRlaE2OKlskZcsS3UpC6oKAmPVfI2ngpb8eQU8fGu4flCxHta1hKYWs5Mz3H
-        XWZIfIW59Ly5xGgBjozQ9MdkjBEin9mGGMHDAwrJro5w4MYk4LA5J35RUwpHZOc2Uf0hdl0yD2/k
-        +MiuaSolrWOcQtYUzULHQrViecVJQUGKybrNkExISzkrTGczSwcuVClpAxSkdOSClrIy5xPAavBi
-        hpWekQSDRZzfHK8WrGp6bhslLr1lQM982pzrGsQIvD/Y/E023zYgQzamsY5xyvoU1iHdo1GfrE3h
-        jCwkCGS/X9i24h67plR+vGsZzsu7lt9j15TiPruWZf3FruX33TX1hV3bsB493pzEOsYp6xNYh3Q/
-        MOjVy0XYgLQGae2XtjmkNUhr4vSPselH9G5XFDw1ncSiYxsJXlP03AayyVB/yCj8kFH8IUP7IaO0
-        zchtL4/lbcOKw5AUgISSfOK3uuPRjNy9rkEp48G0oiDkBcYmmLL82BuR7amopQxLgClr5poWKYnU
-        DEdAGQ7dbLz0RoGby8Kk5uJo7b//yfZPcT23ucwomBnMKSBlvillbtkv98INAQQUBBQE1FsCKhtF
-        VhD7USgchsk1WWDVzJSHge9EyJaaZFw78FKq0G9CJ3IsI0RzBy0MMRPhcjubuAjItxv5tjgWyk78
-        WVIq0USqx+MYR5KaV4hTpgTOjSOLLgqjqFYo0RNtoikNIyvwbUyu3mVFK2r5NXbSyOlL8p/n2XaN
-        njRfUSqCucJ1BweVUl5hgpxh+jZTMhldzldkpdJXql8K+S/5/L/zyhd6pt0dxLibFuDHODLDaMsm
-        qkKMUSfb6b6nSUqKWioU9zZJUVVeZZKirCpvMYkwARMtuT+2B/2Tbv2k2ejquQwsKMwMLTOKJmgh
-        HQdx6KPfsdQmywlNa4rC35JO3F78s2PXSpdnSQs5ErhLvDxIJcgsKBhkelGMa64zX7ULKCHEI7Ia
-        M5ccR8sZqmHHm7lU+yYzipJ+rEWw4hlGJLtkdFs+x8b2HF+aO8Wbgyye2zH2GAXU+mZNd01ypYmJ
-        ITXliGSR1aHuBv6Yf5TzRwptWgF6Lu1P5WdylaZ6M2bC9RpAVVSa35C9kk/FISt1wtj3aYHE9l9R
-        RbWzhrLb6x28TfR1QjoH49Ck19cMLUE4ga4hCD3TJ7mZTX8L1enVjqvpJ0pXKvbbJBEnUCIN28Tk
-        lG1MPV4e7MB1PAkWXLVny+EPPdYxHRO/JnQ2OHoirkPKejpcBk44PG2Qdqm3xBHypCEKgxWVBwFx
-        i1h069VPrxvd3l3j+rpHbkjSBkFiHXqm7aKQhNUdcSSc0IQwLR4v/OPuzJKFr3mFZVoT4ilJcY/p
-        WFsYKPcgcf3aNv9bJK7S6yUubY9dU5V3krgK+0hcpXeUuNR9d634kyQuFZR7SGsf2OaQ1iCtgXIP
-        QiOkTFDuIaAgoA4joLJR9Ksowy9Jlew7q0HgCiUk/R5rilHl0HU8+tSB6XOZw3cTnJm0xmcn16v8
-        voIBogUbcwc7I1fIcZsgZ6VKL1fqginya1NZlh+K/ZLp3Fe/X7abV+XeZdl/PFkM5qcn/ql9/nXs
-        dG+UMD7rFvE5Kpfbzcnoq9xqLqs3/bNOYaBdPt+LM/IRxejLmRDmGrdJ8wrSt2XSdYmUfemauUX5
-        qJCXvraIn60g3jqZeB4mu18tsMckWYyfL1U+QfCCyvAfZnOoDKEyBMEL0toHszmkNUhrIHhBfQ4p
-        EwQvCCgIqMMIqN2C11nofJZU1bd/huBVKFYrrxC81AMRvNS3CV7aOwteebP5rI2/9b93vgdDXFLj
-        ZSAXbupP6Lh3V2hd4LNC83kYPmNfsYqdbvnJti+v688geEGGgMrwQG0OlSFUhiB4QVr7YDaHtAZp
-        DQQvqM8hZYLgBQEFAXUYAbVb8OrF/mdJLdK/h35/wUtT1dIrBK/igQhexbcJXuV3Frx69XG//Vi6
-        uI6ng1Lr6iFa+sW+dS97F0huDfrYaWnLanRm40Jn/O2224vQ+BIvQPCCDAGV4YHaHCpDqAxB8IK0
-        9sFsDmkN0hoIXlCfQ8oEwQsCCgLqMAJqt+DVCqjgpf0cwauUr+7/+39FupSDELy0twlelff+hpdx
-        VnKanYen1q12/FSeat3LynW7FMWz255sDAxtoHbKBfv5ZK4tryfD1mOnc3MM3/CCDAGV4aHaHCpD
-        qAxB8IK09sFsDmkN0hoIXlCfQ8oEwQsCCgLqMALqhd/witFnSS39JMGrqr3mN7xKByJ4ld4meFXf
-        JnjRV+fWLn3LjenLiqWRaU0lTDdTmpk46cVIPxDIWmPZanYW5cXtt0KpV7/Q0H27k38Ipv5ZpdRt
-        P1wp/pU5VBCSb06/3ZzPlzcT8+IJBDLIKFBJHqjNoZKEShIEMkhrH8zmkNYgrYFABvU8pEwQyCCg
-        IKAOI6B2C2R3yP4sqeWfI5CVK8prfvOrfCACWfltAln9nb8R5i2Gz/3uxfHw/sYJ7k87z87Do41u
-        sbkoTK4047zy1fJPz1vKYKF878SXcmdYvRn8On8CmYtpfufv4My8lZVEeohMMcc7EuGrI97AztWY
-        o3C5mCD6CtkU1UfOOJ7xaodnvSygWzSvspFc4oSBL7P3Mq9A3s4GumbtolG8htk16RLYP5y/eodt
-        BhPt4vURa+18GLL7nklvNNlwyXtbM1DyYtMpWiZnyK3eakpBnfiLoCY9V8jaeClvx5BTx8a7h+UL
-        Ee1rWErhvxZoeo67zJDE20rT8+YSo0FBDwX9r2zzv6WgXxWY+xf0xT12LVOs/38FfX6fgr64z67t
-        WdDn99019ScV9HnQKSGtfWCbQ1qDtAY6JcgqkDJBp4SAgoA6jIDKRpEVxH4UCodhck0WWDUz5WHg
-        U3FPapJx7cBLqUK/CZ3IsYwQzR20MMRMhMvtbOISJd9u5NtbLwZVKlQzjccxjt5TNC0rWlHb/89o
-        K0plSzT9K3WzIiuVfdXN3E4L8GMcmWH067ws9b3eaprbNgEXpZk/tgf9k279pNnoJlo1d1P+mf8B
-        thlFE7SQjoM49NHvWGqT5YSmNUXhb0knbq+XpG/+ySVeHqQSZBYUDDK9KMY115mv2gWUEFa6Mz+m
-        OnANO97MRWS1ZEZR0o+1CFY8w4hkl4xgy+fY2J7jS3OneHOQxXM7xh6jgFrfrOmuSa40MTGkphyR
-        LLI61N3AH/OPcv5IoU0rQM+l/emDAXKVpkIzZo8C1gCqotL8RnJgIp+KQ1bqbEviWyi7vd7B20R1
-        HyGb7O6M+E1MrinUl9h8duGCHIcmvb5maAnCCVlFnU1/C9Xp1Y6r6SdKVyr22yQRJ1AiDdvE5JRt
-        TD1eHuzAdTwJFlyuZ8thp9vAdEz82hKPE9ATcR1S1tPhMnDC4WmDtEu9JY6QJw1RGKyoPAiIW8Si
-        W69+et3o9u4a19c9ckOSNggS/0FP03ZRSMLqjjgSTmhCmBaPF7ivffD7s5cWaQWui6yIPyMju/MU
-        pRg7aqKlFE1CRJ9bZPFtVuD/Nac/cbBE/seBhyRyD+b4EsU3++R2TYnnWfbwSEydXJ5x7Ea1/wEX
-        xwQgCqcAAA==
+        H4sIAAAAAAAAA91a2ZLiSJZ9n6/A6mG6x2aUaEWomqaNVSySWAQIeJEJyYUE2tCK+J35k/mycS0E
+        S0RkRGRnVs10Wlmm/Phxl/v1e8+9Xqjxj7NtVWLgB6br/P037Bv6WwU4qquZzv7vvy0XfaT+2z+a
+        /9ZQYsW0lJ1pmWEqu14I2YHsgyCywmYjiHaaayumI0cB8GUzkHeK1nTcRvXtnsYpUpzwbqZmI1Ys
+        U5OveBNrVJ+QZwb+IYP4kEF+yKA+ZNReM6qvt6f6qRe68s5y1WOzhyJI7zyk8NG8c0L2XDeIz2Ti
+        LLeXrSiJm+7pBOJRn40t0nM7Ztw5LZd6vORa6z2z85j1voao6pjiwtlIjOc2B2JwBhiBmtSFmu17
+        0sXBJLuHp+tkvzprgsuI9khXwTrd0GNeCOuXKF2NEkaZryfigUr7goegSUuL8XF7EHtGTe2f5hPV
+        vzAIaXWN6IyvB0rLxvqkuHO0EW6fkuN8v21UH/bUgKtwoCsoPlBk6D6g2ZMa1Vur6NBAoDZ70NvS
+        xAA+KAk52lAzg+Vcy3U010GiI3zHC1j051Qu7y87y8GWEgTlPwVf8cMAUm5A2ZnzW7Cz8u+K7f2t
+        0oEeHGVLuetuQD/NnbaYNgVwpkeoEQDFVw35CNL8TVXo6jckC4iSdx32gjxMduM9z6cpjgrenrTY
+        zpXwAN44+T7aimWBsNxo92lAsdPqbQnVqxHdyAn90uz5IdwDL935+KVjhkCrjKFawDi/UctT8c3Q
+        VKFMxCZIZA/4auYjGIpmzvNWV0NTQiD7irMHMnC0sp1PtjCi/6pgQVgRgRcCewf8Co5iMPpulIId
+        hars6noAwiZRy171jN5oAVChKwVNjKRxmiIf2dfOgp7CP7atac3spSiDYiXzBYcn7dZrKCbnsOJo
+        cmjaIKcjKIOg2AJjfifQ31H0P1Hs9+xNbw8o5322QdEOQugcr6xChUaFV9KfaY8aTtIE+ml7UCj1
+        JXtQ8L8fsUe5/1xrCncUlovOvNUZ9+aN6h1cUnIz8EoYGiCptN3Id8BfgooAt+Mr6hG60KInLq4D
+        C5sVz6bWrA371x7YKnELOrrbhNMpYaYZ92DJ8JTQaFbhYMQu3ovs8vciAeK8vBcJQRBWr+PzIeVw
+        uMMwCpqWGb9MX0JXAsyoSqhUr+0w9UAzMG3PAtBgcPLwOi7vKVmRFwDLgisNwoct9l5vET7xA/Qe
+        r74xxx642UEpzYalwFQXQZtT2DcKZ2oYRtCN6gvagGq+Lx4R9BuGwhOmajB53+BG9TaZoQSy42Z6
+        oAd5AfEAZGoKFREqzouMls2GrZxlP3IceBSF32A43MMrtGFD1X2D94w2HAA06BEe9DeYHXKfzNfz
+        Fl6SI1/Jsv0d7YoUhGwPrm9nMlws/xXa8NwgLJJnB5tXyIXQqL5A1xShQftnbPloN9Fv6EuOuMcb
+        geHmqqoX28lf94Q1AuiXkJ5PDs7QX6BPZtPdwVdOkbfPIfAdxaosILHSzhzZ0Sq3EUX85HXeW4r/
+        VkcDOlZUvktsdbneXJR6HCfCmurWUZLy6UVFs4APY1iCrhhcaWUqK0uQB4ve1FACGkwg2K/QSobB
+        yM9rJfY6d7wnOpn3e65r5W5e1g5PWBYTlmlnaTj3vLvmBxKMfTol5U5TrA5poVPolCVQ9gRybAbm
+        ziod7RksWDfhKnwQqlNZKK7KITeo8TpEH8Mz+7s4OPobgVamfKN6g4pew7BtWM5gTJHH7rHifS8+
+        oka+D+886e2pWMV+58FC5QG6MXRFDV2/LGaewBvLibJKpVnHa3esEryxPEtRQZBdaZ6hOw7UATlI
+        7Z1rVe9hKEIF2vyf/74ff8NvaPPhGpfZKcsXZaLwfBMG8U7JSg5lF7hWBH0gUGJo9EJnnsHGLvcQ
+        F8pAE8EQZIbZlxm6lcYiULdH5kJKU3rbHiH9IzazDnMODOrMOWaCzgbUdz0QY4Rh9AdKmsq1jbbc
+        DVpsmvTmNXGeOhukDdbGIjnhioaolNFK6ltj7I0cmxBq+Fi/8ISXtgN7inSSznK4QdR9IJ3i8QY7
+        Ie1ZS+6IyUipD+ZqqMfbmTkar2m/r6l9LvU6NbXjdtb7iSG7QSypbjrjuS0dDU1zN5kfNz65jMNh
+        cpEx23AlYrqU9C7Yi3iwHQVS1zwJF9vX9g4trOs+Aw982zUmA1plRjt4JbqzCKyT7Z3pwDAkmMx6
+        L80sYKGaQAcow7VoNBzXKR7lp5FvdNyRMxXIj65JUI/sW889HUq1ofh70CSf2C8dd+zSQd6e/6Gz
+        UTi1XDoYjHro8a+wRin8yv7mWnkwPoF3zljEXQuynqB7Thb21Qfkpja+ksAB8D6+j9woKFUTgyXK
+        mx05PXRDxXpi3mONZ6PfmfrJwHdmfcOYjyas3ofgPxWOAYogh8WaJfudM0rjDomOtoaeDmqsO+wl
+        kbfsgMRo0dhhtw2IGUPxmLbe1LGpxWyiiRPRF0Rk+zFyPJnTmSPWiAXOS9SMtU/u0FPVwbFGYeqG
+        YrpthtK52YI9ORO8xoCtFAgpfsE5Kegt4A0i1mrcTmSAtiUwXuDpAxPoNj0/TWY4z7FMcKkp1tIf
+        tDG97k3NMzvltmo0R/n5AXGESVJjpUvLbxMrxe1KEbbGhEEHSRQRN7yY6qCmbnKGwruBb9NDMNHq
+        6agDZejdMCQfwxCclbxovqZRrSn0CaYOQ1J7adWuLehhIXTi/HZsZZkvZ5bPDT2y8odygmszi3Qf
+        1krwJGE6lrPK5xrzz3DDh7VZPgP0tuIxdzJYlJ2LK001A2DZqcAEA5+r92t6c321t9dX+xPWV32y
+        9UNTVmCq8oFi5e9+p+srokl+STTRXyya6J8nmu2fLJrMZzWT+b5koj8omeivlEweSiZw9yq54pb+
+        bOx7F16WNgtmBa/rjDJoezzDS9wCxQaYZoordVlPrAUaLk9yYg8WqIeJx9pI3QsdkfK2fXVy7vn0
+        iUr4QWchbjEBbA94Z4/s7LG00QVC6x4mnEa3iB3O6h0l0Ud8dwRNciDN9ZE1STmKPLK72iRgQjL7
+        5Ng6LCcqwrdWyILVeWSDDJNwFB1pQbfqZ7k1V8nDMaUHYIPHxtTueO13ZRD/4WoE/1I1gv/iauR5
+        /j8ysDo/uxrBP12N4N8NLfwHqxH8o2rk7qZQmmA473C9lzF3V7d7pPh/xB40aUU1fdUCjwOut7Ub
+        UnhrTUYQQW+huGbXW/vZrMfWWf+80uxQoclu7ApWbT8fHuZgfZmyR9XSl7EVqrsaNT7V3SO7Rtas
+        7i8tkNhnssYk2HpjKKczJsi71mKAX1ShNtlvHpdShkn14Ur08+5HR6guYqByQX0/UTouuUvlAe7a
+        I3tpJfaaDwRw2UYjJdVWyoQdHTibjk4pT9V3ywuclem7mjaZUrouME7fuqjTORDZDnPcSXMhmrYl
+        yefFhYZPJ7IiubNEdTd2OOcX8xk9bFubVEesCyGbYCi1lVCou1zNPPjmoo/Ce057zY3n/kTQF2s9
+        Xq1T1PeUvqb0xsFJu5wOZ5Jx27uVOWPP0VFIguPS7faDuhYjZn+K8BI9QCYSkbRlKdIjBEzF9kWY
+        td5Xn4+LsBlOobciDLawd4uwnPmqyCkm+GeKnNlPKsLytb+1PuxPWN8fWoThXyrCcOxLuYL4cq7A
+        /oVurj8tV2Dv5griu7kC+5VlWPbbOLVmtNXiPN0RbZYRo5Zat5f79WKpGr6rqPyW1lIxGVHYekr7
+        nWgWipRrz5lLWDeGMb4fzdrpcmi0+DHnjhF0MpV3J2O7HE2AiPbSS7JfCpzLLsbB/uLhZwpDzM2h
+        TuDavC8JEse1geXyTlBP0vMsCZmotxixInmeh5pjukzUAjpvs9pkcaqhSxDWKXowRk++34lrk2nP
+        WZ1W8uZd8cN+uPTCvhJOWP3XhtPz/B+EE/F/+U5DfDaaiO8GU2GSrwdTMe4rhZe4aOU/kHyi8BLh
+        UrMfST5TciGw5DJSm5KQmWybREpup+r2xM+27IRh0nActvtkD50NDGw80zVdXZlD58hPemOnHZ20
+        No5tVJ9c4wv9NMHFWFtTKZbEKkHaMJ7/2FIru8itRWqoDlLVnjk8DN+WavZlvSUIF/FwvPC4GYm4
+        iMysy3AmjMZnIhZImh1GC3Zb69b7wzVLzlahKaD7cKfUfVc4iM5cOQjEaCOhs7W4YILFZpjMtPWB
+        i46TVrdHDdatIKql4ZAkRmfXitNo4NG11SVZrGKa39iu7cXbjuRie4e97Obt5cWzApoaIeLIZfk5
+        ioosxTqcPpguuInHIz43Qn07Elz53VKKwn9UTYqRn1UTkv6Smjxf+z5Uk+f5/z8n56yw+5ycXJnv
+        6ElhlDf1hPqenhTjvqIn7RbXmQibTwlKW7HgztLPX+LmPMLECnEk9wEiwoPoneswhyqWt1gGzLxT
+        JxeGuOWJHllHB64wE8Ydlxv4E02od0O3N14nU8yr+Ypj71uXU69tG+G+xazZNuKetcQfGJ9Rlurj
+        b16q4sgWUGLoFNAlLFD+qvoabsCNeUqoGrev+F4QG4SGq90BxZ140p40qo/YPSUIm9g36oGRfUrx
+        0swt2XEtC6hhRfdduxIaoJL/xH03qPy5+tosPTL/EGbSvuNdO27UwjwqPJd+Olp19Xo37XUNfrOs
+        6Rvr6LYwFrscOCfWVolBj7nRceevTQPZpvhZ9MRJVxsog4uWKuwB8fyBRtJjOtY78/464nujaHmY
+        j9sB60jzkz0ImToSGFww3w57DsO1JUJajQNiiiDJyJkNJvLFS7dRujRbWXZ4WuHdirMTVAuL3NOK
+        g33/ON4+n+kk+9jnu+dDfHg+U4hV/rocl1/VDX1gwcCquI6V/senTgmu4hOnFMBTYkmQ0K3zkSA5
+        mkuT5WIvTTcLzjqdtQU636XMQETIAWeN6PaGTxBdlaUevU763S7Gjri2kAa+NhuiPjZRWwx1pOVw
+        2Kt3TpxObwNNIr3VSmnPbFeWXPUwNckJ4ZJnJOmfx6O93Z+0vBprjSwrZS54zEbnLWgPVIfejXy/
+        LfR7knD+8OSy36xfHRuUZdsMs0tt8bGgCW7fHD59fGiC7358WNr++avD6vNkP/OTxtvk1Tc38top
+        b8iLjlS/9zX1/wIb1fiHki0AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3142']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:11 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3838']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:58 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <availability_options><perf_token>k---mwZzTRHBZYQioYDOzifqdeVsaw3hJ5_G8PcnDGM1Uw1jOuI-OZ9QUw9QTFO3U5IzY</perf_token><self_print_mode>html</self_print_mode><user_id>whitelabel-testuser</user_id><crypto_block>s_--9fK1tkqiDClzcsDU915x1-emUezMAUAMT_nlJYQ_yykNe5cY81v8NqKZd9j5vzWPew5txbxnd71hYyFHfkZeWKoHMD27aw0Dl3NEJK-7OQnTiuJti-4NZy8rgwG-BAkpirqehuUaAYVF4GVzwOEMzXO6bjBiZp5bZ</crypto_block></availability_options>'
+    body: !!binary |
+      PGRpc2NvdW50X29wdGlvbnM+PGJhbmRfdG9rZW4+LTEtLVExbXpRMFpXS1NlY1prOXo0V1A3WkJK
+      LUZrMVFsalJMZUg4OXh2OXNDWWU4YkVldjEzaGhGSGF5eV82WWRVYkhBR3l3RVI2U1J5blktQmVY
+      aFR3cTJhZC1jNWhBdzhaaEtwSm5tM042Mktmek0zcHlCc21QLUN3Q1VJWS1jZ3NXcXZLWTFxLUJR
+      QV9DU3dKYThIUmN0ZnZaUWlKS1g3ckZkY0ZMeXBDNmNDb0NYZ09oX29zdldjb3lRTUxaN3VJaWli
+      T1JrWXI0VXZ0SXd6XzFtaG9XM1BVV2ZEZWdTMnNaSnNXRGlxTnptcmRnbjdOWDhyOV9mYVpEaE9I
+      N2M5SmJaPC9iYW5kX3Rva2VuPjxjcnlwdG9fYmxvY2s+RTAtLUV4STUySlJDcS1nTERzdng0d25V
+      WnpaU1dTWURxcWV2SkZHdmw0cG9DaXZDcVVVZnZVTEFYZzlicDlYZzYtY2NLNUx0UUpTdlJtTGV2
+      ZXhlMTMwaTV6NVFnRVd6bjFXbUUyeVh3Z1Z4ZE5vOVNtSmZjZVh5WTdLTU50OHp1eVZKdzlhUlhP
+      U2o1eUZOcC0wd0FkdjJLQkh2cGg2Y0ZxUk9jcno5LTRsRGh1eDJYSGFBbTFGNFNibmRKMm1xd2tS
+      Z1o8L2NyeXB0b19ibG9jaz48bm9fb2ZfdGlja2V0cz4xPC9ub19vZl90aWNrZXRzPjx1c2VyX2lk
+      PmRlbW88L3VzZXJfaWQ+PGRlc3BhdGNoX3Rva2VuPmNfLS1GeUpWRGY4RHlFRGhNWVU2Zllsa29B
+      MUcxempMbnZkVndoN0tMSmticlhpaC1aeTJ4U3BTT0RkSGFIemR5YUdqLXBySGQ0N0s3dmZDUkZY
+      dU1FSnVValJLQnNHbldScW1IdDk4LXNoTHNSWklFbjlMQlczV1ZLczNQLS13Sm5RSE9fenB5WnV5
+      VWlBLVk8L2Rlc3BhdGNoX3Rva2VuPjxwdXp6bGVkPnllczwvcHV6emxlZD48L2Rpc2NvdW50X29w
+      dGlvbnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['449']
+      Content-Length: ['804']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+V72ZKjSrble39FdD1037LbnGAGVavimgbEJIEkBgEvGDOIUUwS/M79k/tlFw0R
-        UkRGTqfynKq2TkvLlC9f7rhv9732dpcY/8cpTZ5ar6yiPPv7X6DfwL88eZmTu1EW/P0virwAyL/8
-        x8v/GFutFSWWHSVR3Zl5UQ/syiy9qknql3HV2G6eWlFmNpVXmlFl2pb70nnV+PnzqvGhsbL6oauX
-        cWslkWu+4i/Q+PkD8pEBf5eBfJeBfpeBfZeBf8l4/nJ6Tp4knlOblWfVlVl7p/qOXUq81z3VYel5
-        4+d3+JesPPs2Rw6j6mn4W+Wp91Qkg+2fzvjHNs+fDqnsijo37SR34hccBICVTtZ9IlrmMSAyvV1i
-        IK9yfKljXT1Z7HyZcTqD0XZmhoZ6zEeFUk3SQFssogWj7PVVoOrE1IBkZrdc+eBuFdpyQOALDAAR
-        G01AhEqYdBTEW3OPAbsFCfS+kRHBabmoiF1v74AqjjPYmDCVpgi+hK8lbrWzoSlhrXSj8kS9tTnH
-        zFthLTQG7k1ndku5wmwYtzHM73EuY6/1smGCVulZ5rC9vRdqN36+l64Vrlc5L9TgDd0x9ErvRrig
-        YzsKmsIclrrxXiAQHD8/AmPnvNqXnpI8c/MMaOJhBG/gtf7S0fJSf6u8du0kVlXd/rvy63BYlPMA
-        HrBb/aWJ/L7+2s3gXBdPu3Z3cb/30HhY6tIJzdjrXp/wPLjoHTx78o362vINedffnfdJl3HkVp93
-        e53Irf4ddqdc5rKw0ijpHkjXGT7fn/v8arS8yeryZuaL0R+Bt+pLeyWLas994gdtG0TpTr2tQhnV
-        kTOIWht5R7PwSue8Yy5L/XnV2LVqzyytLPBML3Nv5dv6NP/nCSLr8GnSBE1VP8EgNAjFnXDlNvWw
-        e32/8uoXBD8/6CN6p1WeM2yc6gVCCQhDMfAd+7XySu+GP2nqui/nh4IkRN6Yb/iwuDmJg5B5ga3M
-        Neso9S50ACQBiJSh0d8Q8G8g+O8g9Lfzkz5vcOv3owWu5aq2yvoLm8DQYIxJUUbJrzQJDsE4gv6w
-        SVAY+imToAAM/R6T3ExwkZ7rfhQUebadzHhqO35+gG+UixlWVj040vFpmjdl5v3v6kkYplNaTuyV
-        //O10dVe18+R+4Kzi9eaoXTDk2GX53cheQRvjGF4dVO9JFH7Vn+DXglD8LZq6/m1XHeF91JFaZF4
-        w2yHEdWv7S41N1ZTVF6SDI+q6ndjpL4c49fGfsZ55RF//qTvwMvP1rdexok1RNtmMCQG/TZE7Lfi
-        eBDj4PoRAH+DzlVvwPj53j60KjPLz47tVy9ZPn5+B5y18BwkPfdNBG/FcWqdzLLJssGs1/WH4GFr
-        fIGO00EzP+F9RMeZ57nD6hbDvmlK77K3LuP5DL+Rm9I65xgPtFfkSjjPIS9TK3O86/C/QMdFXtXX
-        mDiDtk+oLIyf36BXgXcHk5/ZZpy+gL+Bb/r+iI+rML/Io3+dzjUDfI+Nq2FfD/RL50POMSQeVX3u
-        7gF+5VxlY6h/krqq9tInwyvzN+rVCYZt0dyaSZP5ktpKO2q5lIak7F5xI10aSJabeOXgVrthI1Wv
-        tFt4uSUJ74xzF6id5w4CRpxF/dcLGDHo9E8IGPGFgH3No85bucjz5JrnXdfkA3be4EmUnoPjZRs9
-        FL+ni8SP6uJlB1xHB0xGk2GH3YBbTWW2URXZyW3XfASvrLsgXTfUoDq3ZE69NblD4y/97b2vnf+9
-        LhzxGwI+rVfj5zt0rQ3DNB2SDGiEXOLtI3Z93tsucZqyHM5N3f3TdRSBXQzpwzvozvAtp87LW4rx
-        Abyzsia1vfKFhPEH1g28s4ZE3/Gq86noI/TAGZzarLrUzpPnR3hQlCv68l//+dj+jt/Rl3dHwbOd
-        znHgFgAGtxgc07bOqYBlV3nSDHugstrB6MMsz6rxER3bly2Sx172EqMAAFjoRnAYyseJdnqauikH
-        7KdhQOEy1wInocGWpLTflS52SPWZGZ9KIXBPdOElWjtidAgvNjqB0yfUiXdrlVdtcF8krXkaVUZa
-        4qtmETWTbStCpIK3MzRg9xOfLqzKzw4JRFka1NghGi9XyWBbKTv6YAXUbOf6uJ5SxuBoibpgh+lb
-        MhdXi2SbI7mJnmAFKWbE6igsJkY7FVAgEiwu1GJhwco6uyYjhyW9hjpl89bpAJUr14I1EepiMh2t
-        jVUvCFmKWYvFMt6vKpzaoxAbLTOcBPxFl3ecN0thLR+0mHD1DSBqWK0bBXTYsRTH63LO7lJf8A+F
-        M/NYQu0Lfc7P48V2BNvp5ChrUDzfekl7TBkUd/amayxKdr6pIlyK+L2FM2o0smUZcxndj12Tckxh
-        KQEMXEFNyvIbJSgBVRV2lsVGIU4vORgPkIW1192dbhfTZU0e9zbYrEMg7zYWLnKrTbKAFBHcEb4w
-        8v1gBSyBJE0CfjQ7jlYrSkO5rSdP6ilu2a1lnJgd5c0DnN73C5GIiDAXfLJmVSOhe7vIdmtHQobg
-        4q0RiinIalaJULTvD1Bc+0iKZRoo2K0atvlpuyJjdrNJY3M49z3sqCH9T+0oG3QMHp1331txPISt
-        S/Z/ixyyMqcEedDUd/CddQ0d57whq5+G8Oo9UN8OX4O+Dy75miJcS+Msz64fzbeHI5exfFLxQD4L
-        88WbXhDsPfte80gfImJolYH3gn5gv1U8sG8++3n/7yrHV50xbz4/CPEgQl9g49uJyAre/PosVl+i
-        DwJxtfA5DnyAHjln0z6/Q+4RoLSOQ4OsHk7heVPdIhk0xMVPKy70Oq+t5APzERvfbQvjtxzn1dZ3
-        QyKXmrtd3xns2u69DZ8fZfFbEvldhVRgANiolrvNaVmcTOx1kYSIvZ+OaIne8KKsjAJsY3lrzqib
-        pa8ee6TMydFyNt9CeujWIeieWorFpQByl7nHF3vVZ6zlGnUcYmdqglvBEAtg9CycBaW0U7OCXc1r
-        DKxPkC0FrO5jLTjbOLw0ZeeLHIyZFO3XCp0U7pIpoUnXUtS8gIIVsTZUH+PQ3Q6cOBokn7JuWVbM
-        FtWWsa6u1pOqJWeCrgXtjNBUi9xviVRgt4CsrTdVHkv9cU+mS4s29ZE7zx0WbPHtaTfDlUOCZim1
-        liF8DycKV63kYmpDtKJlpwOBWUYWobsopy0hXw1SF3mjRG61I6iHpjmldhorwnHKH7zkYE0oBRTm
-        SJAt66M0rwNb3vCT3YElBJvbHI6AsXAqPPOCTtaFaESRhLhjtF0N9vTXFAZB3yvMmwTcMqpv6AH6
-        U3oA/sF6AP4RegD+kBxMf7EcjH5UDUbfFAME/KoYoN8Sg2u73ykGxI+kS40BVtMtKZFzls1nIr9A
-        1Hji4pxrlAcRyBeSKkMNH24IsgisE7z0Z93MxX0JpCdy5XLiccn6NWKsNRMKFEZLkEO3HXISbcHm
-        HCXWR6JsiwxpxFBPbaLhU4hNuNjPkXUimCpV4ZzX2COpW5wQwBN5KMXkXsAAYLsfzrWMLCgcZjCC
-        0WhoyKnLA9uYBTyK+QPaISbjSaPDCu32sNj2k81Rm3FRL/sABtACAm1PmKwVAR5G2xoO2JM2tQy4
-        UxybLqIDoGX+ChAOQNXvAzSCiRa3iUnQ76oD5VFFJ6degW9XsKP7dYbr1cKsD4PcVYyUbU+UatSO
-        pRVNhnbciJPjVW+M8qhiiwM1TxzOPM2FCS5oVCUDKccfoAmfssg0wWl0mkrC4ihw+b5kkSPOUyIq
-        mLuGhnfeqPRd0Yxq2i3UOaH6sX3cukUbiY4BHdHFLEAaFXP66T6bWtTBhNJmdAAzfsZOFZgjjljW
-        EcvehycRtdbpSFgoKmXrBIdVtpBFDNUFe8IOoa1XrE4FVB4VEVpOZxJoEjZ1EFRsfsTilO1JXNxI
-        JBUmcQJxjts28cyFpyBWIuoxUztik5L52tug3spfeBbUTL+aLsF/cLrknazLNdLrAdR9mS5REh2U
-        0n0rQa+loU09aMv1a5TzmfHCvH0e+01y+XDr4LV4FuDSq+rBxYaDrHm+uX2V4o/wuMyP1x4GGbh+
-        vHj/5UuRy9yez0BhDVPJy+Hz8+OYPh0f9Pn4oH/C+J4/2Ppd0bSGQ17pWcnl2V+p+pnkFv6p5Bb+
-        g5Pbj/3/ouQW/aFoNvvVyS38w8kt/M14Bo1+X3J7bfeNePZwGXAzAbudLam3Ng+3M4/I9cuZYjDp
-        kxOVTuK9b/B6IXNHrnKFmwBQIh5j8BI7cqJGTwsMAswyquYQPISddGkcc3YWG4JUJ5Iyheb0wZSK
-        baaUxhr3RmHGMaOGo3GdNqVQdCku4zi3my1qZT1Z2rY126D6+6HcdPL53a3HD1+B4N8L6dUQ0s20
-        m0YpzPZG0cPpEA+hUFFns3mRJMj+YKR4ki8421I1Be+4BOYCQYoQ2NTRCSpOCEVmtlGjcpiuGX0k
-        cI296iQ8Hel2dFz4Knci6ZgmamC2ZFmRWixZXTHNDUCtQX7TMyii2z0lHfQY4NWIlVZDcn9AZJ+U
-        QK0o2tovlD6lnVM0wZ1NuMDM+Wl9VGNFE9WRJIhHwej9mN3laZ2HAMlmgIoXvbLfmjnfpiOYYSeb
-        8uhRE6cON0K5duryuIEbCp3PuxpnCUagTxQnLfg9PD9x2SIVxRlXLGVkY5QUSymTTXLkfVk8HRn5
-        UKYmNrc6GqoEojAlGWY2knrSK4hAMF914WW62tB7EKG1dNvtjY3GTnKM9byM7UN4kXEkoEW9U3Qs
-        OGE7MN0P04BEsQpSIMTVlDZEtsQcthwCbnbwls7cBBSyQ3aJNTL9w66T+RifafvWFCDAAkuY2y/o
-        mSesR3Onz3JOil11Mgm23M7wFMhR1FMNmo0ljZa8E9r72bQ8JClCbLYIphAaYa/QSkrZYLPHg03T
-        uJXUnBB5Qc6RPT2nQv7o7sEJ6J0aIB8cmtJaTAOkSesV+mkqVwK+iianXsSYIdVjT2tu5BDemkCB
-        r4V3iPzTw7vBYufb8lt4P5eIr4b3C/Nj+Lx18A+ET4P9ReH9MvbPxkf8E8b3J4f3nzqrwtBPhXfk
-        p8M79IeEd+yfc3f1y8L71++u4G+G9z/07iqGh2gdWiJ1Ypu2EyfkTkLSLUzqNUMHCzcnWXlOLQj1
-        FJs+ngKT3AX9IuCl0UTLJwEXDbF4rdiUgxmt2RyyqWSB1mrBL5eIuIAkp8t3ZAnEjt6rU9k72d1C
-        06at43XKJi6xGb0lFBCMJ2SEFShUbhKUCraM026aCFamU6XAeEtEe5rF5HBm5Jrl79y8bI4bzmD3
-        hJcdxL3SE+vTEQLncZXFWjhlEYoPt6s8CSIZzJiAXiqrUb7UICZuDkaJJvPED4Kw3oFM6i9HAQKS
-        eLI4rLaYUEaiHU7VPlhtV6qaJhOXbxp+OLHNRiynOUYbIubKX8oCAKxtxjQ8AEgXzYacwtpyhtQp
-        TkZ7aYW5UDkKEo91o9VsxOFYmpqU3epzo+8LgMi09BiUZIToa7lpDKXnkZKjiFI+ovZOobvltGSx
-        o2Zcfy31+TEQ+r13Wh8989s6cY1Hf5xOfOz/OzqB/CvfaSE/qhLIt0WC/J1nAPIfEAnsRxLgTlDD
-        mhYZIKT0ludAYaeoCh4smVOJYieq9nd1PHhzGnhuEyV+xkYqnpDyejNNPUIMSxnsShmzaIYdXMWh
-        HZsADA/eLHhEKqjzVdcMPqJmkXFbdZbgwHJGMmHPtwUqbusN12yzXpxbSokXR8KguIDvNqcjulCH
-        rNxk9LQ94TDJ0iggbmer03Cij3e6GvMtbZK+njs7e7Od21OCdE5rWvR3xqRPbD/bF0BfCyTcLQDY
-        Qot6rpyEHaIVyUjdOywC7kfUFrGdaoVtNruNEB+hhZUCwSEyXWMTD3nkJuv6NabBKLWoVQLMl2Tc
-        I1XpJjGwkChrxUSnbJZuJ8iOWivLeqMki8V8RntdPJ9zRELVbQnPk0NeNAI5EpwT3xpiZ87U/lg4
-        0p42AzoGfDlGZmLVbEvcTbFtjzBUV0LdglQ6lN6TiMxQoW/qSuCYFO+IRayuUj2TVLWZ2xoI2U7M
-        4VMnr3fBvGuDFBPlfGKA1QqiZ9z8sMOqnDtEtQFvGhZ3GskcoXwyHNNQhNivkdwVT2Si7mMaLrbH
-        mJiJNSgpgC9BZQYzo4qc2Gw2ZzW/XWp7AgmIvtkamGUV1YnZ8uJG1MzERlmAAQ/s0twufMmLiK8n
-        wPifngAzIoq9pbznEg5+/X4L+yTBvHXwDySYjPir7rdw8NPxneE/fXx/cgL8/0Fg+yfdb/2qyIb+
-        zvQX/dnbLUmeXH5q9gO3W3LoPUnDcJOnf8u841N9Nv1ff+yaa2UCQOFu1t5oVC/NxBBbJilHrW6j
-        PF+1kGUQM66JW4ibRVm/P03XR8Q9wlKkR8k6kVd2QLBHsqKX8kGfT7j1ntqwcd9v2pibN+nIJEiF
-        7ZFVKPBCmrSH1MH5rdc4LNoOz/2l118Q8r3wTw3h3yXpgjqKq8rXXHtXBV1UMO20tTh2UYZLigQO
-        B7s+hMbhhPRVkNI76Ch2ctBzM2m+zzIPPmgKMer3KhWAK61tOT5j4sOB9OPDNK2gUFcycOeSVrM/
-        wDyjTGDWWZ/gxbbWRiQ8R9WEIXwWyy1wLmgINOXAhatsIcipioPtMAd9FSHGUo1kbq+DqB27I3Yn
-        LAvWaI+rtDqq/ZLfZ3GIh1W8sbo5XdIzytRwWS/6lSRzu+MpL/NV4GSKx7D4sYdQnw7Wm2hD16KL
-        MqYyUfuIXUndUd6NIjUaor3T60ofxNue2PRUlwEQV7EkLbNLDPH0lTxPDCmuA9Y7jtYF5XYIUCVk
-        ShALT6r2tLWaSoc9TaBWuelD1DM7qeTYQDpk8zQ8buS2DsvTvGczbmSC/abqVi5or4A6pdV2uxQV
-        pu13dErK4vzQ76bz40FnjHC2ggCiDwssq6VMZgEKPgCcgOWbTq86TupB1xwxHZXOMiIA3I3a1LIL
-        FqFsQ0bRdbNqK5GH0lcKcJW2252QultAz4IQdNE5sJSmaArKUAWxRUR7BEXnVQ99/YyC/Av9sgeD
-        fyY4oMRPBYePX5V8Nzh87P//6dsRDPrR6PDK/NqX+djv/DIf+9nwMJ0sZ6Kg/1B8mFrJMLPuJ774
-        2OdCULRifDRmGratGJ1hWd6hsEDLvGi5nYJmFBFLQmCAEZ9iEWjyjLGo4Y6gTklYTb2lMgjTHFj1
-        YYM4EBtDwEHWRNzeTyOjwOwfUf7n9z8FdazMTDyrHTbFsCUS7/Zj4y/h8TCxwqqd8P5+3BuSenWY
-        uw/ANdUQp0Nu+B57pFT1y+WX/++hO+Niydn1hbcnv8zTp3oIyJfffj80uv2K+7V425GXlzbE6QPv
-        teJOvZrHGdYF5H1TNg5gwTs8XTbhKY03xDRZ6xrVtCfGASFQYWZ0LGCZtYpOtdWtCGo7TzJoahzm
-        6wxPhLltOUZfS7KpsbjRoyrh74ERofpcekr3OpyYqSvSs2zOV7Nsso4YIxKEtBamy6XDNJWTOL0X
-        4p15jt4fRvgw4vMK3l4BfKRdF/bry/H5+qxFSf7O+iDfXZ/1gD39m8I//a8hS/+/T2zpJYNjPeVZ
-        0v31h1ZpGMUPrFI8rNKe2ShNtlrYHLklq320FX27tYtAXiL7IxbsdtUxPI7itaaw8hF0jiJIpxNV
-        K8mThVDIbGK2lFQveBJGq906n2k1SANi7JC2i7WUtqeVUaHwnoz2+/0xlA9TxABtkyNhwHVJHeME
-        oNrl6iRTcx301E13qHhe3oDA91fs/BPuL5ZrkOM0qs/HqesbbZF3fzHuwxtykffNN+RuNv/4atzz
-        W2fPnz7ry/1yR95c/Plb7xD/Nx8jurqIPAAA
+        H4sIAAAAAAAAA+1Z2baiSBZ9769w5UP3Qzcpk1M1ZS0HvDihIg7XFxZDKMgoBCj+Tv9Jf1kHg4Je
+        O4fKzLeqlauS2GfHCeLEOWcHJvPHxbYqEfADw3V+/0R8xj9VgKO6muEcfv+0EgdY89Mf7b8xmhGo
+        buhAyfUgYgaSD4LQgm0mCBXNtWXDkcIA+JIRSIqstR2Xqb62MCACDpon+0CW0DqgzW6YajHKDBoI
+        1DaLXis+68AHOSFFGdWAcca1XEdzHSw0mWoBZvaUOkntuTGfbMlBkP+V8WUfBohSALkx5XeQsfJ3
+        2fb+Xemh7YbJq5TMDNpUusPMbQyQp0eICYDsq7pkgjhdqYriUiBJ9HLebdodeXBW8J79abKjgtdO
+        s+3cCA9gwUn30ZUtC8B8o/2nCdlOq8UrVG9BTBLCz8OeHkIZuJvT+SvHgECrjFFaoaQoqPmp+AY0
+        VJRTkQHOkgd8NckRAscR8aWJ0WQIJF92DkACjpaPU2eiHv6rQgSwsgQeBLYC/AqJE3WmWlAydghV
+        yd3vAwDbVD1Z6hktaAFQUSoFbYJukI0a/ci+GTN6jP6zbU1rJ4viLZzImXccnbTbrOOElMKyo0nQ
+        sEFKx/AWhhMi0fqNwn/D8X/ixG/JSq8n5H6fY5CNA4iS40NUalCvTOX4Z8ajTtINCv/meNTw2nfF
+        o4b+/Jl45PtPe02WjvxK7Amd3pgVmGoJzilpGKYyhDo4V7pu6DvgH0GFR9vxZdVEKSSyS/E2MYtZ
+        9mxo7fpwcLMYt/4mWSjR3TZyJ8OkZ5TBnOHJUG9X0WTMztbFlHRdLMCc+7oYBAGs3uanU/LpaIcw
+        DNqWEd3d59CNgNqvDOXqbQxjD7QDw/YsgAKGnMPbvNSSs0IvAJaF3jSAD1tkP24RPU05vIxXX/g4
+        ADc5KLnNWDI0YIhiXiM+18hWnSCoBlO9owzq5ofsEcM/Ezg64VqdRIQ7zFQLZ7ocSI6b9IN9kKrN
+        A5B0U9QRUce5t9F8yNjyRfJDx0FHkeUNQaI9fEAZG3XdF7xnlHEA0FBGeCjfkDqkOZm+zys8J4e+
+        nGhoiXZDMkKyB9e3kzacvf4HlPHcAGbi2SOECi3yTPUO3SQCSTZM2JJpt/HP+F0jyjgT6G7aVffZ
+        dtLlnjAmQHmJ6KlzcEH5gnIycVeCb5xMty8Q+I5sVURErHSTRHa0SjEjq5/0UvCq478yMCixwnyt
+        Zac/YYXlhp1Mlky1ZMhJqfulrFnARzW8QakY3Gi5lOVXkIeIFt1wAzQkIMSv6JWtFkF/e68kPmrH
+        /2s6SfZ7rmulaZ7fHZ6wpCYsw05kOM280vArLZj4ZklKkyZ7O6yDz1FS5kBuCaTICAzFyhPtGcxY
+        RePKchB1p/yiuM6nFBDzsUQfyzP5f3Zwjc8UXplPmWoBZVZdt210nSFamY6VsWy9e46ofuxBV1Is
+        VzXbUwrDvHkNEtSBlVXalIXudWeTuhutBMPhuVlgkuo4UubOUbCgNrqQvd4RP9dbR77FLk5S5F35
+        2DT7K8FuGrQ+6jkreFUipdk5cUNLBc3x3pZ74tjXvL1lDYQmO5KPVmO6dq3RwWxQxHKCNa5DsS/W
+        pS0fen2bVcXTGIZDSu1btBoC1rBFZ4L7RmdPc7EAIHccWoK4PMCVt2GbEmsv+krUeANrsyX68/gw
+        P+v6ecguW+bUtg+z/uy9f9VDq7GmG5sWL0Flya3mZ3eh0YOr1j8tsV204eaDbp/g5pG55jcTjDxv
+        V9Pu+0ggllA4jKlOIOG0wq5rltPz9my0cFW18cZe6xam6ZFKBRNtAPvyXMPm516NdJeu4hIgNiPB
+        Hg1mKuQ9TtqO3ll8Rtgrj+pq/JEfnrjxmxWc1V7EwcF+KncGrLAJ3wMruA58F9DcdQ4243ptSvOD
+        3di3CfXisFAzzoPl5djvw+OkT485stsYyjVX0YQ3BXawXXLXLJ0vo1iyg1RSKj59HCtOS+e1pfhG
+        SuuqTaHqfUQYNfR99HUVF09ZGh8UD63+ABWMvaxC189vw09gwXLC5KrbbpL1EisHC5ZnySoI2mSJ
+        k0MlDhISKYhtxbWqZRipWIa2//uf8vwCL9AiGMFDXNCNAH8IS3JFQLLt7qViAo0U7wm6+0Dfh0rg
+        WiFqO4EcoTrPpO0ZRB8ftmI4qLdRrcR+HxYvk0a5019NxNILZaG/D7NvQA19+VUSzdRkXyuRcz34
+        yu7uQ+giHWyrOIadTKzVXY/jCx5zw8b727pPDh1BdLX94rR78whpEZIUy5HN96CGMm0VXTWcvcwI
+        +mw1WHuwhz2ObACbr8VU1xodD1YwkMddthlxTTpyur6+UehtxxjESmfKc9vOarzAj9aJXkP7PD5z
+        /MzpT8QemG0Wi94+gkGzZfqboOGdotp+PhiMdmezNbXOHe1AKFdlI7sxPFIm5UbWdGlSfJeXVq7W
+        s2EX7weqUbP2FuYd9dF4PN4u+ucBuSsFIdt1KQrJZbMcpez2iVQAKSfK1VyasgFKDSd7lJ4O9IWh
+        RE4Uz/MN1LOp2iO7sJTp6Fqiy/4BtOkn9t1QYmeXZ+m1/wcjk9WfJEeyYcmJwiFF/4Ax+SVHPhQ5
+        nQrPE8ikTiUlkdsseRHrCSpzkvSsPiCFsvryGU1woHEI3TDIbwgEuo6/NKR06ELZemKWMeY56KVQ
+        PwW4FNYXwXwMYbWo/D/dA0jiSz2gxw0n/a/0gJ5uWFoF3dLBj9Y/hup/MrPtKdcbqoPpZLVRjAO2
+        ssfieL2bAKTbI3vcXGMY2Y+3w51CBCJ+4PZCPzk6QG8miq0vunWjX9eIix7hsqGe4vCs26ap2dtA
+        wSSIBHl42I07kWVKFKcvWuxA1nbS25BerhoT1msK727Ei+PT6r0xmVDXQcvvXqh+h++1LrPNynwb
+        rsH1elI9aYdhX61l4gdqOTuYb61lovldtUx9by0/+/+rlu9BeVnL1JdqOZv3C2r5i3q+FFd9lv+a
+        oi+TnxMc+FPq2UT17GPxebJddlnWqznX/ZD2uzzRiHrWfOny5mEyn7iR8z7ZHvsX8chpR65Xj+Z2
+        NI15DzojxdKN6I2bDa2Q3bwfV+pKEt6l3tCGbOOkHK52d79Vh6fNsYOu9cLaP8lig641u9dQsE7u
+        uaY3LouDyHbZCF3FLd7t4cPl2TwbyKUn7bueQY5YZbicjI6NWcemPPYwmR2c4/xiYS3K655W5D6O
+        pyuBvtRngIhtasg1AqMJTD7e94Y0JvC0EPaImo3PZuTX+wH5I/3gu7SdrP/afvDs/69+cA/K9/eD
+        bN7P7wfUF7V91pl/rRcAx3D9impA4wqcn9IS6qglDEyKmxgcTte6Y0ne4wK7D4TgeMbttdUYGWK0
+        ah6W0LlsKa+3vhr+vjmCO6G31UdGf2SbMqV350rY6h54rTkX45ALdV912bXWXEN/esa242406ZHH
+        eG1uZ4Sxj5quxQn8pkZOehoei9KFvC75GPi7S3PhHWcCCXbXGqmfSJ2iRKsf8EJwUtXjEA99bo6j
+        b3TaOknfIPfUj1zdv0vuyV8s98/+/yrve1D+RHl/We7vj0H2W2VRkrprJD8/3H+x/GAp5dvTvz3/
+        D1lRoYe8HgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['5841']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:12 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2688']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:08:59 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <discount_options><no_of_tickets>1</no_of_tickets><crypto_block>60--MY8tzlOa_wg7nYvL50KVJKrY5ytAFWfTHcyZHXW_n4hYkKipUsAmgXFFiFHUjYMgVY7BZ1THWLMf0WMhbTg76F5-03b4l03ElHm9gkR_j5-WF8-zfZn7gxLFs7WzbW-skkn2ZAHsXUNfS6PSJMWb1B7aMYZseOYvbJc_ovNPNuZ6eBCbvEdNC0--Z</crypto_block><user_id>whitelabel-testuser</user_id><band_token>k4---a4QNcHEf67vBxBdmJ-jBhgE6TJv-xNu5L8SjWrd5qmYC_kxrNgdxGpelXv9HY16pQY76Gx4ckWPVKVb0jplv_x9sZmr6MuFiuARvO18U6vC4gIjAfGpasfnql1EaX1ubh4kLMlberSnwf0s-tIydf6YmEZyymlVFIavaaTJksFlRo3o_4x2U3pC7MwNFAZvBN4-iNaJhXkNFITYIP8icI8euExnDvcy-VJrPNaANtpAB9PZMzNNnm5aFFLkjMs6Ej41IiLn68-fFyoyJeCm2Xotco7dYQ-OX5tYZp1qWIEJKYToIWmfNfqpcCeI7VzpYDKDkFR92bmAwTX1kDRelvwmH46cj_dZFrIDQsi6SiKja6HVi9bTT5dHYfkd_Ec_NLS-H2s1umIKQUgr-VVNWaaIih6GLJ26g3FajYdWYbpBLt8wjb0uPh-oyQa6OJMQlF1UO0W7fN9ffgM-L-lmlgK9Cw9MMEX4JReTAtB6abvaZxHWEeDg6GjzFO7i7hoNf8tIVZlGzbpnWPcS3taneP3EHp8sCsO1ijzq1ktf3m5nX0NbvVhvoxRM8kIQQmk_Z</band_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></discount_options>'
+    body: !!binary |
+      PGNyZWF0ZV9vcmRlcj48Y3J5cHRvX2Jsb2NrPk0zLS1wUDV0MTNnRWFjNGthUkJ6Wm0yaG92VVJp
+      bk5IT3NrMmNLdmJQbmpSbHRkSngyQ0NqMHc2OWpOOUVRcV92cHpOeWtrRFVSbThpNGhKQ25VdHpi
+      dmI4QXFISWxjZThLZm1hQ1RLcmRwZmxsRlI4RUphamw3TVZvbEpnazczMVNMLTd6SVREVDZfWE51
+      cERtRWNUcUt0dUkzY0RsNGN1ZUVpbVRuTDByaUFmNEh5UmV0SGpJbFJUU2d0VXBXRThfRW1RRGJ2
+      N0dlVms5VHJQeWdQd2hod0lFUzlrTW1tZ09ET1lEemh1bDdWNDdXOU5fdGJTSFVQd29RZDRGemRE
+      cVMtWnZXSFBGQkQxSFB2a1ZOV0wtMndYVU1CWUpSMVN0UmdLM0FzXzA0YkVWNWxuQ3BmRXZRb2Nj
+      N0dFejZsLWRodmMzc0xkRnREYVBkLVB3QzUyb1NvYm8xZXlrdlJtSkZPY3ROcEhfWEpZRTBPMW1V
+      cDNCZE5qTklxSEtHbHN3Y0N2SHRGZk1hQUZFUld1WXNsc3pGcm9lNEh6UGVXSzY1TTRORlpLcm0x
+      Y3huRXRkaXdGU3hqRER0akxENEtIMkI3SWE1b2JkUkdidEEtWjwvY3J5cHRvX2Jsb2NrPjxkZXNw
+      YXRjaF90b2tlbj5jXy0tRnlKVkRmOER5RURoTVlVNmZZbGtvQTFHMXpqTG52ZFZ3aDdLTEprYnJY
+      aWgtWnkyeFNwU09EZEhhSHpkeWFHai1wckhkNDdLN3ZmQ1JGWHVNRUp1VWpSS0JzR25XUnFtSHQ5
+      OC1zaExzUlpJRW45TEJXM1dWS3MzUC0td0puUUhPX3pweVp1eVVpQS1ZPC9kZXNwYXRjaF90b2tl
+      bj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxwdXp6bGVkPnllczwvcHV6emxlZD48ZGlzY291bnRf
+      dG9rZW4+YzAtLXFrLTlCVkt5eDB5SEk3WUdWRDJJblJUb2RmUXFaR3AxX1F1MjNFSDI4WXM1YW5r
+      VXZ6ZDBFeE8xNHdsN0VtRmZ0Q0gyN2VtTjV5M0JsSmpnbHNGYUtCRTh2SDg0dm5CcmhXYjRYQWlG
+      eWJBTU5IWEFVS1EwamxxNFZ0bXdLd0hOT25ETFRDZU9XUVFDZnZ0czg5a3JXczdwcXY1ZlBGRkpa
+      d2s5TWx3QWRnMWJ6Yldhb3l0ajNrM292bE1TazNOQk5fVW9kQ210QjBEc2NpNWxmbC1wamhKS0tL
+      WFFEd0YyWjwvZGlzY291bnRfdG9rZW4+PC9jcmVhdGVfb3JkZXI+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1148']
+      Content-Length: ['1008']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1Zy7aiSBad91fYOelBNykoItairKUCvlHxhU5YPEIIeQqBir/Tf9Jf1oFwfd1b
-        eSsrs2aVg0xinx1BxOGcfU6Y3G9nzy0dQRTDwP/1C/WV/FICvhGY0Ld+/bJciAT75bfmPzgTxkaQ
-        +EgNQoSZsRqBOHFRk4sT3Qw8DfpqEoNIhbGqa2YzBTFX/tjEgSPw8UQtApqKXwSawpor30e5wQSx
-        0RTwvtKTDSJQEK4op0MrCdWj5iagSZEkV34EOAOiNF/JDXwz8InE4cp3MLdfFxpd7YUxX9pwtTgu
-        /sn5yAYayjbwgBX265TFsz1fBh/1eu58uaszniEuBlpk2KoD0rc3lLHD7mDm14L6NvOGPK13532w
-        pAPN+ONl84MU9ifsTrmeRdQ86KYPpPyE5ft7y29Oy+IjKtx8dfojcDNf5y99iIBZGuIowyFypxZf
-        IYIIGjjEjhCc1BBERhYx10/9sYkzNQTUSPMtoALfLMbF90n+U6JYZJdaiZXEqFQhKYYr3wk5N0GG
-        Gux2MUDNKpO96BW902Jg4MCJmxRdp2p0jXxivxlzeor/eJ5pNrOXkizFFswbjj9uwDIkpV5hzTdV
-        BD1wpRMkS1Dsgmr8UiV/Icl/k9Qv2Zs+nlCs++qBfBwjLULvfFKhsDNaYQTdn+kShqowVfoPu4Su
-        UN/lEpqoUH/GJYULrtKTx6O0XHTkVmcoyFz5AS4oVzeMNYQT6VRqB0nkg3/FJQkfJ9IMB0T/fJuU
-        +yt/hmaT6YtvFvgmdaqLozy4C8kjWDDw9lASN114vNkL6I2ApVRDWvltjNIQNGPohS7Ap8U7Qm/z
-        rpaClYQxcF38qhg97VF4v8ff23uGD5ePePmDtS0QZN7XmpyrIYgS7Mga9bXGlW9DDouxlT8S5Fcq
-        M90Arnyfb2ux6gdZYu/iph9w5Scg00KsZlg6biJYDDlPO6tR4vvYrfn3pyo4NN6hnIc18wPeK8r5
-        AJj464Y4bpIIXGPrup+P8IKcRFpWGx9ob0hOyM4QRJ7mGyDf/juUC4MY5TWxQ8kleiFx5Rv0JvC4
-        FKOMrTpek/xK3vT9EediO7jK4y4/Tl6PnzEuxnGN6dfFwRmHDohRttwD/MbJZQPbS/M0RsArbUEU
-        3Kh5EuCwSIpp8xY/EuT5WhiN5lz5wVCQrhPmmumCCKfVGgdS/EYrykvRJDw55y5Qa2BiAatnov7z
-        BayOdfo7BKz+TsB+L6OyUA6DwL3GbFHGX7AswF3oZcXxGkYPw890sf5HdfEaAfnuiFajhSOsAApL
-        rB5hDHW3iJpXMGfdBSkPKKw6RTO3KqbcIe59vj3nWvZ3/uHqX6tkaTrmyncot9q25+Emg2pUr/X2
-        Ecvfd4sSI0pDFKi6GxhOU6gThJSc+rYfs3OxEc5Fb9JBWtoNprAWRHErdcwVmqFOsvOH/koxa3Df
-        Q/5BrmPhFzaNOUwa3nC9Vaw5rJGnpR97zGy6WPi1VliNBLuSsgdUH80m0BpZggXgqEenLtzDweRS
-        NTpGt7fzLoQX1WpKv76TIpEZ1ryNvZlVDz7ldwzQn1TVsGsTaWXCtxZDlUr8k7XTZOPo7RqR3O6u
-        kqBvo9owGdGDY9rfUb3uaT9Zhb6wtXrTgVd3zsu6LV+2ne784p+Fbc8NpFiu9yvhQj/QJKofK94o
-        oPbasSV5LFx2hw5CRC2gmHboj0YIpFMyPURoTbPC1tUb1PzU0QyNmA4Ucs62j5dhR0OSseJVW1i4
-        gds9T4EzCTaGfE7tyZwMDjY9lUb0rlsb786Ksu+dQ7Ojz47tiIc6PIpz5mjre08EbWO2WUNHc83+
-        WunOxCDozXsVcz2O1baCv8WFIfbsauzTpFgZbWFsN3pVi9m39ysn8rV0S0vj6eJQE5FimEO1Nqqv
-        RafSmo+0ZNA5DILTRNVXrFKJp4raQizZqNvVWaicqKFNThzrvFsqxwvf08W+qkukMh/DAam5jVQN
-        iZWi6WyVYOxuA/T4pWwyPBIkrcVszalM6RWnI6socPxIbYfi0OClyzls8/sG0V3vZFkPYWc5bkTT
-        Dc87cH+uxeIMJkayomVppJ7l8em0R169AdiZKu5iVdb35FjpqJGwSzaTvuvZ8gSJHWUQKl26IwU0
-        o68oadhbssBrTab7RVoDUi3tDf2ddRzH0fBA9s8MkYoeL52V+YUOtcvKsPdqyILJyYR9nO0bcqPb
-        DXnQjrRjnZG3y/jMm+vDeCgfgvUgHakEsc266Ydc4XRX83Enod7ver6bXmXoY8v9UnjVqGYVK+Ez
-        whlJFOHrZHp/yiXB0kP89ifozthpBgqiot9/Ae8sP/F0EDXZCvPAKsA7K3Q1A8TNygOngB44uMKq
-        cerpgVt+hHF5z9Hm//77OP+O39G7M+Inv+DuiHxyS9Yu4X4m2Kn3CTRuBV6g2xr4PqzHgZtgCY+1
-        I9bMvOa/gvh65enQx3Wi0sjst+F9M3llXix5QVo8bCl3/m2Yl+asL/NRCbcv4IFa1NZPTncb4owB
-        ftMhCaJ2UAWLVokzJV0ocbp0NupeCbxTvVcXKHW6P8PlUNosh1XgeaQg75PYOvrr5UacHba9Pd8V
-        gHNmKLvTgP0IRgk1CsHZnZlQXO8aQWDbW7nq1WjkrZyRMO73UXdKgq59mC1HPmxbsh7N+5aYxMle
-        SOekfGpQi+OkGh4UNrIkIKakyLdGRK/aFQHatZe7kc9TW0g06KEhtsGS7AxP/Fxp9dBZXC9r6y0U
-        B8RpDPBeJHeoJkFrLNdYodVnV4dOllYvHnjwSNacP3os79ZxdcUdCY7bouTnAxwmfv6ovnzcDwwP
-        5KyTwF0RroUV5pl9tzzScQtna5EFmtUX9s3wwM4vG+rH6z8ZuTwXVe2oQVfLOgd81XuHccUVXrPu
-        8X0t6C8gd11U1bM25hqxWd/yAj1yslAtPyH3jiXSTniCj6CVBElcdF4U7uM+NFzpKECa+8J8xLhX
-        pz+4+sXBD279wJnPLizfVeBP60H1m3rQ4pejz9SgZSYuKmWXC1OLzB/VAwPrgeBGG5IR/LjqJXB8
-        WldYfXTp8ntHEuTN2bE0gdqGncBpdezqeuEMesx65msNdzyv1a10wyJlQHZX+zM4ibgjorvLy8pU
-        xBjYA/K4EviWK87BoBf6nQNVRbC31ZFPiHR6YYXVWknqzpBZ8+sBraSt6nRUmdjdY2SMkW+SrWXV
-        WlackElCOT5W63NjHC21LdvahinJHOr2/mSTFymKhr2Za9GntZeiDnWh90bFmljBfDZrnU+S9qkG
-        UD+gAdXv0oBq7bs0gP5eDXhd/28NuDnlQw2gv6UB+byfrwEV6lsa0On1R/wnGtCxoWv+lH6AwPlP
-        X0aWEpHxLLB8GJ18fXsgpX5vYqShyjiLwUatT5c8yfI7+ez3TgvF8KwwSipHZmyLR6Jy2Eq059XI
-        9dZwiPGMWPBnn2QHK2iO1uvQhSidqAPadFDvzDvJPnFMqND9reKPdzSsLaFirlRd8SRNxK1JV6tD
-        dtZgWOCOV4xz2k6puKdNlhtpJc/4z+t55UfqOfU9uUyxf209f13/71y+OeX763k+7y+o59/M5Ulr
-        +llvD3wYRCUDIngB/k9JaQan9KA10qxqdzsXkmkvmh6lgecF1m52WNVsMF3FlC0la+UwXfA8Mzx1
-        VcluTDpMqm0FCkoVRVkyRLfrrtWLkConUdb89NjvEoeZ6W53EbmlF6tLj6p1dJGprZZabTgb2wro
-        6pfAnpi8s+nxyooO+U66p4Ymsz+sxlCPLtte0IZKGqTRQRLbFzizV4cVMyKkk9BBIKYI4vP0rv5I
-        qf6u9K78xen9uv7f6X1zyp9o17+d3rfHOP/d956SdgCznx9uv/6+szzE28t/tv8frBbKO60fAAA=
+        H4sIAAAAAAAAA7VY2XLjuBV9z1ew+mHmIaG5aO9wOKW9ZVleJFmS/cLiAkm0SEICQC3+nfxJviyX
+        BChSsqbSmSSuLps491wA9+IuQBu/H8NA2iNCfRz99k27U79JKHKx50er3769Tnty/dvv5l8MlyCb
+        IQsTDxGLIBoHzDRo7Hg4tP3IiinAPrUc2zMjbCi3JYYbEwKzn/IvC5ZC5srZGsollDOWtsswMTVV
+        LXAEmLOiOHQQMet6tcASYM7aBraLqKkXOAIqcDBlFj2FDg6UIkyQQM1//qOon+M5CnrktGXYcgLs
+        bkzXkuWq7NCP+dNHMF4RJNOOcz9uPLXcZX09rB53k8dlnz1OnlvPTlUL1FPTd7a96Wr8Uhp674PP
+        jk9XnztGG97sx2uLWCffDwYrHZfr82iP3iZPM2cR9OkMP+/mnfmh5jgvGpr9mPW2sku0T//9hOy5
+        u5r1ds1P0pHfYKfF/Rn8XBneoMis6rL8flRlbRAd2/t5a9hYdtnboq82WAc1SbsfPcz6h9Wu8mPR
+        H9XR8TCddOo7/aU/6O3wptq+Xyx71n21/PBWZq1HN3Le41pVnSH/1B2w8eDw2Qg6u8FLadHc6c1h
+        975B1eWL3w3aeDhh6nTf7ez9Zs/W/U515I7eV/KijJv3R28dbYa91uKw9BalaIlaFW0zGNn68Zmw
+        oFtvfp68NVKX/rv9uWmMYxmTUml3Qp3RyDno88/jev/08sZG+DirnWrTYzir3J9au1Kz9XL/OGnY
+        4Xo/bTmd9kelNNdPVth2lg3NPtgf8vuQ6m5ra+nHwJ8ebH+kq4/DnX2oTiqzUT0s43c3Umn51WrY
+        nWnY1/36y3bufiw+P96qbzPWWw/cx2CNdtFC7i+I68z1Pn43lKLLuf9Nw0N0azN3bcGHa7ZxECCX
+        SUuCQ4mtEaRpFCNDuWTlSiFia+wVgDSR2k+tp4IOT67CkDJTu6tcMAD6L7eS5L/NbPPxdQrrF3iZ
+        IKey0xaZLp+/QEzhwvhsnE9dHEewQxeHjh8hzyw17pLSkA3PFG5rs/P6MIWJLsCck2686UE9kyiz
+        I88mXoHMzYqwhZcWhQpITc1QikMhY767QUVpBhgJbUt8F5mlSrLNfAzlk7hrm6yQWU4l52G+AdNA
+        4Gn4Y0P95Vvvzg0lH3FBus0uVPHTYY0IEgS+eddnoqQGOPJwJMcbcNYZ5PKU+pDKhVAoBzal4g/n
+        24RRoOSAEHI/glD6xQ63f5fa4NE42UpBbEAfSJsCn/aEYKZLKHEXeMHaoFO6kpI6LEOShiN4mdoZ
+        uZgs513P59mRi25Pys3JCBdgzkntaNkQrUwY2rlS4JYq+RaUzInJgRLh9vQQisBZnOq/Rj5DnjSE
+        Lgx9NKeKUyE+xBe04b2PDtYWETeJEd4gb4oML2nexI5WyEKRJ8bpZNN1/DdJo0yaoC1DSbuUdFWD
+        JppTODtmLgT2kiJmlqrJUtdoTqPIhVCCbCjX9FqlfMnOhJx+gp8w9DwzWVRtqJpgnnE4aVyvqpqV
+        wpCgkFohSumy2pBVbao1vpfU76r6V1X7nqx0W0HMe+0DPobMJ+yLVypsLY3s0//SH1W9XCupP+2P
+        ilr5j/xRgX9/xh/C/rTW8HBMCve42R52x4ZSgAUldcPIZtAJDlILxyRCv1LpEcwhNtQ9Ik27k2mm
+        yH3Gv33PrA56mQRGAg8g0LEJ09ksqRlFUDCgC6xNBZTlkK8rO+m6MpWj87oyQ5QpmX6qItTBQhZT
+        M/D35+kFlBF4Y1Kycdp/qB9uAySKeabHOxP/jrcUBQHslLILE7tfTYSv0Q+1iCs35lghbPEGGdjM
+        ZzH4vALtWW9UNa1UM5QzakA1X/FPWb3TVDjhShXutTlsKPlka5ta0JigHixpekG/AJJqmvQlaJ5Z
+        GRVDI7SPFomjCI6Cx42mgw1fUCOEqnuDd40aEUIeRMQW4g26QxqT6X5u4YIcE7AZRwVahnBCYgMm
+        YVKG+fa/oEZypefNs62NpfL00VDOUNYioOWyhG1tQlMVnfoaN+gap1V1yc1Jl7vCDApxCfR0cnSE
+        eIGYTKYrwBmH9+0jQySyA2kKRKmVBHLkSbkGz5/0HXWr4t8SGOn1jK81aXYeuuPJvPvwMDGUgkCQ
+        0uknthcgAjk8h1CkGU20MnEF+dOpD60szJ5iST0qDI2LY8pL7Bx50JW0/0cBbjS08s8XYO1rQ/qj
+        Spak1BbjQNwM09i4wpJEC/ww6e1pOBeG/6auaz/d59JI5LuTm+ozRLoAhIRae5/6TiCi9xrkrLwa
+        8sCGkidunzOhkkPG17y/zPnkNz+42l1JlZ5HhpJDXLpehyHckbQGb45FjK+Xp3Jyd7acxF5+vQf5
+        FVTkJGsoF0huWnImkDm7GNFzN4jwGUIev61fUwzeDgoeaA/G7Ydusu0rwQWVX+y2YI3k+sQN0KWC
+        8AZmdmBdPW2uQEG6epV8BS94hRfKLVhwr18r12hGu3y5XIM/XVnEs1e59b9L/wL2/DbImhIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2906']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:13 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1879']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:00 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <create_order><crypto_block>E7--NuwIhns8SF9pSFmOCtayGoPi5orsAykdVtQtCufnKnVXd5ijHtnqR7hewEY9Siu9mKWZXgSi50wUnsm6QPTTn5Ap3rEh2y8qt7LQOigLgEgeiLH4ylijiJOz3cCcGHfmz-mr55XI7fNrF6K5mYhYQ3qn1nCceIO3_pGh-y2ODATK_1unwgfaRcvmf9rRBGVuoIht5KuL4JvyIf1HGwjOVpnEZgHPJm7kxU7hRzZCGSznxEZHloNsR7I2pTbq40t7v2mLo1javANm8iUGKktt-5o16BpnLLteyP0yqrtW48EZlb91SwCaca-PJX0S8BvzKCatNcVD_hETlolGxPekOoYcRxyhOS0oqh4PNL4fG5MfxXXjHxpdCbQvBrDibivFS6vhbjmFeBcQYWikaldIWXGQFooHSH2dWMs_BXrsAz6-j8VMn40F2LZish9H3g6jBjVkrnayZ4NMPTq5FtXcdK_5L7WFk2ASLauJCqJowO_bV8X2sPX_At8097h3QpXw1Kh0OkgxfUXvzDHbFI_bN0XSMiJ0al9y_p-VXab83-6hG9eHDURd6DtENaA6ZdPR1b2kCR_toknr_BpFKcDNzxpBDj9-GWfRRbpiCUM9rPYDDkijx5sFQiucuV4RNL_xRMwwjtm79e8Q_Ffs_Rbj0MXC_rEfuYOIlmhROtFCXJpXG4CNo46bV1NKHU8emAOPjTy5eN5yHKnfgvMsrKq0Ix6-yFmDNxXSz4pazVchj_p8eOwdiIe_aY0Ybh9RJBrav76RZUsxDdWqMKRqoWJyL_--Z</crypto_block><user_id>whitelabel-testuser</user_id><discount_token>k0--5q_Eg4_-x1Nz1FPUkY_jXomw7H7E1_PjxiUKNYUK3emm0ERjusgvnWUYFQqZHjDGEekx61hC9iIriru1LpexlQdiFWf9oohhZR3m54tmVkLEMIItGP0eGhqQULniBgRbrSIgFusujEyS0Rw91TvO3pqX8rgNeFy0FDAL-H3GFetfBUfLnD1Zi-94KcFBeU0CKwDSXAHtxFWU5WZiFJ-wMeIriNlK_uoAMR58EAI8VqC-Z</discount_token><despatch_token>c_--0Kf_TZq0pKcKGruhxmkQ7BlPYXEuvxHc010UHCGkN5naMixtayM7ERDln1BZqDPn6lNDbacZztST_XI6Zz4V7fj-97VfJmxmjY2l_mdOGCnDKsCnAPiHZiNNmtNBLLcHusclczeh6y_-Y</despatch_token></create_order>'
+    body: !!binary |
+      PHRyb2xsZXlfYWRkX29yZGVyPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRnUlEzS2RaSXpEaXNnenF0czlkVkhVQnJf
+      eWlpbElnMm80OFdudmVZU09WYlhsR3NWb1BxV0RXdzdiYlExZVZIVkZwLWNyMXppWnllYVdjZ1ZG
+      cUF6ckQtWTwvY3J5cHRvX2Jsb2NrPjxvcmRlcl90b2tlbj42Mi0tWngwLTFJbnhDdldCSzlmRXRZ
+      WEcwOXREZUFyQ0duTFZHd2dxNUhYR004ZXh3VFNEOHEyUUdJRnFvazZDSlhmRl9KNjRMWTR0Qk5j
+      bmJadTc2MFZlaXlFSXRSSXd6OWxEcUlRM1hBcTJBS0VKOXMwZlFpRWxDb0tTdDBUdkVEdmlBRmEy
+      aUQ2TWNNWmctWDRvQUp4ZGhua0tGQlh3ZmRYM25mZUI1MWtJTWEyeFBydGxFOEF6eWRoZTBmaVph
+      ems5UnUtb3IzM3F5ZURNTWJ3Mld6eGh2T1FZdE1veFY3eTdUeG1WNUp5QnEzQUJRSk5TOWFtaHZU
+      QmJEQ2o1M1cyeV9tQ2JmOTFhd2FqLVpLczJjQnBfMnhsaVR3YWlNMjBOS3FhdzZTNVZNOG00b1pj
+      bjBzNFVfOWFEVG1HMmk4UXBXY2pYempZNllWdEZoSWNObGhlcW5YLUdYcmNiVzJHb1o8L29yZGVy
+      X3Rva2VuPjxkZXNjcmliZV90cm9sbGV5IC8+PHVzZXJfaWQ+ZGVtbzwvdXNlcl9pZD48cHV6emxl
+      ZD55ZXM8L3B1enpsZWQ+PC90cm9sbGV5X2FkZF9vcmRlcj4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1384']
+      Content-Length: ['662']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61Y23arNhB971e456UPLQGM7eCzKF2O7cSJr8eX2M4LC4NsEwMiSPj2O/2TflkH
-        JAw47urpJQ8J2rMljUaaPVK0346eW9qjkDjY//WLfCd9KSHfwrbjb379Mps+CuqX3/QfNCtEJkUG
-        Dm0UGiEikUt1jUQrG3um4xsRAdghxsq09RMimnjbpFlRGMLwp+zLgLmQvlkFmliEMsbatCgOdVmS
-        chwOZiw/8lYo1NVyLcfiYMYKXNNCRC/nOBzKcTChBjl5K+yKeThEHNX/+D3fP8MzFPqFp4BiY+Vi
-        a6fPDEHY74J1fdesB7PqcCVsQry2Zfp0sAaj5buCLPKutJZy7f3bbigt535r7027WzJrrduLozVr
-        dk4fS7e36ODFYycc7pzm49ZS3pUK8YYtuTYvnxfl1+FUmPq78NR4f1EHctUZHdQP1HHnZ9I9P66X
-        4F3eJ41tJsU75OvtsiBUUadq7KMoaLxvvlmbRefQD6aovqh/bCZueSm5i6Bq4f1hJhNSeZ4vHxrC
-        eKYaG2XUi9Tn7nmDwrOhdFxJUfCz8NpvW+et1Gjuh/35Uq2co6qC5s11Y9NYlPeV+5O6eXMx7TkV
-        ggeDtUqXiO4WH294JAzkrdudvewOb/ZqLjUnR1SbnTyzbb9PFuH5MJSGRms4HlvzoHZ8RuOHD2Oz
-        O1bmUX359jIiw261idqCGTwaPeXQDOyPLpooo5qhfHtr7MevU3v89BBNzhNh0XkJXmsR7ftC1OvK
-        C9MJBpFKW8+NoTto9NWn1pM1Wi7HMJJihB0Htu5bf9h7c04P/frD1vJPvaemOnVmw6k5PE4n87ra
-        wXar1Yx6HyevLffnlve6mGxrxxfyGvlWxaOjxWhwdO+FN03Mh5/tha7ZiAQmtbYGfFh6E7susmhp
-        HWKvRLcI8tSPkCYWWVknD9EttnNAkkjN4cMw14clV65JqC7fVQsMgP6jK3H+m9TUB7MpzJ/jpYaM
-        Sk8B0i02fo6YwLn2ZXEOsXDkg4cW9laOj2y9XL+LpSFtXihsrZPprNUeTGGoApyxEtcnNLKRT0sh
-        yFyOypblYwOvDQISSHRZE/NNbqOOtUN5awpoMS0IHQvp5VrsZtYG/QytrRlukK4klkszc0DXEEQa
-        /pggwMzx9lwTsxYzJG62QcZPhy0KEScw51fOJgqMvelGiGloHtAsh3LBdbFvY8iEHYTyAjJ7MlAv
-        sXMjG9pyTUL4H8aHo2HS2IEcxu1Jl2nRzoaB6pCUCjZcUj+KUBxEiI2xQ6d0BjGJZArGpYhT054X
-        pDBexrsx5M6xye1h2UK4vYBllGQtj6bnuKccia1QzOYV06DF2xvyMCdBzwMXc9J/5jsU2aUuFGWo
-        qhmV70LowGmDqrx30MEIUGjFJ4aVy5smzY5reWj6G2Qg3+Ztvj/RLyVZpdtSI9pEhJbKkgwFNSMw
-        bkQtOORrgqiu1OKJrtGMRpAFBwcyo3IvVytVqcBOjYx+gh/PsyGhYVJJlVXOvOCwuVitSbKRwKZv
-        Q5p5KKELkirI6lSuf1Wkr5L0syR/jWe63YGPex0B1ibUDOmnmJRlCEYDEtf9P0NSk8s1pfLdIamU
-        5X8UkopQlv9NSHgIEulh5zHW8XGj2W2PNTEHc0oShr5JIZEOpQcchT76iZQGsJzQBBkMf0w7sXix
-        b8fWa8+PqQVaHHfhlONMSPIgZ4B7NCK66+wvdg6lBFZkxLSd1BLieIGLuDCn/ViVYd9RQJDrwlSE
-        Fnxsf/bxr3yP8e4sj4s3xt4gbLAi6JrUiQuPXk1K8KWpgRhv2Kcg3cmx6QJoYtZ/axID6g0k9pro
-        PtbEAhBrYVxukH0RQd7UPPNohJHvQ1jZ/stlOBqfUM0DzbzBu0Y1HyEbdjeAcxPBfTg+S4k/t3BO
-        jqDUwqMjR0sRRojXgEPP9KFUJu5/QrX4ps5qYlMelyrTgSZeoFTgoZLSmG3sPF3iBfga18gWJ/K4
-        ZsthT5giphE410BPBkdHODqI0Hi4HJxymGyAvTQ5EYq80hsK8YXKkiC5QPEbSqPVa48n83avN9HE
-        nIGT2AXFtF0UQlrN4SCRlMbLC78k/KtshNLipQ+lWB5yTa0Q7Uzx5sgGRbyPq8T/r4j3IPz/QBHv
-        PyniX6VonBsBxi6/uSWbfIXFGeM6Xlxtk3OZa/6d0N5/r9AmR4p5JzTqDTiyHOAWYuwd4qxcfgyv
-        QcbKFI6dUJAxfjt85V0ySPucwMXkjX+zjbu/U6TSqK+JGcSs263nwa1FritJAc9jbL4sJ+O7Lbz2
-        Yb3J7PECr6A8J55DLCDZ0uI9gbvLR4TIReF9fIGQzW7T1xSNSXwuAs3ncbPXjt2+MhSo7KoVwGpK
-        lhNaLip24NHA1HSNq6fHFchJV6+Gz2CBl3tB3II59/o1cY2mtOLL4hr8bl3hz1Lx1r9//gSe8Zbz
-        OxIAAA==
+        H4sIAAAAAAAAA7VY2XLqSBJ9n68g7sPMw4wsiZ07anWwGS+A2TG8KLQUIKONqhK2+J35k/6yTqkk
+        tMCNud0z7XDY0smTVZVZWZlZkn79sq3SGWFius4v38QH4VsJObprmM7+l2/LxSPX/Par/DeJYtey
+        UKCohqG42EBYwYj4FpUl4muGa6umo/gEYJMommrIjivx9yWSjgOPuopmufpR1hWOq3Ma+Vi/fViz
+        PUYc6Wkvs9ZbR981D6/1r9N8vBvQ8XzSmWh10RKCtql5j4v9bFp5NbbPl55J9pcTJS1j9bTsYCUw
+        Tet5X3arzbVzRpv520p7twZk5U5O6976s6FpUxGtnlaPHqdj8WJuA6Su9f3q8dS+4B63kfjc+qTQ
+        YM8lxNQsJAeISHwOuTqGukfkyPUKx1HltKPN4eZY/uQmY/OptqzOp4Y4OiCn2zMGtQDhz4G2Pguz
+        zVzbUkvd4O6upzoz1fQUNDY/4LF9IC+HdqX2YdSmi+eX2X4wtt6f943eevh+mXK1Chl0q4/meXS8
+        LH3zNH45dgJ62jp1vTzcfwUcev7s69MWVha2s3ndHmtvDj4/NbYNQ7QWRlM1zFdaGc0NI/CHh8eX
+        Dlcr94YeFygf/ZZm+ZfutPxWNTRjUz4tuu7r61PD7ArKhbaXA6WL/W6lhbTatvuiiFPRPVU3uvf+
+        Wf0Uh8qL3l8ZDc/ptBtH/VQdjQZ+q+NazY0uBo35YmXsyeSwmfc6fvujgrwGOl0Cd3z0a0652dOV
+        dr1RW5y1lepsyNtw2xla50V3Ig5O5TWtNN87Z63zPL+sZ+vlBW/JadhZdD/Gu7H4rin13mZbFyvT
+        WXnT2I1OC7wZzDa7yevmYz3ZzNr9CapNB8EXXZKn3mbzrgTTL6XpcX2s2YueJ3DcVuLzm3ndWxbw
+        uus7VBZTVhYO4wQZikmRrTi+rSEcMm/BZExZ0nzHCAOI/S/OcQdNmMT1sY4ANJCMvqhCEaHCVSMr
+        LWgYiOhy/4si7KhWaQFqpY6qg6VG6UY/4ib61KWqBUPamukgQ660HlJ+QVZUIVSuCg+1GzqhBSpM
+        6KlUP8jiDfsqymsQpFIPmzqSK7WbBaXCghJYd1DxHsnVW52rTNJ9jCENBukT8+he8yBB5KCUsVN1
+        6sK+C0KGE4MpKw6EZrmeYSXRcQU8S9URkcsZTgxlOOBFhQS25lp8FsYoRuXf/pPVT/EUlaUoxGQp
+        cTLb+W4YpDot7bBrl+gBQYVwfCTxeVaqZCN6cI0MELmm+9Z5y+gwd2VeIQii3c5D/+NSwqqjUlUe
+        Lxcwf4aXCFIqDTwk62z8DDGCM+9X40wSn8TCUUijP6EwW9u95XABA+XAlBMtvG1AFS0RqjqGio0M
+        mZnluIq7i6KZhGkh+xrLqAlHOCtNAKl4QDJnonAMMpHPp1Yi8HSY2TBS2dL7a0hp1zcmYEkFGojg
+        84Awigls8bpJ40NiuY7hOpx/BGddQSaPqMNIHgtjZUslJP7H+CqmUH4zQCxkfgRh6e+q7f271AWP
+        +uFSMmIJuo+oFWHDRoU8D4XuAi8oR0jO4Ux85LAECducmJeoXZHcYCmvOJ6hOjq6PygzJyHkwJQT
+        2dFRIVppbGivoMAs5dMl8IkTww3FsdujTcgCV3Gkv3SgXhmlV2gAoXtLqfGuYBPiC5q/s4k+FQ9B
+        rQgLVpTy7ookOHNIwaqzRwpUmvg9Gmxx8P9VEqEKzZEHJRISYKksiJAWUwpj+1SHwN4RROVKPZyq
+        iKY0gnQIJTgN1Ua5Uavm2YmQ0QP4sW3DkMNJhZYgxswrDjvtNuuCqEQwHFA4WjaK6JzQ4gRxIba+
+        V4TvgvBPQfweznRfIR636AP2Dicf0xuv1OihNFKD/6c/6uVqoyL8tD9qQu0P+aMGv3/GH7H9Ua5h
+        4Rgm7lm7+9qfSXwGjimRG0YqhUrwWepAs+Kgf5DSGMzBYS+DS4v+fJEoMp+xZ9OQ68+PiQTeYtyC
+        QHdlGE6lYc7IgjEDqsBB5kGZs9m8nBbNyxHOuc7LhW0Yn+hHKrE6WEh9Ilvm+Tp8DCUEVpj45D2q
+        P8S0vbAziZJ5oscqE3v2PYIsC1ZKaM7E/q2J8DR6ErI4f2eMPXIVViAtlZrUB5/XoDyXW3VRrDQk
+        /opKkM337JETHkQBdrhWh04lhSU+HeygEgUKE+SDHYmuhTkgzKZhXYLimaTR+FWy1S8F+44DW8Hi
+        RiyDDTeoZEPWvcMropKDoBc3kAfxBtUhisloPffwmOxjsNl1MrQEYYTQBhfbYRpmy79BpbBJY8Wz
+        K85K1cVY4q9QUiKg5NKQrRxtWYgrdRGXyMGNsuqOmRNNV8CkH1wNcneCn7oM5G4B0e39Xsa/J5Ci
+        9ozNNW/3hv3ZfN0fDucSnxHEpGj4uQodOIYzvIZQJAktLmVxC/Knj37hPpa7ieW2KU2xa2RAVRL/
+        igTcaonVn0/A4m1B+lEmC4+U57pW3BlGsVHAwoNmmXZY26Nwzrz+l7wu/nSdiyKRrY5rCxOI9BiI
+        JUQ5m5kPKUWQsdJsyAIbUl7cfa5ilRSSbs99/syHf9nGNR4qQmkygtv7FWLSw8G2oUcSW6w4ZjE2
+        X3qUw95Z0UJ7WXsP8gKU5YRz8DkkNS3cEzg5Jx+RazVw3CuEDNatFykSKwcZD3SfZ91hP1x2QZCj
+        ssbOA2tKuol1C+UVYm/cu+UXr/fsvXAruQVzvMwN5R4s3b/O39zj717gb27uP5tZ4mvvX5Mx+eTj
+        TvKpKP7OcPMJKYf/oe9N/PVDEv/Db7O/A9pPXdzdFQAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1828']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:13 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2085']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:01 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <trolley_add_order><describe_trolley /><user_id>whitelabel-testuser</user_id><order_token>E2--5eH5_vuupAjgQcgXHwMpTe9X9qgSl2Y0lXp5covwU1ss4IWYBA-RU8_g3PLu8IKzgerz_3Hl033oI-VMEczh0ACvOMWY84zu53eWCfAgAX2v47y8gZlotLi4soNNf8tYetkXqZoP-N1hlKUJkwZdbW0CSxe6UymaEdjSXrzwO0O_DORRcWp6xIeRBq_gkx4Wu9YZJPsOK5CeE-apF_L3wCpdqKeS3P6_3QZAvRVTdRGBuSzS-XHJpV6utMn-uLK1XaipNu8tDIAOlNAM8GDGcPYYRpF_3_rHi9pUQMOLZiyBM9BhcnyLGC8TiUOTaOxTSW98HodDDCuLqymE1MWcmVXSh6xJsVunc4mtPXPNxl7-Z</order_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsUDfEXxcUCHyqYlLXHoXFHrOkiCFhc3j34smOD16W2zX2VOT-TnkryAjJ8N15iPw8qeHlWzsKzFfY</crypto_block></trolley_add_order>'
+    body: !!binary |
+      PHN0YXJ0X3Nlc3Npb24+PHVzZXJfaWQ+ZGVtbzwvdXNlcl9pZD48dXNlcl9wYXNzd2Q+ZGVtb3Bh
+      c3M8L3VzZXJfcGFzc3dkPjwvc3RhcnRfc2Vzc2lvbj4=
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['694']
+      Content-Length: ['89']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA61YyZbiOBbd91fQualFN4HNTB6X6zBGkBAQASYYNj7GEth4DEsGzO/Un/SXtWzJ
-        I2R1ZnXmIgPdd5+GpzdZwh9XyyydoYd0x/79C//EfSlBW3WAbh9//7KSRuX2lz/EfwjYc0wTBrIC
-        gOx4AHqyB5FvYlFA/h44lqLbso8IrCN5rwAxgEioPBYJqhe42JH3pqMa4koul8+Ge+gY/Y67asz3
-        5aPnHACPny/q7G17qkEVnWqDLd88vRtzbru2B2dLmmhoNTgMN1d11X8JPrfmdPPibEYv3tzQ+yNN
-        rZ1qdWTNB3xzXb1tqh9zqSzZhhd0T9/aM76hv13an/DFXN/Q5DY6bIVKbk9CeErXQUjfm5AeJYck
-        1sCOAW2xWS+XdamGlY+2U61hua87DXgz24u1PaqCi2J9PtvX7jV4GV1ul+m5DgdtUJ4fpE7Dfx13
-        WvBtMzPQ+HX8MeeWo8PGOrsjvfF5Ac83/Tg4OtaQO43gDh28+lXvfszWvqoFL9bQ3pd372tzLUNi
-        JSmozdu93v6wQB/c+MOWDbDRpt3XRb87O/Dqdbp7vaKPPexIvU/34jacz8ZAA9Kwf3h2LP0KBsRQ
-        Jv/+8aENXv25Xquqp9bu1IDBYHDqtnby+HZsD/zF1Lm0x3Z9vXr+9N6Pi5GM3qA0WS6MUc/aYvXZ
-        qLfxoXY4ti4zs76a11cvcEXOic6b3vR96kp+Q7+1LEM78/K6Pmmure6u6jRWBuirE9ezTe+0rIE3
-        tf920s6X3nZX7WxXxjoYDYddaXRDw/Gnuw9UHQwnx8GmCYatjS55U74qvbQG0sUdztZcT/12la5b
-        ubpuapfn+rLz3us/j8G3YATWPe/sHSdL3ZSnr+f9rnXrgWALlU79E8tb6CxtY+bOvr2OVz17NBnM
-        p4FR3uh827QMeJPVzRyM7IVuBDO3vz+eaiCAg0bQHu93XvtdW3S0/UwbvzfLO6GSd5DEX2jkqI5v
-        Y5FPWVk49D0IZB1DS7Z9aw+9kHkPxnOKwt63QeiU9G9xjQdozESO76mQgACK8IplDBHmEo2stKAB
-        IFJFibBLywCRPZV20HOKihEpVsQOVkwyl7XXbQjEaucpXaggK6ogLNa4p8YdHeEClSzoKljVRP6O
-        nYjyGggq2PV0FYrV5t2GUmFBiZxOU7wjFGv3OolMUH3PI4k0SH9RUx73Lsk2OShlHBQVO+TCOS7D
-        YWDKYh7QrjYzrNgtEsA1FRUisZrhMCjDIVaUUWDtHbOShT3IUPE/f2b1UzxFRQHAvU52KKuao0fz
-        MyCVUIfRYGngW1ZQ6iseKA2oTKjkSImKbmN49BRMypIMFKxUUpGtWFAE4UypcoQlDBy4d4wIS4bp
-        r3TbUYyEk1BnoRvqh1Gm4tLBc6wSJkc4Q9uHoXaWlSpZEGsOyADRFffnvXlGh157ZkicOfLaPPR/
-        biUsv8Ry4mwlkfUzvFiQUiPjqHT+DDGxWfFwOmKppBDSaRTHFHrWpbQaDGcSmSoHp6xo60vsA2jj
-        Erl2mKHSY9mO7ByiqERhXssOmQzrqgGz0hgQioGeie1COGciuJKeEhJLh6nZgwrd+HBNcnIyooJo
-        m0PSSgUXDXqQEVga1I++K58V04c0urOAoOqYpQLTsYFjl32DmDIBqTyaaBrJmZBOrZoKQuwP5RPX
-        UHC4gQzG5HEgZuV0GtKcRZ0anS7qefJQaERiG9kgNYetUIksGYNhJ8iosWaC5OZLeQ+mNHSAHk9L
-        D8LkOSylRGcZKZZuBhkSPWElXbcSGy28Xo+ZOTJ6FkjEkf7KJuUXlCakMSZNbUplt+DpxNtIU3zW
-        4UV2IamAYf2NEvlDkUAiEMqeYh+hDG3Axux+/H+X+DbWSl3/6JMqW+V4kupTAuX6WCVOfkCQFMhm
-        uFARTWkIqsRxSGTUW3yj3uBy7FhI6QH5Z1mABDRZlGvzbcZMcHK5TrvJ8XIEKzYgYUZyb0gvc+0y
-        35b4ztca95Xj/sXxX8OVHiuweYsWoGOEFQ/f2aTKE2N0SeCav9IkTb7arNV/2CT1Kv9TJqmXq/zf
-        MQkzQZR6qD+GeXzR7U+GC6GSgRklMsOrgkkgXUo90oPZ8DdUmpHjeApJg94/YyVqL/pbB2JzPIol
-        ZMRwk3i5kyaSLMgYZHvYR6KpnxM5g2ICLTKVeBzVEqRbbtgtRYk51qNVhv72XQRNkyyFcG6Pw/s9
-        fm/vIT5ZZfHKg7mP0JFpETRJkxEWHrERleBkKJBkfKQ/y9wTH4oSQKik+pqCZFJvSGAfkGiTPjgH
-        hLkwLDcQJEmQDQVLucqeb9vErPT++SpxjTtUsEjOfMArooINyTcCgC7xG590aqEvRft5hDOyTzus
-        DC1GKCE8g+NZiq2y7+A7VAh7SFoT+/yiVJdmQiWB4gRPKikO2bJhiRwrwEVcQJoTpccDPQ59Qchj
-        wnc+WXLfKn/9kZL7OokaKNahdAfT4WK5Hk6nS6GSETASbVAU0ut7JKzWxJFQTGPlhTUJfysaC597
-        uQ+9nLXTjLeGgGTEVlglfn1GbJHE/xMZsXWXEb8XomFsuI5jss4tuuQCFkaMqVthtY38MjP8X4m2
-        9aOJNnIpurtyt9MlLssAJkHyWc+8/hRBykozHPVQksZYd/jBVFJIuA/gfPCG/9OLaz3VuNLbq1BJ
-        ISrVNMsiXQvfqUUFPIvR9dKYDHtbeR+eN1o9PGABynLCNSo5JD1aeCekd/n0IUoyvO0kEAS0my5S
-        BJriMxbojxf96TDcdkGQo9JWyyWnKam6p5owr8Cs8eg1ofiMQMeFr4Z7MMfLfEE8goXHzwZ37wUP
-        HwruXgh+NK+wz9JfnPoq8bNR/AjFHjLuHqdy+E+9ZFWSJ6rKd5+P/wu8uhIsgBYAAA==
+        H4sIAAAAAAAAA21SXW/aMBR9369AvHuhTGIgua7GECtjgg4atvFi+eMmNSR2ajsM+utnB7ouGi+J
+        r8+x7rnnXHx3LIvOAaxTRt92b973uh3Qwkil89tu+jhFw+4deYedZ9ZTBy7yqAVXF55gV3NpSqY0
+        rR1YqhzlTBJtcHIdwcKeKm8oL4zYk5QiNEDc7X4sd8Uqt4DchH9djZZjkQ2f5oPj83qRffGL9cP4
+        gQ9uit7pk+LV9DFfff8wl9vZy0S5/OXZu5Hc3Kdju/im5HC72Y6edp/zTTWq7bL/Uez1nOdgit1h
+        uq5m5vBzdhjzdTbo6W3//vcvnLQ0YVtrHWZvZBPMmdiDljS3pq6IhNJQpT1YzQoqgSt/RnDSJmJh
+        Aktf0IRgCRkLjlFhau3tKfwlkHqPk6sAjnb1eWPk5YgthJaalUAmQYV23jIfouikQSdO3tCYlIcy
+        NpfghFVhNpvE61MBJFNHkMgz7kJEzU3MkJ6PzVcilmXoIqvJkf5L/FsGj8IWOINy0GCVuFDb9Ghi
+        6H1eAdn4h5PXKqhuef2fN21PXqs4FUm18iA78/A6rNkbtQHjaFe29Q9od30C6wIAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2158']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:13 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['448']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:01 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PHRyb2xsZXlfZGVzY3JpYmU+PGNyeXB0b19ibG9jaz5VXy0tNi1ic2pXT2psUmdyZS1zRGJKUjlP
+      QmNmOGhLNnhxU05mR3ROU1BCUGI2MWwweUFpYnBGVGdSUTNLZFpJekRpc2d6cXRzOWRWSFVCck5M
+      aWQ4WlZaOWhqQ2dWcDl1ck8yN2NrbktiZ2VvbGp2RlNwSW92WEl2QmJTZjYwbloySHdZPC9jcnlw
+      dG9fYmxvY2s+PHRyb2xsZXlfdG9rZW4+NjMtLXRfcWZ0OExZazJ3LVBOaUg1VTRTUWQxTWhlbkNE
+      ZEc1eWVyd0diV3YwUllTYlp0bGFZckNmRGFuUmFpcF9lTmlqYW5SQWhzSmhBMzVqZDVRVElKUmdH
+      TmxYSWc3RFdMWHpRLTUzc0dDNEZpdk1relV1aXFOSmtCeXRxWm42YzJMZ3h5LWVJd0VjUTlyX1Rt
+      bllLWms1T25ydkg3WjdkMWxUZDhhZGlLdDNNU2RkeXVMaEZKQi01MkRMcC15X2pFOWJsdXpDUTJP
+      NGRiZFkycVRDb0tLSDdpQzBfenRBVUdfQ3J1QzM5ZWI1WkNKXzFRMW9xNFljcFh3NHcxTF9KY0VW
+      ZDdwbkJBN2tjcTRNTUd1OUJvbDhZYzF5N1NUVmRnc1BoWVNEQnVBajNlcDdlcXp5b05rdTVuMjhE
+      Y19BNjc1VHZiVmFuWXNPTFpCTGx2VENQMUdxMld0MzhYQnZiQklTeldSV1V6clpzcUxCVENqTmZO
+      MVhiXzZEWVo2MTNRUjJZN2ZNcVRyWUdSWWZQS1lqV1BZUkFFUGU1UUd5eHRVc0hEWVlYX3lReF84
+      cC1FcmJtVERwMC0tWjwvdHJvbGxleV90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxwdXp6
+      bGVkPnllczwvcHV6emxlZD48L3Ryb2xsZXlfZGVzY3JpYmU+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['720']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA7VY227cNhB971cIfmgf2rWkvTnrMgzs9QYNYieBva4fBa5EewXrVpKyvd/TP+mX
+        dXiRSF2CumkTGFnxzBmSM5oLKfTuJc+8J8p4WhZvj8Lj4MijRVwmafHw9uh2+37y5ugd/gEJVmYZ
+        PUQJ5TFLdzRilNeZwIjXu6TMSVpENacsSnm0IwkuSuSPS5qZMNrVRZLR5jcqWQKsuKwLgUPkj6AN
+        k5c1iymACcX0RUSCchG0Gq60pyE3jzcvgrKCZN4W1LxzEj/SIvEG+orb6ItSkAymzHdpQRM8Wx1b
+        fk/WV+ECz4PjxYDORY8KC1ZExHscDtitqKvBKREVS2OKZ4vBhqywpwTW7Ql7oHg+1GllKK4Zgzg4
+        2Cft0YddhfwuZBn3JBYlw2EQOBwDWlZR5zvK8Jvp0mEZ0LKqjMSU46nDMZDDAS9G/JDvysx3YUYN
+        iv/609W3uEUxUiGGUeNk/ebXMkhj4d2zMvfEnkKKFDVFfpdllXIq9mXiAMo168/nnx0d7S5nCEGg
+        3nYX+o9bkXlHBMGfbrewvsNrBJYqDhXFsZ7fISrYGbfGpdxkYi8VbPQ3FG3r2cXt5RYm6oCWozZ+
+        lkAd8bggRUJY4pC1WUUZlfcqmrksC+7QyEQKKexKGwD1E8TJiV4aOJHvWyspeBp+CKNEb31zh3w7
+        0gJdVKCCHp73lFFD0JuPU2GSJCuLpCwm9SM4qwW1XFEvldwIjXJGODc/mk+Y4ECxgBFqP4LQ+5Hk
+        1a/eGjxay604YgT1VxVjPe2BwkxdSLoLvBA9QnGWK/nKYQ0iC73hNWot0pnM8vrzJaSI6fik2pyG
+        0AEtR9lxTiBahTH0oqegLfXtFvzGifKFMuN29RJcoBUr/dsiFTTxPkIHhP5lqeatsBTiC9rfU0qf
+        o4pCr5ANS5W8URGCnIN2SYoHGkGnMWM12XZf/+KF0IVuaCWoLIDeNAihLFqKZtcihsC+51Tg2VIu
+        1UctjdMYQgmyYX4yPVnMu+xGqOkH+JfnSYLlosEqCA2zxeFNl2+WQRgpGBIUUiunij4JVpMg3Iar
+        01lwGgQ/B+GpXGlcwczb94EeQ+YzMfDKQuy9K3L4P/2xnM5PZsGr/bEIFv/KHwv4+xZ/GPtVrdHh
+        KAv39dn64+Ya+Q5sKMoNV0RAJ3j2zuGwUtCfuPcJzGHyLMO87eZm2yhqn+nnNMHLD+8bCYwMnkGg
+        lximI0LWDBc0DOgCe+yD8iTX6052at0JnxTtuhN5DPMbfaVi1MFCUXOcpU/t9AZqCLox+c1Y9R+e
+        5pU8mahi3ujpzqSf64rTLIOdctExcTM0EZ6ufgtc3B+Z44GWkW6QGRGpqMHnC2jP09UyDGcnyG9R
+        BNX8QT9OguMwgDe8WMJJxcLIt5PtCY+gMUE9uOfqYNwBZDWVfQmaZ1NGzRDl5CVidVHAq9BxE07B
+        hgGKcqi6I7w+igpKE4iICuINuoOKSbWfMdyQawY2l4VDaxBNkDaULJdlWG9/gCJ5SNPNcx1ee/Pt
+        J+S3UNMioOUKyY4ecxyYTt3HEd+Xqqrea3PUcj0MfeVq0LkTvOoy0LkFqPvLWMUfEyB1PNNr3Zxd
+        XG6ub+42l5c3yHcEhqSmvyFwAmeQw3cQiryhmVZmjiDfnPrQyvLmcA313R2izmuyJfaOJtCVwu9R
+        gFercP76AhwOG9LXKplMqaosM3MyVLHRw2SiZWkue7sKZ2f4D3U9fHWfU5Godzc5C75ApBvASHj0
+        lPJ0l5no7YOaZauhDmwoeeb0+btRsRAa5n035+X/+sWdHM8C78sV8i2kpft9nsMZKVzp5uhiej2b
+        yvLsDLd4sFcf70Heg1yOXMPvINY0+U4gc/6oKW+7QVG2EE30ab1PQbodOB5Yf7heX27ktnuCDlUf
+        7CqwxotTFme0q2C8MXbL71/v9bh3KxmCHZ5zQxmD0fh1fnCPH73AD27ur60s5tr7fSqm33zcab4b
+        me8M7eedUbxl974FjcEtap8GH6f+BmwctZjdEgAA
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:14 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1512']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:09:02 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <trolley_describe><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><trolley_token>64--iT3taV8o23t_Cio5ezl8RWnF2dwamqGnxAxyHFwzwLv4eD8d-OfT95uMI97ePXNksIMIVO0SFfXmvpFi5qwdGzigDgomE0jFeZsfr4xiAVNWuchyHmEnb-ZQWlW_eYj3Ty3O8BBbfRsV0IVn_kdXhLAMRCANf1cxLZMxsVbe9TBqpwp5oq5DhdTECfGomixdD6W2l1QVVhDMuOi32cj7Zj5eyDDjA7Z_Izg8DuRLow8In4WUGqrQgRF_sPeTKSRkFBmYtcGk48tf3fg7wNl4UO4UHeUT95svXBLQLpTu5iz7mkhv1_W4K6WmAZ2o5UkdCcKprnlrjS3dPcCPjhvwBYZ29YUkWyFEEATFzsEIqpbycidEKgDX6dE7XiTrL12TH7DTwpENW0BcJxTxY_2W6hwG4S9QBCGIdJyFdWBrvrgKSil_LMvbZ7zBdyYea94qt_YeoSnkNpNJMIUBnFKDOLyk-Xi18lmkez_cXOdFnRikyNpCbgj3dyeD5y8IbZr8QhR9hbNhIQ6-Z</trolley_token><user_id>whitelabel-testuser</user_id></trolley_describe>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['848']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA61Y23LbNhB971ewfulDK5OUbVnOIMw4sjyTseN0bLme6QsHItcSx7yoAGhH35M/
-        6Zd1cSEBXtI6afIQC2fP4rLYG0HefS5y7xkYz6ry7UF4GBx4UCZVmpWbtwf3q8vJ/OBd9BMRrMpz
-        2Mcp8IRla4gZ8DoXEeH1Oq0KmpVxzYHFGY/XNI32wIk/Lmqmisi6LtMcmr9xxVJkJVVdiigk/gja
-        MHlVswQQTCGCzyIWwEXQarjSnobcfbRCtne35wIK709gVV9RkRpFUQma41zFOishjaZnh3ahnqyv
-        wkV0FByeDOhc9Ki44I6KZBuFA3Yr6mpwoGLHsgSi6WywISvsKeHptpRtIDoa6rQyktSMoQfs7S9t
-        ys16R/wuZBmPNBEVi8IgcDgGtKyyLtbAovl05rAMaFm7nCbAo6nDMZDDQSvGfF+sq9x3YQYGjf7+
-        4upb3KIRSWGd4Q7jZFtlan4DWIl2mC14F3VR7L0FZal3oWXE75BalawUsGFUYDzFKRXUt6KSFhCl
-        ciarrLCWIfa7AUNh7dD+sttWMSIn0c6iN7SQUZYI75FVhSfwCM9Q1iC1XZZVKkBsq9QB1BUvPr3/
-        5Ojoa3eG6MzKa7vQ/9yKTBxouejmfoXrO7xGYKnKOIme3yG2NusfLuMmlfRC2kZxQ9FnvVvdXyxv
-        VjhVB7YstfU7UadQCg+vHRyqPlZZxdWjikou85o7NDKRJU/gShuA9APdie1eODsR7NtTAloa/1AG
-        VG98+UB8O9ICtc0l1oD9yxYYGIJJg9mm3sXPNK9BR7cLkCQTJhXkVZlW5aR+QlO2oJaria6V3Aj1
-        1ElOOTd/NB9dgwq5AQcz8iYQXbmeBsuKqjF6OlV4upA0ItomfsKaY1bwlSUbUNYwQ200W6Qzn+WN
-        TPmUpXx8Wn0QI+9glqLOckmLLN87JH1C367rN0aT18uMmZXRXaAVK/37MhOQeldY0bEcW6q5BZah
-        t2E5f87gJd4BVkBZf1UiHxURjEAs/7TcQAxlasbmfurfvHAutt55vamxyk6DEFO9JWhuLRJ08kcO
-        WCBncqE+amkcEnQcjIzj0/Dk+CTosBuhpu/xX1GkGNC4aDAP54bZ4ni51XwWhLGCaZlimGHulfRJ
-        MJ+E81V49uYoeBMEvwbhG7nSuIKZt28BPeaCMjGwyTREY5xj4OY/0iSzcDo7On61SY6n4TeZ5Hgy
-        Db/HJMYEKvVof5R5/PZ8cbW8Jb4DG4oyw0cqMJBevPfYg5XwC/du8DiMYhpkPzdK2l76d5ZGsw+X
-        jQRHBs/RyyubSFzQMHB7ouZRnj23cgM1BF1k/GasagnPip3sllRibvR0ldG/6x2HPMeluOjscTnc
-        49f2LvGrexf3R+beQBXrIphjkyELT3SiSnA7JJiMN/rnJDgMpagFiG/1t5THWG8wsB95VGIf3AFk
-        LpTlBtI2CZohKejnmNVliWbV9x9O0TUGKCkwZ47w+igpAVK83R36TY2dmvQltZ8x3JBr3WE5tAbR
-        BHmGihW0xFKptj9AiewhdU1chLfe8eqG+C3UJHispEKy46ciCkwB7uOEbyuVHh/1cfS3TxcjX/lk
-        6Xyr/PtHSufrRDVQpkM5v7he3t49LK+v74jvCAxJNygUe32GYfWAjsQbmikvpkn4rmjE0lI0LTym
-        F3dIOta2Ge8BUsyIp7JK/PiMeIqJ/xsy4ukgI34tRGVs7KoqN52buuQeJiMmzwpZbZVfOsP/SrSn
-        r020yqX07ibnZ+fosgYwEh4/Zzxb58YN+6Bm2QynPRTTmOkO/zAqFiLDAO4Gr/xfX9zp4VHg/f6R
-        +BbS0u22KLBrCc+OVAF3Mb2ejUnZ28ZreV61ujxgD3I5cg2/g9ijyTvB3uWvGnib4cuqhSDV3XSf
-        QnSKdyyw+HC7uF7KbfcEHaputXZ4Gi/JWJJDV8FYY+w1of+MoMe9r4Yh2OE5XxBjMBl/Nhi8F4w+
-        FAxeCF6bV8xn6Q9OfX7zbNQ8SZmHjPbhaBRv2b1XpjG4Re2vwbvXPzViY2o4EwAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1530']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:20:14 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/ValidEventTests.test_all_performances.yaml
+++ b/tests/interface_objects/cassettes/ValidEventTests.test_all_performances.yaml
@@ -1,388 +1,309 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:15 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:18 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+NklG
+      PC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxjcnlwdG9fYmxvY2s+Y18tLTYt
+      YnNqV09qbFJncmUtc0RiSlI5T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZ
+      YzY4Q3U1TEJQYWhVU1BSOV9Dc1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgy
+      YWlmOWwzZDVmeWJoTTVRNU1ObDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6
+      emxlZD48L2RhdGVfdGltZV9vcHRpb25zPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['310']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2d2ZKqyrrv789TVKyLvS/OYhZJz9q1awf2fQeKekOAIKA0SiPi6+w3OU92sKlR
+        NZrpGhIaQyBnVMxRJgkIX5b/Xybf9/ftf/a29bLTPN90nf/+B/gL/ceL5ixc1XT0//7HWKghzD/+
+        5/3/vKlyoEmBaWuSuwmSrr7kaX5oBe9vfqiori2bjhT6mieZvqTI6rvjvr3+esvbwos3gSsplrtY
+        vyMoglCI4q/E/soa6YNI7gur8cLa4rqAY/Ux0p5tR7Ppsru0qvzaKAcHtrqwexrSwVR8qFe2cUAP
+        tnN0TdU6LsJxB9frS8s98DCgThpOmei5sWHwe6wjrVpqnwWhxKOat13YQ3HHKBMtbLfUsG7RbX22
+        8coK6e7avmXWmX24KseA8yY46fPioLEhNQ0nkdnb63fv/83RNFVStY3sBaGnScf7dLr4X7W/GbIv
+        bTRvKTmyrfnvsea/vf7Q9hb6ya0/t1imn9xgbac5n//IniZLSXy096r49vr56rxB1fzFezUJZxwZ
+        mqddOpxa3xZmEJ/7Wq6jug4SrpOL+dZ43n7q2jltv2y87GzJvn/559w/ubDk3X9puGw89eeSjS//
+        Idub/3opJ6MkPL6VL5vfkrFwGhjnw57uw/dNb74mewtDWmvx6UyvyXD6bDkOuku/j92+tXx3sM9+
+        Px5PlZ2F9uuDni/no8N3jZ99TtdRki1LCy4XWvlhh/OVvn6+hdePm+j6geTJjp4cz5b3yZFtxXQ0
+        9Z3E/kLfXr9rOnVI3mSw8cyF9k7QHz0+285dwuQyZC85JPmtx7emN/t4Xz8OiYFTj69Npw6fRwTM
+        R4+vZzndzo9D4t96fJ7FcaXj2LW0483K5yVuQ9kJjn8Vl0/B97edbJmq9NH+Dt5ef2j5sQf2b3vg
+        /7YH8W97kP+2B/Vzj9efL+8UQ2kRel6iCkmXj9/Ofw66sklG9XdNnz2W8iJwvXeAol/6XBo/ezmh
+        rWjeO4NRX3pdGj97bSx5kXw4Yl/6XJq+9DmOOT+2Fdd6/dqcfPqeW9//3/9+3f+z/e31x8t8/Zux
+        DONfkPh/DfrCDZ3Au1zfSTS/NnzbfPq8HztmoKkv7WTsJOzz2fWiop4ZmIsEnXamFh01fnHU9PMd
+        +uWmM3ed353mqJfXp4MJRvjPF+AHL7y2CbTj/XrBUJDcxc8u595hsJDc5dLXgnecOp7qx9bPbr62
+        SKTffwcEjdEk8X3vj43n7nHyn22ryWdtclKURcGl57f2RJldhkLBCX0k2VFP+HjqjqAsggIBsP/C
+        0X+h6P9Fwb+OZ/r1Dpfj/ngPzq/9IBHzn+4KGRgvXTm+5/2gMILG0d++HyRK3nQ/yOQnzf24XP+J
+        Dc/DsTcWyiOu3K6O3l6/NF+6nG5DVw4CQ4teSm7oOdp/+i+95HI8ebFOhpBQ5YWPHc/37Py7qb5T
+        zdrHluTVpd1KBrr7nhxODo6M97Xx0mMjB8b7a7IzYp/Piyin8yI+4nw7LxJofvD6sf9pl8vuyRUG
+        of9umbtvh780fXRIZhlyIL9+vA7ijfbum/bGOk5YkoMHH/udtlx6hRtfs6yvhH2+xOrPl5j81m2g
+        X9tff3EMXXOPgZLf3yw5+QgNk3tOgr9IjKUAwOm312+tbwl96+dfEfQvgCYRJqnkg+2z+e3182DH
+        2UGiRcfpgH+aV3zXcKTfI78kfPOBvZeXJ2LyQsc5TiZO4wZgF2j6rvXEPL/o92PrbfOcc2PoyUcV
+        +dLto+Xc4XgNrmcfsfn89n9qfTt+pp8nO2UweiGE3tvrt6YPpFeT+3/sLa3td/TIbL9of/MNNzpP
+        qk6XczrdD21vfjIuk+6ng2v7ZLwkY/J4uC/NH33O86x9oHmObL0ISceX0nEgO+rL5x7nv5/T3PdX
+        n/i/2vCWDKzwci6eq3SqI16sdjp8otWfGy6dTofnZdXSvORvWEyGov/R7TL1uEwZCwctHxf+3VBa
+        yAsjGV4fEwv/eKyf2uDcLLuXWLhhXlQ2h3OzYsf/a9AzQf5/h9CnpV/XtS7i87kc/Nl2JDzLtI+T
+        yhNHfXl5twnFCYHO7w7h0FaCWJeGyxZf2pm+qVgXbPqx8dzrE8PPROUmMPS+RhAEZ53uzDfLKy7S
+        GkOzrcZVPkC1EuULW1/3osoqMAdrWd5RDoO2/RVdIsYdYUnoU62moz17djnj+YiXoyckf1kEn3xs
+        /tb09jPOfo+yp8cYp2FB/4WjL4Pu2+tn03mrYdi2n0SfPUf+a9v5fJ+EChkDMgbUmLxpDGSMYsf/
+        14xR88x/vlCPYAySZIkbGIN6Esag0jFG+86MoYynQ7PCMdXNpjFgRb26GJXLCNZq6eJWPrQFtNIx
+        x4xTZScSwfeWI2JgGeURZIzsCTBkDKgxedEYyBjFjv+vGYMPnX++MI9gDBrHsBsYg3kSxmDSMUb3
+        zowR7uJo2C31ZnLHqxs6U8E7XtzyaanU6E4GFWVG7WN2sY4lJKzN9y0W4earLWSMDAowZAyoMXnR
+        GMgYxY7/rxmj6yaMwT6CMRjA/H7WGImyT8IYbDrG6N2ZMdC6uEMUHizNlRMZe8GacQK+x70hOWPK
+        ZW7e3dmdba+/G/fWbbt8wERaMoIhZIzsCTBkDKgxedEYyBjFjv/f5GOE2j9fAPoIyGATcvh9yADo
+        c0AGQNNBRj8dZBzLCd+bzsIKj7WcL4q8WL/4gaxrLxvZ/9jr1OnfQInVXC9L09VoMtrWkU3FQkbm
+        di0dKHy7tmY1t9Wo0ao/R+bRci1zSrgPPccbQyjJoGJDKIGilBdRglBS7Pj/GkpETU2gBDwESlhw
+        QwYH+Lle7s9AyW+X4X0PJYM7r3xQ/KzGzimAaCjLdPe6uxtrcbfHz+eb0cCvWDXbwqptyjPra9OQ
+        ZDToMBgKISODCgwhA4pMXkQGQkax43+lEgVgD4AMHKVp5gbIwJ4EMrB0kDG8M2TstxWybaxwubXd
+        uHOtaUTrSJ0EeknRReWw21XUhmWMe9qctKezbr1rGpSHwVKUDCowhAwoMnkRGQgZxY7/lVIUgD8C
+        MgBF3JAnCvAngQw8HWSM7gwZo/bINFuEuLQHvoRam313X8GMw6DXZ8oDFsQdnBqGEd+teNzB7ZZH
+        THNf3vEQMrKnwBAyoMjkRWQgZBQ7/ldqUcAjTDVwHKdvyeF4ElMNkNJUQ7gzZPB7e8/Fa5wxmKkH
+        8GbJEhfTcOR4woISZ+3lrBqPcCVa1iuLJL4R4y4ndQBXMjKowBAyoMjkRWQgZBQ7/leKUcAjXDVw
+        AsNvycl4ElcNkNJVY3xnyKjGNWwT19Thwa+pkWm4BjAGrBtwE9AyurWGb5N7FKCYO5ZaQ3lWwZgF
+        K0PIyKACQ8iAIpMXkYGQUez4X6tGoR8BGSTK3pKTQT8JZNDpIGPyh6tRvE17vAh4du33yTqL2TMb
+        GO6yU4kPfXFDqEifGdoSa4yRSsvEKZs+DMmmDm04MqjYEEqgKOVFlCCUFDv+16pRHuH1hZMsdUsO
+        x5N4fYGUXl/inVc+5m2/G+ITeVVrl+bKQNfbwtzfIaJmcK7UilbL0p4iPTMstbd2syGarlTRUAgZ
+        GVRgCBlQZPIiMhAyih3/a9UojzD7wqnkDtwAGU9i9gVSmn1N7wwZwcKbMcNtadhpr6VNa1zltjNz
+        a3VM1O7XV+hswxs2V2Gn3X68rkw6jNdcVrrw8UoGFRhCBhSZvIgMhIxix/9KNQr2CLMvnKbYGxJF
+        MfQ5IANLafY1uzNkxGhjsG8bOk4gm8aaVGe2tFbxmmBVp/HK9VtaxO1Nd7ZX5+hw7QYLdCX2mnAl
+        I4MKDCEDikxeRAZCRrHjf6UaBcMc9f6QwRLghhwO7El8NbB0vhpHQ9S7Qga5IaLZfCpVnLmmkouR
+        SOGHmrvjDnLyElDTmCYoU9rsB5pa6w/Jw6I8LnOw5DWDCgwhA4pMXkQGQkax43+lGgXDvftDBoFi
+        zA05GdiT+Gpg6Xw1jgand4WMDjbAUAkXuv5sq1tyIBmDqRI5odtwPWCXNma43fUVdqeODqIWrEBJ
+        EbU+XMnIoAJDyIAikxeRgZBR7PhfqUbBiAc8LiFA8r8bIIN4Esgg0kEG9oerUUTNLTdHG7a50OWS
+        tl6IvSmYCHHPAGN/W1a6YAuEieiT4dCtlvr9ObrcVjdw5SODig2hBIpSXkQJQkmx43+lGgV7hNkX
+        kRzslhyOJzH7wtKZfR0NUe+68kFIk159PyOJfXXmuE2VkaqON5ooaIcXgtpC6JDEZh2ORLrbrdU3
+        K4b2lsYEQkYGFRhCBhSZvIgMhIxix/9KNQr2CLMvAmPoG8y+sCcx+8LSmX0B4s6Qga83Ea7gVcMS
+        W7TiMB5VOcyWVWfvc83auj0GWFQzrGiLhGYdDzi+TjY1BT5eyaACQ8iAIpMXkYGQUez4X6tGeYTZ
+        F4HT+C2Jok9i9oWlM/s6uq7fFTKi0dIqL9qVfrBZiX15wLSc+pipB1WthvXo/mEir/q+Afoa0ncH
+        FkOLgl2fwpLXDCowhAwoMnkRGQgZxY7/tWqUR/hqECRB3ZLD8SS+Glg6X42jIepdISOszjrB5kAa
+        pFJp+fXhxpqN5hRNxU1+JEfIellnnE65zWH+hue0+TLYjZUehIwMKjCEDCgyeREZCBnFjv+VahT8
+        Eb4ax69guyEnA0efAzLwdL4aR4PTu0JGf7RzJpsDUSZQT6wrTs3x3NkItEe7GA8PblvkxNZBxb24
+        xR0OcbDvthS9DnMyMqjAEDKgyORFZCBkFDv+V6pRcOAH94cMGrA35GTg4EkgA6SDDPYPV6OUe/1G
+        vNNrvjov4TYd7tiy3m9TB1fBrai1arhDNRbtYZ1HDiFPrLnScBRu4cpHBhUbQgkUpbyIEoSSYsf/
+        2nejJEzSCh3tvlDCoOTv53Akov8MUJL8pIQS7s4rH1a1DDxjPhVAya1MaL3Odkd0EEleFDZdYqaq
+        S5fHmb0x15FBYz8n+yLmOUMIGdlTYAgZUGTyIjIQMood/2vVKI76CMhgsd83+6LQp3AUTX5SOoqW
+        7gwZQzIkKTnaKtqhP2e5ilTih3OOZNtUhShtpQZF1ym+p4JFv9YumaYnkjHJw2qUDCowhAwoMnkR
+        GQgZxY7/lWqUo6Ho/SGDpZnfTxSl0KdwFE1+UjqKlu8MGV1kHRKTuLKNgdSiDaCYYtNcT+djfY12
+        9I05dpashEuy4Pj9zcGdIcAUFLiSkUEFhpABRSYvIgMho9jxv1KNcvTuujtkkIAEv5/DQaFPYd51
+        TONIBxnVO0OGPovrC7NjGFtmt+pilfGh3DLm7THH9IBRm4QobnUZXmTbOlsZjNFabeuLG5iTkUEF
+        hpABRSYvIgMho9jxv1KNQj0EMjCcviUn4ynMu44/6SCjdmfImPCLplVGtwdT6fbaitpjbE9iaHXM
+        dJX9oDncjknKpdY2vaj1Varnd2ZDyoLVKBlUYAgZUGTyIjIQMood/yvVKPRDIAPHiFtyMp7CvCv5
+        SWneVf/D1SilrYq3MMXvBA3B80d0qy+ELlbebeymGlFlYs5EDbe0LnvbLRLuq42Ks2nLEEoyqNgQ
+        SqAo5UWUIJQUO/5XqlGYh0AJAdBbcjiYJ4ESJh2UNO688mHuo7YtMcstijPcNO40tNYAXShRr24P
+        yuZmOsKGh2adU0KkjWmcvEAUYkdAyMigAkPIgCKTF5GBkFHs+F+pRmEfAxks/ftmXxT6FI6iyU9K
+        R9HmnSFDq28HnoDiZBMJsNGK0zo9dbEpOagyZScisjQiaTMmo4AdhAbeqx1KK2RTgtUoGVRgCBlQ
+        ZPIiMhAyih3/K9UoAH0IZZAMfkOmKECfgzJASkvR1p0po+cs516FkSu7PTc3gpLDtptd2dYYlG7v
+        uY7rDhb6oWeXSL3V5vc+0lfXdB9SRgYlGFIGVJm8qAykjGLH/0o5CsAeQhk0Sd2QxQGexFkDpHTW
+        6NyZMkB9ZfkBtWrNuCXfs4ZGy/f46kxdoLHvrqMyyottZZM02uHGsJUSN6/odViPkkEJhpQBVSYv
+        KgMpo9jxv1KPAvCHUAZDYDekZYAnsdYAKa01unemjM4GXYVdWfWXeM0FYCUjS7XMx8SupevbHT21
+        VUbm46lSovjqgto07bExbELKyKAEQ8qAKpMXlYGUUez4XylIAcRDKIPF2BvyMgDxJJRBpKOM3h+u
+        SLGrGGj01/X+rM2hDlEbmeW4PLVMj9WqcrcONusDE9DtXVNU1KFZMfqcRWLQ8CuDkg2pBKpSXlQJ
+        Ukmx43/t+1Ee4viV6Dh5Sx7Hkzh+gZSOX/07r32II6w+o1FlxlO74SSq9xiiNTmwnjAWKNFfLIOW
+        IYmMsUbEiaJODx7Yrk0KUkYGJRhSBlSZvKgMpIxix/9KSQp4iOUXBVBwg+XXtxP/acpIafk1uDNl
+        2MSsO1AJMR6Y2lCdtmsLt9Vr7IwQkeaDVq+n031Vqc6EeLW0OuvJqtYvjVX4hCWDEgwpA6pMXlQG
+        Ukax43+tJuUhnl8UYJhbskWfxPMLpPT8Gt6ZMmZBKPA2sxcpZyeHwO+qIlfFLbS2i2xxUDP6+thX
+        +LYkNeSleKgFmEF1REgZGZRgSBlQZfKiMpAyih3/azUpD/HXoHAK3JLH8ST+GiClvwZ/Z8pYlq1Z
+        iaO2u76OhyWWxhuqPdjHK/5Qn/a40r5WmXf7XTzuDiMS3/OOLNkLF1a+ZlCCIWVAlcmLykDKKHb8
+        r9SkYA/x16AIgr4hLwNDn4MysJT+GsLdK18dSkLq400btNgaHQxZr7MKpd6guTeddQOpmmy4XM6m
+        qtzYMSI6GTWHJgrzMjIowZAyoMrkRWUgZRQ7/ldqUjDgBw+gDBLHb8jLwMCTUAZIRxnjP1yTglR0
+        wz2M26Ml2h6tbObQKmFUZzDqdVweWLvVciiMKQUxuPFwHrChaXKzYQ0amGdQsiGVQFXKiypBKil2
+        /K/UpGCYoz6ASigMvSGPA3sS1y8spevX5M5rH8NQ1Ea8ND8sy/yY5dvjkHRHo0kX7Scf3nFYqcy4
+        XVNsA3txmM7Xc03mWssGzOPIoARDyoAqkxeVgZRR7PhfqUnBcO8RlEGj1A2uX9iTuH5hKV2/xDtT
+        BtfjXb1Z8yLZoxRnT7Rryt7VK7axnRBzZiIFk2FpUbOWB6sJ+oephQ+V3QE+YcmgBEPKgCqTF5WB
+        lFHs+F+pScEe4vpF0Ret+U3KeBLXLyyl69f0zpQxIPjq0t6RAxSZVRRrZQ62bSts65W+5SHthmdV
+        EbXTISpYzdUofzWVZqg2g5SRQQmGlAFVJi8qAymj2PG/UpOCPcZfg6XIW/I4nsRfA0vprzG/M2Uw
+        Q2fW5BugIvlA6NAdd9GlCGG4w62aRMds7dDfxgrB7PpAniD8pIZXeiH8npQsSjCkDKgyeVEZSBnF
+        jv+1mpSH+GvQKIndkpfxJP4aWDp/jaMo35UyVNr3GgrKj5sVUDqYnBbYW37oxttuD9iHRciOxZkk
+        Okhkx3tRmA2tEOcbMPszgxIMKQOqTF5UBlJGseN/rSaFeQhlAJy5JS+DeRLKYNJRBvjDNSmu2W4p
+        k3656mDiNGaX+2VrtIqrk6kcrOLpyuw367JZqw9kPxhylcpsvWdkBPpxZFCyIZVAVcqLKkEqKXb8
+        r9WkPMT1i8Yw8pY8jidx/cLSuX4dS2ruuvZB0x3T6xuLiBkbg91SqzTIyvKgNmj0QMpTb6iouumN
+        2BggLH0YKG1RZ2IdPmHJoARDyoAqkxeVgZRR7PhfqUnBH+L6ReMA3OD6haPPQRl4OtevY0nNfZ+w
+        lLl+2/KaPLqwBpuRuVltdmXPq/crey1qzfx+ODMptX8Qep5G8CI37lHUAmaLZlCCIWVAlcmLykDK
+        KHb8r31Pysn0y4rvDBks/fvJojT6FKZfNIKmM/06VtTcFTImuoohwsbVd5yr7vVlcyy6OuJJI3XY
+        ZISFU7ZlnFgrobdF0N08GFqzWguFaRwZVGAIGVBk8iIyEDKKHf8rJSlnd417QwZJo7+fxUGjT+Gu
+        kUBGOneNY7DvChkeOdmXOaEarN3OXuwEsdDnSth8qKKoQHmr6a7uq+2GjlPN8hQv7b2xgdh7CBkZ
+        VGAIGVBk8iIyEDKKHf8rFSlnc417QwaVUMYNkPEU5hoJZKQz1zjW09wVMvZaVV1o69IYm4wCq4lP
+        J2ZggpVx8IWZd/A8jpVGmEZtg0pEx5uGGpJRxYKpnxlUYAgZUGTyIjIQMood/ysFKeRDIIMm8N/P
+        yaBR8kkgg0wHGcwfrkcJ9WBd2q0c26gxy9Y+OgwVNqAnBNpxxeFiy/EYKa9riLgbdw2wsSMhanRb
+        MIcjg4oNoQSKUl5ECUJJseN/pR6FegiUMBh7Sw7HUxh+JVCSzvDrWE1z15UPe+IYyx09tHUMcTr1
+        Bkt1cGwCkIk0DgS6vhsujQPR0kiCcMWx0BrE/a6GQcjIoAJDyIAikxeRgZBR7PhfKUehHwIZLKB+
+        3++LRp/C7yuBjJR+X9ydIQMjybrnBITYFxAjCKUGGdeb4npUGtP2YTqo6H6p2u5a7IpWUWm0mOAb
+        vdyGNa8ZVGAIGVBk8iIyEDKKHf8r1SjMIyCDQVHslkTRp7D7SiAjpd1X6c6QEW8bNUpsRG1kJetd
+        v7TfudUAHwYzUKtODqRhBq2tXW8y7RI7WVl0FdHnZQ7mcGRQgSFkQJHJi8hAyCh2/K9UowD0IZQB
+        aPKGJA6APgdlgJTGGpU7U4ZkjSfa1GkcBqpXYjel0kie7SNpOpv1KhVyJQmOFa4G0zU/l4eiamxn
+        40oLhUsZGZRgSBlQZfKiMpAyih3/K+UoADyEMjAK3JCVAZ7EWQOkdNao3psyRh2tIrfnOGtRFT+c
+        BVtRpcJwyfcMQe1Nh72agBCGRLcmMr5GDKFS9REFrmVkUIIhZUCVyYvKQMoodvyv1KMA7CGUgRPM
+        DWkZAHsSysDSUUbtDxekKCjtKA1UQ4DabyyikUgoiBqvKuu95Y4iv9d1YnLjNp2ypyhoGxVWOyXC
+        4NpHBiUbUglUpbyoEqSSYsf/SkEKwB9CJQRO3JDHAZ7E8AukNPyq33nto1arq/Mhv9rKhrNlrO14
+        VRnKjdqyWR1vJ8NZB6/rnEAdzHV9R0ohOoxHnD+Aax8ZlGBIGVBl8qIykDKKHf8rFSngIY5fDImB
+        Gxy/wJM4foGUjl+NO1PGjol4Zkj1rC0Vm/3xsLOxKgRh1Gq7g9VyGjTtiw3fxDVy4jpbJxovQ7YR
+        wbWMDEowpAyoMnlRGUgZxY7/tS9IeYjlVyLM9C3Zok9i+QVSWn4170wZrjfshygYOGh5HFY0s1nl
+        J9FOpfzKQBoEbXs+UhWBH6ox2u63Tbo0OSjkHK5lZFCCIWVAlcmLykDKKHb8r9WkPMReg6EZ9JY8
+        jiex1wAp7TXad6aMQdseldr61jQPdpNx+2qtTvtTsdNeCq5RRiSmPpYrGzIcrbaTw5J3OWSARpAy
+        MijBkDKgyuRFZSBlFDv+12pSHuOvwVDULXkZT+KvAVL6a3TuTBmOFwXCwdsMyrvGAEOGlGJXMPOA
+        yKhWEteIE1XnB3XQoNZgUk+YgmmueGIKv4gtgxIMKQOqTF5UBlJGseN/rSaFfQhlsCR+S14G+ySU
+        waajjO4frklpdFudkYgSvqjgnRkSKWPCWwjUUhQxljwwOMksHCZeL0BFW7fLbi2Ug94a+pdnULIh
+        lUBVyosqQSopdvyv1KRgD3H9YlGcvSGPA0Ofg0qwlK5fvTuvfVTGzZW4ZqdlXDXMiV4agjpAh3Os
+        Rw5B7dAWDojsb8bMkgIDoPvUTlFVh4KUkUEJhpQBVSYvKgMpo9jxv1KTggE/eABlAIy8wfULexLX
+        Lyyl61f/3t/FJnIBUEcI1Yl2znZani50xG20LaGni1UZXcR2iTo0pJLEudVpZVirqcsNrHzNogRD
+        yoAqkxeVgZRR7PhfqUnBMEd9AGVgALshWxR7EtcvLKXr1+DOlKFwBIIa5miosnTgHPYGt5noC9sp
+        bdS4mryRHmeAyGX1Sk02qAqhTObzlg7XMjIowZAyoMrkRWUgZRQ7/ldqUrCH+GuwOEPekMeBPYm/
+        BpbSX2N0Z8qY1/p8A93svUYg0M6iGU0jBJfbCIUvYhyJNXsA1KZBH+TqeFiXnSXeiKcbuJaRQQmG
+        lAFVJi8qAymj2PG/UpOCPcRfgyVocEtexpP4a2Ap/TX4O1PG0mIFa9a1SdR0GXcRW7jQiVB160yD
+        mBww9aATEzWzqe9xn7Y9bRb6I2kLa1IyKMGQMqDK5EVlIGUUO/5XalIw6iGUQZL0LXkZ1JNQBpWO
+        MoQ/XJPibr2gzY0XZa1n1XpLkcE7WrWsGFJbN0ql+RCpBc6mH6u90pxng1G0n83VJfQWzaBkQyqB
+        qpQXVYJUUuz4X6tJeYjrF0sRxC15HE/i+oWldP0a33ntY0qRm4UdBvVDb0mpNop7u144oYhJg2zr
+        1rgmxjEynQssP1XR5c5Zhc0a6EHKyKAEQ8qAKpMXlYGUUez4X6tJeYjrF0vj6A2uX9iTuH5hKV2/
+        JvfO45B24qG1Y8j92N/zNLOrNmVTamqDmlA2xPm8vliyPjtRJXoxZha7cWNvlwz4hCWDEgwpA6pM
+        XlQGUkax43+tJuUhrl8sA+hbskWfxPULS+n6Jd6ZMvia7iiu6K0Zca7Ly41H7MvWshYNx0Fbdc39
+        YRxNBXbWDlh6Wsf8TY+19BJcy8igBEPKgCqTF5WBlFHs+F+pScEf46/BMuwNeRz4k/hr4Cn9NWZ3
+        pozmVGxPmszSnJCDvjJQ6n2v4e6Wsy7JqfhiuJ5o09ZC7+m1jWWudFDx40gMYeVrBiUYUgZUmbyo
+        DKSMYsf/2vekJJDBhXqY/HNHzKBRlKZ+PzGDQZ8CMxgETYkZ8ztjxiQgO/KGsx2kotRxbl8Rmq6C
+        DmmZF1CcSNRZICgmQOLmgRJDgLkrrq/u4SOTDGowxAwoM3mRGYgZxY7/taIUR30IZgAK+/3MDAZ9
+        Ch+vBDPS+Xjh6B+uSiHEubGqAM6OGkBnVP6wdMQ9eSBmO0eMiDIXRfISK4OBgfX08bzVVahGpwaf
+        sWRQsyGWQFnKiyxBLCl2/K9UpeDeY7AEI9jfT+VgUPxJsARPhyXgzqsf2ojoVdblnYhtG6OtsFdo
+        Qq/0MU5quwO5yvZK+6q9bTKczW9dXVe1w6w+r8LVjwxqMMQMKDN5kRmIGcWO/5WylKO76CMwA8fJ
+        33f+YtCn8BdNMCOdvyiO3RkzmD0gkL4wWTUXVVRsxk5NtOYC6PGOK7S0nRPjS3ei2LNo3omYbas7
+        WcWxBP1FM6jBEDOgzORFZiBmFDv+V+pSyAdhBoGB308ZZdCnMBhNMCOdwSiO3xkzasRmojsDlCFW
+        3pwANuISXbo5Km9GTjxp98dkLS4r1DZuxxioVudaGAWYCx+aZFCDIWZAmcmLzEDMKHb8rxSm0A/C
+        DJIlbsnleAovrwQz0nl54eSdMaO/RbAKF85nC0BEItvTp+poMTRKA0HjW/ZuNq8fFo1ux4qnwp7n
+        LbLO9ZEmXM3IoAZDzIAykxeZgZhR7PhfqUxhHoQZFANuyc14CjOvBDPSmXnh1J0xQyS62LRLslXa
+        ZufzCthbgWLVg5JBK8bE4hywXx6kroJWJXnRHytsgK9ZEmJGBjUYYgaUmbzIDMSMYsf/SmUK+yDM
+        oCn6ltyMp3DzSjAjnZsXTv/hyhR9X1pZNsdVB4HTKi2Bbpq1hjvEWHqESnwHx7aEqTDN0nrGzEtM
+        0OvvdRJ+X0oWNRtiCZSlvMgSxJJix/9KZQpAH8QlDInfkMwB0OfgEoCm4xLmzssfCU/gFtHd1OtG
+        bzoSuvhQPuhkPZQbHObNBJEl1dHQHO/GwXztdFeb4aTaCODyRwZFGHIG1Jm86AzkjGLH/0ppCgAP
+        4gyWQG8wAANPYgAG0hmA4eydOcMrLexZDfWiZlTlekZ/N++zlbZUqW03oTWoz3zaW5dDXyt1qYbO
+        c47K+ksPlsBmUIQhZ0CdyYvOQM4odvyv1KYA7DGcAVCMuiFrFDyJAxhI6QDG3ZszOlSvyprBYem0
+        3XZUqnDrvn/gYp7ybX7bZIbW2lpMWruxO2U3dMPh8diqwvWMDIow5AyoM3nRGcgZxY7/leIU8CCv
+        DQBY9oZ8DvAkXhsgpddG+d5eG66waVYGM6LdbawMRnUSvdbKrLxbbVVp2WizNTWc9CpVAbQ1pdff
+        eVGnj8P8jAyKMOQMqDN50RnIGcWO/7XvTXmQ2QbAGPKW/IwnMdsAKc02KnfmDLcuzMxye1vD8F4b
+        EyPGaTle0yT26sgvDQ/znloSWp3eurXnvdHAr5rrepWAz00yKMKQM6DO5EVnIGcUO/5XylMA9SDO
+        wGnslvwM6kk4g0rHGdU/XJ8y5g4hsdRjbdZsDirKqDNpHbb7ir+Sy+6UNyXBUbQOxyCdgdrbRcNW
+        MJwe4HOWLIo25BKoS3nRJcglxY7/tfqUB7mAAYJkbsnneBIXMJDSBax25/UPHCOj3dy3zf3IkgRy
+        aUgaNvajVtPTOoHTGNI+oOnxlg8izGNFRqfFdjyGz1kyKMKQM6DO5EVnIGcUO/7X6lMeZAMGSIK8
+        wQYMPIkNGEhpA1a/M2eENXS2qggHXBh1xKHfWI4a/aGAVNmlTvasIIyI2k5ujxairdc76LhLNA/b
+        LXzOkkERhpwBdSYvOgM5o9jxv1af8iAfMEDh4Ja80SfxAQMpfcAad+YMnUJw3ljOdaDjVEeyps5+
+        tx2wfJkN+7NuZxkajcifrkb2qFRqkSao1cDOGELOyJ4IQ86AOpMXnYGcUez4X6lPwUACGI/gDAYl
+        bsjnwJ7EbwNL6bfRujNnBPrKIZna/qCMhNF0F1dW0YpsNBa1Zg1Uq7vNalTqUbXNcLmiepau6R0a
+        Z2XIGRkUYcgZUGfyojOQM4od/yv1KRjmqI/hDBa9IT8DexK/DSyl30b7zpxBWdPI62Puml5P0eFu
+        wB/q0ZwIlvokGg4jRrZFpx4ccJpeM8NuP0a1arU1gM9NMijCkDOgzuRFZyBnFDv+V+pTMNx7DGew
+        NH1DfgaGPwln4Ok4o/OH61OW+lguV/HKSp4ND8NSfd/zGbJXd1mGiPh4FY7MYYCuwmmz1qD9iPB7
+        am8QwvWPDIo25BKoS3nRJcglxY7/lfoU7EE+YBhK4Tfkc2BP4gOGpfQB6955/YPD5e1G39d9MuJ9
+        bSn37KXbnjZjry+QfaLH+Bs6uaBIDzqaTkttltWlDg/XPzIowpAzoM7kRWcgZxQ7/lfqU7AH+YBh
+        gGBv8AHDnsQHDEvpA9a7t9/oRJ6pgx7Xnw5EbLA3wE5rWfs9mki/rCwNjFttI8QRGgdhEKg7udOZ
+        GYcF9NvIoAhDzoA6kxedgZxR7PhfqU/BHuQDhmE4dUve6JP4gGEpfcD6d+aMqDyzGsMB3dwBuWks
+        V0JYIziuhAhrA6+V9XqH7hjW1MfF6WLW2bU7kSVMJtBvI4MiDDkD6kxedAZyRrHjf60+5UF+GxiB
+        srfkczyJ3waW0m9jeGfOEJYx64FyuFAxYWuBYDuuVvkwCMb61F8Jiu45ddYxp1KvEpDC1uHCBd4f
+        Qc7IoAhDzoA6kxedgZxR7Phfq095kN8GRrDkLfkZT+K3gaX02xjdmTPUw1gxR/Nk8PYDtzuwRuZa
+        XVYooJZ7woZnw/JyWiZodDI0VgQ4VOe7TgXZwjzQDIow5AyoM3nRGcgZxY7/lfoUHH0QZ5AMuCE/
+        A0efgzNwNB1n8H+4PgXX8f2gF7PIqstYHQ64M7YSRq1FYAkbvam4S+swqXHmblKxqMHe5VR55uwz
+        ms/xQyYz/iDHGIyimBue/OFP4hiDp3SMEe5MyhYhGd0wqjnTbhBqfOCR9KBzaPPyUgeMya/mHafb
+        wYlp8nbtcl2hQmS3QjKayfxDzttxQPLaJtCOn/v3HZM0Sfy+uwCLPsWYZBE05Zgc33lMKgNCMxbz
+        EVXGVK3bQkC30abX036FwUZb15l1vI1vIyUxriOMyGkzq9e1sezM3l7DI+VJp/dgmX5wifb7m+xp
+        8uU9im+vn6/OG07nqu40L44MzdMuHc7vYHHkp1NfKxlmroOE6wQnvjWet5+6dk7bLxsvO1vy8U2e
+        /jn3l70gidqXhsvGU38u2fjyH7K9+a+XcmgF4fGtfNl8HH62fJwFnQ57iv/3TW/JOE0mN9Jai09n
+        en17/dLylgyLS7+P3b61fHewz34/Hk893udfH/R8OR8dvmv87HO6jpJsWVpwudDKDzucr/T18y28
+        ftzEnM5B4TQbTrPyMs2C0+xix/9r0Bdu6ATe5fpOovm14dvm0+f92DlC1Es7GTuqa392vaioZwbm
+        QvK0nalFR3FfHDX9fId+uemMgud3pzlqpvD0Xhz5+st7cH6dTLC94Ke7cqxT6crxPe8HhRE0/vtJ
+        HST6c5HKtftBJj9p7sfl+s/sfxqOvbFQHnHldnX0MSU4j9Lz7+eHUnIQGFr0UnJDz9H+03/pJZfj
+        yYt1MoSEKi987Hi+Z383yzj/ZiUD3X1PDicHR8b72njpsZED4/31OAmwz+dFlNN5ER9xvp0XCTQ/
+        eP3Y/7TLZffkCoPQf7fM3bfDX5o+OnybIZxfH4n93TftjaUlNyw5ePCx32nLpVe48TXL+orW50us
+        /nyJyW/dBvq1/fUXx9A19xgo+f3NkpOP0DC55yT4i8RYCgCcfnv91vqW0Ld+/hVB/wJoEmGSSj7Y
+        PpvfXj8Pdpy3JVp0nAf4p5nadw1H+j3yS8I3H9h7eXkipp9nLD+1npjnF/1+bH1zNE1NRsQmGW8J
+        zZ/G5On9/Kr90jn05KOKfOn20XLu8HXCc3r7P7W+HT/Tz5OdMhi9EMKxduqj6QPp1eT+H3tLa/sd
+        PTLbL9rffMONzrOp0+WcTvdD25ufjMvFZban7ZPxkozJ4+G+NH/0Oc+z9oHmObL1IiQdX0rHgeyo
+        L597nP9+Ql/zfvmJ/6sNb8nACi/n4rlKpzrixWqnwyda/bnh0umcyCarluYlf8NiMhT9j26Xqcdl
+        yngerTlHl7+7yPOn5WmmfWlL7rmfzEnf/z9OhiWt1ngDAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:16 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['11263']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:19 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['330']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+2d15bi2pql7/spos9NXfThpLypEZU18N57bjSEJIRASCCDe51+k36yxoVJs0nQ
-        FidXUrPGGbUzFgsCfmlOYn5aWv/rf28X9sva8HzLdf7rH/S/qH+8GI7m6pZj/tc/up1cQvrHf3/9
-        X6+6GhhKYC0MxV0Gh6m+4hl+aAdfX/1wrLsL1XKU0Dc8xfKVsap/3Rn+65efP/Sqebtl4Cpj29Xm
-        X30lkZAnZTqYr6xM2t5rfqYr0/yWThiLrrGvJrvJakdx7NKwqex285rBa0OJXku1VXmkyzN+ve83
-        jA0fbMdbRxfp6XCXK0zmI6NfdgvVDCOqGypjs7VsqZwQ602nY4WlwEpwtdFO8sxNPpFKzpeWtzKm
-        YVdNDns5Lt/bb+rZ6n5QF8azlDVa8uPR65dv3vOrYxi6ohtL1QtCz1COxfnquK9ffjb+OlV9ZWl4
-        E8VRF4Z/rsx3Y6+hf6j3ecS2/ENVjbXhfPxH9QxVORwU42u2//rl46fzA7rha1+zh2O420wNz7hM
-        OI2+ji0zXCpr1Q6NrzRFvX75PPCqWcHu/Eq26+iukwjnh4/6Pnh+/PRCldPjlwfPL63Zqu9f/nOe
-        H0wNNTi+gU9jl8dPT+l8+/j5ZQ5nxekUOb/cqTrfDr36huppU2Vu7N5+w5fDufUxeDwFL1Pfnvk+
-        8s3rfcz7yUvOLd3/+cueP8jl8W/GPqacPktOXVj27tOk8yf88vF7v7wVzfUDxVMd8/AaY+Pw79MB
-        UdzJxPAOR3Xsu3Z4EJyvrg/nxVea/dfhyH0/+joJbfvwPhZjyzH0rzxznPTt2HnK4TMFS8/SjK+c
-        +D7nY/AyKTx8btU7vCH+Y8772OvpnX28MCsfJ303eJn08cos/zHr0++7DLy/OPdp1sdvPIhBO5z8
-        qvn+gRn+9cuPo4dT+ocCLtTt9+/1m6HThPPzUfNINf+xgKeR797Gt2PnKd++hW+HXhdH1b99Nvo8
-        4/PQZcLheP/FYeNuOGq09Ouj9mnOXx816oajRnO3HLXPs64cNerWo8b8xVH7rnrHn79/E9+Onad8
-        +wa+HXp1XOX47WUbvgJbg6390TWHrcHWLr9+FapOcPxr9xJ4vr4etGjpytv4V/r1y3cj389gfjmD
-        /eUM7pcz+F/OEH6c8eXHj3fybUULPe8QAA9T3v51/lPXHC8Pf71+M/QxY6JqgeudA8b3gx+znHAx
-        PhweiRE+zboMfsxa2qp2iETMpzmXoU9zjgfb3y3Grv3l8/Ahc51Hv/6///v5+R/jr1++/5iBu1RO
-        JwUsM5Jl/lC/L3/xBwEEBUFBUFEE9VlFmhs6gXc5YU645vPA+8Mn8tB1rMDQX8qH19XdxcfUC7/x
-        rMDSFM9YW8ZGubyTyyn304fOEPB8uA1Hv/x8ITvhP19oKZi+JEMz9IMXhqIPJ+XHhPPcMNCOH8o3
-        gq+scPxF349+TPMNzXV0//DtLdI8x1PfzH578Dx9d/i/xULXvx5/KSXR0mXm+/ir5buSQNEnIKeo
-        jn4imafpCUpK0FKHlv+Tpf6Tov4PRf/n8Tf9/AmX1/2+Auef/UD1gh9qwtCHYiQPh9OOsyQCzQgs
-        d3NJOIa+qyRcgqGjlORSghO0PJ+PtW4n3Uqmy9nW65dPw5cppzJU1SCYGpuXlBt6jvEf/kvt8HE8
-        VZsb3v9+e9K5Xud/W/pXoZh7e+Tw02XcPpzl7geC/Dx4mXF4e0Hof7Wt9fvjl6G3CeH48GnUL28/
-        B7ul8dW3Fkv7yL4P7yh4e97pkcuscOkbB3f5xG3P7zH743v8q/d+HC93P49/+clrm4Z7rL769dVW
-        D9804aGQPP2vg4u8//hqu455/meC+hd9fOh94PXLx/OP+PnwLX3kzf4JXH8zcKSoR38z9Hd8evnx
-        FHW80HGOAel0/Gnmkna+GT39ef2Ted+P3gfSz4Ohpx6/Xz9Nexs5Tzh+BtdbqM7Bm09v/4fR1+O3
-        3Zmmp+nWC9epHYz4begNDeuHkh9nK/PFOR78ZPzVn7qbM7U/fZzzRY9vx179w3l9mH56cWN7OHUO
-        sf74cp+G3+acbePw+Et75wfG4mVkeO771LMIDqdFeHlaO5mpZFvtfrZSaR/+IPl44DLp9IS2qtuG
-        d5BV/3Ai+W/TLmD6cnnhf9xfZm8f/JuzQlO16eFMeQv3/vG1fhgDuQfi+rNr/m9BXML9iIu/4agx
-        dEyIi70FcQkxIi7m1qPGPQhxMSD3sLUnrjlsDbYGcg/QCMsEuYegICgyBPVZRX8KGf4rVHlas+q6
-        9oWEfKxj/Rg7kkPbWhyvOpz43KcfYwPOJ7R2fneJpHz+u+I0cHnEV9aWb43tC477fvA864P0nkmd
-        Ozecr/NEIjHhOoJqDeVZsVYuie2i6KzSm+46k3Yyer5hWq0m7YW5FufnDVGslafjRqJa3snNTq7O
-        dvnifnj5jedXvLz6bnkBc9ne28PvQ68/YtJvEelp0fXptBD/xVIvjerhPHsfOj86nS4W/uHoy+zp
-        MsnnsfPv+yCfAF5Ihv/Dao5kiGQI4AVbe7Kaw9ZgawBeyOewTAAvCAqCIkNQPwdeOc/65wvDOPoj
-        gBfLydIdwIshBHgx0YAXHzPwotTynjcHnVl95o58gQl3boJtJrdGqt1nqwU/x5b3I2/vO7TG1Vvi
-        VteLleQewAsOgWRIaM2RDJEMAbxga09Wc9gabA3AC/kclgngBUFBUGQI6ufAqx06/3xhuOP90PED
-        L55hhDuAF0cI8OKiAS8xZuDVTpqd2kooVMJ5V6iWJsHO4TraMLEoGIlqt+NbVX4nBzndZ+vmoNdq
-        B4ZZ9DcAXnAIJENCa45kiGQI4AVbe7Kaw9ZgawBeyOewTAAvCAqCIkNQPwdeVfcIvPjHAC+Bkm/f
-        /487fhQigBcfDXhJca/wUnKCVa5PttUen9qKc75VlCo1IQiXvXZC6Sp8l6mLrL5Pr/ldZTqqrur1
-        ZgorvOAQSIak1hzJEMkQwAu29mQ1h63B1gC8kM9hmQBeEBQERYag/mIPr9D45wsjPAh4yfw9e3gJ
-        hAAvIRrwkqMBr2Pr3K9FR7PDY7Pil7GqzV/848F8War+27NOk34ByKpmQivXN+KmN2CFdrLAG8Na
-        nZq4cycnCa3apEQ7JXVEG0aimRk08+tdc6oWtgBkcBQkSUJrjiSJJAlABlt7sprD1mBrAGTI87BM
-        ADIICoIiQ1A/B2R9Q//nCyM+BpCJEn3Pnl8iIYBMjAbIkjGvCFtsRvtOq5AaDZuWO8zU99ZkpRs9
-        X92w0xKv5KWG5mTyVbq7oWf1sJioj+RmF7dAwiGQDEmtOZIhkiGAF2ztyWoOW4OtAXghn8MyAbwg
-        KAiKDEFd6+ooPQZ4SYLE3AG8JEKAlxQNeKViBl5Bb9p2JmV3xqzl7FoaOZNRceea+wUj7lR+6FHF
-        bNscJ8pyIc+NpXp5Ost3m1jhBYdAMiS15kiGSIYAXrC1J6s5bA22BuCFfA7LBPCCoCAoMgR1rauj
-        /BjgJfPcPZvcy4QALzka8ErHDLwa/Gy3ZlaMUDBX1VTdLKZ4XS0IPcrQ2/pkkCh3Ro3KeDZL7gOp
-        wO7no2TgiFjhBYdAMiS15v+OZMi855Dbk6F4SzKUf33UGP6Go8bdcNQY5pajRss3HTX2sclQ/mUy
-        ZAG8YGtPXHPYGmwNwAv5HJYJ4AVBQVBkCOpKV0faD16q6i5W2sXQjHj7hl88RZNAu/gERUejXdmY
-        aZeQdKe5ui1Xs/y8TTdalYG4K4s8NaglmFrWbG35klBXrFKrEDpUGNIqMyqLO9Cud3tgbrCHT9L/
-        e/ZA3WIPfIz2QN1qD0K0WPieUO6Khaj5tZrHEAupX66DeL8uf3ss5G44ap/WOPy9dRC3HLXPKxz+
-        9jqIm48a86B1EFSstAsSg62RVXPYGmwNtAvhHJZ5s2WCdkFQENRDBXWtpaOjx0+7GJq9ffcunmII
-        oV1MNNqVi5l2GaG0rK/3Xn5RnhphRnflaWXWG3teYsKHglgYp8f8cO20tGC519oVnw/FYIibGWEP
-        iIWk1hyxELEQtAu29mQ1h63B1kC7EM5hmaBdEBQERYagrvRzZL0H0C6Wom7fuounWEJoFxuNduV/
-        czPHpCN7fGtoyrNdX1sVrLklC5pmhUJhyxjb+dyppruFvJwxM3PBmeqLjMtmO6BjWCqKW4RIrTn2
-        xHm7YeZXMfLp98TBnY+wtWepOWwNtgY6hjAPy7zZMkHHICgI6qGCutLMkQumD6BjknD7Pl88xRFC
-        x7hodKwQ81owc9wZt8XUJN/329yI4Tm6ti7MJrm6LLbYFFVQEjllMt4E44moTDOCujHElAvaBXtA
-        LCS15oiFiIWgXbC1J6s5bA22BtqFcA7LBO2CoCAoMgR1pZMj/wjaxYln5nEj7eIJoV18NNpVjJl2
-        0RbNddrz5GY0LfYzcqDX1Roz30v1cmkmTf3eor2R5TbH54qZ0njRmLl1bc1jV3ssFcUtQqTWHLcI
-        4RYh3PkIW3uymsPWYGugXQjnsMybLRO0C4KCoB4qqCttHIVH0C6el+/Z1V4ghHYJ0WhXKWbatUwV
-        GqleeWb0A2ayc1P1VNHK1hOlUi2vbAbNw4/Zpbir9WvGiFpPvWXBaHSme9Au2ANiIaE1RyxELATt
-        gq09Wc1ha7A10C6Ec1gmaBcEBUGRIagrPRylR9AukWXu2edLIoR2SdFoVyVm2iVZsrZf7ZajUC2b
-        Za5aTEyWZqkj0vxkwDe1YqqhL1tML3Dqe39oDVZVdlPM4k5G2ANiIak1RyxELATtgq09Wc1ha7A1
-        0C6Ec1gmaBcEBUGRIagrPRzlR9AuiZbu2bdLJoR2ydFoVzVm2lXYbLozvd9W7HmvkcgWgr2ZmXlV
-        tTHKdFsszUu1dtDYCXlrXh+pu/FmO8qwCaztwo3O2OCG1JpjgxsTG9z8XdoFicHWyKo5bA22BtqF
-        cA7LvNkyQbsgKAjqoYK60sORph6Bu2SKv2PjLpoiA3fRVDTcVfvNTRzrfHGu7YecNhoORNZrpXkv
-        uQ6X+wGjGb1Cpr3sWKORpIlsbr4bpDPjtDRXKzvgMfgJciShNUeORI4EHoOtPVnNYWuwNeAxpHlY
-        JvAYBAVBkSGoK00cafoheEym79jpi6YJwWN0NDxWj3k1WJgph8MiM3QVe7wthrYbMJbWbBgSp5eV
-        sFzPDPrWwJ0lpzLV2jTtoucPsgXgLvgDciGpNUcuRC4E7oKtPVnNYWuwNeAupHNYJnAXBAVBkSGo
-        K10caeYBuIulRFG6A3cxhOAuJhruasSMu5SSvKoGRivVac83A6q6aWSCaaHAp/KDRruZ9I20qPB2
-        cTnW5Wa9VTV2dXXWws2P8AfkQlJrjlyIXAjcBVt7sprD1mBrwF1I57BM4C4ICoIiQ1BX2jjS7CNw
-        Fy1wd+xsT7OE4C42Gu5qxoy71t2MTmk7fu74reZ+WdumW53qdnRQpqiMt2yj1Ov42UyukDR6w85+
-        tN8N+gkFO9t/+AO2Ajz5A7aAJqbm2AL6xqP2/FtAY2d72Nqz1By2BlsD7kI6h2XebJnAXRAUBPVQ
-        QV3p40jzj8BdLCves9cXTwju4qPhrnbMuGvW141ib624OZ4rdGcFLmdkerO+tK4Y41aeShlzc6+t
-        zLq76FWl5WK+o2YZBTczwh+QC0mtOXIhciFwF2ztyWoOW4OtAXchncMygbsgKAiKDEFdaeRIC4/A
-        XRzD3rN3l0AI7hKi4a5O3Lhrvpmoo3yiV0naOS6hjVqJbXrAVnRnkUqMRsPVoN5YU11NXJrr0At6
-        vCOnfeAu+ANyIak1Ry5ELgTugq09Wc1ha7A14C6kc1gmcBcEBUGRIahrnRzFR+AunpLv2btLJAR3
-        idFwV/c3d3JcT2luPZc1Z1FbsKlBcTeuytqoVhWb4x6lbvXVpNXPDjV3U9m6rSybHFedxhB7fcFP
-        kCNJrTlyJHIk8Bhs7clqDluDrQGPIc3DMoHHICgIigxBXevkKD0Ej8nCPXt9SYTgMSkaHuvFvBpM
-        EdZ+pmSJ7YbeSbQpa9Xrr4N+eerJC0lPBd0OVR5ORsF6lBzq5ZJpT3xmTwN3wR+QC0mtOXIhciFw
-        F2ztyWoOW4OtAXchncMygbsgKAiKDEFd6+QoPwJ3CYdT6g7cJROCu+RouKsfM+7KN/bLada1WyV9
-        NZ9uZXFfG9WzRsuwl+KSNxdra7PYdc1SbtcrDPIbva8OBQq4C/6AXEhqzZELkQuBu2BrT1Zz2Bps
-        DbgL6RyWCdwFQUFQZAjqSidHhnoE7hIF+Y6t7RmKDNzFUNFw1yBm3GUMd2orvdu7K3cy6BXdmllK
-        s1ohtefmblbK+Io4sdKjoFPJdRq0Ke1ZJz9xNsBd8AfkQkJrjlyIXAjcBVt7sprD1mBrwF1I57BM
-        4C4ICoIiQ1BXOjkyjKPHj7tkjr5jr6/j1zIRuIuJhrtGMeOuVccpm8Mkr/TFVKW5WyYLA0ZhakGt
-        NaQ1s083k/bI1stsyMvybp41s/WGWcfW9vAH5EJSa45ciFwI3AVbe7Kaw9Zga8BdSOewTOAuCAqC
-        IkNQVzo5MqwXP+7iKEa6Y+8uhiUEd7FRcFfqOC9W3MVx676dVctaRRxN69uh6Ni0nhTVcW/YKgXz
-        gjQx+E2zWFX24Xo1aHMJUZeULXAX/AG5kNCak5sLee6WYHicFUsyfH8h0qIhB+L1x6sMzgZng7P9
-        TmdDRkdGh2sCekFQEBSR0OvUz5HhHnBLI0cf/t8d0IsjBHpx0aAX/Zv7OU6cTX0400bjwSa5VQKF
-        FdtLfSTp23Y+XZXaqyI/bitjYeuOegO3WtDzTLCvYscv+AmiJKk1JzdKYvEE1oQ9hcRga7A12BrW
-        hCHNI80TbJnAYxAUBPUb8NipnyPDPwKPHV7snh2/eELwGB8NjzExrwnLFKQJxxe2VrDcZtmMVAtZ
-        rZor+ny7VM4bbMdnLCEzLpRYc1ST1/1drqKXeOAu+ANyIak1JzcXYuUE1oQ9i8rgbHA2OBvWhCGj
-        I6OT7ZqAXhAUBPU71oQduzoywkOglyRyd0AvgRDoJUSDXmzM0Et10u1qrsyzwySXWY9H+nBd3sy7
-        XS5Uw7RXzSue39gwFiNsw3nFHIn8apqYYpv7D39gb/AHnonJH/hb/EGO0R+4W/2BjxYN5UjREDW/
-        VvMYoiH3y2go3B8N+RuOGkPHtBiCvWUxhBBjLmR+dy5kYiVekBhsjayaw9Zga8BdSOewzJstE7gL
-        goKgHiqoa10dxUfgLlZk79nmXiQEd4nRcBcX975f7dIinVslxYXSVXfVRlhyqmG9rI/sVaU0G00k
-        ebRiu5Q7rtSqw1KpM09MxhVscw9/QC4ktebIhciFwF2wtSerOWwNtgbchXQOywTugqAgKDIEda2r
-        o/wI3MVzwj07fsmE4C45Gu4S4r6lsVEp+KnRPtineo1Fflag93prVEvbnWJ52/bKA1/vSWpd2ivJ
-        5rir96tZazoB7sLqT9z4Q2rNyb3x59dHDVvd4H7GP0BisDXYGmwNO3ghnePeK4ItE7gLgoKgHiqo
-        K10dWeoRuEtg2Tt28GIpMnAXS0XDXWLMuKsmGuupu89QzVbWHYh5VaC2UsZZMws9W6mX0psuJ3O1
-        1a6y7+byIsWHO03BhvXA4VgGQWzNsQwCyyCwugu29mQ1h63B1oC7kM5hmVjdBUFBUGQI6ko/R5b2
-        g/hxl0jLd+zdxdKE4C46Gu6SfnM/R98ZTDq2upLHTMFNN6j0umsPE8NKf0Illm5O2hW2Y5ebhGkv
-        aC9MZTFxnHawBR4DPseyCUJr/m9ZNiHfnyOFW3Ik/+uj9mnO31w2cdM37+dZcRy1aDnyvd5YDUaA
-        xGBrsDXY2m+zNaR5pHlYJlaDQVAQFJGrwU79HI90rBQ6Rrx4TKL42/f6Eigi8NjhfxHxmBzzajC/
-        KNfUUsaqFdR6YdPLO1uz19yZ20FmNxD6a6HVZxVzXu+k5Pl2WleH3KIjtrG1PfwBuZDUmuMuIdwl
-        BNwFW3uymsPWYGvAXUjnsEzgLggKgiJDUNc6OTr6I3CXzDB34C6GENzFRMNdybhxV3czykzZet2d
-        5UWu00lO2zpXHpUSfNvfzrWFOVg03DDJrKjdZKSkV0M2m+kDd8EfkAtJrTlyIXIhcBds7clqDluD
-        rQF3IZ3DMoG7ICgIigxBXenkyHqPwF2yKN2+tb1AsYTgLjYa7krFjLtafkaoCPX0puc26s3efDfp
-        WXXfS5Tm7VV9vayp6wTXUbiRyk+3W0qfSnqK6uJmRvgDciGpNUcuRC4E7oKtPVnNYWuwNeAupHNY
-        JnAXBAVBkSGoK50c+WAaP+7iaZ6+fa8vgeIJwV18NNyViRl3bTRNV9LtdWWWDPopd7cw9lRYpYb5
-        0qLTm/Xs4TrZ9EuZpe016yG7FAfZ1XwO3AV/QC4ktebIhciFwF2wtSerOWwNtgbchXQOywTugqAg
-        KDIEdaWTo/AQ3MWw4j17dwmE4C4hGu7Kxoy7RMFO2s1QTgzyXXPUVoY9qtyqZ6zcnpVW+VCoFCxX
-        n6ykeludLfN0217S2TJuZoQ/IBeSWnPkQuRC4C7Y2pPVHLYGWwPuQjqHZQJ3QVAQFBmCutLJUXwI
-        7mIZ7p69u0RCcJcYDXflfnMnR2s2MM3VwNTHS32RkfOBk81xdNMvSPneMsUmk5tSwUuMsrVhXxD0
-        xr4+KZgLrAaDnyBHklpz5EjkSOAx2NqT1Ry2BlsDHkOah2UCj0FQEBQZgrrSyVF6CB7jaOqevb4k
-        QvCYFA2P5WNeDZbo1zPdqVbQ0jlTKC2nVG9hNwLdY7i51QqGfjigqXxaKO6WtXow14p8dZTS98Bd
-        8AfkQkJrjlyIXAjcBVt7sprD1mBrwF1I57BM4C4ICoIiQ1BXOjnKj8FdskjdgbtkQnCXHA13FWLG
-        XaVRpduu9mblRLmeCWf7TT0pZrVsKcMvrbKXXk+pfiZP2+1ccbeajsSsMq97PlZ3wR+QC0mtOXIh
-        ciFwF2ztyWoOW4OtAXchncMygbsgKAiKDEFd6eRIUw/hXbzE3rG3PU2RwbtoKhrvKsbMu6rDzMbZ
-        7y0tUy+PgkW7XqYSQyE7n2WnOZOShD4VBn1VWal9tRp4w162QHn5HXgXDALBkNCaIxgiGIJ3wdae
-        rOawNdgaeBfiOSwTvAuCgqDIENSVVo408xDeJfLCHbt90QwhvIuJxrvKMfOuvqkYfseuGkMmu9tl
-        siIrb3r+iA5EU0sVW3s+4Xb42ZgzZ9Vqa7aVDHGs5bG+68Mg2BsMgmdiMgj+FoOQYzQI7laD4KMF
-        QzlSMETNr9U8hmDI/TIYCvcHQ/6Go8bQMQVD9pZgKMQYDJlbjxr3oGDIxMq7IDHYGlk1h63B1sC7
-        EM9hmTdbJngXBAVBPVRQV3o50uxDeJfEMXds30WzhPAuNhrvqsTMuzbdUjqzrSU7a8Ga7nSv6tqc
-        LsjjToNrDdMszy+DVX3iFdy8QOWNWj+99ZMMtu+CQSAYklpzBEMEQ/Au2NqT1Ry2BlsD70I8h2WC
-        d0FQEBQZgrrSzJHmHsK7ZEa+Y/8umiOEd3HReFf1N3dzXLCzga4xw3xQ4x2jkej6pe1gwbnVTt9P
-        m74zlgqzeXJaCie1UodyCkt13srg/kcYCoIkqTVHkESQBB+DrT1ZzWFrsDXwMcR5WCb4GAQFQZEh
-        qCvdHGn+EXxMoGj+nv2+eEL4GB+Nj9ViXg+W6Y2X+41WWLJZzanb4taaTJdtebOX2HQtmxl6LT5M
-        iZ3FXkmrEs+0jd5gXMZ6MBgEgiGpNUcwRDAE74KtPVnNYWuwNfAuxHNYJngXBAVBkSGoK+0caeEh
-        vIumaOkO3iUQwruEaLyrHjPv6u3p9kagO7y+YhvGMMX5S708YOjZwNDTC8qfhK15vtdfUUOpXMpR
-        azaf3TlY3wWDQDAkteYIhgiG4F2wtSerOWwNtgbehXgOywTvgqAgKDIEda2fo/gY3iVJ9+xvLxLC
-        u8RovKsRM+9qraVWYrP0zOx0vZ9nBqVJJVGdSe3Uel1WkgWqkJAbEkvVJgl/m6aW/tRkJo0NeNe7
-        QaABxskg0PiMmJqj8dmNR+35G5+hnyNs7VlqDluDrYF3IZ7DMm+2TPAuCAqCeqigrvVzlB/Cu1iB
-        vme/L5kQ3iVH412tmHlXY8TWGolypxLqbUtw+72lo5mdDl2ecRvRbKRogxPH0yJjzWfFzaKiNArS
-        qIx+jgDiWAhBas2xEAILIbC+C7b2ZDWHrcHWwLsQz2GZWN8FQUFQZAjqSj9HhnoI7+I48Y79uxiK
-        DN7FUNF4Vztm3jUQG9NRp1i2fEos7GWluNN2w+5Y3ZYajbYzHWZ6diIQG75AF3pZi5kyHZ0a4n5G
-        GASCIak1RzBEMATvgq09Wc1ha7A18C7Ec1gmeBcEBUGRIagr/RwZ2g8ewLt4lr1j/y6GJoR30dF4
-        V+c393Oc9YLJIliGGi+HTnpLtYdmwrH8lbk0Emvf9Kx0Rm1VsmtlMe23GXuSC1PKBvvbw1AQJEmt
-        OYIkgiT4GGztyWoOW4OtgY8hzsMywccgKAiKDEFd6efIMI7+AD4mMNQd+30d9yUggo8x0fhYN+b1
-        YHVhlWjv8m1T45bZIJHVlsWdkcptgwyV5fZ1NZdPLUW6sZhTKtem/W6+b1by4F0wCARDUmuOYIhg
-        CN4FW3uymsPWYGvgXYjnsEzwLggKgiJDUFf6OTKs9wjeJVKCcAfvYgnhXWw03tWLmXe109VFqrLq
-        W+G0OsqP2b6YajHpJJXISeXkmvbDuWabWYmjmCSb9zSrQXnlDva3h0EgGJJacwRDBEPwLtjak9Uc
-        tgZbA+9CPIdlgndBUBAUGYK60s+R4R6y35d4oR438i6OEN7FReNd/Zh5V19cJbJhscxJ6XV97UtB
-        fVxt+ktJqaqazg/3ZiJsjYXEZGTMp4bYLXdYTexhv68Pg0ADjJNBoPEZMTVH47Mbj9rzNz5DP0fY
-        2rPUHLYGWwPvQjyHZd5smeBdEBQE9VBBXennyAgP4V2ywN+z35dACO8SovGuYcy8K8ePq66dK0+n
-        +0orVdOkjjWZsb637wjZ7FCppkr+cDdZaMW5Rc1nhd124vVwPyOAOBZCEFtzLITAQgis74KtPVnN
-        YWuwNfAuxHNYJtZ3QVAQFBmCutbPUXwE7xIpnrln/y6REN4lRuNdo5h5V2IwE/yWxEy4SrJQFpR2
-        Ye7qs1q21WTN3FbfTPvtZrXUrnB5exUybK1nBM1gC94Fg0AwJLTmCIYIhuBdsLUnqzlsDbYG3oV4
-        DssE74KgICgyBHWtn6P0EN5Fs9I9+3dJhPAuKRLvoqnf3M+xIbsbZzOxq5lZ3mTS++xqxi/XGjdM
-        rNj0PBtWKibLpfTyTkoxdLJdaFXTnoP7H2EoCJKk1hxBEkESfAy29mQ1h63B1sDHEOdhmeBjEBQE
-        RYagrvVzlB/CxxiGv2e/L5kQPiZH42N0zOvBtowr24OqOaoMhotGd1vvaopSLpt0qb+vZCtTke5W
-        tnOxyEt2m6a5VFLoyNjfHgaBYEhszREMEQzBu2BrT1Zz2BpsDbwL8RyWCd4FQUFQZAjqSj9HlnoI
-        72Jpmrudd7EUGbyLpaLxLiZm3jVlRrM618lRlf3CFHwzqaTkbTvpuRRjacrOKvZm00bBX1R2nBfY
-        Db6wTgUJ3P8Ig0AwJLXm/45gyLzHkNuDoXhLMJR/fdQY/oajxt1w1BjmlqNGyzcdNfaxwVD+ZTBk
-        wbtga09cc9gabA28C/EclgneBUFBUGQI6ko/R9oPXkqhvYsZd8ni7dvbixRNAu4SExQdDXexMeMu
-        e9HotlrWZqwkByw36AY1xxRMJicmZqwrCuV6QWgpm5YyKXSXgtNqZ+dsq4LlXR/+gP4XJ39A3zNi
-        ak5u3zOeu6Xx2XFWDCshqI8XurIU4re0PnvUUgh0dISzPXPN4WxwNkAvZHS4Jpo6QlAQFDGCutLU
-        kfX0B0AvXqRu3/NLpFhCoBcbDXrxMUOvAeUuXDYReItWwrXESVDRwlEh2QrpTLJEN9eePGvx1fnE
-        morZZqacXc031BZ7eAGKYzEEqTXHzT+4+QdrvGBrT1Zz2BpsDbgL6RyWiTVeEBQERYagrvR05E63
-        NMaNuwRevH0LL5HiCMFdXDTcJcSMu4rpkm1O69Ua283stP5qpW38mtoWChWmpzP0bNFdSju1JTpF
-        mykzPCPsRkICa7zgD8iFpNYcuRC5ELgLtvZkNYetwdaAu5DOYZnAXRAUBEWGoK60dOQfgrtEjr19
-        By+R4gnBXXw03CX+5o6O2qyda/fHjXyp2thu9qOiNRushglvuRdCZp3ZsJyg7pV9IaUu1emyoHO0
-        TllYDQY/QY4ktebIkciRwGOwtSerOWwNtgY8hjQPywQeg6AgKDIEdaWjo/AQPCYx8j07fgmE4DEh
-        Gh6TYl4NNhrM9qVBLjFOrXr+Pq/YzT3VCBhRSO1T/lJuz9dtxhqNlEmqbs0600ngG2kFG9zDH5AL
-        Sa05ciFyIXAXbO3Jag5bg60BdyGdwzKBuyAoCIoMQV1p6Cg+BHfJtMDcgbtEQnCXGA13yTHjLm9P
-        W2Glse+si0I6te9uujNO363mqS0/UGRJaYjVbSHXrtpLoU1TQz9YrjY2cBf8AbmQ1JojFyIXAnfB
-        1p6s5rA12BpwF9I5LBO4C4KCoMgQ1JV+jtIjcJdEUcw9W9tLhOAuKRruSsaMu9jJQEglGrLeGWa9
-        xHhcLTADeZOjk9PiqMLIVtdVS6w56Cyn/Zxeq7qNpV1bA3d9+ANaX5z8AV3PiKk5up5dPgO6nv0t
-        4gWVwdnIqjmcDc4G6IWMDtdEP0cICoIiRlBX+jnS1EOoFy3yd2z5RVNkUC+aika90jFTr0y9VG1N
-        ih2xPUk7M0t3EpxvlwwhO2FqymKR5fRepWFUi+xM9z2lx264wdrZg3qBimM1BKE1x2oIrIbAIi/Y
-        2pPVHLYGWwPvQjyHZWKRFwQFQZEhqCsNHWn6IbyLEeg79vCiaUJ4Fx2Nd2Vi5l0zK+M4Q3W/0/pN
-        pmVzBVYNK3UvUe6VvHxzWxGHw0mmm1zrQVhUaiOpllE1Gh0dYRAIhqTWHMEQwRC8C7b2ZDWHrcHW
-        wLsQz2GZ4F0QFARFhqCudHSkmYfwLpaT7tjEi2YI4V1MNN6V/c0tHblZOVPnmzstJXBSUKvuWJVO
-        mco8dNILf1xiuuZitE7zvTnt7FpDeVq20sk91oPBUBAkSa05giSCJPgYbO3Jag5bg62BjyHOwzLB
-        xyAoCIoMQV1p6UizD+FjHMvdsesXzRLCx9hofCwX83qwsLrz8/V1azxwB5W6VjIrpcVAmg/znSHv
-        JPTqTOxUVdZap8zNxGovDidKKbnCrl8wCARDUmuOYIhgCN4FW3uymsPWYGvgXYjnsEzwLggKgiJD
-        UFd6OtLcQ3gXz9DUHbyLI4R3cdF4Vz5m3jXUtOJosR+vc5UF0y3SbdOUNjm+Xe73+lXebBXV5LLH
-        trYjSpbkeYVPm47igXfBIBAMSa05giGCIXgXbO3Jag5bg62BdyGewzLBuyAoCIoMQV1p6kjzD+Fd
-        AiXes789Twjv4qPxrkLc+33l2ovAq3TrbYVfWaOMtt43llp+sRc7o+Gw1trsm6muUJ30U4OkV8xa
-        pljM98C7PgwCDTBOBoHeZ8TUHL3PLp8Bvc/+FvKCyuBsZNUczgZnA/VCSIdroqsjBAVBESOoa10d
-        xYdQL1Gi7tn1SySEeonRqFcpZurFat2hVl9nU7nNfpYIKsld3xY6s4FD7Y1td1sShFGtY6Qm7K6s
-        l8psXxdzTQPUC1gcyyFIrTmWQ2A5BFZ5wdaerOawNdgaeBfiOSwTq7wgKAiKDEFd6+ooPYR3SYJw
-        zy5eEiG8S4rGu8ox865WcrlXBzkqN9z3C2a9M2uYycNZoCy01ohaB0zoL3f+TqtRVCal+PPiTB0J
-        S+xaD4NAMCS15giGCIbgXbC1J6s5bA22Bt6FeA7LBO+CoCAoMgR1rauj/BDeJfPsPbt4yYTwLjka
-        76r85q6OyTwvB/ViZRHQlV0ntZ7o9ppnzG2+kqh6ZcrvufrQtKRRo6eUR351sG2t5mPwMRgKgiSp
-        NUeQRJAEH4OtPVnNYWuwNfAxxHlYJvgYBAVBkSGoK10dGeoRfEymWPmOXb8Yigw+xlDR+Fg15vVg
-        88pk1fdqQ2u1llfZ2jgr1WV12TezhW0tLW5KmWyBKneXZoGeamurJe2WglkF74JBIBiSWnMEQwRD
-        8C7Y2pPVHLYGWwPvQjyHZYJ3QVAQFBmCutLVkaH94AG8i2Z46Q7eRRPCu+hovKsWM+/K1PTtqF9s
-        7cZpocqud11uu0iM2Vm3P3ITRUNUJpX1pKbL2W51oyRrXorf2tsNeBcMAsGQ0JojGCIYgnfB1p6s
-        5rA12Bp4F+I5LBO8C4KCoMgQ1JWujgzj6A/gXQzN3LG/PcMQwruYaLyrHjPvapbt6XiSnxs7e+bm
-        +51w27IVa1EbdAt8trHv2FzPNa1pa7ys+41Zys/nWnsG+9t/GAQaYJwMAr3PiKk5ep9dPgN6n/0t
-        5AWVwdnIqjmcDc4G6oWQDtdEV0cICoIiRlBXujoy3EPuamQl/o5dv47fy0RQLy4a9WrGTL1qIutY
-        qeGiUj0cNLebyGfpZHG+XLQkp1zql8fZETXKbux90N9sMiWqNvT3/BbUC1gcyyFIrTmWQ2A5BFZ5
-        wdaerOawNdgaeBfiOSwTq7wgKAiKDEFd6erI8A/hXZxI37OLF08I7+Kj8a5WzLzL9DKJoZUfBWyo
-        pYS2kTHCsOaFo3CQ3ixW3UZn54+T9e6KbtRmSba3Lu/7ozTuaoRBIBiSWnMEQwRD8C7Y2pPVHLYG
-        WwPvQjyHZYJ3QVAQFBmCutLVkREewrt4XrxnFy+BEN4lRONd7d/c1XG94BrcpqJ6s2XdzNb7+6ox
-        6LK5YbZoNQfyqJFpUEZ2Ps02pJ3ItlJNe7lsbMDHYCgIkqTWHEESQRJ8DLb2ZDWHrcHWwMcQ52GZ
-        4GMQFARFhqCudXUUH8LHBI67Z9cvkRA+JkbjY52Y14MNqlsp5C0zMXPaC6/PVTmKHfO5fLq+7iU3
-        dn7aE1qcuyjry+puuNwXW6OyEuD+RxgEgiGpNUcwRDAE74KtPVnNYWuwNfAuxHNYJngXBAVBkSGo
-        a10dpYfwLpGlhDt4l0QI75Ki8a5uzLwrt6cSq/3KszfpkjPz0m2V0g3Gn1QX8l5em2E1X2R7+6Bo
-        bZplM6kozLic3e3Au2AQCIaE1hzBEMEQvAu29mQ1h63B1sC7EM9hmeBdEBQERYagrnV1lB/CuyRa
-        vGd/e5kQ3iVH4129mHnXeLUsj8Ml77UKSadrLXcr1VEaZt+oiJlS0awapa46VTxfYtLFtJbccuK6
-        PNyDd70bBBpgnAwCvc+IqTl6n10+A3qf/S3kBZXB2ciqOZwNzgbqhZAO10RXRwgKgiJGUFe6OrK0
-        HzyAesmSfMeuXyxNBvVi6WjUaxAz9UpUi8OStCuKqVVrxU/nRl8ceUm1oHgVcyysm5tdK5dgebY7
-        SVFbqzJMd+amj128gMWxHILUmv87lkMw7xffb8+G4i3LIeRfHzWGv+GocTccNYa55ajR8k1HjX1s
-        MJR/GQzZWJEXJAZbI6vmsDXYGngX4jksE6u8ICgIigxBXenqeMRdydAMD/+JEXiJFCUKt2/jJVFE
-        AC8pQUUEXsOYgdewV09UxXpjNZoqiQwz0xPrhF0LB9lhpSrrbZ2udH05Vc9rzW3Ocdig22gMXNzW
-        CIdAMiS15rj/B/f/AHjB1p6s5rA12BqAF/I5LBPAC4KCoMgQ1LW2jo7+EOBFC8zt+3hJFEMI8GKi
-        Aa/Rb+7rmPIKzcw4ue/2ufosXEl0nalv2ZKwVxpZodmreHZW2KdaTitTHkw5em7znqQAkMFRkCRJ
-        rTmSJJIkABls7clqDluDrQGQIc/DMgHIICgIigxBXenryHqPAWQMJ9++8ZdEsYQAMjYSIDvyoVhX
-        hG31Qm44KKtaIVVVh2wuW1xMBaW8KJqSIKw71WSpa1Y73d6Ebhcnky4TOoE4wcZfcAgkQ1JrjmSI
-        ZAjgBVt7sprD1mBrAF7I57BMAC8ICoIiQ1BXGjtywfQhwItlee4O4MURAry4aMCLjhl4BatZjUrI
-        zZKeMvfZWrCnB44iDtJ9X614Sa9Zq3XzXcbb1YqVQqq44PjeusIBeMEhkAxJrTmSIZIhgBds7clq
-        DluDrQF4IZ/DMgG8ICgIigxBXensyD8IeHEMffsm9xLFEwK8+GjAi4kZeAmenVKFZkNMcdlyZpNh
-        dFZkR+PBzGkl+cl20m/mc0WHNnWtp5a6E30hbCfyFsALDoFkSGjNkQyRDAG8YGtPVnPYGmwNwAv5
-        HJYJ4AVBQVBkCOpKU0fxQcCLl7l79vwSCQFeYjTgxcUMvGoqQ7WkhM1vHc1p+3p2msklZbpoVhmr
-        nOw0Bvai2m/5utvssu46OzbK7UUFe3jBIZAMSa05kiGSIYAXbO3Jag5bg60BeCGfwzIBvCAoCIoM
-        QV3p6ig9CHgJEn3PHl4SIcBLiga8+LiBF7PIl/ez7SDcZTMrZs3JZVMSatOOspgtKp3pstBOddNV
-        2uWzbKlXkzdjZ8LjlkY4BJIhqTVHMkQyBPCCrT1ZzWFrsDUAL+RzWCaAFwQFQZEhqCtdHeUHAS9R
-        EO/Zw0smBHjJ0YCX8Ju7OiYGqa05rbsje9zP+DMjLaTc+rxfq/O96cwf7sJmrVhrjrquWFqmJk3G
-        plpV7PkFR0GSJLbmSJJIkgBksLUnqzlsDbYGQIY8D8sEIIOgICgyBHWlqyNNPYiQSTx7x6ZfNEUG
-        IaOpaIRMjHlJWDg0AzXdEY3uZrvZtmzOq2dNx9LcIp/khUyd1YfjsifPF9MKm252TcVgh53Nn0m8
-        vmu7QNMPOiNljmLuOCNpQs5IOtoZKcV8RsrD7t6o2cGALyd3WkK3wznvh/1SfjlqKgyj0/O52yy1
-        9wMqqISthcbNB5XUH7oN3Xf7ItLMY85ImmKEO+4Tp5lHnZGnx+84JZlop6Qc8ylZn9Cd0pzOqFSx
-        WfQ7TLGwnbR77YyhzPOVarWjD7jpauX4XVqp7jiPKg5EWvpDbxT/tHOBGhxOSfZBpyRNs3es5KYf
-        1o353lMyYjvmZNzf215LqXemzZwetAeZYSGV2tvZajLXHwwHYq7bac7F/mqglRrVem3obTP11qrB
-        /aHf27hSBaT7P6DmQLpAurhSBVt7sprD1mBruFIFsA7LxJUqCAqCIkNQVzbrpB/Uj5mmZfmOtdw0
-        If2Y6Yj9mFMxE69kfVSR5HyRb+rbVTqfWpfKLUXbbW1hs0r3UwOxMix4zbQxYsueEQRbZTCUUn88
-        hD3tpkE/qGESzUj8PddOCWmYREdsmJSO+YzsrLZyTxB7g8Ss1dFKrTVb9NM0V05V2s3GPhEszG6o
-        OC1/GBTDWs+cVIZKdvyH3i3w3e0utPCgM5IVmXuunQqEnJFCtDMy85vvd9lnhazc7aRnkwJd3c1G
-        wXK37QmVieunuFmTnTQS7W6hL+qDgbSTOtviOuxq4z/eU8/rUR60JzfN8dI911oJ2ZObjrgndzZm
-        T/VS9US9Xhw0u7rOUftxUZ6sOxVpuGnJQ0rvL+wGnS5LPhvmfW66TlQ0o5P/U69rfb8e5UGbZtE8
-        x99zqZWQTbPoiJtm5WI+IzMMv/HbbWNkl3k63fK1MJvsGKmWl1uoNXZPidvkolrvuROVH1edTdtg
-        V3Tnz/mW/xIewYJyeg+25QeXo32ImJ6hXt5j/xAt3386P3D6Xdm14e02U8MzLhPO72BsmeHyjNnP
-        cfvzwKt2DPSnV7IPJ6HrJML5IY69D54fP71Q5fT45cHzS2u2evwIp/+c5wfTw3l2fAOfxi6PX6T1
-        zePnlzkc/YV6JJynl3tbAvBp6PVw9h5ypjI3dm+/4cvrl0+Dr4fz5TL17ZnvI9+83se8n7zk3NL9
-        n7/s+YNcHv9m7GPKeeGQurDs3adJ50/45eP3fnkrGq4k4UrSn1zzf8uVpPcrG7dfSeJuOGqfrhL9
-        vStJ1C1XkrhbjtqNV5KoW48a86ArSRQukMPWnrjmsDXYGi6Q43oeLBMXyCEoCIoMQX1WkeaGTuBd
-        TpgTrvk88P7wiTx0nSPceykfXld3Fx9TL/zGswJLUzxjbRkb5fJOLqfcTx86I8rz4TYc/Q+CpnHR
-        zS8/rcD5Zz9QveCHmjD0oRjJw+G04yyJQDMCe/v6BY758b7GayXhEszNNyB++bEEZyh9Oh9r3U66
-        lUyXs603Vn0+Tc//Pl9VV4NgamxeUm7oOcZ/+C+1w8fxVG1ueP/77Unnev0V+j7/yz6c5e4Hgvw8
-        eJlxeHtB6H+1rfX745ehtwnv3Pn885EDf/WtxdI2Dp/28I6Ct+edHrnMCpe+cXCXT8D2/B6zP77H
-        v3rvx/Fy9/P4l5+8tmm4x+qrX19t9fBNEx4KydP/OrjI+4+vtuuY538mqH8d1wh8DLx++Xj+8cLA
-        4Vv6CJr906WAbwaOFPXob5/uyLr8eIo6PyLxH0ZPf17/ZN73o6+OYeiHo7s8nDfh4TvleC6d3s/P
-        xi+TQ089fr9+mvY2cp7wmaif3v4Po6/Hb7szTU/TrReuUzsY8dvQGxrWDyU/zlbmi3M8+Mn4qz91
-        N2dcf/o4p1/33dirfzivtcvlBGN7OHUOsf74cp+G3+acbePw+Et75wfG4mVkeO771LMIDqdFeHla
-        O5mpZFvtfrZSaR/+IPl44DLpcuegbhveQVb9w4nkv027gOnL5YXzufbkf5/91YfUXNs2tOB8jexw
-        dLbBx9jpp7KxewmmnnG8bvF5/MdZrnN9Tmdq+S+H//nuwng5/A1mOS/H8e+f8+Vnb+nss6eLR5e3
-        fvh69kM7+Pr/AdSCuXFgdwcA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['14154']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:16 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/ValidEventTests.test_boolean_properties.yaml
+++ b/tests/interface_objects/cassettes/ValidEventTests.test_boolean_properties.yaml
@@ -1,137 +1,114 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF92aWRlb19pZnJhbWUgLz48
+      cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNj
+      YXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21l
+      ZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9m
+      b3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlh
+      PnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVx
+      dWVzdF9tZWRpYT48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHJlcXVlc3RfcmV2aWV3cyAvPjxyZXF1
+      ZXN0X2N1c3RvbV9maWVsZHMgLz48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxtaW1lX3RleHRfdHlw
+      ZT5odG1sPC9taW1lX3RleHRfdHlwZT48cmVxdWVzdF9tZXRhX2NvbXBvbmVudHMgLz48cmVxdWVz
+      dF9leHRyYV9pbmZvIC8+PHJlcXVlc3Rfc291cmNlX2luZm8gLz48cmVxdWVzdF9jb3N0X3Jhbmdl
+      IC8+PC9ldmVudF9zZWFyY2g+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['759']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+077XbbuLH/8xTI3nM27aklkhKpj0TV1nacNF9Oaiubtn94QBIUGZOAQoCWta/T
+        P32Oe1/szgCkRMqyLSebnnQ3OUxCDgaYDwwGA8xo8tNVnpFLVshU8D//4HTtHwjjoYhSPv/zD+9n
+        zzqjH36aPpiwS8aVLxktwsQvmCwzNZ3IMohETlPul5IVfir9gEZTLibW7pZJWKwWSvhBJsKLaeh3
+        OoNOID9+ePsxO5sXrCOfBi/Pxm+PwniUvBpcfTo/jZ+r0/N3R++CgZPZq8M0WDybzdVR8Cn4RzgY
+        HZfe66N3NHl//u5s7B/Lv//8zyv5izwvnw5mvYXb48EiOFu+/NvRy5OX/7x67q6OL5KkR9N4nPUj
+        L14FyRvvb96b08xeHLmdf0ysFn+TKJWK8pBJnxbMv6RZaoTbBTcKmk4AQn1QH5uefJhYmy/TEDEZ
+        Tk9A26tlwgpWIWjoJEzVyuBmgkeCd8oLYGgNNO0a9bVurxqrzhmVsvrP4NNCSUDZAKpGjX8IjeRH
+        mi+e/E9/9IQcw2yWyE4DZQJzpifQDL1iMFobNKms4YKtNDULpn0DQeOo8Opua0hrsA3e9ngRKnn3
+        oEakGqEF3OBoOY5oljFlhCVPtzoYSa0NC1atSCGVX1A+h/FyegUj50HKWTT1el17YrVAGgGYVIsi
+        DdnUHdYYG5hBKUEMWsCQ3hpjDZrkqNd6yJ6jMZogjbAZ0RnVGE0qWp31kP01xoYKF76ElZ0xVNZv
+        U8RPJeUKV4ZYKPBpMJl6hfo1fOpMrC3INkbvToz+nRjunRjenRiD6xjWdfH0HPphWRTguAGlfjPL
+        YR4swKpboA1GTEMliqlj2w2cCrjB4mUesGI66g0aWBVwg7XIKLhE1N02qIGDNidXeSAyqwkGN2qg
+        0//9V7P/Bj6xtsW0brDl7/P/O5n/5qSHouSqqOTTG2cTsG7W/v49TxWLyCuwHYhRNqjVTlqkKg0h
+        xLlM2dJfsCLEfd1oaGfTJKKKGT58xqPqWw82S8oD4khFztlCMdQX6dkOaHGDYrBLFfoijiVT0/4A
+        SW1DN2iShbD9y6njDntDz21j140GfQV/8jwCXwtE7bHtVJhrOOzMYjSwHV+DKY98leZMo3fsccd2
+        Zs74cd9+bNt/sp3HSGl3h2rcbR2Yb4iVCnVNK55KyBu6+jX1Mei5w769tz4827uXPjx4Pkcflfwm
+        gNbmePp+dnx2ePzq5GxiNcAVilbDG6pUwpbkSJQFZ48kOQVxChpegAnNTs5ndUejM/MOUejgxbO6
+        ZR2T+imPxfTHTD2J0ssf5+oJvi7w5RoRqUrOYVmQRSGiMkT/QkTcoP2QFAwiRS5JymHq7BFRgpzT
+        KGMFdP/AskyShF7iEEEhLhgnEH2RQFzBMDHs39A9FEUkSVQWiATBliIriO+QOPTuiFLBC5WCd5FN
+        S/P5YM3xLEkliZlU6SUjCmJnRRBQAhHgExtVQSOW0+IChFllDMHLVB2QBVWJkASmiIDMVEE0QTOS
+        03kadlsCxiLLxFKS44wWFNj6qJWzInEhckJJkDF6QY6TAs4AOZUEgnkCXDwtuk8LIeUj8rZYJJTT
+        OTsAQoUo5wn0kkma50yLDFroyAuq8H0JxsmKDJnSjAnkjcgFCxUNS2CAhABfIU8XKMn5kjGVMuyw
+        Uz1vM9BLQeiSFlFnmZq5BBNJ5xzAhxxUwFfkA7RqejMImdILcSkvViBoXoZJJxOX4BolTBIjdVyG
+        CkyITH/5JcPxwgQaxbygi2RF5iVoiSsGs5GAGm4x24c4UxTUyGRyQLJ00ZE5NMCIBzDjhbYZEBHn
+        L0XDg9nZaDmGc9JOidsEwfaARpikDKUIBLANaw/GSEMtMEgEsxCmMLYsQ9iapJENDSdFW+BUWxaH
+        EasjsUSm9KFAG0ygTxOyS17Xlqs7v8vAlX2AodB+P2gLz8EOYeIKPaVnYgWdT2kl2ExbIFgILAeW
+        Iq9qKQjOXorzhNNnTBWGlqBula3QOAJcP5eI39CFfqtW9gOtmMTF96dlocnpdgN6sMsJHJLnIotS
+        PPHqZak7kQ7hAg5NgMRyxFJC6IHMF4ETKkzbrSia7wPysQQ9oQqKdJ4oQnPcbPVEg6PcQ4wPCTiR
+        Y8rJC+DzpzuF4Sscl6xECSZ2wR6SQ6mZJWAYCo/cj6RejmJJwMV092MA1kIkgIH53QzMrrlDNB8w
+        Tske7kOLqupUPn4iyQseZmXEojup6hsFleASQsk528tCngsBPkCQV1ws76IAPgOdyUPyBqYDfD8S
+        hCnEKdX/yj3onZepouA/yTNYFcdJmkUQyd1F+LzEdaKtCMwfPZv26WhRFFYXy2GHA4PFJbQvH8d4
+        CZBlxtDfiSwNVzdwcSpgwcUlRBAEWGZX4C9hRwcLuqRppkWhsYIVu9CnT1nZc01yvRPj/lvtxehB
+        xdTsQKxGMMAKI2dRSiEMpTq8hygZti01jZzllbvse2WQR+lVN8xEGcGOxFWXMzWxNM4k5RDvgL7w
+        RL0ANwUxUJFNE6UW8rFl3TqEJeH0zCKrwQOEu2IBQa417sMT2m4Q21HPZXE/sj02ilnsBnQ4tMdR
+        bLt9l1GnH3Y/LuYQFO3kY8IphEa4d0kQDoTX3xPcmKe/Knk94uTbUMVORchysQDnKH3kp7oubULa
+        CNV12RZsYrXM5Vu1nSGDx3ZH4cDz4uE4ciizHdcZh+Oe27NHAyeKHW8QjPrxHrYDYd2nku1vOfcm
+        /hUt5968/AYs5wv05WtMqzeGZ+gybzQcDyksurEz9HrBsB/R/timbBCPYjpg7mjQu9t88BYRPC3e
+        SvB9behz+fh6lvS5HO1hT9et5RszqC9agR6Dx7bduOcFHqXBIHb7vTAassGoPw7Aebu9aES92BkG
+        e9jSJzj47O+J7k37K3qie/PyO/VE7Er5ikllW3+SK6lY7m8gKEgGZ7U9DKXCvNNU9if3FWxjf+K/
+        ezcSj+GhFCI+iAPd4TDs2/1oOApCz7GHYWgPPTeKR+6AhqO7rUMVKYL8GA71ezuTe3PwFZ3JvXn5
+        DTiTb9B8RHm3g/luPt+G+Xx57GczeHqeF7nxeBBEdi+gdBjEUa8Hf0MajO1wFA9CFvXd/W1I8L09
+        0Oey8dWD4ntz9FvYzb5cbSEAaC9yvdGYjsbuyPYcF04UEBmGLBzR8ag38Hq9kW2P+/vbk1qKe9rT
+        vdn46vZ0b47+w/ZkFDt48ayTmzxIJ9B5kI7s8HXipYNhnFX3NzqrqvkUVaWcZjr4aIFqhDKIqKJW
+        /a0wpddMMhpA3bpaQLyboui+SoG0WqNhS4VVLjDR52epVK3E5cmOxGU0ffNXuwm3dowxZwLTr6AU
+        vNJVZcSmntP1euOB4/SHE2sNnWAiwLx27K5jD2zHG/QAYQ2eWJvBEip9LjDLH0u9p7QAWNOG9wks
+        WhezVZ+6DqoweVSTDXZ6VSlUC6ormXbgbUMneJvvR2xBC6zR05lmzc8ueIVcZXEaaDXEIKAMosjx
+        Htywfw06wUoNU8Z47JwRd3YKy60GTUwFhKxftDZ0nWf1jXS3QBWqT0uViGI6SxiZgXhAu91Q4wUi
+        Wk2PKcccEyaN85zp1K3JiC0J45hafbjurvHrzo1ag5IdEGeoEnIqLtcVGN66W6PwoAlpVgp4juMM
+        2x02BQMVNKN8PmV8jaW/60ZRpJhZzNAbWGsoTq6h7Nhd2yaHb9a9N00t5CTJcymxFEUXOexo2qCr
+        jE3f8zyVEtMUDxvY2DLBmgS/0NdhWIbU/KxRb5zc2t5vmV3MypLDLFsUTN4+w5jxqhJyDzEtSoBl
+        1mG8I8P/+zdnmADVOXqaHeicTyv5DI0mgx6XVbNUolhVnXiKFQdcVTl/IVmdIup2ScpDcP0p6KZL
+        XjzCGgVGgnKFGTTjumSVu63tjc5pyvVQ+u1Ou8Mal94I7O6wnGPyCgzJvY/VufaoN/pvtDpYs48U
+        mTN1bYnex/astYupqn/rmmv/Ip/aWPW5Az7BmdJuzLhOs4+2YRMJO2TITMXN+pID0BrgGsdUa18p
+        VuikPSCSI9xSwQg2PYzGGh8+VorAQDxO53v1bnWoR2L8U5kWKZM+y2maTc21jPwLqAkXleiGoot1
+        bjeg18OgzwYboFFUTDH/ysjQOyA/p1jhl1KsWwjBQWKmeonZ4HNVMKYOyBHLYixwOJo5PeI9+/ua
+        TnO8mkZ1Y2Qqp2uVrnu0WusuStdKhVPMBIMf0dl5VBBuvUTwbNV9AM4AGwpGzBYAOtSbvymMoHxF
+        wMmwfAEAJdYZWJKilkyxjlm81e0VWaZmlYcm+1uVtWC9BowPjqK75rhmDiy1KEPcXKMqhxs2Mseg
+        CswcV1HvjpxyHf1e0qxkFtYr7urd2JkRu67aaHWefmvFGrostdR1bmv252A/EA/6F1wsK2GaBQY3
+        CHSfuoIN1TYt2NgL4zU0ibfV5w0Uvxe9fS96+1709l9e9LZxBZvFjz8QwVNTxBTsgLJy2doHvDNN
+        pGoi2AQHnVsc7ZEQFyRYkb6NIRwMnWmxGkekapNxbPKyBE47+FbFeijEAnTDgXsYBynHYCzgV9bx
+        5C5Rdgsgq6opHwj7YVU1Vcm1s6LqBom+oJBqw+INzCxhGSC/plytYu6mYrYb+Lu9hm3DwjatZcK4
+        Dx7DT/25WJNuFg3etJd+fq1gk5sWdf2rPj8SW8w0CghvYGa/usEW3SYh61qo0jidtX/EsKthAoFV
+        yUxUdwYHJTgmwzZ8qKFIPSiIpV3QC4neUJmq0jXU/B6xBXr/CnjdDFoR0NH1+eHT1ydn5x9OXr8+
+        r5FM2G3edUDdVkaNZmJt867FnJ0d/nzyukW59XEKvgrjyve45cxhY+LRY9gS5iwjfzgFFwNa5DD5
+        nP3x7jHOYFE+1r8agX0St72tIdBZ6aFvGYuQWYnoLIawqtShleEG790w8NAOWw+uwzBBI9xo9ckX
+        oQgwJ9NzRV6KhFcRe5dsTxt6Ue1w6mBO+3z8rIoPCQ2QA7AJkjP4hvBELHmrT7fWuzGpyzRiYHBx
+        YQy48eVvbrRb4IThMNM+XrjsatjCxovu5XLZhRWpyoDBESff7qfvwlsgcweKVzuR9dx5uTj56/P0
+        lwt3q6O59myBrmeNbmm+pWt1X3sbQrs3HMh97Tfqa/T1dfWW8HdKdX2kGyj9WnR2UlmmESjXxdvL
+        HfA2sL7CXV/ltn9R/v+e+0Ywjj4AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:18 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3898']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:21 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_extra_info /><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_video_iframe
-      /><request_reviews /><request_cost_range /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><request_source_info
-      /><mime_text_type>html</mime_text_type></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['903']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1b63LbNhb+n6dAujPtj9oiKVG3hlXXtZ1sNmmS2s5ms384IAmKjEhCBkAr6uvs
-        m+yT7TkASZGSfMsm07TrjCYmDz6cO248pPfTxzwjV0zIlBc/fuP07G8IK0IepcX8x2/eXjw9nHzz
-        0+yRx65YoXzJqAgTXzBZZmrmyTKIeE7Twi8lE34q/YBGszWTnrW/yQvFeqm4H2Q8XMze+oeHV4tl
-        PF0cT5dvh6+Dw7ngceSoZ6vw1Zv3HwYslB8GJ++d0YdfF6/t9++Kk6v84kUijwZL/+Pby/HZy6fr
-        k3B4eBY58ejFZVy+f345P3oqX58Vq/UltS+c0WtX+Cf54OXz01/Xl+L0w+Vkmon+m+fFdHCyWM2z
-        957V0cmLUqloETLpU8H8K5ql0azgnrWPbrwy84BCffAZm52+86zNnWmImAxnp+Di9SphglUATfWC
-        dF4ukVvJZo5te1ab4IWpWhtOGS8iXhyWC1C3IZp2zeilbq8aDeswo1JWfwxeJYwqVKBFq9p1l4tu
-        u2EDkdNhNOx0bLskr0qKBVvXEiyI/4aIaVJB654NpcNvg9vDcpFGcj9bY0jV3qFtINqWpzRPs3UL
-        ZCy0NnKt2mlcKl/QYg48AgbXOiA+j2MmIKqB5FmpmC/pFQyTmTPoQeS2qV5cZhnokQdpwaLZsI+g
-        Ls1AwCa1FGnIZu64wWyIFagEu6kAhYYbTEPztGYbxoMpgraIFWjDeTDcoFryKkLD3G2hNhKXTISQ
-        /HTeGNwfetYuFVJ6x4E5/bita4ekAab/g88/yee7DtSULTW6NAPpqtAleTmO+to2xyDapAoA8b4m
-        bO4douZMbo9aC3N91Ow7RM1x7xK1NuqGqNl3jVr/mqhteQ/vt5Xo0gykq0CX5BXcl8A+Y9J/mNYe
-        prU/tM8fprWHaa0Sf1nSQuFuly8VHF1g06b35H5NnzmetUXZRvRvRQxuRbi3Ioa3Ika7CGvXPD1v
-        +2EpBJzPAFJfma3uPFjC7rVD2iBiGiouzAFjm7hBFWUeQHgm/VELVRE3qGVG4RCEvtsmtTAYbLnO
-        A55ZbTIcnAx19p9/t/tv6J61babiS18nxcOU+UlT5o7/rGs2BA8D6mFAPQyoTxlQ7VEU8rJQokoY
-        /bimTWia9ZOHt0WqWEReAN+I5xto9fxGpCoNfcGuUrbyK02qlNvb5EUUwmXCzYqouq+e7JQHxJmo
-        hByV81Iq0rcdSMoNwGBLFaJRkqnZYISCtqkbmGQhLyIJq/fYGbpDu4OuGw18Df/yPIpmKNSeOJMK
-        2dC9VPLJyHZ8TaZF5Ks0Zxp+aE8OncmFM/1hYP9g29/bzg8oaX+Hiu+2B8y9VFSoHZ/0HXDGEYQz
-        +5wuGTn90cC9s0vcvnMvl7iHfedTXFK5wDzK1fn46u3F8dnR8YvTM89qkSuIdsMvVKmErcjPvBQF
-        +06SV2COoOGCicd1J+Mvc51Gs9Hzp3VL85DUT4uYz77N1JMovfp2rp50+X5L8+WTvwymTySRqiwK
-        GBJkKXhUhjhZEx63xRLBFHSSJC0gavaEKE7OaZQx0WLzjmWZJIketSQQfMEKQrOMBPwjsIth/AKb
-        kItIkqgUCMoo5MKa0TYXCVwOeanggkpe9NCAQBALLXjUublIUkliOBOmV4woAfMPQQJMbKg9NipB
-        I5ZTsQAT1xlD8ipVB2RJVcIlgZgR87AzDWlGcjpPw17H7JhnGV9JcpxRQVtKftAuXJNY8JxQEmSM
-        LshxIlKpcirJKSgE2pyI3ongUjYdyWuxTGgBk9sBCBa8nCfQWyZpnjPtEPDRoVxQhdcryF4mMlRS
-        K8pRVyKXLFQ0LEEhEgJ9jTou0LLzFWMqZdjhBqe9zsBbgtAVFdHhKjVxh2xK5wWQjwpwTLEm76BV
-        S72A2Tpd8Cu5WLfMz8swOcz4FUylEgLKSL1EoHsTItPffsuQb5hAI58LukzWZF6CDwvFIFYJOOfa
-        bGz7H2JIwclMJgckS5eHMocG4HwA2SF0noHhGOUUkxZiuIlBTAW7wQ9d8ZC1IClMUoY2BRyMgIEL
-        nNJQuwHsgwiFKUiQZQg7BWksxSRLMW8KqrOwAI5VZUeiavrhtk6uAEYCU7JHXtY5rzu/ySh4G1hh
-        xr/TYyOHnIWgCh3uM76Gzq9oZV5VLzjAgcRS1FWtOMGYphg9DKpJa2AtwfkqW2PiBDjyrhCvPWJV
-        E8Ij7ZLExet3CYzWY1qQ5+QZ/0mjTMOj1gxyVKxxjiNrXkI4FuwxOZIk4xAGcJ/CUksrjpjYfEVg
-        CPdukgrZc8JvlIqXS7y4qCed7+rJBl0MAZTsse67rOH7ZVHVUu95EWZlxKLrpOrykUowx9Dcgt3g
-        vGecw1Dh5EXBV9ewgxGFQ+0x+QX8DLMocicqnSfK/C+vZX5eporCDEOeQk4cJ2kWwbbyGinnJSbH
-        B9xvQMxxkOtJDzOJQkqxHNYFyCTMmz1CmyUEF45qEcFxzDd1rDaxQuQsSilsnqje5cNmGaZWNdPU
-        HoyfBWQ9jJUw6YW449KNXlrA6gy64t5yCeMCVmyRzRKllvIHy9rf15KwcWSR1ZIK2zK+hM2YNR3A
-        L7TdILajvsviQWQP2SRmsRvQ8dieRrHtDlxGnUHY+7Ccw9q9VwGvoLCC4wwqwRwwV997uFzMPqt4
-        zdH7nX2w1wOyXC5h3pA+KqLLsF1KFyDr0nOH5lmdzPh60mTM4Ge7k3A0HMbjaeRQZjuuMw2nfbdv
-        T0ZOFDvDUTAZxHdIE9hXXJbs7klyb+FfIknurcT/X5IMGfxs2437w2BIaTCK3UE/jMZsNBlMAxhI
-        bj+a0GHsjIPbk0Rewq7n7jlyb9lfIkfurcTXkCORs/rorgbDMsij9GMvzHgZwe68UL2CqdtTBRx1
-        I4d9/mIfla/g+GFb38u1VCz3NxQ0JIM92R0ypELemiN3F3d7UnxBW++QDLuh/mPPGPEUfpTCQgvL
-        rzsehwN7EI0nQTh07HEY2uOhG8UTd0TDye35AIdRJPkxbNfvPG/cW4MvMW/cW4mvYd74M2QKnIAe
-        MuXPuMJU/vI10poO4RdMw8Cl00lMx8HQcQPXHbn2dEztyTgOgnEwdpwwpHdPHjgM3jV3PlWNL7Ac
-        /Y8afRVr1O+eT/0h/OzRMJqGo4j2w9Fo7AymcD8eUzdy3cFoOgqd4TQa3COfVCLufib6VEW+eEbd
-        W6OvIqP+BGuZWvGHpewzLmVSUVXKWaY3kx1SDSiDiCpq1fcKyzbtepIh1K3rJZxYUlTdN15qYNhS
-        ocolFnH8LJWqU6M63VOjuq52BfQXb9t0aw/vOeNYfQNrM6pSVUZsNnR6Q89qbj18Om0uD+2eg00N
-        wbM2/RMq/YJjYTeW2v8dAr5Fj/VtFjWvz1e3+lU3Ycpnpv7n9Ku33TpU/XrVHtw21cPnzH7EllQo
-        TBOsJWp99tErcCl0eaAFqykGgDZwkeOnFEb9HaqHbzuYrymOnTPiXryCwVKTPFP0lvWF9ob+xKS6
-        R7lbpArq01IlXOBnDuQCzAPZ3YYaF/BoPTumRcGVrhHmOdO1OVPGWBFWYK3scdNd4+vOrQJzyQ6I
-        M1YJecWvGL71gTXmYdOtVWpuU9q14aHjOONuh02JuKJmtJjPWNGg9H3dyEWK5aAMB7bVUDG4RvKw
-        15+SN780nTctHWyS5LmUM2fcn2KRfE/TBq4yNntb5KmUWCd43EJji4dFaF/ooiK+ydO+raHNxeZL
-        kPrrG3+Rm7cB99A9DI7OJJO9Zlrq0jwJxxOA01jh+x8UX4JiOU2zWVhKxXMmdCkvZPKvoJFgUnKY
-        c3v4Ise1PWueOj+bBxFNh+pLFHNjEgPaybl+cEH+xQRvoMbxrRsfS7rAoYjT+c3dOsiaBSsuy1Sk
-        97Zxu1/NLy3A9qIq//kx/Tj73nUhqQfEGYzHrtNvOOwi9/NYJrDl73Lp29dwMdiaT8bDirO9T4FN
-        c7eDYWLvk9YG1J1w3gEijSIxw9IXI+PhAflHim96pRQLpiEMciz/rbDqdq5gv6kOyM8si7Gy+vOF
-        0yfDp/9sZLT51TKqR1jm06M6f5oenda6i9JveIQzLMLBTKcLnpgduHwQXmTr3iOY5bBBMGKmMZoR
-        vWaZiiwt1oQqYLwEguJkqd+Egg5gYi7NmwRmwqsep5FVii9PMCzzh2BuVV3HQjHwh2TqNRrXysFQ
-        F2WIC0RUFfHQbIZm6D3Vkbmrd1jmm7emvHrGJQuwLHkEWuNM+lxioU/x4oCYr902RVb9uh9+MGc1
-        EuYQDtgt+IuCryp57bpoR6iFi28HD/O1MDORhr2ubnd6bXD4RhiumxFTMGJkZbCGvzFNpGoi2ARL
-        HWb1DsP9bGRVdPWhox9WRdeK+96C7A7fazisEqpQiCk+VxyvK03vMN3uvUpY4UN++Kk/5w2zdiV/
-        D4tOF/2BpB/xLQ6tqvw12XK3YvwmT7YEWTupqpPOjNN9xf/7ZOdWVbvFuZKiV4jzo5OXp2fn705f
-        vjyvQWbpMNd6bejaWMPMsmGum9estGhScSWaLXl+To7Im5dHx6cdn2w6eldpBLvQNBbGya07f3O8
-        65AThrX72QA3NvsattB4+FutVr01zBxlwMyRcBfS7WUOX7iFiqxnzt+Xp397lv62cLc6mgNVh7R7
-        krmh+Yau1RnnJkC3N2y3fJ3b9TGzOdRtGX+rVbucrpH0ueTslbJKI3CuXi330LvE+nTUnJK6X43/
-        F5UfhalyPgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3543']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:18 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/ValidEventTests.test_categories.yaml
+++ b/tests/interface_objects/cassettes/ValidEventTests.test_categories.yaml
@@ -1,137 +1,114 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF92aWRlb19pZnJhbWUgLz48
+      cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNj
+      YXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21l
+      ZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9m
+      b3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlh
+      PnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVx
+      dWVzdF9tZWRpYT48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHJlcXVlc3RfcmV2aWV3cyAvPjxyZXF1
+      ZXN0X2N1c3RvbV9maWVsZHMgLz48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxtaW1lX3RleHRfdHlw
+      ZT5odG1sPC9taW1lX3RleHRfdHlwZT48cmVxdWVzdF9tZXRhX2NvbXBvbmVudHMgLz48cmVxdWVz
+      dF9leHRyYV9pbmZvIC8+PHJlcXVlc3Rfc291cmNlX2luZm8gLz48cmVxdWVzdF9jb3N0X3Jhbmdl
+      IC8+PC9ldmVudF9zZWFyY2g+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['759']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+077XbbuLH/8xTI3nM27aklkhKpj0TV1nacNF9Oaiubtn94QBIUGZOAQoCWta/T
+        P32Oe1/szgCkRMqyLSebnnQ3OUxCDgaYDwwGA8xo8tNVnpFLVshU8D//4HTtHwjjoYhSPv/zD+9n
+        zzqjH36aPpiwS8aVLxktwsQvmCwzNZ3IMohETlPul5IVfir9gEZTLibW7pZJWKwWSvhBJsKLaeh3
+        OoNOID9+ePsxO5sXrCOfBi/Pxm+PwniUvBpcfTo/jZ+r0/N3R++CgZPZq8M0WDybzdVR8Cn4RzgY
+        HZfe66N3NHl//u5s7B/Lv//8zyv5izwvnw5mvYXb48EiOFu+/NvRy5OX/7x67q6OL5KkR9N4nPUj
+        L14FyRvvb96b08xeHLmdf0ysFn+TKJWK8pBJnxbMv6RZaoTbBTcKmk4AQn1QH5uefJhYmy/TEDEZ
+        Tk9A26tlwgpWIWjoJEzVyuBmgkeCd8oLYGgNNO0a9bVurxqrzhmVsvrP4NNCSUDZAKpGjX8IjeRH
+        mi+e/E9/9IQcw2yWyE4DZQJzpifQDL1iMFobNKms4YKtNDULpn0DQeOo8Opua0hrsA3e9ngRKnn3
+        oEakGqEF3OBoOY5oljFlhCVPtzoYSa0NC1atSCGVX1A+h/FyegUj50HKWTT1el17YrVAGgGYVIsi
+        DdnUHdYYG5hBKUEMWsCQ3hpjDZrkqNd6yJ6jMZogjbAZ0RnVGE0qWp31kP01xoYKF76ElZ0xVNZv
+        U8RPJeUKV4ZYKPBpMJl6hfo1fOpMrC3INkbvToz+nRjunRjenRiD6xjWdfH0HPphWRTguAGlfjPL
+        YR4swKpboA1GTEMliqlj2w2cCrjB4mUesGI66g0aWBVwg7XIKLhE1N02qIGDNidXeSAyqwkGN2qg
+        0//9V7P/Bj6xtsW0brDl7/P/O5n/5qSHouSqqOTTG2cTsG7W/v49TxWLyCuwHYhRNqjVTlqkKg0h
+        xLlM2dJfsCLEfd1oaGfTJKKKGT58xqPqWw82S8oD4khFztlCMdQX6dkOaHGDYrBLFfoijiVT0/4A
+        SW1DN2iShbD9y6njDntDz21j140GfQV/8jwCXwtE7bHtVJhrOOzMYjSwHV+DKY98leZMo3fsccd2
+        Zs74cd9+bNt/sp3HSGl3h2rcbR2Yb4iVCnVNK55KyBu6+jX1Mei5w769tz4827uXPjx4Pkcflfwm
+        gNbmePp+dnx2ePzq5GxiNcAVilbDG6pUwpbkSJQFZ48kOQVxChpegAnNTs5ndUejM/MOUejgxbO6
+        ZR2T+imPxfTHTD2J0ssf5+oJvi7w5RoRqUrOYVmQRSGiMkT/QkTcoP2QFAwiRS5JymHq7BFRgpzT
+        KGMFdP/AskyShF7iEEEhLhgnEH2RQFzBMDHs39A9FEUkSVQWiATBliIriO+QOPTuiFLBC5WCd5FN
+        S/P5YM3xLEkliZlU6SUjCmJnRRBQAhHgExtVQSOW0+IChFllDMHLVB2QBVWJkASmiIDMVEE0QTOS
+        03kadlsCxiLLxFKS44wWFNj6qJWzInEhckJJkDF6QY6TAs4AOZUEgnkCXDwtuk8LIeUj8rZYJJTT
+        OTsAQoUo5wn0kkma50yLDFroyAuq8H0JxsmKDJnSjAnkjcgFCxUNS2CAhABfIU8XKMn5kjGVMuyw
+        Uz1vM9BLQeiSFlFnmZq5BBNJ5xzAhxxUwFfkA7RqejMImdILcSkvViBoXoZJJxOX4BolTBIjdVyG
+        CkyITH/5JcPxwgQaxbygi2RF5iVoiSsGs5GAGm4x24c4UxTUyGRyQLJ00ZE5NMCIBzDjhbYZEBHn
+        L0XDg9nZaDmGc9JOidsEwfaARpikDKUIBLANaw/GSEMtMEgEsxCmMLYsQ9iapJENDSdFW+BUWxaH
+        EasjsUSm9KFAG0ygTxOyS17Xlqs7v8vAlX2AodB+P2gLz8EOYeIKPaVnYgWdT2kl2ExbIFgILAeW
+        Iq9qKQjOXorzhNNnTBWGlqBula3QOAJcP5eI39CFfqtW9gOtmMTF96dlocnpdgN6sMsJHJLnIotS
+        PPHqZak7kQ7hAg5NgMRyxFJC6IHMF4ETKkzbrSia7wPysQQ9oQqKdJ4oQnPcbPVEg6PcQ4wPCTiR
+        Y8rJC+DzpzuF4Sscl6xECSZ2wR6SQ6mZJWAYCo/cj6RejmJJwMV092MA1kIkgIH53QzMrrlDNB8w
+        Tske7kOLqupUPn4iyQseZmXEojup6hsFleASQsk528tCngsBPkCQV1ws76IAPgOdyUPyBqYDfD8S
+        hCnEKdX/yj3onZepouA/yTNYFcdJmkUQyd1F+LzEdaKtCMwfPZv26WhRFFYXy2GHA4PFJbQvH8d4
+        CZBlxtDfiSwNVzdwcSpgwcUlRBAEWGZX4C9hRwcLuqRppkWhsYIVu9CnT1nZc01yvRPj/lvtxehB
+        xdTsQKxGMMAKI2dRSiEMpTq8hygZti01jZzllbvse2WQR+lVN8xEGcGOxFWXMzWxNM4k5RDvgL7w
+        RL0ANwUxUJFNE6UW8rFl3TqEJeH0zCKrwQOEu2IBQa417sMT2m4Q21HPZXE/sj02ilnsBnQ4tMdR
+        bLt9l1GnH3Y/LuYQFO3kY8IphEa4d0kQDoTX3xPcmKe/Knk94uTbUMVORchysQDnKH3kp7oubULa
+        CNV12RZsYrXM5Vu1nSGDx3ZH4cDz4uE4ciizHdcZh+Oe27NHAyeKHW8QjPrxHrYDYd2nku1vOfcm
+        /hUt5968/AYs5wv05WtMqzeGZ+gybzQcDyksurEz9HrBsB/R/timbBCPYjpg7mjQu9t88BYRPC3e
+        SvB9behz+fh6lvS5HO1hT9et5RszqC9agR6Dx7bduOcFHqXBIHb7vTAassGoPw7Aebu9aES92BkG
+        e9jSJzj47O+J7k37K3qie/PyO/VE7Er5ikllW3+SK6lY7m8gKEgGZ7U9DKXCvNNU9if3FWxjf+K/
+        ezcSj+GhFCI+iAPd4TDs2/1oOApCz7GHYWgPPTeKR+6AhqO7rUMVKYL8GA71ezuTe3PwFZ3JvXn5
+        DTiTb9B8RHm3g/luPt+G+Xx57GczeHqeF7nxeBBEdi+gdBjEUa8Hf0MajO1wFA9CFvXd/W1I8L09
+        0Oey8dWD4ntz9FvYzb5cbSEAaC9yvdGYjsbuyPYcF04UEBmGLBzR8ag38Hq9kW2P+/vbk1qKe9rT
+        vdn46vZ0b47+w/ZkFDt48ayTmzxIJ9B5kI7s8HXipYNhnFX3NzqrqvkUVaWcZjr4aIFqhDKIqKJW
+        /a0wpddMMhpA3bpaQLyboui+SoG0WqNhS4VVLjDR52epVK3E5cmOxGU0ffNXuwm3dowxZwLTr6AU
+        vNJVZcSmntP1euOB4/SHE2sNnWAiwLx27K5jD2zHG/QAYQ2eWJvBEip9LjDLH0u9p7QAWNOG9wks
+        WhezVZ+6DqoweVSTDXZ6VSlUC6ormXbgbUMneJvvR2xBC6zR05lmzc8ueIVcZXEaaDXEIKAMosjx
+        Htywfw06wUoNU8Z47JwRd3YKy60GTUwFhKxftDZ0nWf1jXS3QBWqT0uViGI6SxiZgXhAu91Q4wUi
+        Wk2PKcccEyaN85zp1K3JiC0J45hafbjurvHrzo1ag5IdEGeoEnIqLtcVGN66W6PwoAlpVgp4juMM
+        2x02BQMVNKN8PmV8jaW/60ZRpJhZzNAbWGsoTq6h7Nhd2yaHb9a9N00t5CTJcymxFEUXOexo2qCr
+        jE3f8zyVEtMUDxvY2DLBmgS/0NdhWIbU/KxRb5zc2t5vmV3MypLDLFsUTN4+w5jxqhJyDzEtSoBl
+        1mG8I8P/+zdnmADVOXqaHeicTyv5DI0mgx6XVbNUolhVnXiKFQdcVTl/IVmdIup2ScpDcP0p6KZL
+        XjzCGgVGgnKFGTTjumSVu63tjc5pyvVQ+u1Ou8Mal94I7O6wnGPyCgzJvY/VufaoN/pvtDpYs48U
+        mTN1bYnex/astYupqn/rmmv/Ip/aWPW5Az7BmdJuzLhOs4+2YRMJO2TITMXN+pID0BrgGsdUa18p
+        VuikPSCSI9xSwQg2PYzGGh8+VorAQDxO53v1bnWoR2L8U5kWKZM+y2maTc21jPwLqAkXleiGoot1
+        bjeg18OgzwYboFFUTDH/ysjQOyA/p1jhl1KsWwjBQWKmeonZ4HNVMKYOyBHLYixwOJo5PeI9+/ua
+        TnO8mkZ1Y2Qqp2uVrnu0WusuStdKhVPMBIMf0dl5VBBuvUTwbNV9AM4AGwpGzBYAOtSbvymMoHxF
+        wMmwfAEAJdYZWJKilkyxjlm81e0VWaZmlYcm+1uVtWC9BowPjqK75rhmDiy1KEPcXKMqhxs2Mseg
+        CswcV1HvjpxyHf1e0qxkFtYr7urd2JkRu67aaHWefmvFGrostdR1bmv252A/EA/6F1wsK2GaBQY3
+        CHSfuoIN1TYt2NgL4zU0ibfV5w0Uvxe9fS96+1709l9e9LZxBZvFjz8QwVNTxBTsgLJy2doHvDNN
+        pGoi2AQHnVsc7ZEQFyRYkb6NIRwMnWmxGkekapNxbPKyBE47+FbFeijEAnTDgXsYBynHYCzgV9bx
+        5C5Rdgsgq6opHwj7YVU1Vcm1s6LqBom+oJBqw+INzCxhGSC/plytYu6mYrYb+Lu9hm3DwjatZcK4
+        Dx7DT/25WJNuFg3etJd+fq1gk5sWdf2rPj8SW8w0CghvYGa/usEW3SYh61qo0jidtX/EsKthAoFV
+        yUxUdwYHJTgmwzZ8qKFIPSiIpV3QC4neUJmq0jXU/B6xBXr/CnjdDFoR0NH1+eHT1ydn5x9OXr8+
+        r5FM2G3edUDdVkaNZmJt867FnJ0d/nzyukW59XEKvgrjyve45cxhY+LRY9gS5iwjfzgFFwNa5DD5
+        nP3x7jHOYFE+1r8agX0St72tIdBZ6aFvGYuQWYnoLIawqtShleEG790w8NAOWw+uwzBBI9xo9ckX
+        oQgwJ9NzRV6KhFcRe5dsTxt6Ue1w6mBO+3z8rIoPCQ2QA7AJkjP4hvBELHmrT7fWuzGpyzRiYHBx
+        YQy48eVvbrRb4IThMNM+XrjsatjCxovu5XLZhRWpyoDBESff7qfvwlsgcweKVzuR9dx5uTj56/P0
+        lwt3q6O59myBrmeNbmm+pWt1X3sbQrs3HMh97Tfqa/T1dfWW8HdKdX2kGyj9WnR2UlmmESjXxdvL
+        HfA2sL7CXV/ltn9R/v+e+0Ywjj4AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:19 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3898']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:23 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_extra_info /><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_video_iframe
-      /><request_reviews /><request_cost_range /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><request_source_info
-      /><mime_text_type>html</mime_text_type></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['903']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1b63LbNhb+n6dAujPtj9oiKVG3hlXXtZ1sNmmS2s5ms384IAmKjEhCBkAr6uvs
-        m+yT7TkASZGSfMsm07TrjCYmDz6cO248pPfTxzwjV0zIlBc/fuP07G8IK0IepcX8x2/eXjw9nHzz
-        0+yRx65YoXzJqAgTXzBZZmrmyTKIeE7Twi8lE34q/YBGszWTnrW/yQvFeqm4H2Q8XMze+oeHV4tl
-        PF0cT5dvh6+Dw7ngceSoZ6vw1Zv3HwYslB8GJ++d0YdfF6/t9++Kk6v84kUijwZL/+Pby/HZy6fr
-        k3B4eBY58ejFZVy+f345P3oqX58Vq/UltS+c0WtX+Cf54OXz01/Xl+L0w+Vkmon+m+fFdHCyWM2z
-        957V0cmLUqloETLpU8H8K5ql0azgnrWPbrwy84BCffAZm52+86zNnWmImAxnp+Di9SphglUATfWC
-        dF4ukVvJZo5te1ab4IWpWhtOGS8iXhyWC1C3IZp2zeilbq8aDeswo1JWfwxeJYwqVKBFq9p1l4tu
-        u2EDkdNhNOx0bLskr0qKBVvXEiyI/4aIaVJB654NpcNvg9vDcpFGcj9bY0jV3qFtINqWpzRPs3UL
-        ZCy0NnKt2mlcKl/QYg48AgbXOiA+j2MmIKqB5FmpmC/pFQyTmTPoQeS2qV5cZhnokQdpwaLZsI+g
-        Ls1AwCa1FGnIZu64wWyIFagEu6kAhYYbTEPztGYbxoMpgraIFWjDeTDcoFryKkLD3G2hNhKXTISQ
-        /HTeGNwfetYuFVJ6x4E5/bita4ekAab/g88/yee7DtSULTW6NAPpqtAleTmO+to2xyDapAoA8b4m
-        bO4douZMbo9aC3N91Ow7RM1x7xK1NuqGqNl3jVr/mqhteQ/vt5Xo0gykq0CX5BXcl8A+Y9J/mNYe
-        prU/tM8fprWHaa0Sf1nSQuFuly8VHF1g06b35H5NnzmetUXZRvRvRQxuRbi3Ioa3Ika7CGvXPD1v
-        +2EpBJzPAFJfma3uPFjC7rVD2iBiGiouzAFjm7hBFWUeQHgm/VELVRE3qGVG4RCEvtsmtTAYbLnO
-        A55ZbTIcnAx19p9/t/tv6J61babiS18nxcOU+UlT5o7/rGs2BA8D6mFAPQyoTxlQ7VEU8rJQokoY
-        /bimTWia9ZOHt0WqWEReAN+I5xto9fxGpCoNfcGuUrbyK02qlNvb5EUUwmXCzYqouq+e7JQHxJmo
-        hByV81Iq0rcdSMoNwGBLFaJRkqnZYISCtqkbmGQhLyIJq/fYGbpDu4OuGw18Df/yPIpmKNSeOJMK
-        2dC9VPLJyHZ8TaZF5Ks0Zxp+aE8OncmFM/1hYP9g29/bzg8oaX+Hiu+2B8y9VFSoHZ/0HXDGEYQz
-        +5wuGTn90cC9s0vcvnMvl7iHfedTXFK5wDzK1fn46u3F8dnR8YvTM89qkSuIdsMvVKmErcjPvBQF
-        +06SV2COoOGCicd1J+Mvc51Gs9Hzp3VL85DUT4uYz77N1JMovfp2rp50+X5L8+WTvwymTySRqiwK
-        GBJkKXhUhjhZEx63xRLBFHSSJC0gavaEKE7OaZQx0WLzjmWZJIketSQQfMEKQrOMBPwjsIth/AKb
-        kItIkqgUCMoo5MKa0TYXCVwOeanggkpe9NCAQBALLXjUublIUkliOBOmV4woAfMPQQJMbKg9NipB
-        I5ZTsQAT1xlD8ipVB2RJVcIlgZgR87AzDWlGcjpPw17H7JhnGV9JcpxRQVtKftAuXJNY8JxQEmSM
-        LshxIlKpcirJKSgE2pyI3ongUjYdyWuxTGgBk9sBCBa8nCfQWyZpnjPtEPDRoVxQhdcryF4mMlRS
-        K8pRVyKXLFQ0LEEhEgJ9jTou0LLzFWMqZdjhBqe9zsBbgtAVFdHhKjVxh2xK5wWQjwpwTLEm76BV
-        S72A2Tpd8Cu5WLfMz8swOcz4FUylEgLKSL1EoHsTItPffsuQb5hAI58LukzWZF6CDwvFIFYJOOfa
-        bGz7H2JIwclMJgckS5eHMocG4HwA2SF0noHhGOUUkxZiuIlBTAW7wQ9d8ZC1IClMUoY2BRyMgIEL
-        nNJQuwHsgwiFKUiQZQg7BWksxSRLMW8KqrOwAI5VZUeiavrhtk6uAEYCU7JHXtY5rzu/ySh4G1hh
-        xr/TYyOHnIWgCh3uM76Gzq9oZV5VLzjAgcRS1FWtOMGYphg9DKpJa2AtwfkqW2PiBDjyrhCvPWJV
-        E8Ij7ZLExet3CYzWY1qQ5+QZ/0mjTMOj1gxyVKxxjiNrXkI4FuwxOZIk4xAGcJ/CUksrjpjYfEVg
-        CPdukgrZc8JvlIqXS7y4qCed7+rJBl0MAZTsse67rOH7ZVHVUu95EWZlxKLrpOrykUowx9Dcgt3g
-        vGecw1Dh5EXBV9ewgxGFQ+0x+QX8DLMocicqnSfK/C+vZX5eporCDEOeQk4cJ2kWwbbyGinnJSbH
-        B9xvQMxxkOtJDzOJQkqxHNYFyCTMmz1CmyUEF45qEcFxzDd1rDaxQuQsSilsnqje5cNmGaZWNdPU
-        HoyfBWQ9jJUw6YW449KNXlrA6gy64t5yCeMCVmyRzRKllvIHy9rf15KwcWSR1ZIK2zK+hM2YNR3A
-        L7TdILajvsviQWQP2SRmsRvQ8dieRrHtDlxGnUHY+7Ccw9q9VwGvoLCC4wwqwRwwV997uFzMPqt4
-        zdH7nX2w1wOyXC5h3pA+KqLLsF1KFyDr0nOH5lmdzPh60mTM4Ge7k3A0HMbjaeRQZjuuMw2nfbdv
-        T0ZOFDvDUTAZxHdIE9hXXJbs7klyb+FfIknurcT/X5IMGfxs2437w2BIaTCK3UE/jMZsNBlMAxhI
-        bj+a0GHsjIPbk0Rewq7n7jlyb9lfIkfurcTXkCORs/rorgbDMsij9GMvzHgZwe68UL2CqdtTBRx1
-        I4d9/mIfla/g+GFb38u1VCz3NxQ0JIM92R0ypELemiN3F3d7UnxBW++QDLuh/mPPGPEUfpTCQgvL
-        rzsehwN7EI0nQTh07HEY2uOhG8UTd0TDye35AIdRJPkxbNfvPG/cW4MvMW/cW4mvYd74M2QKnIAe
-        MuXPuMJU/vI10poO4RdMw8Cl00lMx8HQcQPXHbn2dEztyTgOgnEwdpwwpHdPHjgM3jV3PlWNL7Ac
-        /Y8afRVr1O+eT/0h/OzRMJqGo4j2w9Fo7AymcD8eUzdy3cFoOgqd4TQa3COfVCLufib6VEW+eEbd
-        W6OvIqP+BGuZWvGHpewzLmVSUVXKWaY3kx1SDSiDiCpq1fcKyzbtepIh1K3rJZxYUlTdN15qYNhS
-        ocolFnH8LJWqU6M63VOjuq52BfQXb9t0aw/vOeNYfQNrM6pSVUZsNnR6Q89qbj18Om0uD+2eg00N
-        wbM2/RMq/YJjYTeW2v8dAr5Fj/VtFjWvz1e3+lU3Ycpnpv7n9Ku33TpU/XrVHtw21cPnzH7EllQo
-        TBOsJWp99tErcCl0eaAFqykGgDZwkeOnFEb9HaqHbzuYrymOnTPiXryCwVKTPFP0lvWF9ob+xKS6
-        R7lbpArq01IlXOBnDuQCzAPZ3YYaF/BoPTumRcGVrhHmOdO1OVPGWBFWYK3scdNd4+vOrQJzyQ6I
-        M1YJecWvGL71gTXmYdOtVWpuU9q14aHjOONuh02JuKJmtJjPWNGg9H3dyEWK5aAMB7bVUDG4RvKw
-        15+SN780nTctHWyS5LmUM2fcn2KRfE/TBq4yNntb5KmUWCd43EJji4dFaF/ooiK+ydO+raHNxeZL
-        kPrrG3+Rm7cB99A9DI7OJJO9Zlrq0jwJxxOA01jh+x8UX4JiOU2zWVhKxXMmdCkvZPKvoJFgUnKY
-        c3v4Ise1PWueOj+bBxFNh+pLFHNjEgPaybl+cEH+xQRvoMbxrRsfS7rAoYjT+c3dOsiaBSsuy1Sk
-        97Zxu1/NLy3A9qIq//kx/Tj73nUhqQfEGYzHrtNvOOwi9/NYJrDl73Lp29dwMdiaT8bDirO9T4FN
-        c7eDYWLvk9YG1J1w3gEijSIxw9IXI+PhAflHim96pRQLpiEMciz/rbDqdq5gv6kOyM8si7Gy+vOF
-        0yfDp/9sZLT51TKqR1jm06M6f5oenda6i9JveIQzLMLBTKcLnpgduHwQXmTr3iOY5bBBMGKmMZoR
-        vWaZiiwt1oQqYLwEguJkqd+Egg5gYi7NmwRmwqsep5FVii9PMCzzh2BuVV3HQjHwh2TqNRrXysFQ
-        F2WIC0RUFfHQbIZm6D3Vkbmrd1jmm7emvHrGJQuwLHkEWuNM+lxioU/x4oCYr902RVb9uh9+MGc1
-        EuYQDtgt+IuCryp57bpoR6iFi28HD/O1MDORhr2ubnd6bXD4RhiumxFTMGJkZbCGvzFNpGoi2ARL
-        HWb1DsP9bGRVdPWhox9WRdeK+96C7A7fazisEqpQiCk+VxyvK03vMN3uvUpY4UN++Kk/5w2zdiV/
-        D4tOF/2BpB/xLQ6tqvw12XK3YvwmT7YEWTupqpPOjNN9xf/7ZOdWVbvFuZKiV4jzo5OXp2fn705f
-        vjyvQWbpMNd6bejaWMPMsmGum9estGhScSWaLXl+To7Im5dHx6cdn2w6eldpBLvQNBbGya07f3O8
-        65AThrX72QA3NvsattB4+FutVr01zBxlwMyRcBfS7WUOX7iFiqxnzt+Xp397lv62cLc6mgNVh7R7
-        krmh+Yau1RnnJkC3N2y3fJ3b9TGzOdRtGX+rVbucrpH0ueTslbJKI3CuXi330LvE+nTUnJK6X43/
-        F5UfhalyPgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3543']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:19 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/ValidEventTests.test_float_properties.yaml
+++ b/tests/interface_objects/cassettes/ValidEventTests.test_float_properties.yaml
@@ -1,137 +1,114 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF92aWRlb19pZnJhbWUgLz48
+      cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNj
+      YXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21l
+      ZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9m
+      b3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlh
+      PnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVx
+      dWVzdF9tZWRpYT48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHJlcXVlc3RfcmV2aWV3cyAvPjxyZXF1
+      ZXN0X2N1c3RvbV9maWVsZHMgLz48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxtaW1lX3RleHRfdHlw
+      ZT5odG1sPC9taW1lX3RleHRfdHlwZT48cmVxdWVzdF9tZXRhX2NvbXBvbmVudHMgLz48cmVxdWVz
+      dF9leHRyYV9pbmZvIC8+PHJlcXVlc3Rfc291cmNlX2luZm8gLz48cmVxdWVzdF9jb3N0X3Jhbmdl
+      IC8+PC9ldmVudF9zZWFyY2g+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['759']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+077XbbuLH/8xTI3nM27aklkhKpj0TV1nacNF9Oaiubtn94QBIUGZOAQoCWta/T
+        P32Oe1/szgCkRMqyLSebnnQ3OUxCDgaYDwwGA8xo8tNVnpFLVshU8D//4HTtHwjjoYhSPv/zD+9n
+        zzqjH36aPpiwS8aVLxktwsQvmCwzNZ3IMohETlPul5IVfir9gEZTLibW7pZJWKwWSvhBJsKLaeh3
+        OoNOID9+ePsxO5sXrCOfBi/Pxm+PwniUvBpcfTo/jZ+r0/N3R++CgZPZq8M0WDybzdVR8Cn4RzgY
+        HZfe66N3NHl//u5s7B/Lv//8zyv5izwvnw5mvYXb48EiOFu+/NvRy5OX/7x67q6OL5KkR9N4nPUj
+        L14FyRvvb96b08xeHLmdf0ysFn+TKJWK8pBJnxbMv6RZaoTbBTcKmk4AQn1QH5uefJhYmy/TEDEZ
+        Tk9A26tlwgpWIWjoJEzVyuBmgkeCd8oLYGgNNO0a9bVurxqrzhmVsvrP4NNCSUDZAKpGjX8IjeRH
+        mi+e/E9/9IQcw2yWyE4DZQJzpifQDL1iMFobNKms4YKtNDULpn0DQeOo8Opua0hrsA3e9ngRKnn3
+        oEakGqEF3OBoOY5oljFlhCVPtzoYSa0NC1atSCGVX1A+h/FyegUj50HKWTT1el17YrVAGgGYVIsi
+        DdnUHdYYG5hBKUEMWsCQ3hpjDZrkqNd6yJ6jMZogjbAZ0RnVGE0qWp31kP01xoYKF76ElZ0xVNZv
+        U8RPJeUKV4ZYKPBpMJl6hfo1fOpMrC3INkbvToz+nRjunRjenRiD6xjWdfH0HPphWRTguAGlfjPL
+        YR4swKpboA1GTEMliqlj2w2cCrjB4mUesGI66g0aWBVwg7XIKLhE1N02qIGDNidXeSAyqwkGN2qg
+        0//9V7P/Bj6xtsW0brDl7/P/O5n/5qSHouSqqOTTG2cTsG7W/v49TxWLyCuwHYhRNqjVTlqkKg0h
+        xLlM2dJfsCLEfd1oaGfTJKKKGT58xqPqWw82S8oD4khFztlCMdQX6dkOaHGDYrBLFfoijiVT0/4A
+        SW1DN2iShbD9y6njDntDz21j140GfQV/8jwCXwtE7bHtVJhrOOzMYjSwHV+DKY98leZMo3fsccd2
+        Zs74cd9+bNt/sp3HSGl3h2rcbR2Yb4iVCnVNK55KyBu6+jX1Mei5w769tz4827uXPjx4Pkcflfwm
+        gNbmePp+dnx2ePzq5GxiNcAVilbDG6pUwpbkSJQFZ48kOQVxChpegAnNTs5ndUejM/MOUejgxbO6
+        ZR2T+imPxfTHTD2J0ssf5+oJvi7w5RoRqUrOYVmQRSGiMkT/QkTcoP2QFAwiRS5JymHq7BFRgpzT
+        KGMFdP/AskyShF7iEEEhLhgnEH2RQFzBMDHs39A9FEUkSVQWiATBliIriO+QOPTuiFLBC5WCd5FN
+        S/P5YM3xLEkliZlU6SUjCmJnRRBQAhHgExtVQSOW0+IChFllDMHLVB2QBVWJkASmiIDMVEE0QTOS
+        03kadlsCxiLLxFKS44wWFNj6qJWzInEhckJJkDF6QY6TAs4AOZUEgnkCXDwtuk8LIeUj8rZYJJTT
+        OTsAQoUo5wn0kkma50yLDFroyAuq8H0JxsmKDJnSjAnkjcgFCxUNS2CAhABfIU8XKMn5kjGVMuyw
+        Uz1vM9BLQeiSFlFnmZq5BBNJ5xzAhxxUwFfkA7RqejMImdILcSkvViBoXoZJJxOX4BolTBIjdVyG
+        CkyITH/5JcPxwgQaxbygi2RF5iVoiSsGs5GAGm4x24c4UxTUyGRyQLJ00ZE5NMCIBzDjhbYZEBHn
+        L0XDg9nZaDmGc9JOidsEwfaARpikDKUIBLANaw/GSEMtMEgEsxCmMLYsQ9iapJENDSdFW+BUWxaH
+        EasjsUSm9KFAG0ygTxOyS17Xlqs7v8vAlX2AodB+P2gLz8EOYeIKPaVnYgWdT2kl2ExbIFgILAeW
+        Iq9qKQjOXorzhNNnTBWGlqBula3QOAJcP5eI39CFfqtW9gOtmMTF96dlocnpdgN6sMsJHJLnIotS
+        PPHqZak7kQ7hAg5NgMRyxFJC6IHMF4ETKkzbrSia7wPysQQ9oQqKdJ4oQnPcbPVEg6PcQ4wPCTiR
+        Y8rJC+DzpzuF4Sscl6xECSZ2wR6SQ6mZJWAYCo/cj6RejmJJwMV092MA1kIkgIH53QzMrrlDNB8w
+        Tske7kOLqupUPn4iyQseZmXEojup6hsFleASQsk528tCngsBPkCQV1ws76IAPgOdyUPyBqYDfD8S
+        hCnEKdX/yj3onZepouA/yTNYFcdJmkUQyd1F+LzEdaKtCMwfPZv26WhRFFYXy2GHA4PFJbQvH8d4
+        CZBlxtDfiSwNVzdwcSpgwcUlRBAEWGZX4C9hRwcLuqRppkWhsYIVu9CnT1nZc01yvRPj/lvtxehB
+        xdTsQKxGMMAKI2dRSiEMpTq8hygZti01jZzllbvse2WQR+lVN8xEGcGOxFWXMzWxNM4k5RDvgL7w
+        RL0ANwUxUJFNE6UW8rFl3TqEJeH0zCKrwQOEu2IBQa417sMT2m4Q21HPZXE/sj02ilnsBnQ4tMdR
+        bLt9l1GnH3Y/LuYQFO3kY8IphEa4d0kQDoTX3xPcmKe/Knk94uTbUMVORchysQDnKH3kp7oubULa
+        CNV12RZsYrXM5Vu1nSGDx3ZH4cDz4uE4ciizHdcZh+Oe27NHAyeKHW8QjPrxHrYDYd2nku1vOfcm
+        /hUt5968/AYs5wv05WtMqzeGZ+gybzQcDyksurEz9HrBsB/R/timbBCPYjpg7mjQu9t88BYRPC3e
+        SvB9behz+fh6lvS5HO1hT9et5RszqC9agR6Dx7bduOcFHqXBIHb7vTAassGoPw7Aebu9aES92BkG
+        e9jSJzj47O+J7k37K3qie/PyO/VE7Er5ikllW3+SK6lY7m8gKEgGZ7U9DKXCvNNU9if3FWxjf+K/
+        ezcSj+GhFCI+iAPd4TDs2/1oOApCz7GHYWgPPTeKR+6AhqO7rUMVKYL8GA71ezuTe3PwFZ3JvXn5
+        DTiTb9B8RHm3g/luPt+G+Xx57GczeHqeF7nxeBBEdi+gdBjEUa8Hf0MajO1wFA9CFvXd/W1I8L09
+        0Oey8dWD4ntz9FvYzb5cbSEAaC9yvdGYjsbuyPYcF04UEBmGLBzR8ag38Hq9kW2P+/vbk1qKe9rT
+        vdn46vZ0b47+w/ZkFDt48ayTmzxIJ9B5kI7s8HXipYNhnFX3NzqrqvkUVaWcZjr4aIFqhDKIqKJW
+        /a0wpddMMhpA3bpaQLyboui+SoG0WqNhS4VVLjDR52epVK3E5cmOxGU0ffNXuwm3dowxZwLTr6AU
+        vNJVZcSmntP1euOB4/SHE2sNnWAiwLx27K5jD2zHG/QAYQ2eWJvBEip9LjDLH0u9p7QAWNOG9wks
+        WhezVZ+6DqoweVSTDXZ6VSlUC6ormXbgbUMneJvvR2xBC6zR05lmzc8ueIVcZXEaaDXEIKAMosjx
+        Htywfw06wUoNU8Z47JwRd3YKy60GTUwFhKxftDZ0nWf1jXS3QBWqT0uViGI6SxiZgXhAu91Q4wUi
+        Wk2PKcccEyaN85zp1K3JiC0J45hafbjurvHrzo1ag5IdEGeoEnIqLtcVGN66W6PwoAlpVgp4juMM
+        2x02BQMVNKN8PmV8jaW/60ZRpJhZzNAbWGsoTq6h7Nhd2yaHb9a9N00t5CTJcymxFEUXOexo2qCr
+        jE3f8zyVEtMUDxvY2DLBmgS/0NdhWIbU/KxRb5zc2t5vmV3MypLDLFsUTN4+w5jxqhJyDzEtSoBl
+        1mG8I8P/+zdnmADVOXqaHeicTyv5DI0mgx6XVbNUolhVnXiKFQdcVTl/IVmdIup2ScpDcP0p6KZL
+        XjzCGgVGgnKFGTTjumSVu63tjc5pyvVQ+u1Ou8Mal94I7O6wnGPyCgzJvY/VufaoN/pvtDpYs48U
+        mTN1bYnex/astYupqn/rmmv/Ip/aWPW5Az7BmdJuzLhOs4+2YRMJO2TITMXN+pID0BrgGsdUa18p
+        VuikPSCSI9xSwQg2PYzGGh8+VorAQDxO53v1bnWoR2L8U5kWKZM+y2maTc21jPwLqAkXleiGoot1
+        bjeg18OgzwYboFFUTDH/ysjQOyA/p1jhl1KsWwjBQWKmeonZ4HNVMKYOyBHLYixwOJo5PeI9+/ua
+        TnO8mkZ1Y2Qqp2uVrnu0WusuStdKhVPMBIMf0dl5VBBuvUTwbNV9AM4AGwpGzBYAOtSbvymMoHxF
+        wMmwfAEAJdYZWJKilkyxjlm81e0VWaZmlYcm+1uVtWC9BowPjqK75rhmDiy1KEPcXKMqhxs2Mseg
+        CswcV1HvjpxyHf1e0qxkFtYr7urd2JkRu67aaHWefmvFGrostdR1bmv252A/EA/6F1wsK2GaBQY3
+        CHSfuoIN1TYt2NgL4zU0ibfV5w0Uvxe9fS96+1709l9e9LZxBZvFjz8QwVNTxBTsgLJy2doHvDNN
+        pGoi2AQHnVsc7ZEQFyRYkb6NIRwMnWmxGkekapNxbPKyBE47+FbFeijEAnTDgXsYBynHYCzgV9bx
+        5C5Rdgsgq6opHwj7YVU1Vcm1s6LqBom+oJBqw+INzCxhGSC/plytYu6mYrYb+Lu9hm3DwjatZcK4
+        Dx7DT/25WJNuFg3etJd+fq1gk5sWdf2rPj8SW8w0CghvYGa/usEW3SYh61qo0jidtX/EsKthAoFV
+        yUxUdwYHJTgmwzZ8qKFIPSiIpV3QC4neUJmq0jXU/B6xBXr/CnjdDFoR0NH1+eHT1ydn5x9OXr8+
+        r5FM2G3edUDdVkaNZmJt867FnJ0d/nzyukW59XEKvgrjyve45cxhY+LRY9gS5iwjfzgFFwNa5DD5
+        nP3x7jHOYFE+1r8agX0St72tIdBZ6aFvGYuQWYnoLIawqtShleEG790w8NAOWw+uwzBBI9xo9ckX
+        oQgwJ9NzRV6KhFcRe5dsTxt6Ue1w6mBO+3z8rIoPCQ2QA7AJkjP4hvBELHmrT7fWuzGpyzRiYHBx
+        YQy48eVvbrRb4IThMNM+XrjsatjCxovu5XLZhRWpyoDBESff7qfvwlsgcweKVzuR9dx5uTj56/P0
+        lwt3q6O59myBrmeNbmm+pWt1X3sbQrs3HMh97Tfqa/T1dfWW8HdKdX2kGyj9WnR2UlmmESjXxdvL
+        HfA2sL7CXV/ltn9R/v+e+0Ywjj4AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:19 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3898']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:24 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_extra_info /><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_video_iframe
-      /><request_reviews /><request_cost_range /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><request_source_info
-      /><mime_text_type>html</mime_text_type></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['903']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1b63LbNhb+n6dAujPtj9oiKVG3hlXXtZ1sNmmS2s5ms384IAmKjEhCBkAr6uvs
-        m+yT7TkASZGSfMsm07TrjCYmDz6cO248pPfTxzwjV0zIlBc/fuP07G8IK0IepcX8x2/eXjw9nHzz
-        0+yRx65YoXzJqAgTXzBZZmrmyTKIeE7Twi8lE34q/YBGszWTnrW/yQvFeqm4H2Q8XMze+oeHV4tl
-        PF0cT5dvh6+Dw7ngceSoZ6vw1Zv3HwYslB8GJ++d0YdfF6/t9++Kk6v84kUijwZL/+Pby/HZy6fr
-        k3B4eBY58ejFZVy+f345P3oqX58Vq/UltS+c0WtX+Cf54OXz01/Xl+L0w+Vkmon+m+fFdHCyWM2z
-        957V0cmLUqloETLpU8H8K5ql0azgnrWPbrwy84BCffAZm52+86zNnWmImAxnp+Di9SphglUATfWC
-        dF4ukVvJZo5te1ab4IWpWhtOGS8iXhyWC1C3IZp2zeilbq8aDeswo1JWfwxeJYwqVKBFq9p1l4tu
-        u2EDkdNhNOx0bLskr0qKBVvXEiyI/4aIaVJB654NpcNvg9vDcpFGcj9bY0jV3qFtINqWpzRPs3UL
-        ZCy0NnKt2mlcKl/QYg48AgbXOiA+j2MmIKqB5FmpmC/pFQyTmTPoQeS2qV5cZhnokQdpwaLZsI+g
-        Ls1AwCa1FGnIZu64wWyIFagEu6kAhYYbTEPztGYbxoMpgraIFWjDeTDcoFryKkLD3G2hNhKXTISQ
-        /HTeGNwfetYuFVJ6x4E5/bita4ekAab/g88/yee7DtSULTW6NAPpqtAleTmO+to2xyDapAoA8b4m
-        bO4douZMbo9aC3N91Ow7RM1x7xK1NuqGqNl3jVr/mqhteQ/vt5Xo0gykq0CX5BXcl8A+Y9J/mNYe
-        prU/tM8fprWHaa0Sf1nSQuFuly8VHF1g06b35H5NnzmetUXZRvRvRQxuRbi3Ioa3Ika7CGvXPD1v
-        +2EpBJzPAFJfma3uPFjC7rVD2iBiGiouzAFjm7hBFWUeQHgm/VELVRE3qGVG4RCEvtsmtTAYbLnO
-        A55ZbTIcnAx19p9/t/tv6J61babiS18nxcOU+UlT5o7/rGs2BA8D6mFAPQyoTxlQ7VEU8rJQokoY
-        /bimTWia9ZOHt0WqWEReAN+I5xto9fxGpCoNfcGuUrbyK02qlNvb5EUUwmXCzYqouq+e7JQHxJmo
-        hByV81Iq0rcdSMoNwGBLFaJRkqnZYISCtqkbmGQhLyIJq/fYGbpDu4OuGw18Df/yPIpmKNSeOJMK
-        2dC9VPLJyHZ8TaZF5Ks0Zxp+aE8OncmFM/1hYP9g29/bzg8oaX+Hiu+2B8y9VFSoHZ/0HXDGEYQz
-        +5wuGTn90cC9s0vcvnMvl7iHfedTXFK5wDzK1fn46u3F8dnR8YvTM89qkSuIdsMvVKmErcjPvBQF
-        +06SV2COoOGCicd1J+Mvc51Gs9Hzp3VL85DUT4uYz77N1JMovfp2rp50+X5L8+WTvwymTySRqiwK
-        GBJkKXhUhjhZEx63xRLBFHSSJC0gavaEKE7OaZQx0WLzjmWZJIketSQQfMEKQrOMBPwjsIth/AKb
-        kItIkqgUCMoo5MKa0TYXCVwOeanggkpe9NCAQBALLXjUublIUkliOBOmV4woAfMPQQJMbKg9NipB
-        I5ZTsQAT1xlD8ipVB2RJVcIlgZgR87AzDWlGcjpPw17H7JhnGV9JcpxRQVtKftAuXJNY8JxQEmSM
-        LshxIlKpcirJKSgE2pyI3ongUjYdyWuxTGgBk9sBCBa8nCfQWyZpnjPtEPDRoVxQhdcryF4mMlRS
-        K8pRVyKXLFQ0LEEhEgJ9jTou0LLzFWMqZdjhBqe9zsBbgtAVFdHhKjVxh2xK5wWQjwpwTLEm76BV
-        S72A2Tpd8Cu5WLfMz8swOcz4FUylEgLKSL1EoHsTItPffsuQb5hAI58LukzWZF6CDwvFIFYJOOfa
-        bGz7H2JIwclMJgckS5eHMocG4HwA2SF0noHhGOUUkxZiuIlBTAW7wQ9d8ZC1IClMUoY2BRyMgIEL
-        nNJQuwHsgwiFKUiQZQg7BWksxSRLMW8KqrOwAI5VZUeiavrhtk6uAEYCU7JHXtY5rzu/ySh4G1hh
-        xr/TYyOHnIWgCh3uM76Gzq9oZV5VLzjAgcRS1FWtOMGYphg9DKpJa2AtwfkqW2PiBDjyrhCvPWJV
-        E8Ij7ZLExet3CYzWY1qQ5+QZ/0mjTMOj1gxyVKxxjiNrXkI4FuwxOZIk4xAGcJ/CUksrjpjYfEVg
-        CPdukgrZc8JvlIqXS7y4qCed7+rJBl0MAZTsse67rOH7ZVHVUu95EWZlxKLrpOrykUowx9Dcgt3g
-        vGecw1Dh5EXBV9ewgxGFQ+0x+QX8DLMocicqnSfK/C+vZX5eporCDEOeQk4cJ2kWwbbyGinnJSbH
-        B9xvQMxxkOtJDzOJQkqxHNYFyCTMmz1CmyUEF45qEcFxzDd1rDaxQuQsSilsnqje5cNmGaZWNdPU
-        HoyfBWQ9jJUw6YW449KNXlrA6gy64t5yCeMCVmyRzRKllvIHy9rf15KwcWSR1ZIK2zK+hM2YNR3A
-        L7TdILajvsviQWQP2SRmsRvQ8dieRrHtDlxGnUHY+7Ccw9q9VwGvoLCC4wwqwRwwV997uFzMPqt4
-        zdH7nX2w1wOyXC5h3pA+KqLLsF1KFyDr0nOH5lmdzPh60mTM4Ge7k3A0HMbjaeRQZjuuMw2nfbdv
-        T0ZOFDvDUTAZxHdIE9hXXJbs7klyb+FfIknurcT/X5IMGfxs2437w2BIaTCK3UE/jMZsNBlMAxhI
-        bj+a0GHsjIPbk0Rewq7n7jlyb9lfIkfurcTXkCORs/rorgbDMsij9GMvzHgZwe68UL2CqdtTBRx1
-        I4d9/mIfla/g+GFb38u1VCz3NxQ0JIM92R0ypELemiN3F3d7UnxBW++QDLuh/mPPGPEUfpTCQgvL
-        rzsehwN7EI0nQTh07HEY2uOhG8UTd0TDye35AIdRJPkxbNfvPG/cW4MvMW/cW4mvYd74M2QKnIAe
-        MuXPuMJU/vI10poO4RdMw8Cl00lMx8HQcQPXHbn2dEztyTgOgnEwdpwwpHdPHjgM3jV3PlWNL7Ac
-        /Y8afRVr1O+eT/0h/OzRMJqGo4j2w9Fo7AymcD8eUzdy3cFoOgqd4TQa3COfVCLufib6VEW+eEbd
-        W6OvIqP+BGuZWvGHpewzLmVSUVXKWaY3kx1SDSiDiCpq1fcKyzbtepIh1K3rJZxYUlTdN15qYNhS
-        ocolFnH8LJWqU6M63VOjuq52BfQXb9t0aw/vOeNYfQNrM6pSVUZsNnR6Q89qbj18Om0uD+2eg00N
-        wbM2/RMq/YJjYTeW2v8dAr5Fj/VtFjWvz1e3+lU3Ycpnpv7n9Ku33TpU/XrVHtw21cPnzH7EllQo
-        TBOsJWp99tErcCl0eaAFqykGgDZwkeOnFEb9HaqHbzuYrymOnTPiXryCwVKTPFP0lvWF9ob+xKS6
-        R7lbpArq01IlXOBnDuQCzAPZ3YYaF/BoPTumRcGVrhHmOdO1OVPGWBFWYK3scdNd4+vOrQJzyQ6I
-        M1YJecWvGL71gTXmYdOtVWpuU9q14aHjOONuh02JuKJmtJjPWNGg9H3dyEWK5aAMB7bVUDG4RvKw
-        15+SN780nTctHWyS5LmUM2fcn2KRfE/TBq4yNntb5KmUWCd43EJji4dFaF/ooiK+ydO+raHNxeZL
-        kPrrG3+Rm7cB99A9DI7OJJO9Zlrq0jwJxxOA01jh+x8UX4JiOU2zWVhKxXMmdCkvZPKvoJFgUnKY
-        c3v4Ise1PWueOj+bBxFNh+pLFHNjEgPaybl+cEH+xQRvoMbxrRsfS7rAoYjT+c3dOsiaBSsuy1Sk
-        97Zxu1/NLy3A9qIq//kx/Tj73nUhqQfEGYzHrtNvOOwi9/NYJrDl73Lp29dwMdiaT8bDirO9T4FN
-        c7eDYWLvk9YG1J1w3gEijSIxw9IXI+PhAflHim96pRQLpiEMciz/rbDqdq5gv6kOyM8si7Gy+vOF
-        0yfDp/9sZLT51TKqR1jm06M6f5oenda6i9JveIQzLMLBTKcLnpgduHwQXmTr3iOY5bBBMGKmMZoR
-        vWaZiiwt1oQqYLwEguJkqd+Egg5gYi7NmwRmwqsep5FVii9PMCzzh2BuVV3HQjHwh2TqNRrXysFQ
-        F2WIC0RUFfHQbIZm6D3Vkbmrd1jmm7emvHrGJQuwLHkEWuNM+lxioU/x4oCYr902RVb9uh9+MGc1
-        EuYQDtgt+IuCryp57bpoR6iFi28HD/O1MDORhr2ubnd6bXD4RhiumxFTMGJkZbCGvzFNpGoi2ARL
-        HWb1DsP9bGRVdPWhox9WRdeK+96C7A7fazisEqpQiCk+VxyvK03vMN3uvUpY4UN++Kk/5w2zdiV/
-        D4tOF/2BpB/xLQ6tqvw12XK3YvwmT7YEWTupqpPOjNN9xf/7ZOdWVbvFuZKiV4jzo5OXp2fn705f
-        vjyvQWbpMNd6bejaWMPMsmGum9estGhScSWaLXl+To7Im5dHx6cdn2w6eldpBLvQNBbGya07f3O8
-        65AThrX72QA3NvsattB4+FutVr01zBxlwMyRcBfS7WUOX7iFiqxnzt+Xp397lv62cLc6mgNVh7R7
-        krmh+Yau1RnnJkC3N2y3fJ3b9TGzOdRtGX+rVbucrpH0ueTslbJKI3CuXi330LvE+nTUnJK6X43/
-        F5UfhalyPgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3543']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:19 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/ValidEventTests.test_no_performances_old_date.yaml
+++ b/tests/interface_objects/cassettes/ValidEventTests.test_no_performances_old_date.yaml
@@ -1,166 +1,136 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:20 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:25 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MDM8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2YzXLbNhDH730Kjg/toaX5IVGyU4QdR1GSxrKdWHJc98KBSEiiRYI0AMpSXqdv
+        0ifr4oMiJSvjptNTWo9nTP73hwV3uQQWRr+s88xaEcbTgr488o7dI4vQuEhSOn95dDN5Y58c/RJ+
+        hxIsSCTSnERFKQDlESO8ykSIeDVNihynNKo4YVHKoylOQlog57AFxWxTiiKaZkW8DG3Xtnv2lN/f
+        Xt1n1/MPj/hqcn8TZw+d+aTjv72xz+8eru9+m13MsuF4uRiIz6fDOL8k9shPOh/nrx82ov/h4Xd3
+        2XszKuyzs88Fu4pma4/5XvLpHR10L4vNYjFe+6Po/n1ydepV0dgl7CHOP96uTqafSHX+PqneZv3z
+        +V3JBtOgWJ3zLH17sq7uBxvvjH3qBHx8++FdGRDSCew75Ow8P6KEJFFCSsxExUgk86SCP6SjBeZR
+        SdgsojgnXHF7Eqo4ZF4rWcqFEyKyIhTyjBnBEbwYEg5vkdPcaUNCeBwO4T1uHheEEQMoFcWp2Gg2
+        K2hSULtaQhRbUdsVOlJ2YzSDM8y5+aN5iIgD0gjGqPgzMFrf47z82RpAeVTyUVpmBEWgKkK73RDw
+        tCshTjCLF9GSbNRMDtRRo8hqM1w9bKvsOGu4fX8JpjE57FSHUwM7YsOoOF7hLCPCBPp6b4CO1Gke
+        wamTWHARMUzn4C/Ha/CcT1NKkjDwj13k7EgKgIcUJUtjEnb7NdFoGqkgDMzAZbAlthLKZV5rl76n
+        iLakgMajd1IT7VlUOmuXnS3RzEKLSFZtRmSyvs0QHypMhfwqzPIXohXO0iSq9dBDzp6yT/jPEp1n
+        ie6zRPAs0XtKOE/DU+8wiivGYDsApL7Sn8N8WkJV70gNMcOxKFjouW6LMWJD0SqfEhae+L0WZcSG
+        KjMcw7LotxgjtRhZc3yTT4vMacuw7Go1/POP9vhGR85+mM4Xavn/9/8fef/tlx4XFRXMxKc2zbaw
+        Nav1/oamgiTWOdQOND0NanZRloo0hp5plZJHubvHck/XGTpo0g2XfjpCE3OvnE0W1U+Wx4U1JqUg
+        Ml+W73qQxQbRdCXiqJjNOBFhpyen2lcbjJMYtn4eet2+3w+6u3Rt1PgGfvI8gbUWJnVPXc+QWx12
+        5uKk53qq54kwTVTfqHDbPbVdb+Kdvui4L1z3R9d7IWc6PMD43c+BvucCNvMnWQnEwrrAm38zHz2/
+        2++4fzsfgRt8VT4C+P0n+TDxq95Ql+PlzWRwfTY4H14jpyUbRKXhAguxII/Wq6JilPzArUsIh+F4
+        CSU0GY4n9UCdM32dJmHv1ze1Be6MnkGhFyG4w0L2eG3RECUWi9CBwXau57Wnal6b23Q7ry0INLn1
+        eDXEDIcIRcXDLF1t3RupBuB4gQWuO+RIbEoS8jQvM3lSAeeiHqcshqpKTrJM9dY7IQ6fhghXF+/c
+        tu4c8DEnhXxROEQZhiW0gpwH3nHgn/Y8r9NHzlZF0H3P9aXtHnsuvOGgBwtbIyOncSbPBbAXyYNA
+        c1DYCrL7lf0L9Dd122tuVcfEKkrlMULVjeebpmlHVT3PAW5f/boDjhYrhuUu0sJqRQMyhoLlsm3W
+        j/9ERXJN14edgXdtdSeXyNlKdUufQP4lHS3z0JU92wEd8UXxqI9TKhw13Z6GONQl4Mo5WUO9QE1K
+        dy25ZvQ5ay0IozizJgBar2Qh08RqRujvRx16D634hwwICqsyc43PXo+G1+Pb4Wg0hr26MRhIuR/j
+        JCMMvuFbKEVeY+boYY6Mulq/8dblS0E6X/yXxV9kU4ws9BAAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:20 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1348']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:26 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160419</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['365']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1Zy3LbNhTd9ytYb7poZZJ6Wc4gzCi2nDSyncaW4tobDkTCEiOSkAFQD/9O/6Rf
-        1osHRVKSY8fTTTvKeCbEuQeX9wUQuELvlklszQnjEU3fHriHzoFF0oCGUTp+ezAcnNU6B++8n1CI
-        BfFFlBCfzgRQuc8Iz2LhIZ6NQprgKPUzTpgfcX+EQ29FOLJ3i1DAVjNB/VFMg6nH/Vrt+L7viulD
-        dHoSPwb8dHjstpZujSRD8njRHXYvBn4af7r94q9W00vSCm477rxz+dC/C4+/teaPN3+QRUssR8s0
-        PHInt6uzj/fTO3LTpx8vTutHeOGcxo3L3qd+7ejzl3QQZZ9EVGte3q06bLz4UHvfnc4i9kAm2RB3
-        b7+eNT98fVx87l08/vm5Pfr2PrqbtUZ3yK7YjFJCQj8kM8xExogvg+OlFNm7cDTB3J8Rdu+nOCFc
-        8TYglHEIt0biiAvbQ2ROUgguZgT7kA3i9W6QXYy0ICQ88HqQvNViQhgxBIWiUTTOZv4cxxnxXMdB
-        dhlAQSRWWlNM05CmtWwKPq5BLVeKzpXcCLXqIMacm/80X0wIFtKAEmbkasqgKtdqoBxUbWh1qmCq
-        EOIEs2DiT8kqf4MNRVWAsvYMNZ+5Rir6Ct4OldMo5LvVakeMvIIVFOXLGU6ieFUiaQ/t4r12HjTK
-        hc9wOgYdIwLPKiE+vb8nDLI64jTOYKVxPIeK8NzGIWRuE0X3WRyDHckoSknoteqSVMU0BXwSMxYF
-        xGserTkFaEgZ+I0ZGNQqOGsMKcsKxY1jSdoADanQ3GgVrNL7DLBW3iyxijfCMgig+PF47XC9hext
-        FEp6K4AJXm7aWoEUQc/fx/xVMd8OoEI2zKhimlI1oQqhRK763DdXM8qQIUC+n0hb8wVZczvPZ63E
-        eTprzguy5jZfkrUy6ztZc16atfoTWduInhxvGlHFNKVqQBVCKfXldysm3N9va/tt7T8d8/22tt/W
-        zOsfMpwKedo1Nx0PwVqMQj/HPRfZG8gmo/4so/Eso/kso/Uso73NsLfdU/u2H2SMwc0PKPmTPuqO
-        RzM4vVaggnGPA0GZvmBsggUrzZIRpKdTb5dYBixYsxgHcBmqlzgGKnFksvkqGdHYLsNw2dKo9/df
-        5fkFjuxNNwWd+aoo9lvmq7bMrfjZTxwI9gtqv6D2C+o1C6q8igKapYKZglHtmjKwFqvOwzCNBAmt
-        PugNaVJQTf+GRSIKfEbmEVn4xhJTcjtFuvun003S0IxNZyf7zXI7YmJ1s3HGhVV3XCjKgqC5mQik
-        U5wIr9GWL9pECxonAU1DDl/vI7fVbDkVdi7U9BX8S5Iw9ORLnY7bMcw1jiJOO23HVZ04H6ehamEq
-        es3p1NzOwD1+03DeOM6vjvtGvmn3BKN3MwJ6zAVmYismdReC0YV0xv9mSNpuvd1ovjgkzbr7QyFp
-        1urua0JiQqCalroeL4eDk6vuSb93hewSbCgqDBdYiAlZWO9pxlLyC7cuwR2GgylhP+eTdLz0cxR6
-        7d/PcgmMDB5DldOiBVkGDQPMExn34mi+lhsoJ2Qj8AbnfVdfrGbE41Eyi2XTGywS+TwlMaxsxgns
-        LrJjW7Gxt23jU7ZLvD8s4/YO3WNCZfSxh2IMX5oMAtlyD2EXWQ9RTNOxfqw5h64UrQFkF/Nl4xm+
-        0rLTXHSi14Dsosr9jYTr9qkZqqsOy9JUXpBU/t26ue1UUHW83sHbRH+sg67BjGH5fS3RckQTpA+U
-        JTiFvVmZv4Ui+bXT3fQT98pqDi5hI86hvDUcQsgl258m+nqwA0d8Qhe6X6/c0b92VDHEoa6BrpST
-        JZQOXOuluhKcc/S2AXLresUFSaw7wuiaqhcBlEVmpl13T897V9c3vfPzaziQFAJDUhOucRgTBsvq
-        BgqJ5zTTmDY/L+ha+5+fz55yMqBxTAKhSpxDdpaiwNSoT1aWmDAif7co49ssmn6fM5hE3II/ThNi
-        wRksSi2Jb86xd5lkP/nT2z+wPEdXvBsAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1507']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:20 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/ValidEventTests.test_performance_calendar.yaml
+++ b/tests/interface_objects/cassettes/ValidEventTests.test_performance_calendar.yaml
@@ -1,388 +1,309 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:21 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:26 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+NklG
+      PC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxjcnlwdG9fYmxvY2s+Y18tLTYt
+      YnNqV09qbFJncmUtc0RiSlI5T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZ
+      YzY4Q3U1TEJQYWhVU1BSOV9Dc1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgy
+      YWlmOWwzZDVmeWJoTTVRNU1ObDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6
+      emxlZD48L2RhdGVfdGltZV9vcHRpb25zPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['310']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2d2ZKqyrrv789TVKyLvS/OYhZJz9q1awf2fQeKekOAIKA0SiPi6+w3OU92sKlR
+        NZrpGhIaQyBnVMxRJgkIX5b/Xybf9/ftf/a29bLTPN90nf/+B/gL/ceL5ixc1XT0//7HWKghzD/+
+        5/3/vKlyoEmBaWuSuwmSrr7kaX5oBe9vfqiori2bjhT6mieZvqTI6rvjvr3+esvbwos3gSsplrtY
+        vyMoglCI4q/E/soa6YNI7gur8cLa4rqAY/Ux0p5tR7Ppsru0qvzaKAcHtrqwexrSwVR8qFe2cUAP
+        tnN0TdU6LsJxB9frS8s98DCgThpOmei5sWHwe6wjrVpqnwWhxKOat13YQ3HHKBMtbLfUsG7RbX22
+        8coK6e7avmXWmX24KseA8yY46fPioLEhNQ0nkdnb63fv/83RNFVStY3sBaGnScf7dLr4X7W/GbIv
+        bTRvKTmyrfnvsea/vf7Q9hb6ya0/t1imn9xgbac5n//IniZLSXy096r49vr56rxB1fzFezUJZxwZ
+        mqddOpxa3xZmEJ/7Wq6jug4SrpOL+dZ43n7q2jltv2y87GzJvn/559w/ubDk3X9puGw89eeSjS//
+        Idub/3opJ6MkPL6VL5vfkrFwGhjnw57uw/dNb74mewtDWmvx6UyvyXD6bDkOuku/j92+tXx3sM9+
+        Px5PlZ2F9uuDni/no8N3jZ99TtdRki1LCy4XWvlhh/OVvn6+hdePm+j6geTJjp4cz5b3yZFtxXQ0
+        9Z3E/kLfXr9rOnVI3mSw8cyF9k7QHz0+285dwuQyZC85JPmtx7emN/t4Xz8OiYFTj69Npw6fRwTM
+        R4+vZzndzo9D4t96fJ7FcaXj2LW0483K5yVuQ9kJjn8Vl0/B97edbJmq9NH+Dt5ef2j5sQf2b3vg
+        /7YH8W97kP+2B/Vzj9efL+8UQ2kRel6iCkmXj9/Ofw66sklG9XdNnz2W8iJwvXeAol/6XBo/ezmh
+        rWjeO4NRX3pdGj97bSx5kXw4Yl/6XJq+9DmOOT+2Fdd6/dqcfPqeW9//3/9+3f+z/e31x8t8/Zux
+        DONfkPh/DfrCDZ3Au1zfSTS/NnzbfPq8HztmoKkv7WTsJOzz2fWiop4ZmIsEnXamFh01fnHU9PMd
+        +uWmM3ed353mqJfXp4MJRvjPF+AHL7y2CbTj/XrBUJDcxc8u595hsJDc5dLXgnecOp7qx9bPbr62
+        SKTffwcEjdEk8X3vj43n7nHyn22ryWdtclKURcGl57f2RJldhkLBCX0k2VFP+HjqjqAsggIBsP/C
+        0X+h6P9Fwb+OZ/r1Dpfj/ngPzq/9IBHzn+4KGRgvXTm+5/2gMILG0d++HyRK3nQ/yOQnzf24XP+J
+        Dc/DsTcWyiOu3K6O3l6/NF+6nG5DVw4CQ4teSm7oOdp/+i+95HI8ebFOhpBQ5YWPHc/37Py7qb5T
+        zdrHluTVpd1KBrr7nhxODo6M97Xx0mMjB8b7a7IzYp/Piyin8yI+4nw7LxJofvD6sf9pl8vuyRUG
+        of9umbtvh780fXRIZhlyIL9+vA7ijfbum/bGOk5YkoMHH/udtlx6hRtfs6yvhH2+xOrPl5j81m2g
+        X9tff3EMXXOPgZLf3yw5+QgNk3tOgr9IjKUAwOm312+tbwl96+dfEfQvgCYRJqnkg+2z+e3182DH
+        2UGiRcfpgH+aV3zXcKTfI78kfPOBvZeXJ2LyQsc5TiZO4wZgF2j6rvXEPL/o92PrbfOcc2PoyUcV
+        +dLto+Xc4XgNrmcfsfn89n9qfTt+pp8nO2UweiGE3tvrt6YPpFeT+3/sLa3td/TIbL9of/MNNzpP
+        qk6XczrdD21vfjIuk+6ng2v7ZLwkY/J4uC/NH33O86x9oHmObL0ISceX0nEgO+rL5x7nv5/T3PdX
+        n/i/2vCWDKzwci6eq3SqI16sdjp8otWfGy6dTofnZdXSvORvWEyGov/R7TL1uEwZCwctHxf+3VBa
+        yAsjGV4fEwv/eKyf2uDcLLuXWLhhXlQ2h3OzYsf/a9AzQf5/h9CnpV/XtS7i87kc/Nl2JDzLtI+T
+        yhNHfXl5twnFCYHO7w7h0FaCWJeGyxZf2pm+qVgXbPqx8dzrE8PPROUmMPS+RhAEZ53uzDfLKy7S
+        GkOzrcZVPkC1EuULW1/3osoqMAdrWd5RDoO2/RVdIsYdYUnoU62moz17djnj+YiXoyckf1kEn3xs
+        /tb09jPOfo+yp8cYp2FB/4WjL4Pu2+tn03mrYdi2n0SfPUf+a9v5fJ+EChkDMgbUmLxpDGSMYsf/
+        14xR88x/vlCPYAySZIkbGIN6Esag0jFG+86MoYynQ7PCMdXNpjFgRb26GJXLCNZq6eJWPrQFtNIx
+        x4xTZScSwfeWI2JgGeURZIzsCTBkDKgxedEYyBjFjv+vGYMPnX++MI9gDBrHsBsYg3kSxmDSMUb3
+        zowR7uJo2C31ZnLHqxs6U8E7XtzyaanU6E4GFWVG7WN2sY4lJKzN9y0W4earLWSMDAowZAyoMXnR
+        GMgYxY7/rxmj6yaMwT6CMRjA/H7WGImyT8IYbDrG6N2ZMdC6uEMUHizNlRMZe8GacQK+x70hOWPK
+        ZW7e3dmdba+/G/fWbbt8wERaMoIhZIzsCTBkDKgxedEYyBjFjv/f5GOE2j9fAPoIyGATcvh9yADo
+        c0AGQNNBRj8dZBzLCd+bzsIKj7WcL4q8WL/4gaxrLxvZ/9jr1OnfQInVXC9L09VoMtrWkU3FQkbm
+        di0dKHy7tmY1t9Wo0ao/R+bRci1zSrgPPccbQyjJoGJDKIGilBdRglBS7Pj/GkpETU2gBDwESlhw
+        QwYH+Lle7s9AyW+X4X0PJYM7r3xQ/KzGzimAaCjLdPe6uxtrcbfHz+eb0cCvWDXbwqptyjPra9OQ
+        ZDToMBgKISODCgwhA4pMXkQGQkax43+lEgVgD4AMHKVp5gbIwJ4EMrB0kDG8M2TstxWybaxwubXd
+        uHOtaUTrSJ0EeknRReWw21XUhmWMe9qctKezbr1rGpSHwVKUDCowhAwoMnkRGQgZxY7/lVIUgD8C
+        MgBF3JAnCvAngQw8HWSM7gwZo/bINFuEuLQHvoRam313X8GMw6DXZ8oDFsQdnBqGEd+teNzB7ZZH
+        THNf3vEQMrKnwBAyoMjkRWQgZBQ7/ldqUcAjTDVwHKdvyeF4ElMNkNJUQ7gzZPB7e8/Fa5wxmKkH
+        8GbJEhfTcOR4woISZ+3lrBqPcCVa1iuLJL4R4y4ndQBXMjKowBAyoMjkRWQgZBQ7/leKUcAjXDVw
+        AsNvycl4ElcNkNJVY3xnyKjGNWwT19Thwa+pkWm4BjAGrBtwE9AyurWGb5N7FKCYO5ZaQ3lWwZgF
+        K0PIyKACQ8iAIpMXkYGQUez4X6tGoR8BGSTK3pKTQT8JZNDpIGPyh6tRvE17vAh4du33yTqL2TMb
+        GO6yU4kPfXFDqEifGdoSa4yRSsvEKZs+DMmmDm04MqjYEEqgKOVFlCCUFDv+16pRHuH1hZMsdUsO
+        x5N4fYGUXl/inVc+5m2/G+ITeVVrl+bKQNfbwtzfIaJmcK7UilbL0p4iPTMstbd2syGarlTRUAgZ
+        GVRgCBlQZPIiMhAyih3/a9UojzD7wqnkDtwAGU9i9gVSmn1N7wwZwcKbMcNtadhpr6VNa1zltjNz
+        a3VM1O7XV+hswxs2V2Gn3X68rkw6jNdcVrrw8UoGFRhCBhSZvIgMhIxix/9KNQr2CLMvnKbYGxJF
+        MfQ5IANLafY1uzNkxGhjsG8bOk4gm8aaVGe2tFbxmmBVp/HK9VtaxO1Nd7ZX5+hw7QYLdCX2mnAl
+        I4MKDCEDikxeRAZCRrHjf6UaBcMc9f6QwRLghhwO7El8NbB0vhpHQ9S7Qga5IaLZfCpVnLmmkouR
+        SOGHmrvjDnLyElDTmCYoU9rsB5pa6w/Jw6I8LnOw5DWDCgwhA4pMXkQGQkax43+lGgXDvftDBoFi
+        zA05GdiT+Gpg6Xw1jgand4WMDjbAUAkXuv5sq1tyIBmDqRI5odtwPWCXNma43fUVdqeODqIWrEBJ
+        EbU+XMnIoAJDyIAikxeRgZBR7PhfqUbBiAc8LiFA8r8bIIN4Esgg0kEG9oerUUTNLTdHG7a50OWS
+        tl6IvSmYCHHPAGN/W1a6YAuEieiT4dCtlvr9ObrcVjdw5SODig2hBIpSXkQJQkmx43+lGgV7hNkX
+        kRzslhyOJzH7wtKZfR0NUe+68kFIk159PyOJfXXmuE2VkaqON5ooaIcXgtpC6JDEZh2ORLrbrdU3
+        K4b2lsYEQkYGFRhCBhSZvIgMhIxix/9KNQr2CLMvAmPoG8y+sCcx+8LSmX0B4s6Qga83Ea7gVcMS
+        W7TiMB5VOcyWVWfvc83auj0GWFQzrGiLhGYdDzi+TjY1BT5eyaACQ8iAIpMXkYGQUez4X6tGeYTZ
+        F4HT+C2Jok9i9oWlM/s6uq7fFTKi0dIqL9qVfrBZiX15wLSc+pipB1WthvXo/mEir/q+Afoa0ncH
+        FkOLgl2fwpLXDCowhAwoMnkRGQgZxY7/tWqUR/hqECRB3ZLD8SS+Glg6X42jIepdISOszjrB5kAa
+        pFJp+fXhxpqN5hRNxU1+JEfIellnnE65zWH+hue0+TLYjZUehIwMKjCEDCgyeREZCBnFjv+VahT8
+        Eb4ax69guyEnA0efAzLwdL4aR4PTu0JGf7RzJpsDUSZQT6wrTs3x3NkItEe7GA8PblvkxNZBxb24
+        xR0OcbDvthS9DnMyMqjAEDKgyORFZCBkFDv+V6pRcOAH94cMGrA35GTg4EkgA6SDDPYPV6OUe/1G
+        vNNrvjov4TYd7tiy3m9TB1fBrai1arhDNRbtYZ1HDiFPrLnScBRu4cpHBhUbQgkUpbyIEoSSYsf/
+        2nejJEzSCh3tvlDCoOTv53Akov8MUJL8pIQS7s4rH1a1DDxjPhVAya1MaL3Odkd0EEleFDZdYqaq
+        S5fHmb0x15FBYz8n+yLmOUMIGdlTYAgZUGTyIjIQMood/2vVKI76CMhgsd83+6LQp3AUTX5SOoqW
+        7gwZQzIkKTnaKtqhP2e5ilTih3OOZNtUhShtpQZF1ym+p4JFv9YumaYnkjHJw2qUDCowhAwoMnkR
+        GQgZxY7/lWqUo6Ho/SGDpZnfTxSl0KdwFE1+UjqKlu8MGV1kHRKTuLKNgdSiDaCYYtNcT+djfY12
+        9I05dpashEuy4Pj9zcGdIcAUFLiSkUEFhpABRSYvIgMho9jxv1KNcvTuujtkkIAEv5/DQaFPYd51
+        TONIBxnVO0OGPovrC7NjGFtmt+pilfGh3DLm7THH9IBRm4QobnUZXmTbOlsZjNFabeuLG5iTkUEF
+        hpABRSYvIgMho9jxv1KNQj0EMjCcviUn4ynMu44/6SCjdmfImPCLplVGtwdT6fbaitpjbE9iaHXM
+        dJX9oDncjknKpdY2vaj1Varnd2ZDyoLVKBlUYAgZUGTyIjIQMood/yvVKPRDIAPHiFtyMp7CvCv5
+        SWneVf/D1SilrYq3MMXvBA3B80d0qy+ELlbebeymGlFlYs5EDbe0LnvbLRLuq42Ks2nLEEoyqNgQ
+        SqAo5UWUIJQUO/5XqlGYh0AJAdBbcjiYJ4ESJh2UNO688mHuo7YtMcstijPcNO40tNYAXShRr24P
+        yuZmOsKGh2adU0KkjWmcvEAUYkdAyMigAkPIgCKTF5GBkFHs+F+pRmEfAxks/ftmXxT6FI6iyU9K
+        R9HmnSFDq28HnoDiZBMJsNGK0zo9dbEpOagyZScisjQiaTMmo4AdhAbeqx1KK2RTgtUoGVRgCBlQ
+        ZPIiMhAyih3/K9UoAH0IZZAMfkOmKECfgzJASkvR1p0po+cs516FkSu7PTc3gpLDtptd2dYYlG7v
+        uY7rDhb6oWeXSL3V5vc+0lfXdB9SRgYlGFIGVJm8qAykjGLH/0o5CsAeQhk0Sd2QxQGexFkDpHTW
+        6NyZMkB9ZfkBtWrNuCXfs4ZGy/f46kxdoLHvrqMyyottZZM02uHGsJUSN6/odViPkkEJhpQBVSYv
+        KgMpo9jxv1KPAvCHUAZDYDekZYAnsdYAKa01unemjM4GXYVdWfWXeM0FYCUjS7XMx8SupevbHT21
+        VUbm46lSovjqgto07bExbELKyKAEQ8qAKpMXlYGUUez4XylIAcRDKIPF2BvyMgDxJJRBpKOM3h+u
+        SLGrGGj01/X+rM2hDlEbmeW4PLVMj9WqcrcONusDE9DtXVNU1KFZMfqcRWLQ8CuDkg2pBKpSXlQJ
+        Ukmx43/t+1Ee4viV6Dh5Sx7Hkzh+gZSOX/07r32II6w+o1FlxlO74SSq9xiiNTmwnjAWKNFfLIOW
+        IYmMsUbEiaJODx7Yrk0KUkYGJRhSBlSZvKgMpIxix/9KSQp4iOUXBVBwg+XXtxP/acpIafk1uDNl
+        2MSsO1AJMR6Y2lCdtmsLt9Vr7IwQkeaDVq+n031Vqc6EeLW0OuvJqtYvjVX4hCWDEgwpA6pMXlQG
+        Ukax43+tJuUhnl8UYJhbskWfxPMLpPT8Gt6ZMmZBKPA2sxcpZyeHwO+qIlfFLbS2i2xxUDP6+thX
+        +LYkNeSleKgFmEF1REgZGZRgSBlQZfKiMpAyih3/azUpD/HXoHAK3JLH8ST+GiClvwZ/Z8pYlq1Z
+        iaO2u76OhyWWxhuqPdjHK/5Qn/a40r5WmXf7XTzuDiMS3/OOLNkLF1a+ZlCCIWVAlcmLykDKKHb8
+        r9SkYA/x16AIgr4hLwNDn4MysJT+GsLdK18dSkLq400btNgaHQxZr7MKpd6guTeddQOpmmy4XM6m
+        qtzYMSI6GTWHJgrzMjIowZAyoMrkRWUgZRQ7/ldqUjDgBw+gDBLHb8jLwMCTUAZIRxnjP1yTglR0
+        wz2M26Ml2h6tbObQKmFUZzDqdVweWLvVciiMKQUxuPFwHrChaXKzYQ0amGdQsiGVQFXKiypBKil2
+        /K/UpGCYoz6ASigMvSGPA3sS1y8spevX5M5rH8NQ1Ea8ND8sy/yY5dvjkHRHo0kX7Scf3nFYqcy4
+        XVNsA3txmM7Xc03mWssGzOPIoARDyoAqkxeVgZRR7PhfqUnBcO8RlEGj1A2uX9iTuH5hKV2/xDtT
+        BtfjXb1Z8yLZoxRnT7Rryt7VK7axnRBzZiIFk2FpUbOWB6sJ+oephQ+V3QE+YcmgBEPKgCqTF5WB
+        lFHs+F+pScEe4vpF0Ret+U3KeBLXLyyl69f0zpQxIPjq0t6RAxSZVRRrZQ62bSts65W+5SHthmdV
+        EbXTISpYzdUofzWVZqg2g5SRQQmGlAFVJi8qAymj2PG/UpOCPcZfg6XIW/I4nsRfA0vprzG/M2Uw
+        Q2fW5BugIvlA6NAdd9GlCGG4w62aRMds7dDfxgrB7PpAniD8pIZXeiH8npQsSjCkDKgyeVEZSBnF
+        jv+1mpSH+GvQKIndkpfxJP4aWDp/jaMo35UyVNr3GgrKj5sVUDqYnBbYW37oxttuD9iHRciOxZkk
+        Okhkx3tRmA2tEOcbMPszgxIMKQOqTF5UBlJGseN/rSaFeQhlAJy5JS+DeRLKYNJRBvjDNSmu2W4p
+        k3656mDiNGaX+2VrtIqrk6kcrOLpyuw367JZqw9kPxhylcpsvWdkBPpxZFCyIZVAVcqLKkEqKXb8
+        r9WkPMT1i8Yw8pY8jidx/cLSuX4dS2ruuvZB0x3T6xuLiBkbg91SqzTIyvKgNmj0QMpTb6iouumN
+        2BggLH0YKG1RZ2IdPmHJoARDyoAqkxeVgZRR7PhfqUnBH+L6ReMA3OD6haPPQRl4OtevY0nNfZ+w
+        lLl+2/KaPLqwBpuRuVltdmXPq/crey1qzfx+ODMptX8Qep5G8CI37lHUAmaLZlCCIWVAlcmLykDK
+        KHb8r31Pysn0y4rvDBks/fvJojT6FKZfNIKmM/06VtTcFTImuoohwsbVd5yr7vVlcyy6OuJJI3XY
+        ZISFU7ZlnFgrobdF0N08GFqzWguFaRwZVGAIGVBk8iIyEDKKHf8rJSlnd417QwZJo7+fxUGjT+Gu
+        kUBGOneNY7DvChkeOdmXOaEarN3OXuwEsdDnSth8qKKoQHmr6a7uq+2GjlPN8hQv7b2xgdh7CBkZ
+        VGAIGVBk8iIyEDKKHf8rFSlnc417QwaVUMYNkPEU5hoJZKQz1zjW09wVMvZaVV1o69IYm4wCq4lP
+        J2ZggpVx8IWZd/A8jpVGmEZtg0pEx5uGGpJRxYKpnxlUYAgZUGTyIjIQMood/ysFKeRDIIMm8N/P
+        yaBR8kkgg0wHGcwfrkcJ9WBd2q0c26gxy9Y+OgwVNqAnBNpxxeFiy/EYKa9riLgbdw2wsSMhanRb
+        MIcjg4oNoQSKUl5ECUJJseN/pR6FegiUMBh7Sw7HUxh+JVCSzvDrWE1z15UPe+IYyx09tHUMcTr1
+        Bkt1cGwCkIk0DgS6vhsujQPR0kiCcMWx0BrE/a6GQcjIoAJDyIAikxeRgZBR7PhfKUehHwIZLKB+
+        3++LRp/C7yuBjJR+X9ydIQMjybrnBITYFxAjCKUGGdeb4npUGtP2YTqo6H6p2u5a7IpWUWm0mOAb
+        vdyGNa8ZVGAIGVBk8iIyEDKKHf8r1SjMIyCDQVHslkTRp7D7SiAjpd1X6c6QEW8bNUpsRG1kJetd
+        v7TfudUAHwYzUKtODqRhBq2tXW8y7RI7WVl0FdHnZQ7mcGRQgSFkQJHJi8hAyCh2/K9UowD0IZQB
+        aPKGJA6APgdlgJTGGpU7U4ZkjSfa1GkcBqpXYjel0kie7SNpOpv1KhVyJQmOFa4G0zU/l4eiamxn
+        40oLhUsZGZRgSBlQZfKiMpAyih3/K+UoADyEMjAK3JCVAZ7EWQOkdNao3psyRh2tIrfnOGtRFT+c
+        BVtRpcJwyfcMQe1Nh72agBCGRLcmMr5GDKFS9REFrmVkUIIhZUCVyYvKQMoodvyv1KMA7CGUgRPM
+        DWkZAHsSysDSUUbtDxekKCjtKA1UQ4DabyyikUgoiBqvKuu95Y4iv9d1YnLjNp2ypyhoGxVWOyXC
+        4NpHBiUbUglUpbyoEqSSYsf/SkEKwB9CJQRO3JDHAZ7E8AukNPyq33nto1arq/Mhv9rKhrNlrO14
+        VRnKjdqyWR1vJ8NZB6/rnEAdzHV9R0ohOoxHnD+Aax8ZlGBIGVBl8qIykDKKHf8rFSngIY5fDImB
+        Gxy/wJM4foGUjl+NO1PGjol4Zkj1rC0Vm/3xsLOxKgRh1Gq7g9VyGjTtiw3fxDVy4jpbJxovQ7YR
+        wbWMDEowpAyoMnlRGUgZxY7/tS9IeYjlVyLM9C3Zok9i+QVSWn4170wZrjfshygYOGh5HFY0s1nl
+        J9FOpfzKQBoEbXs+UhWBH6ox2u63Tbo0OSjkHK5lZFCCIWVAlcmLykDKKHb8r9WkPMReg6EZ9JY8
+        jiex1wAp7TXad6aMQdseldr61jQPdpNx+2qtTvtTsdNeCq5RRiSmPpYrGzIcrbaTw5J3OWSARpAy
+        MijBkDKgyuRFZSBlFDv+12pSHuOvwVDULXkZT+KvAVL6a3TuTBmOFwXCwdsMyrvGAEOGlGJXMPOA
+        yKhWEteIE1XnB3XQoNZgUk+YgmmueGIKv4gtgxIMKQOqTF5UBlJGseN/rSaFfQhlsCR+S14G+ySU
+        waajjO4frklpdFudkYgSvqjgnRkSKWPCWwjUUhQxljwwOMksHCZeL0BFW7fLbi2Ug94a+pdnULIh
+        lUBVyosqQSopdvyv1KRgD3H9YlGcvSGPA0Ofg0qwlK5fvTuvfVTGzZW4ZqdlXDXMiV4agjpAh3Os
+        Rw5B7dAWDojsb8bMkgIDoPvUTlFVh4KUkUEJhpQBVSYvKgMpo9jxv1KTggE/eABlAIy8wfULexLX
+        Lyyl61f/3t/FJnIBUEcI1Yl2znZani50xG20LaGni1UZXcR2iTo0pJLEudVpZVirqcsNrHzNogRD
+        yoAqkxeVgZRR7PhfqUnBMEd9AGVgALshWxR7EtcvLKXr1+DOlKFwBIIa5miosnTgHPYGt5noC9sp
+        bdS4mryRHmeAyGX1Sk02qAqhTObzlg7XMjIowZAyoMrkRWUgZRQ7/ldqUrCH+GuwOEPekMeBPYm/
+        BpbSX2N0Z8qY1/p8A93svUYg0M6iGU0jBJfbCIUvYhyJNXsA1KZBH+TqeFiXnSXeiKcbuJaRQQmG
+        lAFVJi8qAymj2PG/UpOCPcRfgyVocEtexpP4a2Ap/TX4O1PG0mIFa9a1SdR0GXcRW7jQiVB160yD
+        mBww9aATEzWzqe9xn7Y9bRb6I2kLa1IyKMGQMqDK5EVlIGUUO/5XalIw6iGUQZL0LXkZ1JNQBpWO
+        MoQ/XJPibr2gzY0XZa1n1XpLkcE7WrWsGFJbN0ql+RCpBc6mH6u90pxng1G0n83VJfQWzaBkQyqB
+        qpQXVYJUUuz4X6tJeYjrF0sRxC15HE/i+oWldP0a33ntY0qRm4UdBvVDb0mpNop7u144oYhJg2zr
+        1rgmxjEynQssP1XR5c5Zhc0a6EHKyKAEQ8qAKpMXlYGUUez4X6tJeYjrF0vj6A2uX9iTuH5hKV2/
+        JvfO45B24qG1Y8j92N/zNLOrNmVTamqDmlA2xPm8vliyPjtRJXoxZha7cWNvlwz4hCWDEgwpA6pM
+        XlQGUkax43+tJuUhrl8sA+hbskWfxPULS+n6Jd6ZMvia7iiu6K0Zca7Ly41H7MvWshYNx0Fbdc39
+        YRxNBXbWDlh6Wsf8TY+19BJcy8igBEPKgCqTF5WBlFHs+F+pScEf46/BMuwNeRz4k/hr4Cn9NWZ3
+        pozmVGxPmszSnJCDvjJQ6n2v4e6Wsy7JqfhiuJ5o09ZC7+m1jWWudFDx40gMYeVrBiUYUgZUmbyo
+        DKSMYsf/2vekJJDBhXqY/HNHzKBRlKZ+PzGDQZ8CMxgETYkZ8ztjxiQgO/KGsx2kotRxbl8Rmq6C
+        DmmZF1CcSNRZICgmQOLmgRJDgLkrrq/u4SOTDGowxAwoM3mRGYgZxY7/taIUR30IZgAK+/3MDAZ9
+        Ch+vBDPS+Xjh6B+uSiHEubGqAM6OGkBnVP6wdMQ9eSBmO0eMiDIXRfISK4OBgfX08bzVVahGpwaf
+        sWRQsyGWQFnKiyxBLCl2/K9UpeDeY7AEI9jfT+VgUPxJsARPhyXgzqsf2ojoVdblnYhtG6OtsFdo
+        Qq/0MU5quwO5yvZK+6q9bTKczW9dXVe1w6w+r8LVjwxqMMQMKDN5kRmIGcWO/5WylKO76CMwA8fJ
+        33f+YtCn8BdNMCOdvyiO3RkzmD0gkL4wWTUXVVRsxk5NtOYC6PGOK7S0nRPjS3ei2LNo3omYbas7
+        WcWxBP1FM6jBEDOgzORFZiBmFDv+V+pSyAdhBoGB308ZZdCnMBhNMCOdwSiO3xkzasRmojsDlCFW
+        3pwANuISXbo5Km9GTjxp98dkLS4r1DZuxxioVudaGAWYCx+aZFCDIWZAmcmLzEDMKHb8rxSm0A/C
+        DJIlbsnleAovrwQz0nl54eSdMaO/RbAKF85nC0BEItvTp+poMTRKA0HjW/ZuNq8fFo1ux4qnwp7n
+        LbLO9ZEmXM3IoAZDzIAykxeZgZhR7PhfqUxhHoQZFANuyc14CjOvBDPSmXnh1J0xQyS62LRLslXa
+        ZufzCthbgWLVg5JBK8bE4hywXx6kroJWJXnRHytsgK9ZEmJGBjUYYgaUmbzIDMSMYsf/SmUK+yDM
+        oCn6ltyMp3DzSjAjnZsXTv/hyhR9X1pZNsdVB4HTKi2Bbpq1hjvEWHqESnwHx7aEqTDN0nrGzEtM
+        0OvvdRJ+X0oWNRtiCZSlvMgSxJJix/9KZQpAH8QlDInfkMwB0OfgEoCm4xLmzssfCU/gFtHd1OtG
+        bzoSuvhQPuhkPZQbHObNBJEl1dHQHO/GwXztdFeb4aTaCODyRwZFGHIG1Jm86AzkjGLH/0ppCgAP
+        4gyWQG8wAANPYgAG0hmA4eydOcMrLexZDfWiZlTlekZ/N++zlbZUqW03oTWoz3zaW5dDXyt1qYbO
+        c47K+ksPlsBmUIQhZ0CdyYvOQM4odvyv1KYA7DGcAVCMuiFrFDyJAxhI6QDG3ZszOlSvyprBYem0
+        3XZUqnDrvn/gYp7ybX7bZIbW2lpMWruxO2U3dMPh8diqwvWMDIow5AyoM3nRGcgZxY7/leIU8CCv
+        DQBY9oZ8DvAkXhsgpddG+d5eG66waVYGM6LdbawMRnUSvdbKrLxbbVVp2WizNTWc9CpVAbQ1pdff
+        eVGnj8P8jAyKMOQMqDN50RnIGcWO/7XvTXmQ2QbAGPKW/IwnMdsAKc02KnfmDLcuzMxye1vD8F4b
+        EyPGaTle0yT26sgvDQ/znloSWp3eurXnvdHAr5rrepWAz00yKMKQM6DO5EVnIGcUO/5XylMA9SDO
+        wGnslvwM6kk4g0rHGdU/XJ8y5g4hsdRjbdZsDirKqDNpHbb7ir+Sy+6UNyXBUbQOxyCdgdrbRcNW
+        MJwe4HOWLIo25BKoS3nRJcglxY7/tfqUB7mAAYJkbsnneBIXMJDSBax25/UPHCOj3dy3zf3IkgRy
+        aUgaNvajVtPTOoHTGNI+oOnxlg8izGNFRqfFdjyGz1kyKMKQM6DO5EVnIGcUO/7X6lMeZAMGSIK8
+        wQYMPIkNGEhpA1a/M2eENXS2qggHXBh1xKHfWI4a/aGAVNmlTvasIIyI2k5ujxairdc76LhLNA/b
+        LXzOkkERhpwBdSYvOgM5o9jxv1af8iAfMEDh4Ja80SfxAQMpfcAad+YMnUJw3ljOdaDjVEeyps5+
+        tx2wfJkN+7NuZxkajcifrkb2qFRqkSao1cDOGELOyJ4IQ86AOpMXnYGcUez4X6lPwUACGI/gDAYl
+        bsjnwJ7EbwNL6bfRujNnBPrKIZna/qCMhNF0F1dW0YpsNBa1Zg1Uq7vNalTqUbXNcLmiepau6R0a
+        Z2XIGRkUYcgZUGfyojOQM4od/yv1KRjmqI/hDBa9IT8DexK/DSyl30b7zpxBWdPI62Puml5P0eFu
+        wB/q0ZwIlvokGg4jRrZFpx4ccJpeM8NuP0a1arU1gM9NMijCkDOgzuRFZyBnFDv+V+pTMNx7DGew
+        NH1DfgaGPwln4Ok4o/OH61OW+lguV/HKSp4ND8NSfd/zGbJXd1mGiPh4FY7MYYCuwmmz1qD9iPB7
+        am8QwvWPDIo25BKoS3nRJcglxY7/lfoU7EE+YBhK4Tfkc2BP4gOGpfQB6955/YPD5e1G39d9MuJ9
+        bSn37KXbnjZjry+QfaLH+Bs6uaBIDzqaTkttltWlDg/XPzIowpAzoM7kRWcgZxQ7/lfqU7AH+YBh
+        gGBv8AHDnsQHDEvpA9a7t9/oRJ6pgx7Xnw5EbLA3wE5rWfs9mki/rCwNjFttI8QRGgdhEKg7udOZ
+        GYcF9NvIoAhDzoA6kxedgZxR7PhfqU/BHuQDhmE4dUve6JP4gGEpfcD6d+aMqDyzGsMB3dwBuWks
+        V0JYIziuhAhrA6+V9XqH7hjW1MfF6WLW2bU7kSVMJtBvI4MiDDkD6kxedAZyRrHjf60+5UF+GxiB
+        srfkczyJ3waW0m9jeGfOEJYx64FyuFAxYWuBYDuuVvkwCMb61F8Jiu45ddYxp1KvEpDC1uHCBd4f
+        Qc7IoAhDzoA6kxedgZxR7Phfq095kN8GRrDkLfkZT+K3gaX02xjdmTPUw1gxR/Nk8PYDtzuwRuZa
+        XVYooJZ7woZnw/JyWiZodDI0VgQ4VOe7TgXZwjzQDIow5AyoM3nRGcgZxY7/lfoUHH0QZ5AMuCE/
+        A0efgzNwNB1n8H+4PgXX8f2gF7PIqstYHQ64M7YSRq1FYAkbvam4S+swqXHmblKxqMHe5VR55uwz
+        ms/xQyYz/iDHGIyimBue/OFP4hiDp3SMEe5MyhYhGd0wqjnTbhBqfOCR9KBzaPPyUgeMya/mHafb
+        wYlp8nbtcl2hQmS3QjKayfxDzttxQPLaJtCOn/v3HZM0Sfy+uwCLPsWYZBE05Zgc33lMKgNCMxbz
+        EVXGVK3bQkC30abX036FwUZb15l1vI1vIyUxriOMyGkzq9e1sezM3l7DI+VJp/dgmX5wifb7m+xp
+        8uU9im+vn6/OG07nqu40L44MzdMuHc7vYHHkp1NfKxlmroOE6wQnvjWet5+6dk7bLxsvO1vy8U2e
+        /jn3l70gidqXhsvGU38u2fjyH7K9+a+XcmgF4fGtfNl8HH62fJwFnQ57iv/3TW/JOE0mN9Jai09n
+        en17/dLylgyLS7+P3b61fHewz34/Hk893udfH/R8OR8dvmv87HO6jpJsWVpwudDKDzucr/T18y28
+        ftzEnM5B4TQbTrPyMs2C0+xix/9r0Bdu6ATe5fpOovm14dvm0+f92DlC1Es7GTuqa392vaioZwbm
+        QvK0nalFR3FfHDX9fId+uemMgud3pzlqpvD0Xhz5+st7cH6dTLC94Ke7cqxT6crxPe8HhRE0/vtJ
+        HST6c5HKtftBJj9p7sfl+s/sfxqOvbFQHnHldnX0MSU4j9Lz7+eHUnIQGFr0UnJDz9H+03/pJZfj
+        yYt1MoSEKi987Hi+Z383yzj/ZiUD3X1PDicHR8b72njpsZED4/31OAmwz+dFlNN5ER9xvp0XCTQ/
+        eP3Y/7TLZffkCoPQf7fM3bfDX5o+OnybIZxfH4n93TftjaUlNyw5ePCx32nLpVe48TXL+orW50us
+        /nyJyW/dBvq1/fUXx9A19xgo+f3NkpOP0DC55yT4i8RYCgCcfnv91vqW0Ld+/hVB/wJoEmGSSj7Y
+        PpvfXj8Pdpy3JVp0nAf4p5nadw1H+j3yS8I3H9h7eXkipp9nLD+1npjnF/1+bH1zNE1NRsQmGW8J
+        zZ/G5On9/Kr90jn05KOKfOn20XLu8HXCc3r7P7W+HT/Tz5OdMhi9EMKxduqj6QPp1eT+H3tLa/sd
+        PTLbL9rffMONzrOp0+WcTvdD25ufjMvFZban7ZPxkozJ4+G+NH/0Oc+z9oHmObL1IiQdX0rHgeyo
+        L597nP9+Ql/zfvmJ/6sNb8nACi/n4rlKpzrixWqnwyda/bnh0umcyCarluYlf8NiMhT9j26Xqcdl
+        yngerTlHl7+7yPOn5WmmfWlL7rmfzEnf/z9OhiWt1ngDAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:21 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['11263']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:27 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['330']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+2d15bi2pql7/spos9NXfThpLypEZU18N57bjSEJIRASCCDe51+k36yxoVJs0nQ
-        FidXUrPGGbUzFgsCfmlOYn5aWv/rf28X9sva8HzLdf7rH/S/qH+8GI7m6pZj/tc/up1cQvrHf3/9
-        X6+6GhhKYC0MxV0Gh6m+4hl+aAdfX/1wrLsL1XKU0Dc8xfKVsap/3Rn+65efP/Sqebtl4Cpj29Xm
-        X30lkZAnZTqYr6xM2t5rfqYr0/yWThiLrrGvJrvJakdx7NKwqex285rBa0OJXku1VXmkyzN+ve83
-        jA0fbMdbRxfp6XCXK0zmI6NfdgvVDCOqGypjs7VsqZwQ602nY4WlwEpwtdFO8sxNPpFKzpeWtzKm
-        YVdNDns5Lt/bb+rZ6n5QF8azlDVa8uPR65dv3vOrYxi6ohtL1QtCz1COxfnquK9ffjb+OlV9ZWl4
-        E8VRF4Z/rsx3Y6+hf6j3ecS2/ENVjbXhfPxH9QxVORwU42u2//rl46fzA7rha1+zh2O420wNz7hM
-        OI2+ji0zXCpr1Q6NrzRFvX75PPCqWcHu/Eq26+iukwjnh4/6Pnh+/PRCldPjlwfPL63Zqu9f/nOe
-        H0wNNTi+gU9jl8dPT+l8+/j5ZQ5nxekUOb/cqTrfDr36huppU2Vu7N5+w5fDufUxeDwFL1Pfnvk+
-        8s3rfcz7yUvOLd3/+cueP8jl8W/GPqacPktOXVj27tOk8yf88vF7v7wVzfUDxVMd8/AaY+Pw79MB
-        UdzJxPAOR3Xsu3Z4EJyvrg/nxVea/dfhyH0/+joJbfvwPhZjyzH0rzxznPTt2HnK4TMFS8/SjK+c
-        +D7nY/AyKTx8btU7vCH+Y8772OvpnX28MCsfJ303eJn08cos/zHr0++7DLy/OPdp1sdvPIhBO5z8
-        qvn+gRn+9cuPo4dT+ocCLtTt9+/1m6HThPPzUfNINf+xgKeR797Gt2PnKd++hW+HXhdH1b99Nvo8
-        4/PQZcLheP/FYeNuOGq09Ouj9mnOXx816oajRnO3HLXPs64cNerWo8b8xVH7rnrHn79/E9+Onad8
-        +wa+HXp1XOX47WUbvgJbg6390TWHrcHWLr9+FapOcPxr9xJ4vr4etGjpytv4V/r1y3cj389gfjmD
-        /eUM7pcz+F/OEH6c8eXHj3fybUULPe8QAA9T3v51/lPXHC8Pf71+M/QxY6JqgeudA8b3gx+znHAx
-        PhweiRE+zboMfsxa2qp2iETMpzmXoU9zjgfb3y3Grv3l8/Ahc51Hv/6///v5+R/jr1++/5iBu1RO
-        JwUsM5Jl/lC/L3/xBwEEBUFBUFEE9VlFmhs6gXc5YU645vPA+8Mn8tB1rMDQX8qH19XdxcfUC7/x
-        rMDSFM9YW8ZGubyTyyn304fOEPB8uA1Hv/x8ITvhP19oKZi+JEMz9IMXhqIPJ+XHhPPcMNCOH8o3
-        gq+scPxF349+TPMNzXV0//DtLdI8x1PfzH578Dx9d/i/xULXvx5/KSXR0mXm+/ir5buSQNEnIKeo
-        jn4imafpCUpK0FKHlv+Tpf6Tov4PRf/n8Tf9/AmX1/2+Auef/UD1gh9qwtCHYiQPh9OOsyQCzQgs
-        d3NJOIa+qyRcgqGjlORSghO0PJ+PtW4n3Uqmy9nW65dPw5cppzJU1SCYGpuXlBt6jvEf/kvt8HE8
-        VZsb3v9+e9K5Xud/W/pXoZh7e+Tw02XcPpzl7geC/Dx4mXF4e0Hof7Wt9fvjl6G3CeH48GnUL28/
-        B7ul8dW3Fkv7yL4P7yh4e97pkcuscOkbB3f5xG3P7zH743v8q/d+HC93P49/+clrm4Z7rL769dVW
-        D9804aGQPP2vg4u8//hqu455/meC+hd9fOh94PXLx/OP+PnwLX3kzf4JXH8zcKSoR38z9Hd8evnx
-        FHW80HGOAel0/Gnmkna+GT39ef2Ted+P3gfSz4Ohpx6/Xz9Nexs5Tzh+BtdbqM7Bm09v/4fR1+O3
-        3Zmmp+nWC9epHYz4begNDeuHkh9nK/PFOR78ZPzVn7qbM7U/fZzzRY9vx179w3l9mH56cWN7OHUO
-        sf74cp+G3+acbePw+Et75wfG4mVkeO771LMIDqdFeHlaO5mpZFvtfrZSaR/+IPl44DLp9IS2qtuG
-        d5BV/3Ai+W/TLmD6cnnhf9xfZm8f/JuzQlO16eFMeQv3/vG1fhgDuQfi+rNr/m9BXML9iIu/4agx
-        dEyIi70FcQkxIi7m1qPGPQhxMSD3sLUnrjlsDbYGcg/QCMsEuYegICgyBPVZRX8KGf4rVHlas+q6
-        9oWEfKxj/Rg7kkPbWhyvOpz43KcfYwPOJ7R2fneJpHz+u+I0cHnEV9aWb43tC477fvA864P0nkmd
-        Ozecr/NEIjHhOoJqDeVZsVYuie2i6KzSm+46k3Yyer5hWq0m7YW5FufnDVGslafjRqJa3snNTq7O
-        dvnifnj5jedXvLz6bnkBc9ne28PvQ68/YtJvEelp0fXptBD/xVIvjerhPHsfOj86nS4W/uHoy+zp
-        MsnnsfPv+yCfAF5Ihv/Dao5kiGQI4AVbe7Kaw9ZgawBeyOewTAAvCAqCIkNQPwdeOc/65wvDOPoj
-        gBfLydIdwIshBHgx0YAXHzPwotTynjcHnVl95o58gQl3boJtJrdGqt1nqwU/x5b3I2/vO7TG1Vvi
-        VteLleQewAsOgWRIaM2RDJEMAbxga09Wc9gabA3AC/kclgngBUFBUGQI6ufAqx06/3xhuOP90PED
-        L55hhDuAF0cI8OKiAS8xZuDVTpqd2kooVMJ5V6iWJsHO4TraMLEoGIlqt+NbVX4nBzndZ+vmoNdq
-        B4ZZ9DcAXnAIJENCa45kiGQI4AVbe7Kaw9ZgawBeyOewTAAvCAqCIkNQPwdeVfcIvPjHAC+Bkm/f
-        /487fhQigBcfDXhJca/wUnKCVa5PttUen9qKc75VlCo1IQiXvXZC6Sp8l6mLrL5Pr/ldZTqqrur1
-        ZgorvOAQSIak1hzJEMkQwAu29mQ1h63B1gC8kM9hmQBeEBQERYag/mIPr9D45wsjPAh4yfw9e3gJ
-        hAAvIRrwkqMBr2Pr3K9FR7PDY7Pil7GqzV/848F8War+27NOk34ByKpmQivXN+KmN2CFdrLAG8Na
-        nZq4cycnCa3apEQ7JXVEG0aimRk08+tdc6oWtgBkcBQkSUJrjiSJJAlABlt7sprD1mBrAGTI87BM
-        ADIICoIiQ1A/B2R9Q//nCyM+BpCJEn3Pnl8iIYBMjAbIkjGvCFtsRvtOq5AaDZuWO8zU99ZkpRs9
-        X92w0xKv5KWG5mTyVbq7oWf1sJioj+RmF7dAwiGQDEmtOZIhkiGAF2ztyWoOW4OtAXghn8MyAbwg
-        KAiKDEFd6+ooPQZ4SYLE3AG8JEKAlxQNeKViBl5Bb9p2JmV3xqzl7FoaOZNRceea+wUj7lR+6FHF
-        bNscJ8pyIc+NpXp5Ost3m1jhBYdAMiS15kiGSIYAXrC1J6s5bA22BuCFfA7LBPCCoCAoMgR1rauj
-        /BjgJfPcPZvcy4QALzka8ErHDLwa/Gy3ZlaMUDBX1VTdLKZ4XS0IPcrQ2/pkkCh3Ro3KeDZL7gOp
-        wO7no2TgiFjhBYdAMiS15v+OZMi855Dbk6F4SzKUf33UGP6Go8bdcNQY5pajRss3HTX2sclQ/mUy
-        ZAG8YGtPXHPYGmwNwAv5HJYJ4AVBQVBkCOpKV0faD16q6i5W2sXQjHj7hl88RZNAu/gERUejXdmY
-        aZeQdKe5ui1Xs/y8TTdalYG4K4s8NaglmFrWbG35klBXrFKrEDpUGNIqMyqLO9Cud3tgbrCHT9L/
-        e/ZA3WIPfIz2QN1qD0K0WPieUO6Khaj5tZrHEAupX66DeL8uf3ss5G44ap/WOPy9dRC3HLXPKxz+
-        9jqIm48a86B1EFSstAsSg62RVXPYGmwNtAvhHJZ5s2WCdkFQENRDBXWtpaOjx0+7GJq9ffcunmII
-        oV1MNNqVi5l2GaG0rK/3Xn5RnhphRnflaWXWG3teYsKHglgYp8f8cO20tGC519oVnw/FYIibGWEP
-        iIWk1hyxELEQtAu29mQ1h63B1kC7EM5hmaBdEBQERYagrvRzZL0H0C6Wom7fuounWEJoFxuNduV/
-        czPHpCN7fGtoyrNdX1sVrLklC5pmhUJhyxjb+dyppruFvJwxM3PBmeqLjMtmO6BjWCqKW4RIrTn2
-        xHm7YeZXMfLp98TBnY+wtWepOWwNtgY6hjAPy7zZMkHHICgI6qGCutLMkQumD6BjknD7Pl88xRFC
-        x7hodKwQ81owc9wZt8XUJN/329yI4Tm6ti7MJrm6LLbYFFVQEjllMt4E44moTDOCujHElAvaBXtA
-        LCS15oiFiIWgXbC1J6s5bA22BtqFcA7LBO2CoCAoMgR1pZMj/wjaxYln5nEj7eIJoV18NNpVjJl2
-        0RbNddrz5GY0LfYzcqDX1Roz30v1cmkmTf3eor2R5TbH54qZ0njRmLl1bc1jV3ssFcUtQqTWHLcI
-        4RYh3PkIW3uymsPWYGugXQjnsMybLRO0C4KCoB4qqCttHIVH0C6el+/Z1V4ghHYJ0WhXKWbatUwV
-        GqleeWb0A2ayc1P1VNHK1hOlUi2vbAbNw4/Zpbir9WvGiFpPvWXBaHSme9Au2ANiIaE1RyxELATt
-        gq09Wc1ha7A10C6Ec1gmaBcEBUGRIagrPRylR9AukWXu2edLIoR2SdFoVyVm2iVZsrZf7ZajUC2b
-        Za5aTEyWZqkj0vxkwDe1YqqhL1tML3Dqe39oDVZVdlPM4k5G2ANiIak1RyxELATtgq09Wc1ha7A1
-        0C6Ec1gmaBcEBUGRIagrPRzlR9AuiZbu2bdLJoR2ydFoVzVm2lXYbLozvd9W7HmvkcgWgr2ZmXlV
-        tTHKdFsszUu1dtDYCXlrXh+pu/FmO8qwCaztwo3O2OCG1JpjgxsTG9z8XdoFicHWyKo5bA22BtqF
-        cA7LvNkyQbsgKAjqoYK60sORph6Bu2SKv2PjLpoiA3fRVDTcVfvNTRzrfHGu7YecNhoORNZrpXkv
-        uQ6X+wGjGb1Cpr3sWKORpIlsbr4bpDPjtDRXKzvgMfgJciShNUeORI4EHoOtPVnNYWuwNeAxpHlY
-        JvAYBAVBkSGoK00cafoheEym79jpi6YJwWN0NDxWj3k1WJgph8MiM3QVe7wthrYbMJbWbBgSp5eV
-        sFzPDPrWwJ0lpzLV2jTtoucPsgXgLvgDciGpNUcuRC4E7oKtPVnNYWuwNeAupHNYJnAXBAVBkSGo
-        K10caeYBuIulRFG6A3cxhOAuJhruasSMu5SSvKoGRivVac83A6q6aWSCaaHAp/KDRruZ9I20qPB2
-        cTnW5Wa9VTV2dXXWws2P8AfkQlJrjlyIXAjcBVt7sprD1mBrwF1I57BM4C4ICoIiQ1BX2jjS7CNw
-        Fy1wd+xsT7OE4C42Gu5qxoy71t2MTmk7fu74reZ+WdumW53qdnRQpqiMt2yj1Ov42UyukDR6w85+
-        tN8N+gkFO9t/+AO2Ajz5A7aAJqbm2AL6xqP2/FtAY2d72Nqz1By2BlsD7kI6h2XebJnAXRAUBPVQ
-        QV3p40jzj8BdLCves9cXTwju4qPhrnbMuGvW141ib624OZ4rdGcFLmdkerO+tK4Y41aeShlzc6+t
-        zLq76FWl5WK+o2YZBTczwh+QC0mtOXIhciFwF2ztyWoOW4OtAXchncMygbsgKAiKDEFdaeRIC4/A
-        XRzD3rN3l0AI7hKi4a5O3Lhrvpmoo3yiV0naOS6hjVqJbXrAVnRnkUqMRsPVoN5YU11NXJrr0At6
-        vCOnfeAu+ANyIak1Ry5ELgTugq09Wc1ha7A14C6kc1gmcBcEBUGRIahrnRzFR+AunpLv2btLJAR3
-        idFwV/c3d3JcT2luPZc1Z1FbsKlBcTeuytqoVhWb4x6lbvXVpNXPDjV3U9m6rSybHFedxhB7fcFP
-        kCNJrTlyJHIk8Bhs7clqDluDrQGPIc3DMoHHICgIigxBXevkKD0Ej8nCPXt9SYTgMSkaHuvFvBpM
-        EdZ+pmSJ7YbeSbQpa9Xrr4N+eerJC0lPBd0OVR5ORsF6lBzq5ZJpT3xmTwN3wR+QC0mtOXIhciFw
-        F2ztyWoOW4OtAXchncMygbsgKAiKDEFd6+QoPwJ3CYdT6g7cJROCu+RouKsfM+7KN/bLada1WyV9
-        NZ9uZXFfG9WzRsuwl+KSNxdra7PYdc1SbtcrDPIbva8OBQq4C/6AXEhqzZELkQuBu2BrT1Zz2Bps
-        DbgL6RyWCdwFQUFQZAjqSidHhnoE7hIF+Y6t7RmKDNzFUNFw1yBm3GUMd2orvdu7K3cy6BXdmllK
-        s1ohtefmblbK+Io4sdKjoFPJdRq0Ke1ZJz9xNsBd8AfkQkJrjlyIXAjcBVt7sprD1mBrwF1I57BM
-        4C4ICoIiQ1BXOjkyjKPHj7tkjr5jr6/j1zIRuIuJhrtGMeOuVccpm8Mkr/TFVKW5WyYLA0ZhakGt
-        NaQ1s083k/bI1stsyMvybp41s/WGWcfW9vAH5EJSa45ciFwI3AVbe7Kaw9Zga8BdSOewTOAuCAqC
-        IkNQVzo5MqwXP+7iKEa6Y+8uhiUEd7FRcFfqOC9W3MVx676dVctaRRxN69uh6Ni0nhTVcW/YKgXz
-        gjQx+E2zWFX24Xo1aHMJUZeULXAX/AG5kNCak5sLee6WYHicFUsyfH8h0qIhB+L1x6sMzgZng7P9
-        TmdDRkdGh2sCekFQEBSR0OvUz5HhHnBLI0cf/t8d0IsjBHpx0aAX/Zv7OU6cTX0400bjwSa5VQKF
-        FdtLfSTp23Y+XZXaqyI/bitjYeuOegO3WtDzTLCvYscv+AmiJKk1JzdKYvEE1oQ9hcRga7A12BrW
-        hCHNI80TbJnAYxAUBPUb8NipnyPDPwKPHV7snh2/eELwGB8NjzExrwnLFKQJxxe2VrDcZtmMVAtZ
-        rZor+ny7VM4bbMdnLCEzLpRYc1ST1/1drqKXeOAu+ANyIak1JzcXYuUE1oQ9i8rgbHA2OBvWhCGj
-        I6OT7ZqAXhAUBPU71oQduzoywkOglyRyd0AvgRDoJUSDXmzM0Et10u1qrsyzwySXWY9H+nBd3sy7
-        XS5Uw7RXzSue39gwFiNsw3nFHIn8apqYYpv7D39gb/AHnonJH/hb/EGO0R+4W/2BjxYN5UjREDW/
-        VvMYoiH3y2go3B8N+RuOGkPHtBiCvWUxhBBjLmR+dy5kYiVekBhsjayaw9Zga8BdSOewzJstE7gL
-        goKgHiqoa10dxUfgLlZk79nmXiQEd4nRcBcX975f7dIinVslxYXSVXfVRlhyqmG9rI/sVaU0G00k
-        ebRiu5Q7rtSqw1KpM09MxhVscw9/QC4ktebIhciFwF2wtSerOWwNtgbchXQOywTugqAgKDIEda2r
-        o/wI3MVzwj07fsmE4C45Gu4S4r6lsVEp+KnRPtineo1Fflag93prVEvbnWJ52/bKA1/vSWpd2ivJ
-        5rir96tZazoB7sLqT9z4Q2rNyb3x59dHDVvd4H7GP0BisDXYGmwNO3ghnePeK4ItE7gLgoKgHiqo
-        K10dWeoRuEtg2Tt28GIpMnAXS0XDXWLMuKsmGuupu89QzVbWHYh5VaC2UsZZMws9W6mX0psuJ3O1
-        1a6y7+byIsWHO03BhvXA4VgGQWzNsQwCyyCwugu29mQ1h63B1oC7kM5hmVjdBUFBUGQI6ko/R5b2
-        g/hxl0jLd+zdxdKE4C46Gu6SfnM/R98ZTDq2upLHTMFNN6j0umsPE8NKf0Illm5O2hW2Y5ebhGkv
-        aC9MZTFxnHawBR4DPseyCUJr/m9ZNiHfnyOFW3Ik/+uj9mnO31w2cdM37+dZcRy1aDnyvd5YDUaA
-        xGBrsDXY2m+zNaR5pHlYJlaDQVAQFJGrwU79HI90rBQ6Rrx4TKL42/f6Eigi8NjhfxHxmBzzajC/
-        KNfUUsaqFdR6YdPLO1uz19yZ20FmNxD6a6HVZxVzXu+k5Pl2WleH3KIjtrG1PfwBuZDUmuMuIdwl
-        BNwFW3uymsPWYGvAXUjnsEzgLggKgiJDUNc6OTr6I3CXzDB34C6GENzFRMNdybhxV3czykzZet2d
-        5UWu00lO2zpXHpUSfNvfzrWFOVg03DDJrKjdZKSkV0M2m+kDd8EfkAtJrTlyIXIhcBds7clqDluD
-        rQF3IZ3DMoG7ICgIigxBXenkyHqPwF2yKN2+tb1AsYTgLjYa7krFjLtafkaoCPX0puc26s3efDfp
-        WXXfS5Tm7VV9vayp6wTXUbiRyk+3W0qfSnqK6uJmRvgDciGpNUcuRC4E7oKtPVnNYWuwNeAupHNY
-        JnAXBAVBkSGoK50c+WAaP+7iaZ6+fa8vgeIJwV18NNyViRl3bTRNV9LtdWWWDPopd7cw9lRYpYb5
-        0qLTm/Xs4TrZ9EuZpe016yG7FAfZ1XwO3AV/QC4ktebIhciFwF2wtSerOWwNtgbchXQOywTugqAg
-        KDIEdaWTo/AQ3MWw4j17dwmE4C4hGu7Kxoy7RMFO2s1QTgzyXXPUVoY9qtyqZ6zcnpVW+VCoFCxX
-        n6ykeludLfN0217S2TJuZoQ/IBeSWnPkQuRC4C7Y2pPVHLYGWwPuQjqHZQJ3QVAQFBmCutLJUXwI
-        7mIZ7p69u0RCcJcYDXflfnMnR2s2MM3VwNTHS32RkfOBk81xdNMvSPneMsUmk5tSwUuMsrVhXxD0
-        xr4+KZgLrAaDnyBHklpz5EjkSOAx2NqT1Ry2BlsDHkOah2UCj0FQEBQZgrrSyVF6CB7jaOqevb4k
-        QvCYFA2P5WNeDZbo1zPdqVbQ0jlTKC2nVG9hNwLdY7i51QqGfjigqXxaKO6WtXow14p8dZTS98Bd
-        8AfkQkJrjlyIXAjcBVt7sprD1mBrwF1I57BM4C4ICoIiQ1BXOjnKj8FdskjdgbtkQnCXHA13FWLG
-        XaVRpduu9mblRLmeCWf7TT0pZrVsKcMvrbKXXk+pfiZP2+1ccbeajsSsMq97PlZ3wR+QC0mtOXIh
-        ciFwF2ztyWoOW4OtAXchncMygbsgKAiKDEFd6eRIUw/hXbzE3rG3PU2RwbtoKhrvKsbMu6rDzMbZ
-        7y0tUy+PgkW7XqYSQyE7n2WnOZOShD4VBn1VWal9tRp4w162QHn5HXgXDALBkNCaIxgiGIJ3wdae
-        rOawNdgaeBfiOSwTvAuCgqDIENSVVo408xDeJfLCHbt90QwhvIuJxrvKMfOuvqkYfseuGkMmu9tl
-        siIrb3r+iA5EU0sVW3s+4Xb42ZgzZ9Vqa7aVDHGs5bG+68Mg2BsMgmdiMgj+FoOQYzQI7laD4KMF
-        QzlSMETNr9U8hmDI/TIYCvcHQ/6Go8bQMQVD9pZgKMQYDJlbjxr3oGDIxMq7IDHYGlk1h63B1sC7
-        EM9hmTdbJngXBAVBPVRQV3o50uxDeJfEMXds30WzhPAuNhrvqsTMuzbdUjqzrSU7a8Ga7nSv6tqc
-        LsjjToNrDdMszy+DVX3iFdy8QOWNWj+99ZMMtu+CQSAYklpzBEMEQ/Au2NqT1Ry2BlsD70I8h2WC
-        d0FQEBQZgrrSzJHmHsK7ZEa+Y/8umiOEd3HReFf1N3dzXLCzga4xw3xQ4x2jkej6pe1gwbnVTt9P
-        m74zlgqzeXJaCie1UodyCkt13srg/kcYCoIkqTVHkESQBB+DrT1ZzWFrsDXwMcR5WCb4GAQFQZEh
-        qCvdHGn+EXxMoGj+nv2+eEL4GB+Nj9ViXg+W6Y2X+41WWLJZzanb4taaTJdtebOX2HQtmxl6LT5M
-        iZ3FXkmrEs+0jd5gXMZ6MBgEgiGpNUcwRDAE74KtPVnNYWuwNfAuxHNYJngXBAVBkSGoK+0caeEh
-        vIumaOkO3iUQwruEaLyrHjPv6u3p9kagO7y+YhvGMMX5S708YOjZwNDTC8qfhK15vtdfUUOpXMpR
-        azaf3TlY3wWDQDAkteYIhgiG4F2wtSerOWwNtgbehXgOywTvgqAgKDIEda2fo/gY3iVJ9+xvLxLC
-        u8RovKsRM+9qraVWYrP0zOx0vZ9nBqVJJVGdSe3Uel1WkgWqkJAbEkvVJgl/m6aW/tRkJo0NeNe7
-        QaABxskg0PiMmJqj8dmNR+35G5+hnyNs7VlqDluDrYF3IZ7DMm+2TPAuCAqCeqigrvVzlB/Cu1iB
-        vme/L5kQ3iVH412tmHlXY8TWGolypxLqbUtw+72lo5mdDl2ecRvRbKRogxPH0yJjzWfFzaKiNArS
-        qIx+jgDiWAhBas2xEAILIbC+C7b2ZDWHrcHWwLsQz2GZWN8FQUFQZAjqSj9HhnoI7+I48Y79uxiK
-        DN7FUNF4Vztm3jUQG9NRp1i2fEos7GWluNN2w+5Y3ZYajbYzHWZ6diIQG75AF3pZi5kyHZ0a4n5G
-        GASCIak1RzBEMATvgq09Wc1ha7A18C7Ec1gmeBcEBUGRIagr/RwZ2g8ewLt4lr1j/y6GJoR30dF4
-        V+c393Oc9YLJIliGGi+HTnpLtYdmwrH8lbk0Emvf9Kx0Rm1VsmtlMe23GXuSC1PKBvvbw1AQJEmt
-        OYIkgiT4GGztyWoOW4OtgY8hzsMywccgKAiKDEFd6efIMI7+AD4mMNQd+30d9yUggo8x0fhYN+b1
-        YHVhlWjv8m1T45bZIJHVlsWdkcptgwyV5fZ1NZdPLUW6sZhTKtem/W6+b1by4F0wCARDUmuOYIhg
-        CN4FW3uymsPWYGvgXYjnsEzwLggKgiJDUFf6OTKs9wjeJVKCcAfvYgnhXWw03tWLmXe109VFqrLq
-        W+G0OsqP2b6YajHpJJXISeXkmvbDuWabWYmjmCSb9zSrQXnlDva3h0EgGJJacwRDBEPwLtjak9Uc
-        tgZbA+9CPIdlgndBUBAUGYK60s+R4R6y35d4oR438i6OEN7FReNd/Zh5V19cJbJhscxJ6XV97UtB
-        fVxt+ktJqaqazg/3ZiJsjYXEZGTMp4bYLXdYTexhv68Pg0ADjJNBoPEZMTVH47Mbj9rzNz5DP0fY
-        2rPUHLYGWwPvQjyHZd5smeBdEBQE9VBBXennyAgP4V2ywN+z35dACO8SovGuYcy8K8ePq66dK0+n
-        +0orVdOkjjWZsb637wjZ7FCppkr+cDdZaMW5Rc1nhd124vVwPyOAOBZCEFtzLITAQgis74KtPVnN
-        YWuwNfAuxHNYJtZ3QVAQFBmCutbPUXwE7xIpnrln/y6REN4lRuNdo5h5V2IwE/yWxEy4SrJQFpR2
-        Ye7qs1q21WTN3FbfTPvtZrXUrnB5exUybK1nBM1gC94Fg0AwJLTmCIYIhuBdsLUnqzlsDbYG3oV4
-        DssE74KgICgyBHWtn6P0EN5Fs9I9+3dJhPAuKRLvoqnf3M+xIbsbZzOxq5lZ3mTS++xqxi/XGjdM
-        rNj0PBtWKibLpfTyTkoxdLJdaFXTnoP7H2EoCJKk1hxBEkESfAy29mQ1h63B1sDHEOdhmeBjEBQE
-        RYagrvVzlB/CxxiGv2e/L5kQPiZH42N0zOvBtowr24OqOaoMhotGd1vvaopSLpt0qb+vZCtTke5W
-        tnOxyEt2m6a5VFLoyNjfHgaBYEhszREMEQzBu2BrT1Zz2BpsDbwL8RyWCd4FQUFQZAjqSj9HlnoI
-        72Jpmrudd7EUGbyLpaLxLiZm3jVlRrM618lRlf3CFHwzqaTkbTvpuRRjacrOKvZm00bBX1R2nBfY
-        Db6wTgUJ3P8Ig0AwJLXm/45gyLzHkNuDoXhLMJR/fdQY/oajxt1w1BjmlqNGyzcdNfaxwVD+ZTBk
-        wbtga09cc9gabA28C/EclgneBUFBUGQI6ko/R9oPXkqhvYsZd8ni7dvbixRNAu4SExQdDXexMeMu
-        e9HotlrWZqwkByw36AY1xxRMJicmZqwrCuV6QWgpm5YyKXSXgtNqZ+dsq4LlXR/+gP4XJ39A3zNi
-        ak5u3zOeu6Xx2XFWDCshqI8XurIU4re0PnvUUgh0dISzPXPN4WxwNkAvZHS4Jpo6QlAQFDGCutLU
-        kfX0B0AvXqRu3/NLpFhCoBcbDXrxMUOvAeUuXDYReItWwrXESVDRwlEh2QrpTLJEN9eePGvx1fnE
-        morZZqacXc031BZ7eAGKYzEEqTXHzT+4+QdrvGBrT1Zz2BpsDbgL6RyWiTVeEBQERYagrvR05E63
-        NMaNuwRevH0LL5HiCMFdXDTcJcSMu4rpkm1O69Ua283stP5qpW38mtoWChWmpzP0bNFdSju1JTpF
-        mykzPCPsRkICa7zgD8iFpNYcuRC5ELgLtvZkNYetwdaAu5DOYZnAXRAUBEWGoK60dOQfgrtEjr19
-        By+R4gnBXXw03CX+5o6O2qyda/fHjXyp2thu9qOiNRushglvuRdCZp3ZsJyg7pV9IaUu1emyoHO0
-        TllYDQY/QY4ktebIkciRwGOwtSerOWwNtgY8hjQPywQeg6AgKDIEdaWjo/AQPCYx8j07fgmE4DEh
-        Gh6TYl4NNhrM9qVBLjFOrXr+Pq/YzT3VCBhRSO1T/lJuz9dtxhqNlEmqbs0600ngG2kFG9zDH5AL
-        Sa05ciFyIXAXbO3Jag5bg60BdyGdwzKBuyAoCIoMQV1p6Cg+BHfJtMDcgbtEQnCXGA13yTHjLm9P
-        W2Glse+si0I6te9uujNO363mqS0/UGRJaYjVbSHXrtpLoU1TQz9YrjY2cBf8AbmQ1JojFyIXAnfB
-        1p6s5rA12BpwF9I5LBO4C4KCoMgQ1JV+jtIjcJdEUcw9W9tLhOAuKRruSsaMu9jJQEglGrLeGWa9
-        xHhcLTADeZOjk9PiqMLIVtdVS6w56Cyn/Zxeq7qNpV1bA3d9+ANaX5z8AV3PiKk5up5dPgO6nv0t
-        4gWVwdnIqjmcDc4G6IWMDtdEP0cICoIiRlBX+jnS1EOoFy3yd2z5RVNkUC+aika90jFTr0y9VG1N
-        ih2xPUk7M0t3EpxvlwwhO2FqymKR5fRepWFUi+xM9z2lx264wdrZg3qBimM1BKE1x2oIrIbAIi/Y
-        2pPVHLYGWwPvQjyHZWKRFwQFQZEhqCsNHWn6IbyLEeg79vCiaUJ4Fx2Nd2Vi5l0zK+M4Q3W/0/pN
-        pmVzBVYNK3UvUe6VvHxzWxGHw0mmm1zrQVhUaiOpllE1Gh0dYRAIhqTWHMEQwRC8C7b2ZDWHrcHW
-        wLsQz2GZ4F0QFARFhqCudHSkmYfwLpaT7tjEi2YI4V1MNN6V/c0tHblZOVPnmzstJXBSUKvuWJVO
-        mco8dNILf1xiuuZitE7zvTnt7FpDeVq20sk91oPBUBAkSa05giSCJPgYbO3Jag5bg62BjyHOwzLB
-        xyAoCIoMQV1p6UizD+FjHMvdsesXzRLCx9hofCwX83qwsLrz8/V1azxwB5W6VjIrpcVAmg/znSHv
-        JPTqTOxUVdZap8zNxGovDidKKbnCrl8wCARDUmuOYIhgCN4FW3uymsPWYGvgXYjnsEzwLggKgiJD
-        UFd6OtLcQ3gXz9DUHbyLI4R3cdF4Vz5m3jXUtOJosR+vc5UF0y3SbdOUNjm+Xe73+lXebBXV5LLH
-        trYjSpbkeYVPm47igXfBIBAMSa05giGCIXgXbO3Jag5bg62BdyGewzLBuyAoCIoMQV1p6kjzD+Fd
-        AiXes789Twjv4qPxrkLc+33l2ovAq3TrbYVfWaOMtt43llp+sRc7o+Gw1trsm6muUJ30U4OkV8xa
-        pljM98C7PgwCDTBOBoHeZ8TUHL3PLp8Bvc/+FvKCyuBsZNUczgZnA/VCSIdroqsjBAVBESOoa10d
-        xYdQL1Gi7tn1SySEeonRqFcpZurFat2hVl9nU7nNfpYIKsld3xY6s4FD7Y1td1sShFGtY6Qm7K6s
-        l8psXxdzTQPUC1gcyyFIrTmWQ2A5BFZ5wdaerOawNdgaeBfiOSwTq7wgKAiKDEFd6+ooPYR3SYJw
-        zy5eEiG8S4rGu8ox865WcrlXBzkqN9z3C2a9M2uYycNZoCy01ohaB0zoL3f+TqtRVCal+PPiTB0J
-        S+xaD4NAMCS15giGCIbgXbC1J6s5bA22Bt6FeA7LBO+CoCAoMgR1rauj/BDeJfPsPbt4yYTwLjka
-        76r85q6OyTwvB/ViZRHQlV0ntZ7o9ppnzG2+kqh6ZcrvufrQtKRRo6eUR351sG2t5mPwMRgKgiSp
-        NUeQRJAEH4OtPVnNYWuwNfAxxHlYJvgYBAVBkSGoK10dGeoRfEymWPmOXb8Yigw+xlDR+Fg15vVg
-        88pk1fdqQ2u1llfZ2jgr1WV12TezhW0tLW5KmWyBKneXZoGeamurJe2WglkF74JBIBiSWnMEQwRD
-        8C7Y2pPVHLYGWwPvQjyHZYJ3QVAQFBmCutLVkaH94AG8i2Z46Q7eRRPCu+hovKsWM+/K1PTtqF9s
-        7cZpocqud11uu0iM2Vm3P3ITRUNUJpX1pKbL2W51oyRrXorf2tsNeBcMAsGQ0JojGCIYgnfB1p6s
-        5rA12Bp4F+I5LBO8C4KCoMgQ1JWujgzj6A/gXQzN3LG/PcMQwruYaLyrHjPvapbt6XiSnxs7e+bm
-        +51w27IVa1EbdAt8trHv2FzPNa1pa7ys+41Zys/nWnsG+9t/GAQaYJwMAr3PiKk5ep9dPgN6n/0t
-        5AWVwdnIqjmcDc4G6oWQDtdEV0cICoIiRlBXujoy3EPuamQl/o5dv47fy0RQLy4a9WrGTL1qIutY
-        qeGiUj0cNLebyGfpZHG+XLQkp1zql8fZETXKbux90N9sMiWqNvT3/BbUC1gcyyFIrTmWQ2A5BFZ5
-        wdaerOawNdgaeBfiOSwTq7wgKAiKDEFd6erI8A/hXZxI37OLF08I7+Kj8a5WzLzL9DKJoZUfBWyo
-        pYS2kTHCsOaFo3CQ3ixW3UZn54+T9e6KbtRmSba3Lu/7ozTuaoRBIBiSWnMEQwRD8C7Y2pPVHLYG
-        WwPvQjyHZYJ3QVAQFBmCutLVkREewrt4XrxnFy+BEN4lRONd7d/c1XG94BrcpqJ6s2XdzNb7+6ox
-        6LK5YbZoNQfyqJFpUEZ2Ps02pJ3ItlJNe7lsbMDHYCgIkqTWHEESQRJ8DLb2ZDWHrcHWwMcQ52GZ
-        4GMQFARFhqCudXUUH8LHBI67Z9cvkRA+JkbjY52Y14MNqlsp5C0zMXPaC6/PVTmKHfO5fLq+7iU3
-        dn7aE1qcuyjry+puuNwXW6OyEuD+RxgEgiGpNUcwRDAE74KtPVnNYWuwNfAuxHNYJngXBAVBkSGo
-        a10dpYfwLpGlhDt4l0QI75Ki8a5uzLwrt6cSq/3KszfpkjPz0m2V0g3Gn1QX8l5em2E1X2R7+6Bo
-        bZplM6kozLic3e3Au2AQCIaE1hzBEMEQvAu29mQ1h63B1sC7EM9hmeBdEBQERYagrnV1lB/CuyRa
-        vGd/e5kQ3iVH4129mHnXeLUsj8Ml77UKSadrLXcr1VEaZt+oiJlS0awapa46VTxfYtLFtJbccuK6
-        PNyDd70bBBpgnAwCvc+IqTl6n10+A3qf/S3kBZXB2ciqOZwNzgbqhZAO10RXRwgKgiJGUFe6OrK0
-        HzyAesmSfMeuXyxNBvVi6WjUaxAz9UpUi8OStCuKqVVrxU/nRl8ceUm1oHgVcyysm5tdK5dgebY7
-        SVFbqzJMd+amj128gMWxHILUmv87lkMw7xffb8+G4i3LIeRfHzWGv+GocTccNYa55ajR8k1HjX1s
-        MJR/GQzZWJEXJAZbI6vmsDXYGngX4jksE6u8ICgIigxBXenqeMRdydAMD/+JEXiJFCUKt2/jJVFE
-        AC8pQUUEXsOYgdewV09UxXpjNZoqiQwz0xPrhF0LB9lhpSrrbZ2udH05Vc9rzW3Ocdig22gMXNzW
-        CIdAMiS15rj/B/f/AHjB1p6s5rA12BqAF/I5LBPAC4KCoMgQ1LW2jo7+EOBFC8zt+3hJFEMI8GKi
-        Aa/Rb+7rmPIKzcw4ue/2ufosXEl0nalv2ZKwVxpZodmreHZW2KdaTitTHkw5em7znqQAkMFRkCRJ
-        rTmSJJIkABls7clqDluDrQGQIc/DMgHIICgIigxBXenryHqPAWQMJ9++8ZdEsYQAMjYSIDvyoVhX
-        hG31Qm44KKtaIVVVh2wuW1xMBaW8KJqSIKw71WSpa1Y73d6Ebhcnky4TOoE4wcZfcAgkQ1JrjmSI
-        ZAjgBVt7sprD1mBrAF7I57BMAC8ICoIiQ1BXGjtywfQhwItlee4O4MURAry4aMCLjhl4BatZjUrI
-        zZKeMvfZWrCnB44iDtJ9X614Sa9Zq3XzXcbb1YqVQqq44PjeusIBeMEhkAxJrTmSIZIhgBds7clq
-        DluDrQF4IZ/DMgG8ICgIigxBXensyD8IeHEMffsm9xLFEwK8+GjAi4kZeAmenVKFZkNMcdlyZpNh
-        dFZkR+PBzGkl+cl20m/mc0WHNnWtp5a6E30hbCfyFsALDoFkSGjNkQyRDAG8YGtPVnPYGmwNwAv5
-        HJYJ4AVBQVBkCOpKU0fxQcCLl7l79vwSCQFeYjTgxcUMvGoqQ7WkhM1vHc1p+3p2msklZbpoVhmr
-        nOw0Bvai2m/5utvssu46OzbK7UUFe3jBIZAMSa05kiGSIYAXbO3Jag5bg60BeCGfwzIBvCAoCIoM
-        QV3p6ig9CHgJEn3PHl4SIcBLiga8+LiBF7PIl/ez7SDcZTMrZs3JZVMSatOOspgtKp3pstBOddNV
-        2uWzbKlXkzdjZ8LjlkY4BJIhqTVHMkQyBPCCrT1ZzWFrsDUAL+RzWCaAFwQFQZEhqCtdHeUHAS9R
-        EO/Zw0smBHjJ0YCX8Ju7OiYGqa05rbsje9zP+DMjLaTc+rxfq/O96cwf7sJmrVhrjrquWFqmJk3G
-        plpV7PkFR0GSJLbmSJJIkgBksLUnqzlsDbYGQIY8D8sEIIOgICgyBHWlqyNNPYiQSTx7x6ZfNEUG
-        IaOpaIRMjHlJWDg0AzXdEY3uZrvZtmzOq2dNx9LcIp/khUyd1YfjsifPF9MKm252TcVgh53Nn0m8
-        vmu7QNMPOiNljmLuOCNpQs5IOtoZKcV8RsrD7t6o2cGALyd3WkK3wznvh/1SfjlqKgyj0/O52yy1
-        9wMqqISthcbNB5XUH7oN3Xf7ItLMY85ImmKEO+4Tp5lHnZGnx+84JZlop6Qc8ylZn9Cd0pzOqFSx
-        WfQ7TLGwnbR77YyhzPOVarWjD7jpauX4XVqp7jiPKg5EWvpDbxT/tHOBGhxOSfZBpyRNs3es5KYf
-        1o353lMyYjvmZNzf215LqXemzZwetAeZYSGV2tvZajLXHwwHYq7bac7F/mqglRrVem3obTP11qrB
-        /aHf27hSBaT7P6DmQLpAurhSBVt7sprD1mBruFIFsA7LxJUqCAqCIkNQVzbrpB/Uj5mmZfmOtdw0
-        If2Y6Yj9mFMxE69kfVSR5HyRb+rbVTqfWpfKLUXbbW1hs0r3UwOxMix4zbQxYsueEQRbZTCUUn88
-        hD3tpkE/qGESzUj8PddOCWmYREdsmJSO+YzsrLZyTxB7g8Ss1dFKrTVb9NM0V05V2s3GPhEszG6o
-        OC1/GBTDWs+cVIZKdvyH3i3w3e0utPCgM5IVmXuunQqEnJFCtDMy85vvd9lnhazc7aRnkwJd3c1G
-        wXK37QmVieunuFmTnTQS7W6hL+qDgbSTOtviOuxq4z/eU8/rUR60JzfN8dI911oJ2ZObjrgndzZm
-        T/VS9US9Xhw0u7rOUftxUZ6sOxVpuGnJQ0rvL+wGnS5LPhvmfW66TlQ0o5P/U69rfb8e5UGbZtE8
-        x99zqZWQTbPoiJtm5WI+IzMMv/HbbWNkl3k63fK1MJvsGKmWl1uoNXZPidvkolrvuROVH1edTdtg
-        V3Tnz/mW/xIewYJyeg+25QeXo32ImJ6hXt5j/xAt3386P3D6Xdm14e02U8MzLhPO72BsmeHyjNnP
-        cfvzwKt2DPSnV7IPJ6HrJML5IY69D54fP71Q5fT45cHzS2u2evwIp/+c5wfTw3l2fAOfxi6PX6T1
-        zePnlzkc/YV6JJynl3tbAvBp6PVw9h5ypjI3dm+/4cvrl0+Dr4fz5TL17ZnvI9+83se8n7zk3NL9
-        n7/s+YNcHv9m7GPKeeGQurDs3adJ50/45eP3fnkrGq4k4UrSn1zzf8uVpPcrG7dfSeJuOGqfrhL9
-        vStJ1C1XkrhbjtqNV5KoW48a86ArSRQukMPWnrjmsDXYGi6Q43oeLBMXyCEoCIoMQX1WkeaGTuBd
-        TpgTrvk88P7wiTx0nSPceykfXld3Fx9TL/zGswJLUzxjbRkb5fJOLqfcTx86I8rz4TYc/Q+CpnHR
-        zS8/rcD5Zz9QveCHmjD0oRjJw+G04yyJQDMCe/v6BY758b7GayXhEszNNyB++bEEZyh9Oh9r3U66
-        lUyXs603Vn0+Tc//Pl9VV4NgamxeUm7oOcZ/+C+1w8fxVG1ueP/77Unnev0V+j7/yz6c5e4Hgvw8
-        eJlxeHtB6H+1rfX745ehtwnv3Pn885EDf/WtxdI2Dp/28I6Ct+edHrnMCpe+cXCXT8D2/B6zP77H
-        v3rvx/Fy9/P4l5+8tmm4x+qrX19t9fBNEx4KydP/OrjI+4+vtuuY538mqH8d1wh8DLx++Xj+8cLA
-        4Vv6CJr906WAbwaOFPXob5/uyLr8eIo6PyLxH0ZPf17/ZN73o6+OYeiHo7s8nDfh4TvleC6d3s/P
-        xi+TQ089fr9+mvY2cp7wmaif3v4Po6/Hb7szTU/TrReuUzsY8dvQGxrWDyU/zlbmi3M8+Mn4qz91
-        N2dcf/o4p1/33dirfzivtcvlBGN7OHUOsf74cp+G3+acbePw+Et75wfG4mVkeO771LMIDqdFeHla
-        O5mpZFvtfrZSaR/+IPl44DLpcuegbhveQVb9w4nkv027gOnL5YXzufbkf5/91YfUXNs2tOB8jexw
-        dLbBx9jpp7KxewmmnnG8bvF5/MdZrnN9Tmdq+S+H//nuwng5/A1mOS/H8e+f8+Vnb+nss6eLR5e3
-        fvh69kM7+Pr/AdSCuXFgdwcA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['14154']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:21 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/ValidEventTests.test_performance_calendar_empty.yaml
+++ b/tests/interface_objects/cassettes/ValidEventTests.test_performance_calendar_empty.yaml
@@ -1,166 +1,136 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:23 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:29 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MDM8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2YzXLbNhDH730Kjg/toaX5IVGyU4QdR1GSxrKdWHJc98KBSEiiRYI0AMpSXqdv
+        0ifr4oMiJSvjptNTWo9nTP73hwV3uQQWRr+s88xaEcbTgr488o7dI4vQuEhSOn95dDN5Y58c/RJ+
+        hxIsSCTSnERFKQDlESO8ykSIeDVNihynNKo4YVHKoylOQlog57AFxWxTiiKaZkW8DG3Xtnv2lN/f
+        Xt1n1/MPj/hqcn8TZw+d+aTjv72xz+8eru9+m13MsuF4uRiIz6fDOL8k9shPOh/nrx82ov/h4Xd3
+        2XszKuyzs88Fu4pma4/5XvLpHR10L4vNYjFe+6Po/n1ydepV0dgl7CHOP96uTqafSHX+PqneZv3z
+        +V3JBtOgWJ3zLH17sq7uBxvvjH3qBHx8++FdGRDSCew75Ow8P6KEJFFCSsxExUgk86SCP6SjBeZR
+        SdgsojgnXHF7Eqo4ZF4rWcqFEyKyIhTyjBnBEbwYEg5vkdPcaUNCeBwO4T1uHheEEQMoFcWp2Gg2
+        K2hSULtaQhRbUdsVOlJ2YzSDM8y5+aN5iIgD0gjGqPgzMFrf47z82RpAeVTyUVpmBEWgKkK73RDw
+        tCshTjCLF9GSbNRMDtRRo8hqM1w9bKvsOGu4fX8JpjE57FSHUwM7YsOoOF7hLCPCBPp6b4CO1Gke
+        wamTWHARMUzn4C/Ha/CcT1NKkjDwj13k7EgKgIcUJUtjEnb7NdFoGqkgDMzAZbAlthLKZV5rl76n
+        iLakgMajd1IT7VlUOmuXnS3RzEKLSFZtRmSyvs0QHypMhfwqzPIXohXO0iSq9dBDzp6yT/jPEp1n
+        ie6zRPAs0XtKOE/DU+8wiivGYDsApL7Sn8N8WkJV70gNMcOxKFjouW6LMWJD0SqfEhae+L0WZcSG
+        KjMcw7LotxgjtRhZc3yTT4vMacuw7Go1/POP9vhGR85+mM4Xavn/9/8fef/tlx4XFRXMxKc2zbaw
+        Nav1/oamgiTWOdQOND0NanZRloo0hp5plZJHubvHck/XGTpo0g2XfjpCE3OvnE0W1U+Wx4U1JqUg
+        Ml+W73qQxQbRdCXiqJjNOBFhpyen2lcbjJMYtn4eet2+3w+6u3Rt1PgGfvI8gbUWJnVPXc+QWx12
+        5uKk53qq54kwTVTfqHDbPbVdb+Kdvui4L1z3R9d7IWc6PMD43c+BvucCNvMnWQnEwrrAm38zHz2/
+        2++4fzsfgRt8VT4C+P0n+TDxq95Ql+PlzWRwfTY4H14jpyUbRKXhAguxII/Wq6JilPzArUsIh+F4
+        CSU0GY4n9UCdM32dJmHv1ze1Be6MnkGhFyG4w0L2eG3RECUWi9CBwXau57Wnal6b23Q7ry0INLn1
+        eDXEDIcIRcXDLF1t3RupBuB4gQWuO+RIbEoS8jQvM3lSAeeiHqcshqpKTrJM9dY7IQ6fhghXF+/c
+        tu4c8DEnhXxROEQZhiW0gpwH3nHgn/Y8r9NHzlZF0H3P9aXtHnsuvOGgBwtbIyOncSbPBbAXyYNA
+        c1DYCrL7lf0L9Dd122tuVcfEKkrlMULVjeebpmlHVT3PAW5f/boDjhYrhuUu0sJqRQMyhoLlsm3W
+        j/9ERXJN14edgXdtdSeXyNlKdUufQP4lHS3z0JU92wEd8UXxqI9TKhw13Z6GONQl4Mo5WUO9QE1K
+        dy25ZvQ5ay0IozizJgBar2Qh08RqRujvRx16D634hwwICqsyc43PXo+G1+Pb4Wg0hr26MRhIuR/j
+        JCMMvuFbKEVeY+boYY6Mulq/8dblS0E6X/yXxV9kU4ws9BAAAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:23 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1348']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:30 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160419</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['365']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1Zy3LbNhTd9ytYb7poZZJ6Wc4gzCi2nDSyncaW4tobDkTCEiOSkAFQD/9O/6Rf
-        1osHRVKSY8fTTTvKeCbEuQeX9wUQuELvlklszQnjEU3fHriHzoFF0oCGUTp+ezAcnNU6B++8n1CI
-        BfFFlBCfzgRQuc8Iz2LhIZ6NQprgKPUzTpgfcX+EQ29FOLJ3i1DAVjNB/VFMg6nH/Vrt+L7viulD
-        dHoSPwb8dHjstpZujSRD8njRHXYvBn4af7r94q9W00vSCm477rxz+dC/C4+/teaPN3+QRUssR8s0
-        PHInt6uzj/fTO3LTpx8vTutHeOGcxo3L3qd+7ejzl3QQZZ9EVGte3q06bLz4UHvfnc4i9kAm2RB3
-        b7+eNT98fVx87l08/vm5Pfr2PrqbtUZ3yK7YjFJCQj8kM8xExogvg+OlFNm7cDTB3J8Rdu+nOCFc
-        8TYglHEIt0biiAvbQ2ROUgguZgT7kA3i9W6QXYy0ICQ88HqQvNViQhgxBIWiUTTOZv4cxxnxXMdB
-        dhlAQSRWWlNM05CmtWwKPq5BLVeKzpXcCLXqIMacm/80X0wIFtKAEmbkasqgKtdqoBxUbWh1qmCq
-        EOIEs2DiT8kqf4MNRVWAsvYMNZ+5Rir6Ct4OldMo5LvVakeMvIIVFOXLGU6ieFUiaQ/t4r12HjTK
-        hc9wOgYdIwLPKiE+vb8nDLI64jTOYKVxPIeK8NzGIWRuE0X3WRyDHckoSknoteqSVMU0BXwSMxYF
-        xGserTkFaEgZ+I0ZGNQqOGsMKcsKxY1jSdoADanQ3GgVrNL7DLBW3iyxijfCMgig+PF47XC9hext
-        FEp6K4AJXm7aWoEUQc/fx/xVMd8OoEI2zKhimlI1oQqhRK763DdXM8qQIUC+n0hb8wVZczvPZ63E
-        eTprzguy5jZfkrUy6ztZc16atfoTWduInhxvGlHFNKVqQBVCKfXldysm3N9va/tt7T8d8/22tt/W
-        zOsfMpwKedo1Nx0PwVqMQj/HPRfZG8gmo/4so/Eso/kso/Uso73NsLfdU/u2H2SMwc0PKPmTPuqO
-        RzM4vVaggnGPA0GZvmBsggUrzZIRpKdTb5dYBixYsxgHcBmqlzgGKnFksvkqGdHYLsNw2dKo9/df
-        5fkFjuxNNwWd+aoo9lvmq7bMrfjZTxwI9gtqv6D2C+o1C6q8igKapYKZglHtmjKwFqvOwzCNBAmt
-        PugNaVJQTf+GRSIKfEbmEVn4xhJTcjtFuvun003S0IxNZyf7zXI7YmJ1s3HGhVV3XCjKgqC5mQik
-        U5wIr9GWL9pECxonAU1DDl/vI7fVbDkVdi7U9BX8S5Iw9ORLnY7bMcw1jiJOO23HVZ04H6ehamEq
-        es3p1NzOwD1+03DeOM6vjvtGvmn3BKN3MwJ6zAVmYismdReC0YV0xv9mSNpuvd1ovjgkzbr7QyFp
-        1urua0JiQqCalroeL4eDk6vuSb93hewSbCgqDBdYiAlZWO9pxlLyC7cuwR2GgylhP+eTdLz0cxR6
-        7d/PcgmMDB5DldOiBVkGDQPMExn34mi+lhsoJ2Qj8AbnfVdfrGbE41Eyi2XTGywS+TwlMaxsxgns
-        LrJjW7Gxt23jU7ZLvD8s4/YO3WNCZfSxh2IMX5oMAtlyD2EXWQ9RTNOxfqw5h64UrQFkF/Nl4xm+
-        0rLTXHSi14Dsosr9jYTr9qkZqqsOy9JUXpBU/t26ue1UUHW83sHbRH+sg67BjGH5fS3RckQTpA+U
-        JTiFvVmZv4Ui+bXT3fQT98pqDi5hI86hvDUcQsgl258m+nqwA0d8Qhe6X6/c0b92VDHEoa6BrpST
-        JZQOXOuluhKcc/S2AXLresUFSaw7wuiaqhcBlEVmpl13T897V9c3vfPzaziQFAJDUhOucRgTBsvq
-        BgqJ5zTTmDY/L+ha+5+fz55yMqBxTAKhSpxDdpaiwNSoT1aWmDAif7co49ssmn6fM5hE3II/ThNi
-        wRksSi2Jb86xd5lkP/nT2z+wPEdXvBsAAA==
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1507']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:23 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/ValidEventTests.test_performances_contains_performance.yaml
+++ b/tests/interface_objects/cassettes/ValidEventTests.test_performances_contains_performance.yaml
@@ -1,388 +1,309 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:24 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:31 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+NklG
+      PC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxjcnlwdG9fYmxvY2s+Y18tLTYt
+      YnNqV09qbFJncmUtc0RiSlI5T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZ
+      YzY4Q3U1TEJQYWhVU1BSOV9Dc1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgy
+      YWlmOWwzZDVmeWJoTTVRNU1ObDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6
+      emxlZD48L2RhdGVfdGltZV9vcHRpb25zPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['310']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2d2ZKqyrrv789TVKyLvS/OYhZJz9q1awf2fQeKekOAIKA0SiPi6+w3OU92sKlR
+        NZrpGhIaQyBnVMxRJgkIX5b/Xybf9/ftf/a29bLTPN90nf/+B/gL/ceL5ixc1XT0//7HWKghzD/+
+        5/3/vKlyoEmBaWuSuwmSrr7kaX5oBe9vfqiori2bjhT6mieZvqTI6rvjvr3+esvbwos3gSsplrtY
+        vyMoglCI4q/E/soa6YNI7gur8cLa4rqAY/Ux0p5tR7Ppsru0qvzaKAcHtrqwexrSwVR8qFe2cUAP
+        tnN0TdU6LsJxB9frS8s98DCgThpOmei5sWHwe6wjrVpqnwWhxKOat13YQ3HHKBMtbLfUsG7RbX22
+        8coK6e7avmXWmX24KseA8yY46fPioLEhNQ0nkdnb63fv/83RNFVStY3sBaGnScf7dLr4X7W/GbIv
+        bTRvKTmyrfnvsea/vf7Q9hb6ya0/t1imn9xgbac5n//IniZLSXy096r49vr56rxB1fzFezUJZxwZ
+        mqddOpxa3xZmEJ/7Wq6jug4SrpOL+dZ43n7q2jltv2y87GzJvn/559w/ubDk3X9puGw89eeSjS//
+        Idub/3opJ6MkPL6VL5vfkrFwGhjnw57uw/dNb74mewtDWmvx6UyvyXD6bDkOuku/j92+tXx3sM9+
+        Px5PlZ2F9uuDni/no8N3jZ99TtdRki1LCy4XWvlhh/OVvn6+hdePm+j6geTJjp4cz5b3yZFtxXQ0
+        9Z3E/kLfXr9rOnVI3mSw8cyF9k7QHz0+285dwuQyZC85JPmtx7emN/t4Xz8OiYFTj69Npw6fRwTM
+        R4+vZzndzo9D4t96fJ7FcaXj2LW0483K5yVuQ9kJjn8Vl0/B97edbJmq9NH+Dt5ef2j5sQf2b3vg
+        /7YH8W97kP+2B/Vzj9efL+8UQ2kRel6iCkmXj9/Ofw66sklG9XdNnz2W8iJwvXeAol/6XBo/ezmh
+        rWjeO4NRX3pdGj97bSx5kXw4Yl/6XJq+9DmOOT+2Fdd6/dqcfPqeW9//3/9+3f+z/e31x8t8/Zux
+        DONfkPh/DfrCDZ3Au1zfSTS/NnzbfPq8HztmoKkv7WTsJOzz2fWiop4ZmIsEnXamFh01fnHU9PMd
+        +uWmM3ed353mqJfXp4MJRvjPF+AHL7y2CbTj/XrBUJDcxc8u595hsJDc5dLXgnecOp7qx9bPbr62
+        SKTffwcEjdEk8X3vj43n7nHyn22ryWdtclKURcGl57f2RJldhkLBCX0k2VFP+HjqjqAsggIBsP/C
+        0X+h6P9Fwb+OZ/r1Dpfj/ngPzq/9IBHzn+4KGRgvXTm+5/2gMILG0d++HyRK3nQ/yOQnzf24XP+J
+        Dc/DsTcWyiOu3K6O3l6/NF+6nG5DVw4CQ4teSm7oOdp/+i+95HI8ebFOhpBQ5YWPHc/37Py7qb5T
+        zdrHluTVpd1KBrr7nhxODo6M97Xx0mMjB8b7a7IzYp/Piyin8yI+4nw7LxJofvD6sf9pl8vuyRUG
+        of9umbtvh780fXRIZhlyIL9+vA7ijfbum/bGOk5YkoMHH/udtlx6hRtfs6yvhH2+xOrPl5j81m2g
+        X9tff3EMXXOPgZLf3yw5+QgNk3tOgr9IjKUAwOm312+tbwl96+dfEfQvgCYRJqnkg+2z+e3182DH
+        2UGiRcfpgH+aV3zXcKTfI78kfPOBvZeXJ2LyQsc5TiZO4wZgF2j6rvXEPL/o92PrbfOcc2PoyUcV
+        +dLto+Xc4XgNrmcfsfn89n9qfTt+pp8nO2UweiGE3tvrt6YPpFeT+3/sLa3td/TIbL9of/MNNzpP
+        qk6XczrdD21vfjIuk+6ng2v7ZLwkY/J4uC/NH33O86x9oHmObL0ISceX0nEgO+rL5x7nv5/T3PdX
+        n/i/2vCWDKzwci6eq3SqI16sdjp8otWfGy6dTofnZdXSvORvWEyGov/R7TL1uEwZCwctHxf+3VBa
+        yAsjGV4fEwv/eKyf2uDcLLuXWLhhXlQ2h3OzYsf/a9AzQf5/h9CnpV/XtS7i87kc/Nl2JDzLtI+T
+        yhNHfXl5twnFCYHO7w7h0FaCWJeGyxZf2pm+qVgXbPqx8dzrE8PPROUmMPS+RhAEZ53uzDfLKy7S
+        GkOzrcZVPkC1EuULW1/3osoqMAdrWd5RDoO2/RVdIsYdYUnoU62moz17djnj+YiXoyckf1kEn3xs
+        /tb09jPOfo+yp8cYp2FB/4WjL4Pu2+tn03mrYdi2n0SfPUf+a9v5fJ+EChkDMgbUmLxpDGSMYsf/
+        14xR88x/vlCPYAySZIkbGIN6Esag0jFG+86MoYynQ7PCMdXNpjFgRb26GJXLCNZq6eJWPrQFtNIx
+        x4xTZScSwfeWI2JgGeURZIzsCTBkDKgxedEYyBjFjv+vGYMPnX++MI9gDBrHsBsYg3kSxmDSMUb3
+        zowR7uJo2C31ZnLHqxs6U8E7XtzyaanU6E4GFWVG7WN2sY4lJKzN9y0W4earLWSMDAowZAyoMXnR
+        GMgYxY7/rxmj6yaMwT6CMRjA/H7WGImyT8IYbDrG6N2ZMdC6uEMUHizNlRMZe8GacQK+x70hOWPK
+        ZW7e3dmdba+/G/fWbbt8wERaMoIhZIzsCTBkDKgxedEYyBjFjv/f5GOE2j9fAPoIyGATcvh9yADo
+        c0AGQNNBRj8dZBzLCd+bzsIKj7WcL4q8WL/4gaxrLxvZ/9jr1OnfQInVXC9L09VoMtrWkU3FQkbm
+        di0dKHy7tmY1t9Wo0ao/R+bRci1zSrgPPccbQyjJoGJDKIGilBdRglBS7Pj/GkpETU2gBDwESlhw
+        QwYH+Lle7s9AyW+X4X0PJYM7r3xQ/KzGzimAaCjLdPe6uxtrcbfHz+eb0cCvWDXbwqptyjPra9OQ
+        ZDToMBgKISODCgwhA4pMXkQGQkax43+lEgVgD4AMHKVp5gbIwJ4EMrB0kDG8M2TstxWybaxwubXd
+        uHOtaUTrSJ0EeknRReWw21XUhmWMe9qctKezbr1rGpSHwVKUDCowhAwoMnkRGQgZxY7/lVIUgD8C
+        MgBF3JAnCvAngQw8HWSM7gwZo/bINFuEuLQHvoRam313X8GMw6DXZ8oDFsQdnBqGEd+teNzB7ZZH
+        THNf3vEQMrKnwBAyoMjkRWQgZBQ7/ldqUcAjTDVwHKdvyeF4ElMNkNJUQ7gzZPB7e8/Fa5wxmKkH
+        8GbJEhfTcOR4woISZ+3lrBqPcCVa1iuLJL4R4y4ndQBXMjKowBAyoMjkRWQgZBQ7/leKUcAjXDVw
+        AsNvycl4ElcNkNJVY3xnyKjGNWwT19Thwa+pkWm4BjAGrBtwE9AyurWGb5N7FKCYO5ZaQ3lWwZgF
+        K0PIyKACQ8iAIpMXkYGQUez4X6tGoR8BGSTK3pKTQT8JZNDpIGPyh6tRvE17vAh4du33yTqL2TMb
+        GO6yU4kPfXFDqEifGdoSa4yRSsvEKZs+DMmmDm04MqjYEEqgKOVFlCCUFDv+16pRHuH1hZMsdUsO
+        x5N4fYGUXl/inVc+5m2/G+ITeVVrl+bKQNfbwtzfIaJmcK7UilbL0p4iPTMstbd2syGarlTRUAgZ
+        GVRgCBlQZPIiMhAyih3/a9UojzD7wqnkDtwAGU9i9gVSmn1N7wwZwcKbMcNtadhpr6VNa1zltjNz
+        a3VM1O7XV+hswxs2V2Gn3X68rkw6jNdcVrrw8UoGFRhCBhSZvIgMhIxix/9KNQr2CLMvnKbYGxJF
+        MfQ5IANLafY1uzNkxGhjsG8bOk4gm8aaVGe2tFbxmmBVp/HK9VtaxO1Nd7ZX5+hw7QYLdCX2mnAl
+        I4MKDCEDikxeRAZCRrHjf6UaBcMc9f6QwRLghhwO7El8NbB0vhpHQ9S7Qga5IaLZfCpVnLmmkouR
+        SOGHmrvjDnLyElDTmCYoU9rsB5pa6w/Jw6I8LnOw5DWDCgwhA4pMXkQGQkax43+lGgXDvftDBoFi
+        zA05GdiT+Gpg6Xw1jgand4WMDjbAUAkXuv5sq1tyIBmDqRI5odtwPWCXNma43fUVdqeODqIWrEBJ
+        EbU+XMnIoAJDyIAikxeRgZBR7PhfqUbBiAc8LiFA8r8bIIN4Esgg0kEG9oerUUTNLTdHG7a50OWS
+        tl6IvSmYCHHPAGN/W1a6YAuEieiT4dCtlvr9ObrcVjdw5SODig2hBIpSXkQJQkmx43+lGgV7hNkX
+        kRzslhyOJzH7wtKZfR0NUe+68kFIk159PyOJfXXmuE2VkaqON5ooaIcXgtpC6JDEZh2ORLrbrdU3
+        K4b2lsYEQkYGFRhCBhSZvIgMhIxix/9KNQr2CLMvAmPoG8y+sCcx+8LSmX0B4s6Qga83Ea7gVcMS
+        W7TiMB5VOcyWVWfvc83auj0GWFQzrGiLhGYdDzi+TjY1BT5eyaACQ8iAIpMXkYGQUez4X6tGeYTZ
+        F4HT+C2Jok9i9oWlM/s6uq7fFTKi0dIqL9qVfrBZiX15wLSc+pipB1WthvXo/mEir/q+Afoa0ncH
+        FkOLgl2fwpLXDCowhAwoMnkRGQgZxY7/tWqUR/hqECRB3ZLD8SS+Glg6X42jIepdISOszjrB5kAa
+        pFJp+fXhxpqN5hRNxU1+JEfIellnnE65zWH+hue0+TLYjZUehIwMKjCEDCgyeREZCBnFjv+VahT8
+        Eb4ax69guyEnA0efAzLwdL4aR4PTu0JGf7RzJpsDUSZQT6wrTs3x3NkItEe7GA8PblvkxNZBxb24
+        xR0OcbDvthS9DnMyMqjAEDKgyORFZCBkFDv+V6pRcOAH94cMGrA35GTg4EkgA6SDDPYPV6OUe/1G
+        vNNrvjov4TYd7tiy3m9TB1fBrai1arhDNRbtYZ1HDiFPrLnScBRu4cpHBhUbQgkUpbyIEoSSYsf/
+        2nejJEzSCh3tvlDCoOTv53Akov8MUJL8pIQS7s4rH1a1DDxjPhVAya1MaL3Odkd0EEleFDZdYqaq
+        S5fHmb0x15FBYz8n+yLmOUMIGdlTYAgZUGTyIjIQMood/2vVKI76CMhgsd83+6LQp3AUTX5SOoqW
+        7gwZQzIkKTnaKtqhP2e5ilTih3OOZNtUhShtpQZF1ym+p4JFv9YumaYnkjHJw2qUDCowhAwoMnkR
+        GQgZxY7/lWqUo6Ho/SGDpZnfTxSl0KdwFE1+UjqKlu8MGV1kHRKTuLKNgdSiDaCYYtNcT+djfY12
+        9I05dpashEuy4Pj9zcGdIcAUFLiSkUEFhpABRSYvIgMho9jxv1KNcvTuujtkkIAEv5/DQaFPYd51
+        TONIBxnVO0OGPovrC7NjGFtmt+pilfGh3DLm7THH9IBRm4QobnUZXmTbOlsZjNFabeuLG5iTkUEF
+        hpABRSYvIgMho9jxv1KNQj0EMjCcviUn4ynMu44/6SCjdmfImPCLplVGtwdT6fbaitpjbE9iaHXM
+        dJX9oDncjknKpdY2vaj1Varnd2ZDyoLVKBlUYAgZUGTyIjIQMood/yvVKPRDIAPHiFtyMp7CvCv5
+        SWneVf/D1SilrYq3MMXvBA3B80d0qy+ELlbebeymGlFlYs5EDbe0LnvbLRLuq42Ks2nLEEoyqNgQ
+        SqAo5UWUIJQUO/5XqlGYh0AJAdBbcjiYJ4ESJh2UNO688mHuo7YtMcstijPcNO40tNYAXShRr24P
+        yuZmOsKGh2adU0KkjWmcvEAUYkdAyMigAkPIgCKTF5GBkFHs+F+pRmEfAxks/ftmXxT6FI6iyU9K
+        R9HmnSFDq28HnoDiZBMJsNGK0zo9dbEpOagyZScisjQiaTMmo4AdhAbeqx1KK2RTgtUoGVRgCBlQ
+        ZPIiMhAyih3/K9UoAH0IZZAMfkOmKECfgzJASkvR1p0po+cs516FkSu7PTc3gpLDtptd2dYYlG7v
+        uY7rDhb6oWeXSL3V5vc+0lfXdB9SRgYlGFIGVJm8qAykjGLH/0o5CsAeQhk0Sd2QxQGexFkDpHTW
+        6NyZMkB9ZfkBtWrNuCXfs4ZGy/f46kxdoLHvrqMyyottZZM02uHGsJUSN6/odViPkkEJhpQBVSYv
+        KgMpo9jxv1KPAvCHUAZDYDekZYAnsdYAKa01unemjM4GXYVdWfWXeM0FYCUjS7XMx8SupevbHT21
+        VUbm46lSovjqgto07bExbELKyKAEQ8qAKpMXlYGUUez4XylIAcRDKIPF2BvyMgDxJJRBpKOM3h+u
+        SLGrGGj01/X+rM2hDlEbmeW4PLVMj9WqcrcONusDE9DtXVNU1KFZMfqcRWLQ8CuDkg2pBKpSXlQJ
+        Ukmx43/t+1Ee4viV6Dh5Sx7Hkzh+gZSOX/07r32II6w+o1FlxlO74SSq9xiiNTmwnjAWKNFfLIOW
+        IYmMsUbEiaJODx7Yrk0KUkYGJRhSBlSZvKgMpIxix/9KSQp4iOUXBVBwg+XXtxP/acpIafk1uDNl
+        2MSsO1AJMR6Y2lCdtmsLt9Vr7IwQkeaDVq+n031Vqc6EeLW0OuvJqtYvjVX4hCWDEgwpA6pMXlQG
+        Ukax43+tJuUhnl8UYJhbskWfxPMLpPT8Gt6ZMmZBKPA2sxcpZyeHwO+qIlfFLbS2i2xxUDP6+thX
+        +LYkNeSleKgFmEF1REgZGZRgSBlQZfKiMpAyih3/azUpD/HXoHAK3JLH8ST+GiClvwZ/Z8pYlq1Z
+        iaO2u76OhyWWxhuqPdjHK/5Qn/a40r5WmXf7XTzuDiMS3/OOLNkLF1a+ZlCCIWVAlcmLykDKKHb8
+        r9SkYA/x16AIgr4hLwNDn4MysJT+GsLdK18dSkLq400btNgaHQxZr7MKpd6guTeddQOpmmy4XM6m
+        qtzYMSI6GTWHJgrzMjIowZAyoMrkRWUgZRQ7/ldqUjDgBw+gDBLHb8jLwMCTUAZIRxnjP1yTglR0
+        wz2M26Ml2h6tbObQKmFUZzDqdVweWLvVciiMKQUxuPFwHrChaXKzYQ0amGdQsiGVQFXKiypBKil2
+        /K/UpGCYoz6ASigMvSGPA3sS1y8spevX5M5rH8NQ1Ea8ND8sy/yY5dvjkHRHo0kX7Scf3nFYqcy4
+        XVNsA3txmM7Xc03mWssGzOPIoARDyoAqkxeVgZRR7PhfqUnBcO8RlEGj1A2uX9iTuH5hKV2/xDtT
+        BtfjXb1Z8yLZoxRnT7Rryt7VK7axnRBzZiIFk2FpUbOWB6sJ+oephQ+V3QE+YcmgBEPKgCqTF5WB
+        lFHs+F+pScEe4vpF0Ret+U3KeBLXLyyl69f0zpQxIPjq0t6RAxSZVRRrZQ62bSts65W+5SHthmdV
+        EbXTISpYzdUofzWVZqg2g5SRQQmGlAFVJi8qAymj2PG/UpOCPcZfg6XIW/I4nsRfA0vprzG/M2Uw
+        Q2fW5BugIvlA6NAdd9GlCGG4w62aRMds7dDfxgrB7PpAniD8pIZXeiH8npQsSjCkDKgyeVEZSBnF
+        jv+1mpSH+GvQKIndkpfxJP4aWDp/jaMo35UyVNr3GgrKj5sVUDqYnBbYW37oxttuD9iHRciOxZkk
+        Okhkx3tRmA2tEOcbMPszgxIMKQOqTF5UBlJGseN/rSaFeQhlAJy5JS+DeRLKYNJRBvjDNSmu2W4p
+        k3656mDiNGaX+2VrtIqrk6kcrOLpyuw367JZqw9kPxhylcpsvWdkBPpxZFCyIZVAVcqLKkEqKXb8
+        r9WkPMT1i8Yw8pY8jidx/cLSuX4dS2ruuvZB0x3T6xuLiBkbg91SqzTIyvKgNmj0QMpTb6iouumN
+        2BggLH0YKG1RZ2IdPmHJoARDyoAqkxeVgZRR7PhfqUnBH+L6ReMA3OD6haPPQRl4OtevY0nNfZ+w
+        lLl+2/KaPLqwBpuRuVltdmXPq/crey1qzfx+ODMptX8Qep5G8CI37lHUAmaLZlCCIWVAlcmLykDK
+        KHb8r31Pysn0y4rvDBks/fvJojT6FKZfNIKmM/06VtTcFTImuoohwsbVd5yr7vVlcyy6OuJJI3XY
+        ZISFU7ZlnFgrobdF0N08GFqzWguFaRwZVGAIGVBk8iIyEDKKHf8rJSlnd417QwZJo7+fxUGjT+Gu
+        kUBGOneNY7DvChkeOdmXOaEarN3OXuwEsdDnSth8qKKoQHmr6a7uq+2GjlPN8hQv7b2xgdh7CBkZ
+        VGAIGVBk8iIyEDKKHf8rFSlnc417QwaVUMYNkPEU5hoJZKQz1zjW09wVMvZaVV1o69IYm4wCq4lP
+        J2ZggpVx8IWZd/A8jpVGmEZtg0pEx5uGGpJRxYKpnxlUYAgZUGTyIjIQMood/ysFKeRDIIMm8N/P
+        yaBR8kkgg0wHGcwfrkcJ9WBd2q0c26gxy9Y+OgwVNqAnBNpxxeFiy/EYKa9riLgbdw2wsSMhanRb
+        MIcjg4oNoQSKUl5ECUJJseN/pR6FegiUMBh7Sw7HUxh+JVCSzvDrWE1z15UPe+IYyx09tHUMcTr1
+        Bkt1cGwCkIk0DgS6vhsujQPR0kiCcMWx0BrE/a6GQcjIoAJDyIAikxeRgZBR7PhfKUehHwIZLKB+
+        3++LRp/C7yuBjJR+X9ydIQMjybrnBITYFxAjCKUGGdeb4npUGtP2YTqo6H6p2u5a7IpWUWm0mOAb
+        vdyGNa8ZVGAIGVBk8iIyEDKKHf8r1SjMIyCDQVHslkTRp7D7SiAjpd1X6c6QEW8bNUpsRG1kJetd
+        v7TfudUAHwYzUKtODqRhBq2tXW8y7RI7WVl0FdHnZQ7mcGRQgSFkQJHJi8hAyCh2/K9UowD0IZQB
+        aPKGJA6APgdlgJTGGpU7U4ZkjSfa1GkcBqpXYjel0kie7SNpOpv1KhVyJQmOFa4G0zU/l4eiamxn
+        40oLhUsZGZRgSBlQZfKiMpAyih3/K+UoADyEMjAK3JCVAZ7EWQOkdNao3psyRh2tIrfnOGtRFT+c
+        BVtRpcJwyfcMQe1Nh72agBCGRLcmMr5GDKFS9REFrmVkUIIhZUCVyYvKQMoodvyv1KMA7CGUgRPM
+        DWkZAHsSysDSUUbtDxekKCjtKA1UQ4DabyyikUgoiBqvKuu95Y4iv9d1YnLjNp2ypyhoGxVWOyXC
+        4NpHBiUbUglUpbyoEqSSYsf/SkEKwB9CJQRO3JDHAZ7E8AukNPyq33nto1arq/Mhv9rKhrNlrO14
+        VRnKjdqyWR1vJ8NZB6/rnEAdzHV9R0ohOoxHnD+Aax8ZlGBIGVBl8qIykDKKHf8rFSngIY5fDImB
+        Gxy/wJM4foGUjl+NO1PGjol4Zkj1rC0Vm/3xsLOxKgRh1Gq7g9VyGjTtiw3fxDVy4jpbJxovQ7YR
+        wbWMDEowpAyoMnlRGUgZxY7/tS9IeYjlVyLM9C3Zok9i+QVSWn4170wZrjfshygYOGh5HFY0s1nl
+        J9FOpfzKQBoEbXs+UhWBH6ox2u63Tbo0OSjkHK5lZFCCIWVAlcmLykDKKHb8r9WkPMReg6EZ9JY8
+        jiex1wAp7TXad6aMQdseldr61jQPdpNx+2qtTvtTsdNeCq5RRiSmPpYrGzIcrbaTw5J3OWSARpAy
+        MijBkDKgyuRFZSBlFDv+12pSHuOvwVDULXkZT+KvAVL6a3TuTBmOFwXCwdsMyrvGAEOGlGJXMPOA
+        yKhWEteIE1XnB3XQoNZgUk+YgmmueGIKv4gtgxIMKQOqTF5UBlJGseN/rSaFfQhlsCR+S14G+ySU
+        waajjO4frklpdFudkYgSvqjgnRkSKWPCWwjUUhQxljwwOMksHCZeL0BFW7fLbi2Ug94a+pdnULIh
+        lUBVyosqQSopdvyv1KRgD3H9YlGcvSGPA0Ofg0qwlK5fvTuvfVTGzZW4ZqdlXDXMiV4agjpAh3Os
+        Rw5B7dAWDojsb8bMkgIDoPvUTlFVh4KUkUEJhpQBVSYvKgMpo9jxv1KTggE/eABlAIy8wfULexLX
+        Lyyl61f/3t/FJnIBUEcI1Yl2znZani50xG20LaGni1UZXcR2iTo0pJLEudVpZVirqcsNrHzNogRD
+        yoAqkxeVgZRR7PhfqUnBMEd9AGVgALshWxR7EtcvLKXr1+DOlKFwBIIa5miosnTgHPYGt5noC9sp
+        bdS4mryRHmeAyGX1Sk02qAqhTObzlg7XMjIowZAyoMrkRWUgZRQ7/ldqUrCH+GuwOEPekMeBPYm/
+        BpbSX2N0Z8qY1/p8A93svUYg0M6iGU0jBJfbCIUvYhyJNXsA1KZBH+TqeFiXnSXeiKcbuJaRQQmG
+        lAFVJi8qAymj2PG/UpOCPcRfgyVocEtexpP4a2Ap/TX4O1PG0mIFa9a1SdR0GXcRW7jQiVB160yD
+        mBww9aATEzWzqe9xn7Y9bRb6I2kLa1IyKMGQMqDK5EVlIGUUO/5XalIw6iGUQZL0LXkZ1JNQBpWO
+        MoQ/XJPibr2gzY0XZa1n1XpLkcE7WrWsGFJbN0ql+RCpBc6mH6u90pxng1G0n83VJfQWzaBkQyqB
+        qpQXVYJUUuz4X6tJeYjrF0sRxC15HE/i+oWldP0a33ntY0qRm4UdBvVDb0mpNop7u144oYhJg2zr
+        1rgmxjEynQssP1XR5c5Zhc0a6EHKyKAEQ8qAKpMXlYGUUez4X6tJeYjrF0vj6A2uX9iTuH5hKV2/
+        JvfO45B24qG1Y8j92N/zNLOrNmVTamqDmlA2xPm8vliyPjtRJXoxZha7cWNvlwz4hCWDEgwpA6pM
+        XlQGUkax43+tJuUhrl8sA+hbskWfxPULS+n6Jd6ZMvia7iiu6K0Zca7Ly41H7MvWshYNx0Fbdc39
+        YRxNBXbWDlh6Wsf8TY+19BJcy8igBEPKgCqTF5WBlFHs+F+pScEf46/BMuwNeRz4k/hr4Cn9NWZ3
+        pozmVGxPmszSnJCDvjJQ6n2v4e6Wsy7JqfhiuJ5o09ZC7+m1jWWudFDx40gMYeVrBiUYUgZUmbyo
+        DKSMYsf/2vekJJDBhXqY/HNHzKBRlKZ+PzGDQZ8CMxgETYkZ8ztjxiQgO/KGsx2kotRxbl8Rmq6C
+        DmmZF1CcSNRZICgmQOLmgRJDgLkrrq/u4SOTDGowxAwoM3mRGYgZxY7/taIUR30IZgAK+/3MDAZ9
+        Ch+vBDPS+Xjh6B+uSiHEubGqAM6OGkBnVP6wdMQ9eSBmO0eMiDIXRfISK4OBgfX08bzVVahGpwaf
+        sWRQsyGWQFnKiyxBLCl2/K9UpeDeY7AEI9jfT+VgUPxJsARPhyXgzqsf2ojoVdblnYhtG6OtsFdo
+        Qq/0MU5quwO5yvZK+6q9bTKczW9dXVe1w6w+r8LVjwxqMMQMKDN5kRmIGcWO/5WylKO76CMwA8fJ
+        33f+YtCn8BdNMCOdvyiO3RkzmD0gkL4wWTUXVVRsxk5NtOYC6PGOK7S0nRPjS3ei2LNo3omYbas7
+        WcWxBP1FM6jBEDOgzORFZiBmFDv+V+pSyAdhBoGB308ZZdCnMBhNMCOdwSiO3xkzasRmojsDlCFW
+        3pwANuISXbo5Km9GTjxp98dkLS4r1DZuxxioVudaGAWYCx+aZFCDIWZAmcmLzEDMKHb8rxSm0A/C
+        DJIlbsnleAovrwQz0nl54eSdMaO/RbAKF85nC0BEItvTp+poMTRKA0HjW/ZuNq8fFo1ux4qnwp7n
+        LbLO9ZEmXM3IoAZDzIAykxeZgZhR7PhfqUxhHoQZFANuyc14CjOvBDPSmXnh1J0xQyS62LRLslXa
+        ZufzCthbgWLVg5JBK8bE4hywXx6kroJWJXnRHytsgK9ZEmJGBjUYYgaUmbzIDMSMYsf/SmUK+yDM
+        oCn6ltyMp3DzSjAjnZsXTv/hyhR9X1pZNsdVB4HTKi2Bbpq1hjvEWHqESnwHx7aEqTDN0nrGzEtM
+        0OvvdRJ+X0oWNRtiCZSlvMgSxJJix/9KZQpAH8QlDInfkMwB0OfgEoCm4xLmzssfCU/gFtHd1OtG
+        bzoSuvhQPuhkPZQbHObNBJEl1dHQHO/GwXztdFeb4aTaCODyRwZFGHIG1Jm86AzkjGLH/0ppCgAP
+        4gyWQG8wAANPYgAG0hmA4eydOcMrLexZDfWiZlTlekZ/N++zlbZUqW03oTWoz3zaW5dDXyt1qYbO
+        c47K+ksPlsBmUIQhZ0CdyYvOQM4odvyv1KYA7DGcAVCMuiFrFDyJAxhI6QDG3ZszOlSvyprBYem0
+        3XZUqnDrvn/gYp7ybX7bZIbW2lpMWruxO2U3dMPh8diqwvWMDIow5AyoM3nRGcgZxY7/leIU8CCv
+        DQBY9oZ8DvAkXhsgpddG+d5eG66waVYGM6LdbawMRnUSvdbKrLxbbVVp2WizNTWc9CpVAbQ1pdff
+        eVGnj8P8jAyKMOQMqDN50RnIGcWO/7XvTXmQ2QbAGPKW/IwnMdsAKc02KnfmDLcuzMxye1vD8F4b
+        EyPGaTle0yT26sgvDQ/znloSWp3eurXnvdHAr5rrepWAz00yKMKQM6DO5EVnIGcUO/5XylMA9SDO
+        wGnslvwM6kk4g0rHGdU/XJ8y5g4hsdRjbdZsDirKqDNpHbb7ir+Sy+6UNyXBUbQOxyCdgdrbRcNW
+        MJwe4HOWLIo25BKoS3nRJcglxY7/tfqUB7mAAYJkbsnneBIXMJDSBax25/UPHCOj3dy3zf3IkgRy
+        aUgaNvajVtPTOoHTGNI+oOnxlg8izGNFRqfFdjyGz1kyKMKQM6DO5EVnIGcUO/7X6lMeZAMGSIK8
+        wQYMPIkNGEhpA1a/M2eENXS2qggHXBh1xKHfWI4a/aGAVNmlTvasIIyI2k5ujxairdc76LhLNA/b
+        LXzOkkERhpwBdSYvOgM5o9jxv1af8iAfMEDh4Ja80SfxAQMpfcAad+YMnUJw3ljOdaDjVEeyps5+
+        tx2wfJkN+7NuZxkajcifrkb2qFRqkSao1cDOGELOyJ4IQ86AOpMXnYGcUez4X6lPwUACGI/gDAYl
+        bsjnwJ7EbwNL6bfRujNnBPrKIZna/qCMhNF0F1dW0YpsNBa1Zg1Uq7vNalTqUbXNcLmiepau6R0a
+        Z2XIGRkUYcgZUGfyojOQM4od/yv1KRjmqI/hDBa9IT8DexK/DSyl30b7zpxBWdPI62Puml5P0eFu
+        wB/q0ZwIlvokGg4jRrZFpx4ccJpeM8NuP0a1arU1gM9NMijCkDOgzuRFZyBnFDv+V+pTMNx7DGew
+        NH1DfgaGPwln4Ok4o/OH61OW+lguV/HKSp4ND8NSfd/zGbJXd1mGiPh4FY7MYYCuwmmz1qD9iPB7
+        am8QwvWPDIo25BKoS3nRJcglxY7/lfoU7EE+YBhK4Tfkc2BP4gOGpfQB6955/YPD5e1G39d9MuJ9
+        bSn37KXbnjZjry+QfaLH+Bs6uaBIDzqaTkttltWlDg/XPzIowpAzoM7kRWcgZxQ7/lfqU7AH+YBh
+        gGBv8AHDnsQHDEvpA9a7t9/oRJ6pgx7Xnw5EbLA3wE5rWfs9mki/rCwNjFttI8QRGgdhEKg7udOZ
+        GYcF9NvIoAhDzoA6kxedgZxR7PhfqU/BHuQDhmE4dUve6JP4gGEpfcD6d+aMqDyzGsMB3dwBuWks
+        V0JYIziuhAhrA6+V9XqH7hjW1MfF6WLW2bU7kSVMJtBvI4MiDDkD6kxedAZyRrHjf60+5UF+GxiB
+        srfkczyJ3waW0m9jeGfOEJYx64FyuFAxYWuBYDuuVvkwCMb61F8Jiu45ddYxp1KvEpDC1uHCBd4f
+        Qc7IoAhDzoA6kxedgZxR7Phfq095kN8GRrDkLfkZT+K3gaX02xjdmTPUw1gxR/Nk8PYDtzuwRuZa
+        XVYooJZ7woZnw/JyWiZodDI0VgQ4VOe7TgXZwjzQDIow5AyoM3nRGcgZxY7/lfoUHH0QZ5AMuCE/
+        A0efgzNwNB1n8H+4PgXX8f2gF7PIqstYHQ64M7YSRq1FYAkbvam4S+swqXHmblKxqMHe5VR55uwz
+        ms/xQyYz/iDHGIyimBue/OFP4hiDp3SMEe5MyhYhGd0wqjnTbhBqfOCR9KBzaPPyUgeMya/mHafb
+        wYlp8nbtcl2hQmS3QjKayfxDzttxQPLaJtCOn/v3HZM0Sfy+uwCLPsWYZBE05Zgc33lMKgNCMxbz
+        EVXGVK3bQkC30abX036FwUZb15l1vI1vIyUxriOMyGkzq9e1sezM3l7DI+VJp/dgmX5wifb7m+xp
+        8uU9im+vn6/OG07nqu40L44MzdMuHc7vYHHkp1NfKxlmroOE6wQnvjWet5+6dk7bLxsvO1vy8U2e
+        /jn3l70gidqXhsvGU38u2fjyH7K9+a+XcmgF4fGtfNl8HH62fJwFnQ57iv/3TW/JOE0mN9Jai09n
+        en17/dLylgyLS7+P3b61fHewz34/Hk893udfH/R8OR8dvmv87HO6jpJsWVpwudDKDzucr/T18y28
+        ftzEnM5B4TQbTrPyMs2C0+xix/9r0Bdu6ATe5fpOovm14dvm0+f92DlC1Es7GTuqa392vaioZwbm
+        QvK0nalFR3FfHDX9fId+uemMgud3pzlqpvD0Xhz5+st7cH6dTLC94Ke7cqxT6crxPe8HhRE0/vtJ
+        HST6c5HKtftBJj9p7sfl+s/sfxqOvbFQHnHldnX0MSU4j9Lz7+eHUnIQGFr0UnJDz9H+03/pJZfj
+        yYt1MoSEKi987Hi+Z383yzj/ZiUD3X1PDicHR8b72njpsZED4/31OAmwz+dFlNN5ER9xvp0XCTQ/
+        eP3Y/7TLZffkCoPQf7fM3bfDX5o+OnybIZxfH4n93TftjaUlNyw5ePCx32nLpVe48TXL+orW50us
+        /nyJyW/dBvq1/fUXx9A19xgo+f3NkpOP0DC55yT4i8RYCgCcfnv91vqW0Ld+/hVB/wJoEmGSSj7Y
+        PpvfXj8Pdpy3JVp0nAf4p5nadw1H+j3yS8I3H9h7eXkipp9nLD+1npjnF/1+bH1zNE1NRsQmGW8J
+        zZ/G5On9/Kr90jn05KOKfOn20XLu8HXCc3r7P7W+HT/Tz5OdMhi9EMKxduqj6QPp1eT+H3tLa/sd
+        PTLbL9rffMONzrOp0+WcTvdD25ufjMvFZban7ZPxkozJ4+G+NH/0Oc+z9oHmObL1IiQdX0rHgeyo
+        L597nP9+Ql/zfvmJ/6sNb8nACi/n4rlKpzrixWqnwyda/bnh0umcyCarluYlf8NiMhT9j26Xqcdl
+        yngerTlHl7+7yPOn5WmmfWlL7rmfzEnf/z9OhiWt1ngDAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:24 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['11263']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:33 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['330']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+2d15bi2pql7/spos9NXfThpLypEZU18N57bjSEJIRASCCDe51+k36yxoVJs0nQ
-        FidXUrPGGbUzFgsCfmlOYn5aWv/rf28X9sva8HzLdf7rH/S/qH+8GI7m6pZj/tc/up1cQvrHf3/9
-        X6+6GhhKYC0MxV0Gh6m+4hl+aAdfX/1wrLsL1XKU0Dc8xfKVsap/3Rn+65efP/Sqebtl4Cpj29Xm
-        X30lkZAnZTqYr6xM2t5rfqYr0/yWThiLrrGvJrvJakdx7NKwqex285rBa0OJXku1VXmkyzN+ve83
-        jA0fbMdbRxfp6XCXK0zmI6NfdgvVDCOqGypjs7VsqZwQ602nY4WlwEpwtdFO8sxNPpFKzpeWtzKm
-        YVdNDns5Lt/bb+rZ6n5QF8azlDVa8uPR65dv3vOrYxi6ohtL1QtCz1COxfnquK9ffjb+OlV9ZWl4
-        E8VRF4Z/rsx3Y6+hf6j3ecS2/ENVjbXhfPxH9QxVORwU42u2//rl46fzA7rha1+zh2O420wNz7hM
-        OI2+ji0zXCpr1Q6NrzRFvX75PPCqWcHu/Eq26+iukwjnh4/6Pnh+/PRCldPjlwfPL63Zqu9f/nOe
-        H0wNNTi+gU9jl8dPT+l8+/j5ZQ5nxekUOb/cqTrfDr36huppU2Vu7N5+w5fDufUxeDwFL1Pfnvk+
-        8s3rfcz7yUvOLd3/+cueP8jl8W/GPqacPktOXVj27tOk8yf88vF7v7wVzfUDxVMd8/AaY+Pw79MB
-        UdzJxPAOR3Xsu3Z4EJyvrg/nxVea/dfhyH0/+joJbfvwPhZjyzH0rzxznPTt2HnK4TMFS8/SjK+c
-        +D7nY/AyKTx8btU7vCH+Y8772OvpnX28MCsfJ303eJn08cos/zHr0++7DLy/OPdp1sdvPIhBO5z8
-        qvn+gRn+9cuPo4dT+ocCLtTt9+/1m6HThPPzUfNINf+xgKeR797Gt2PnKd++hW+HXhdH1b99Nvo8
-        4/PQZcLheP/FYeNuOGq09Ouj9mnOXx816oajRnO3HLXPs64cNerWo8b8xVH7rnrHn79/E9+Onad8
-        +wa+HXp1XOX47WUbvgJbg6390TWHrcHWLr9+FapOcPxr9xJ4vr4etGjpytv4V/r1y3cj389gfjmD
-        /eUM7pcz+F/OEH6c8eXHj3fybUULPe8QAA9T3v51/lPXHC8Pf71+M/QxY6JqgeudA8b3gx+znHAx
-        PhweiRE+zboMfsxa2qp2iETMpzmXoU9zjgfb3y3Grv3l8/Ahc51Hv/6///v5+R/jr1++/5iBu1RO
-        JwUsM5Jl/lC/L3/xBwEEBUFBUFEE9VlFmhs6gXc5YU645vPA+8Mn8tB1rMDQX8qH19XdxcfUC7/x
-        rMDSFM9YW8ZGubyTyyn304fOEPB8uA1Hv/x8ITvhP19oKZi+JEMz9IMXhqIPJ+XHhPPcMNCOH8o3
-        gq+scPxF349+TPMNzXV0//DtLdI8x1PfzH578Dx9d/i/xULXvx5/KSXR0mXm+/ir5buSQNEnIKeo
-        jn4imafpCUpK0FKHlv+Tpf6Tov4PRf/n8Tf9/AmX1/2+Auef/UD1gh9qwtCHYiQPh9OOsyQCzQgs
-        d3NJOIa+qyRcgqGjlORSghO0PJ+PtW4n3Uqmy9nW65dPw5cppzJU1SCYGpuXlBt6jvEf/kvt8HE8
-        VZsb3v9+e9K5Xud/W/pXoZh7e+Tw02XcPpzl7geC/Dx4mXF4e0Hof7Wt9fvjl6G3CeH48GnUL28/
-        B7ul8dW3Fkv7yL4P7yh4e97pkcuscOkbB3f5xG3P7zH743v8q/d+HC93P49/+clrm4Z7rL769dVW
-        D9804aGQPP2vg4u8//hqu455/meC+hd9fOh94PXLx/OP+PnwLX3kzf4JXH8zcKSoR38z9Hd8evnx
-        FHW80HGOAel0/Gnmkna+GT39ef2Ted+P3gfSz4Ohpx6/Xz9Nexs5Tzh+BtdbqM7Bm09v/4fR1+O3
-        3Zmmp+nWC9epHYz4begNDeuHkh9nK/PFOR78ZPzVn7qbM7U/fZzzRY9vx179w3l9mH56cWN7OHUO
-        sf74cp+G3+acbePw+Et75wfG4mVkeO771LMIDqdFeHlaO5mpZFvtfrZSaR/+IPl44DLp9IS2qtuG
-        d5BV/3Ai+W/TLmD6cnnhf9xfZm8f/JuzQlO16eFMeQv3/vG1fhgDuQfi+rNr/m9BXML9iIu/4agx
-        dEyIi70FcQkxIi7m1qPGPQhxMSD3sLUnrjlsDbYGcg/QCMsEuYegICgyBPVZRX8KGf4rVHlas+q6
-        9oWEfKxj/Rg7kkPbWhyvOpz43KcfYwPOJ7R2fneJpHz+u+I0cHnEV9aWb43tC477fvA864P0nkmd
-        Ozecr/NEIjHhOoJqDeVZsVYuie2i6KzSm+46k3Yyer5hWq0m7YW5FufnDVGslafjRqJa3snNTq7O
-        dvnifnj5jedXvLz6bnkBc9ne28PvQ68/YtJvEelp0fXptBD/xVIvjerhPHsfOj86nS4W/uHoy+zp
-        MsnnsfPv+yCfAF5Ihv/Dao5kiGQI4AVbe7Kaw9ZgawBeyOewTAAvCAqCIkNQPwdeOc/65wvDOPoj
-        gBfLydIdwIshBHgx0YAXHzPwotTynjcHnVl95o58gQl3boJtJrdGqt1nqwU/x5b3I2/vO7TG1Vvi
-        VteLleQewAsOgWRIaM2RDJEMAbxga09Wc9gabA3AC/kclgngBUFBUGQI6ufAqx06/3xhuOP90PED
-        L55hhDuAF0cI8OKiAS8xZuDVTpqd2kooVMJ5V6iWJsHO4TraMLEoGIlqt+NbVX4nBzndZ+vmoNdq
-        B4ZZ9DcAXnAIJENCa45kiGQI4AVbe7Kaw9ZgawBeyOewTAAvCAqCIkNQPwdeVfcIvPjHAC+Bkm/f
-        /487fhQigBcfDXhJca/wUnKCVa5PttUen9qKc75VlCo1IQiXvXZC6Sp8l6mLrL5Pr/ldZTqqrur1
-        ZgorvOAQSIak1hzJEMkQwAu29mQ1h63B1gC8kM9hmQBeEBQERYag/mIPr9D45wsjPAh4yfw9e3gJ
-        hAAvIRrwkqMBr2Pr3K9FR7PDY7Pil7GqzV/848F8War+27NOk34ByKpmQivXN+KmN2CFdrLAG8Na
-        nZq4cycnCa3apEQ7JXVEG0aimRk08+tdc6oWtgBkcBQkSUJrjiSJJAlABlt7sprD1mBrAGTI87BM
-        ADIICoIiQ1A/B2R9Q//nCyM+BpCJEn3Pnl8iIYBMjAbIkjGvCFtsRvtOq5AaDZuWO8zU99ZkpRs9
-        X92w0xKv5KWG5mTyVbq7oWf1sJioj+RmF7dAwiGQDEmtOZIhkiGAF2ztyWoOW4OtAXghn8MyAbwg
-        KAiKDEFd6+ooPQZ4SYLE3AG8JEKAlxQNeKViBl5Bb9p2JmV3xqzl7FoaOZNRceea+wUj7lR+6FHF
-        bNscJ8pyIc+NpXp5Ost3m1jhBYdAMiS15kiGSIYAXrC1J6s5bA22BuCFfA7LBPCCoCAoMgR1rauj
-        /BjgJfPcPZvcy4QALzka8ErHDLwa/Gy3ZlaMUDBX1VTdLKZ4XS0IPcrQ2/pkkCh3Ro3KeDZL7gOp
-        wO7no2TgiFjhBYdAMiS15v+OZMi855Dbk6F4SzKUf33UGP6Go8bdcNQY5pajRss3HTX2sclQ/mUy
-        ZAG8YGtPXHPYGmwNwAv5HJYJ4AVBQVBkCOpKV0faD16q6i5W2sXQjHj7hl88RZNAu/gERUejXdmY
-        aZeQdKe5ui1Xs/y8TTdalYG4K4s8NaglmFrWbG35klBXrFKrEDpUGNIqMyqLO9Cud3tgbrCHT9L/
-        e/ZA3WIPfIz2QN1qD0K0WPieUO6Khaj5tZrHEAupX66DeL8uf3ss5G44ap/WOPy9dRC3HLXPKxz+
-        9jqIm48a86B1EFSstAsSg62RVXPYGmwNtAvhHJZ5s2WCdkFQENRDBXWtpaOjx0+7GJq9ffcunmII
-        oV1MNNqVi5l2GaG0rK/3Xn5RnhphRnflaWXWG3teYsKHglgYp8f8cO20tGC519oVnw/FYIibGWEP
-        iIWk1hyxELEQtAu29mQ1h63B1kC7EM5hmaBdEBQERYagrvRzZL0H0C6Wom7fuounWEJoFxuNduV/
-        czPHpCN7fGtoyrNdX1sVrLklC5pmhUJhyxjb+dyppruFvJwxM3PBmeqLjMtmO6BjWCqKW4RIrTn2
-        xHm7YeZXMfLp98TBnY+wtWepOWwNtgY6hjAPy7zZMkHHICgI6qGCutLMkQumD6BjknD7Pl88xRFC
-        x7hodKwQ81owc9wZt8XUJN/329yI4Tm6ti7MJrm6LLbYFFVQEjllMt4E44moTDOCujHElAvaBXtA
-        LCS15oiFiIWgXbC1J6s5bA22BtqFcA7LBO2CoCAoMgR1pZMj/wjaxYln5nEj7eIJoV18NNpVjJl2
-        0RbNddrz5GY0LfYzcqDX1Roz30v1cmkmTf3eor2R5TbH54qZ0njRmLl1bc1jV3ssFcUtQqTWHLcI
-        4RYh3PkIW3uymsPWYGugXQjnsMybLRO0C4KCoB4qqCttHIVH0C6el+/Z1V4ghHYJ0WhXKWbatUwV
-        GqleeWb0A2ayc1P1VNHK1hOlUi2vbAbNw4/Zpbir9WvGiFpPvWXBaHSme9Au2ANiIaE1RyxELATt
-        gq09Wc1ha7A10C6Ec1gmaBcEBUGRIagrPRylR9AukWXu2edLIoR2SdFoVyVm2iVZsrZf7ZajUC2b
-        Za5aTEyWZqkj0vxkwDe1YqqhL1tML3Dqe39oDVZVdlPM4k5G2ANiIak1RyxELATtgq09Wc1ha7A1
-        0C6Ec1gmaBcEBUGRIagrPRzlR9AuiZbu2bdLJoR2ydFoVzVm2lXYbLozvd9W7HmvkcgWgr2ZmXlV
-        tTHKdFsszUu1dtDYCXlrXh+pu/FmO8qwCaztwo3O2OCG1JpjgxsTG9z8XdoFicHWyKo5bA22BtqF
-        cA7LvNkyQbsgKAjqoYK60sORph6Bu2SKv2PjLpoiA3fRVDTcVfvNTRzrfHGu7YecNhoORNZrpXkv
-        uQ6X+wGjGb1Cpr3sWKORpIlsbr4bpDPjtDRXKzvgMfgJciShNUeORI4EHoOtPVnNYWuwNeAxpHlY
-        JvAYBAVBkSGoK00cafoheEym79jpi6YJwWN0NDxWj3k1WJgph8MiM3QVe7wthrYbMJbWbBgSp5eV
-        sFzPDPrWwJ0lpzLV2jTtoucPsgXgLvgDciGpNUcuRC4E7oKtPVnNYWuwNeAupHNYJnAXBAVBkSGo
-        K10caeYBuIulRFG6A3cxhOAuJhruasSMu5SSvKoGRivVac83A6q6aWSCaaHAp/KDRruZ9I20qPB2
-        cTnW5Wa9VTV2dXXWws2P8AfkQlJrjlyIXAjcBVt7sprD1mBrwF1I57BM4C4ICoIiQ1BX2jjS7CNw
-        Fy1wd+xsT7OE4C42Gu5qxoy71t2MTmk7fu74reZ+WdumW53qdnRQpqiMt2yj1Ov42UyukDR6w85+
-        tN8N+gkFO9t/+AO2Ajz5A7aAJqbm2AL6xqP2/FtAY2d72Nqz1By2BlsD7kI6h2XebJnAXRAUBPVQ
-        QV3p40jzj8BdLCves9cXTwju4qPhrnbMuGvW141ib624OZ4rdGcFLmdkerO+tK4Y41aeShlzc6+t
-        zLq76FWl5WK+o2YZBTczwh+QC0mtOXIhciFwF2ztyWoOW4OtAXchncMygbsgKAiKDEFdaeRIC4/A
-        XRzD3rN3l0AI7hKi4a5O3Lhrvpmoo3yiV0naOS6hjVqJbXrAVnRnkUqMRsPVoN5YU11NXJrr0At6
-        vCOnfeAu+ANyIak1Ry5ELgTugq09Wc1ha7A14C6kc1gmcBcEBUGRIahrnRzFR+AunpLv2btLJAR3
-        idFwV/c3d3JcT2luPZc1Z1FbsKlBcTeuytqoVhWb4x6lbvXVpNXPDjV3U9m6rSybHFedxhB7fcFP
-        kCNJrTlyJHIk8Bhs7clqDluDrQGPIc3DMoHHICgIigxBXevkKD0Ej8nCPXt9SYTgMSkaHuvFvBpM
-        EdZ+pmSJ7YbeSbQpa9Xrr4N+eerJC0lPBd0OVR5ORsF6lBzq5ZJpT3xmTwN3wR+QC0mtOXIhciFw
-        F2ztyWoOW4OtAXchncMygbsgKAiKDEFd6+QoPwJ3CYdT6g7cJROCu+RouKsfM+7KN/bLada1WyV9
-        NZ9uZXFfG9WzRsuwl+KSNxdra7PYdc1SbtcrDPIbva8OBQq4C/6AXEhqzZELkQuBu2BrT1Zz2Bps
-        DbgL6RyWCdwFQUFQZAjqSidHhnoE7hIF+Y6t7RmKDNzFUNFw1yBm3GUMd2orvdu7K3cy6BXdmllK
-        s1ohtefmblbK+Io4sdKjoFPJdRq0Ke1ZJz9xNsBd8AfkQkJrjlyIXAjcBVt7sprD1mBrwF1I57BM
-        4C4ICoIiQ1BXOjkyjKPHj7tkjr5jr6/j1zIRuIuJhrtGMeOuVccpm8Mkr/TFVKW5WyYLA0ZhakGt
-        NaQ1s083k/bI1stsyMvybp41s/WGWcfW9vAH5EJSa45ciFwI3AVbe7Kaw9Zga8BdSOewTOAuCAqC
-        IkNQVzo5MqwXP+7iKEa6Y+8uhiUEd7FRcFfqOC9W3MVx676dVctaRRxN69uh6Ni0nhTVcW/YKgXz
-        gjQx+E2zWFX24Xo1aHMJUZeULXAX/AG5kNCak5sLee6WYHicFUsyfH8h0qIhB+L1x6sMzgZng7P9
-        TmdDRkdGh2sCekFQEBSR0OvUz5HhHnBLI0cf/t8d0IsjBHpx0aAX/Zv7OU6cTX0400bjwSa5VQKF
-        FdtLfSTp23Y+XZXaqyI/bitjYeuOegO3WtDzTLCvYscv+AmiJKk1JzdKYvEE1oQ9hcRga7A12BrW
-        hCHNI80TbJnAYxAUBPUb8NipnyPDPwKPHV7snh2/eELwGB8NjzExrwnLFKQJxxe2VrDcZtmMVAtZ
-        rZor+ny7VM4bbMdnLCEzLpRYc1ST1/1drqKXeOAu+ANyIak1JzcXYuUE1oQ9i8rgbHA2OBvWhCGj
-        I6OT7ZqAXhAUBPU71oQduzoywkOglyRyd0AvgRDoJUSDXmzM0Et10u1qrsyzwySXWY9H+nBd3sy7
-        XS5Uw7RXzSue39gwFiNsw3nFHIn8apqYYpv7D39gb/AHnonJH/hb/EGO0R+4W/2BjxYN5UjREDW/
-        VvMYoiH3y2go3B8N+RuOGkPHtBiCvWUxhBBjLmR+dy5kYiVekBhsjayaw9Zga8BdSOewzJstE7gL
-        goKgHiqoa10dxUfgLlZk79nmXiQEd4nRcBcX975f7dIinVslxYXSVXfVRlhyqmG9rI/sVaU0G00k
-        ebRiu5Q7rtSqw1KpM09MxhVscw9/QC4ktebIhciFwF2wtSerOWwNtgbchXQOywTugqAgKDIEda2r
-        o/wI3MVzwj07fsmE4C45Gu4S4r6lsVEp+KnRPtineo1Fflag93prVEvbnWJ52/bKA1/vSWpd2ivJ
-        5rir96tZazoB7sLqT9z4Q2rNyb3x59dHDVvd4H7GP0BisDXYGmwNO3ghnePeK4ItE7gLgoKgHiqo
-        K10dWeoRuEtg2Tt28GIpMnAXS0XDXWLMuKsmGuupu89QzVbWHYh5VaC2UsZZMws9W6mX0psuJ3O1
-        1a6y7+byIsWHO03BhvXA4VgGQWzNsQwCyyCwugu29mQ1h63B1oC7kM5hmVjdBUFBUGQI6ko/R5b2
-        g/hxl0jLd+zdxdKE4C46Gu6SfnM/R98ZTDq2upLHTMFNN6j0umsPE8NKf0Illm5O2hW2Y5ebhGkv
-        aC9MZTFxnHawBR4DPseyCUJr/m9ZNiHfnyOFW3Ik/+uj9mnO31w2cdM37+dZcRy1aDnyvd5YDUaA
-        xGBrsDXY2m+zNaR5pHlYJlaDQVAQFJGrwU79HI90rBQ6Rrx4TKL42/f6Eigi8NjhfxHxmBzzajC/
-        KNfUUsaqFdR6YdPLO1uz19yZ20FmNxD6a6HVZxVzXu+k5Pl2WleH3KIjtrG1PfwBuZDUmuMuIdwl
-        BNwFW3uymsPWYGvAXUjnsEzgLggKgiJDUNc6OTr6I3CXzDB34C6GENzFRMNdybhxV3czykzZet2d
-        5UWu00lO2zpXHpUSfNvfzrWFOVg03DDJrKjdZKSkV0M2m+kDd8EfkAtJrTlyIXIhcBds7clqDluD
-        rQF3IZ3DMoG7ICgIigxBXenkyHqPwF2yKN2+tb1AsYTgLjYa7krFjLtafkaoCPX0puc26s3efDfp
-        WXXfS5Tm7VV9vayp6wTXUbiRyk+3W0qfSnqK6uJmRvgDciGpNUcuRC4E7oKtPVnNYWuwNeAupHNY
-        JnAXBAVBkSGoK50c+WAaP+7iaZ6+fa8vgeIJwV18NNyViRl3bTRNV9LtdWWWDPopd7cw9lRYpYb5
-        0qLTm/Xs4TrZ9EuZpe016yG7FAfZ1XwO3AV/QC4ktebIhciFwF2wtSerOWwNtgbchXQOywTugqAg
-        KDIEdaWTo/AQ3MWw4j17dwmE4C4hGu7Kxoy7RMFO2s1QTgzyXXPUVoY9qtyqZ6zcnpVW+VCoFCxX
-        n6ykeludLfN0217S2TJuZoQ/IBeSWnPkQuRC4C7Y2pPVHLYGWwPuQjqHZQJ3QVAQFBmCutLJUXwI
-        7mIZ7p69u0RCcJcYDXflfnMnR2s2MM3VwNTHS32RkfOBk81xdNMvSPneMsUmk5tSwUuMsrVhXxD0
-        xr4+KZgLrAaDnyBHklpz5EjkSOAx2NqT1Ry2BlsDHkOah2UCj0FQEBQZgrrSyVF6CB7jaOqevb4k
-        QvCYFA2P5WNeDZbo1zPdqVbQ0jlTKC2nVG9hNwLdY7i51QqGfjigqXxaKO6WtXow14p8dZTS98Bd
-        8AfkQkJrjlyIXAjcBVt7sprD1mBrwF1I57BM4C4ICoIiQ1BXOjnKj8FdskjdgbtkQnCXHA13FWLG
-        XaVRpduu9mblRLmeCWf7TT0pZrVsKcMvrbKXXk+pfiZP2+1ccbeajsSsMq97PlZ3wR+QC0mtOXIh
-        ciFwF2ztyWoOW4OtAXchncMygbsgKAiKDEFd6eRIUw/hXbzE3rG3PU2RwbtoKhrvKsbMu6rDzMbZ
-        7y0tUy+PgkW7XqYSQyE7n2WnOZOShD4VBn1VWal9tRp4w162QHn5HXgXDALBkNCaIxgiGIJ3wdae
-        rOawNdgaeBfiOSwTvAuCgqDIENSVVo408xDeJfLCHbt90QwhvIuJxrvKMfOuvqkYfseuGkMmu9tl
-        siIrb3r+iA5EU0sVW3s+4Xb42ZgzZ9Vqa7aVDHGs5bG+68Mg2BsMgmdiMgj+FoOQYzQI7laD4KMF
-        QzlSMETNr9U8hmDI/TIYCvcHQ/6Go8bQMQVD9pZgKMQYDJlbjxr3oGDIxMq7IDHYGlk1h63B1sC7
-        EM9hmTdbJngXBAVBPVRQV3o50uxDeJfEMXds30WzhPAuNhrvqsTMuzbdUjqzrSU7a8Ga7nSv6tqc
-        LsjjToNrDdMszy+DVX3iFdy8QOWNWj+99ZMMtu+CQSAYklpzBEMEQ/Au2NqT1Ry2BlsD70I8h2WC
-        d0FQEBQZgrrSzJHmHsK7ZEa+Y/8umiOEd3HReFf1N3dzXLCzga4xw3xQ4x2jkej6pe1gwbnVTt9P
-        m74zlgqzeXJaCie1UodyCkt13srg/kcYCoIkqTVHkESQBB+DrT1ZzWFrsDXwMcR5WCb4GAQFQZEh
-        qCvdHGn+EXxMoGj+nv2+eEL4GB+Nj9ViXg+W6Y2X+41WWLJZzanb4taaTJdtebOX2HQtmxl6LT5M
-        iZ3FXkmrEs+0jd5gXMZ6MBgEgiGpNUcwRDAE74KtPVnNYWuwNfAuxHNYJngXBAVBkSGoK+0caeEh
-        vIumaOkO3iUQwruEaLyrHjPv6u3p9kagO7y+YhvGMMX5S708YOjZwNDTC8qfhK15vtdfUUOpXMpR
-        azaf3TlY3wWDQDAkteYIhgiG4F2wtSerOWwNtgbehXgOywTvgqAgKDIEda2fo/gY3iVJ9+xvLxLC
-        u8RovKsRM+9qraVWYrP0zOx0vZ9nBqVJJVGdSe3Uel1WkgWqkJAbEkvVJgl/m6aW/tRkJo0NeNe7
-        QaABxskg0PiMmJqj8dmNR+35G5+hnyNs7VlqDluDrYF3IZ7DMm+2TPAuCAqCeqigrvVzlB/Cu1iB
-        vme/L5kQ3iVH412tmHlXY8TWGolypxLqbUtw+72lo5mdDl2ecRvRbKRogxPH0yJjzWfFzaKiNArS
-        qIx+jgDiWAhBas2xEAILIbC+C7b2ZDWHrcHWwLsQz2GZWN8FQUFQZAjqSj9HhnoI7+I48Y79uxiK
-        DN7FUNF4Vztm3jUQG9NRp1i2fEos7GWluNN2w+5Y3ZYajbYzHWZ6diIQG75AF3pZi5kyHZ0a4n5G
-        GASCIak1RzBEMATvgq09Wc1ha7A18C7Ec1gmeBcEBUGRIagr/RwZ2g8ewLt4lr1j/y6GJoR30dF4
-        V+c393Oc9YLJIliGGi+HTnpLtYdmwrH8lbk0Emvf9Kx0Rm1VsmtlMe23GXuSC1PKBvvbw1AQJEmt
-        OYIkgiT4GGztyWoOW4OtgY8hzsMywccgKAiKDEFd6efIMI7+AD4mMNQd+30d9yUggo8x0fhYN+b1
-        YHVhlWjv8m1T45bZIJHVlsWdkcptgwyV5fZ1NZdPLUW6sZhTKtem/W6+b1by4F0wCARDUmuOYIhg
-        CN4FW3uymsPWYGvgXYjnsEzwLggKgiJDUFf6OTKs9wjeJVKCcAfvYgnhXWw03tWLmXe109VFqrLq
-        W+G0OsqP2b6YajHpJJXISeXkmvbDuWabWYmjmCSb9zSrQXnlDva3h0EgGJJacwRDBEPwLtjak9Uc
-        tgZbA+9CPIdlgndBUBAUGYK60s+R4R6y35d4oR438i6OEN7FReNd/Zh5V19cJbJhscxJ6XV97UtB
-        fVxt+ktJqaqazg/3ZiJsjYXEZGTMp4bYLXdYTexhv68Pg0ADjJNBoPEZMTVH47Mbj9rzNz5DP0fY
-        2rPUHLYGWwPvQjyHZd5smeBdEBQE9VBBXennyAgP4V2ywN+z35dACO8SovGuYcy8K8ePq66dK0+n
-        +0orVdOkjjWZsb637wjZ7FCppkr+cDdZaMW5Rc1nhd124vVwPyOAOBZCEFtzLITAQgis74KtPVnN
-        YWuwNfAuxHNYJtZ3QVAQFBmCutbPUXwE7xIpnrln/y6REN4lRuNdo5h5V2IwE/yWxEy4SrJQFpR2
-        Ye7qs1q21WTN3FbfTPvtZrXUrnB5exUybK1nBM1gC94Fg0AwJLTmCIYIhuBdsLUnqzlsDbYG3oV4
-        DssE74KgICgyBHWtn6P0EN5Fs9I9+3dJhPAuKRLvoqnf3M+xIbsbZzOxq5lZ3mTS++xqxi/XGjdM
-        rNj0PBtWKibLpfTyTkoxdLJdaFXTnoP7H2EoCJKk1hxBEkESfAy29mQ1h63B1sDHEOdhmeBjEBQE
-        RYagrvVzlB/CxxiGv2e/L5kQPiZH42N0zOvBtowr24OqOaoMhotGd1vvaopSLpt0qb+vZCtTke5W
-        tnOxyEt2m6a5VFLoyNjfHgaBYEhszREMEQzBu2BrT1Zz2BpsDbwL8RyWCd4FQUFQZAjqSj9HlnoI
-        72Jpmrudd7EUGbyLpaLxLiZm3jVlRrM618lRlf3CFHwzqaTkbTvpuRRjacrOKvZm00bBX1R2nBfY
-        Db6wTgUJ3P8Ig0AwJLXm/45gyLzHkNuDoXhLMJR/fdQY/oajxt1w1BjmlqNGyzcdNfaxwVD+ZTBk
-        wbtga09cc9gabA28C/EclgneBUFBUGQI6ko/R9oPXkqhvYsZd8ni7dvbixRNAu4SExQdDXexMeMu
-        e9HotlrWZqwkByw36AY1xxRMJicmZqwrCuV6QWgpm5YyKXSXgtNqZ+dsq4LlXR/+gP4XJ39A3zNi
-        ak5u3zOeu6Xx2XFWDCshqI8XurIU4re0PnvUUgh0dISzPXPN4WxwNkAvZHS4Jpo6QlAQFDGCutLU
-        kfX0B0AvXqRu3/NLpFhCoBcbDXrxMUOvAeUuXDYReItWwrXESVDRwlEh2QrpTLJEN9eePGvx1fnE
-        morZZqacXc031BZ7eAGKYzEEqTXHzT+4+QdrvGBrT1Zz2BpsDbgL6RyWiTVeEBQERYagrvR05E63
-        NMaNuwRevH0LL5HiCMFdXDTcJcSMu4rpkm1O69Ua283stP5qpW38mtoWChWmpzP0bNFdSju1JTpF
-        mykzPCPsRkICa7zgD8iFpNYcuRC5ELgLtvZkNYetwdaAu5DOYZnAXRAUBEWGoK60dOQfgrtEjr19
-        By+R4gnBXXw03CX+5o6O2qyda/fHjXyp2thu9qOiNRushglvuRdCZp3ZsJyg7pV9IaUu1emyoHO0
-        TllYDQY/QY4ktebIkciRwGOwtSerOWwNtgY8hjQPywQeg6AgKDIEdaWjo/AQPCYx8j07fgmE4DEh
-        Gh6TYl4NNhrM9qVBLjFOrXr+Pq/YzT3VCBhRSO1T/lJuz9dtxhqNlEmqbs0600ngG2kFG9zDH5AL
-        Sa05ciFyIXAXbO3Jag5bg60BdyGdwzKBuyAoCIoMQV1p6Cg+BHfJtMDcgbtEQnCXGA13yTHjLm9P
-        W2Glse+si0I6te9uujNO363mqS0/UGRJaYjVbSHXrtpLoU1TQz9YrjY2cBf8AbmQ1JojFyIXAnfB
-        1p6s5rA12BpwF9I5LBO4C4KCoMgQ1JV+jtIjcJdEUcw9W9tLhOAuKRruSsaMu9jJQEglGrLeGWa9
-        xHhcLTADeZOjk9PiqMLIVtdVS6w56Cyn/Zxeq7qNpV1bA3d9+ANaX5z8AV3PiKk5up5dPgO6nv0t
-        4gWVwdnIqjmcDc4G6IWMDtdEP0cICoIiRlBX+jnS1EOoFy3yd2z5RVNkUC+aika90jFTr0y9VG1N
-        ih2xPUk7M0t3EpxvlwwhO2FqymKR5fRepWFUi+xM9z2lx264wdrZg3qBimM1BKE1x2oIrIbAIi/Y
-        2pPVHLYGWwPvQjyHZWKRFwQFQZEhqCsNHWn6IbyLEeg79vCiaUJ4Fx2Nd2Vi5l0zK+M4Q3W/0/pN
-        pmVzBVYNK3UvUe6VvHxzWxGHw0mmm1zrQVhUaiOpllE1Gh0dYRAIhqTWHMEQwRC8C7b2ZDWHrcHW
-        wLsQz2GZ4F0QFARFhqCudHSkmYfwLpaT7tjEi2YI4V1MNN6V/c0tHblZOVPnmzstJXBSUKvuWJVO
-        mco8dNILf1xiuuZitE7zvTnt7FpDeVq20sk91oPBUBAkSa05giSCJPgYbO3Jag5bg62BjyHOwzLB
-        xyAoCIoMQV1p6UizD+FjHMvdsesXzRLCx9hofCwX83qwsLrz8/V1azxwB5W6VjIrpcVAmg/znSHv
-        JPTqTOxUVdZap8zNxGovDidKKbnCrl8wCARDUmuOYIhgCN4FW3uymsPWYGvgXYjnsEzwLggKgiJD
-        UFd6OtLcQ3gXz9DUHbyLI4R3cdF4Vz5m3jXUtOJosR+vc5UF0y3SbdOUNjm+Xe73+lXebBXV5LLH
-        trYjSpbkeYVPm47igXfBIBAMSa05giGCIXgXbO3Jag5bg62BdyGewzLBuyAoCIoMQV1p6kjzD+Fd
-        AiXes789Twjv4qPxrkLc+33l2ovAq3TrbYVfWaOMtt43llp+sRc7o+Gw1trsm6muUJ30U4OkV8xa
-        pljM98C7PgwCDTBOBoHeZ8TUHL3PLp8Bvc/+FvKCyuBsZNUczgZnA/VCSIdroqsjBAVBESOoa10d
-        xYdQL1Gi7tn1SySEeonRqFcpZurFat2hVl9nU7nNfpYIKsld3xY6s4FD7Y1td1sShFGtY6Qm7K6s
-        l8psXxdzTQPUC1gcyyFIrTmWQ2A5BFZ5wdaerOawNdgaeBfiOSwTq7wgKAiKDEFd6+ooPYR3SYJw
-        zy5eEiG8S4rGu8ox865WcrlXBzkqN9z3C2a9M2uYycNZoCy01ohaB0zoL3f+TqtRVCal+PPiTB0J
-        S+xaD4NAMCS15giGCIbgXbC1J6s5bA22Bt6FeA7LBO+CoCAoMgR1rauj/BDeJfPsPbt4yYTwLjka
-        76r85q6OyTwvB/ViZRHQlV0ntZ7o9ppnzG2+kqh6ZcrvufrQtKRRo6eUR351sG2t5mPwMRgKgiSp
-        NUeQRJAEH4OtPVnNYWuwNfAxxHlYJvgYBAVBkSGoK10dGeoRfEymWPmOXb8Yigw+xlDR+Fg15vVg
-        88pk1fdqQ2u1llfZ2jgr1WV12TezhW0tLW5KmWyBKneXZoGeamurJe2WglkF74JBIBiSWnMEQwRD
-        8C7Y2pPVHLYGWwPvQjyHZYJ3QVAQFBmCutLVkaH94AG8i2Z46Q7eRRPCu+hovKsWM+/K1PTtqF9s
-        7cZpocqud11uu0iM2Vm3P3ITRUNUJpX1pKbL2W51oyRrXorf2tsNeBcMAsGQ0JojGCIYgnfB1p6s
-        5rA12Bp4F+I5LBO8C4KCoMgQ1JWujgzj6A/gXQzN3LG/PcMQwruYaLyrHjPvapbt6XiSnxs7e+bm
-        +51w27IVa1EbdAt8trHv2FzPNa1pa7ys+41Zys/nWnsG+9t/GAQaYJwMAr3PiKk5ep9dPgN6n/0t
-        5AWVwdnIqjmcDc4G6oWQDtdEV0cICoIiRlBXujoy3EPuamQl/o5dv47fy0RQLy4a9WrGTL1qIutY
-        qeGiUj0cNLebyGfpZHG+XLQkp1zql8fZETXKbux90N9sMiWqNvT3/BbUC1gcyyFIrTmWQ2A5BFZ5
-        wdaerOawNdgaeBfiOSwTq7wgKAiKDEFd6erI8A/hXZxI37OLF08I7+Kj8a5WzLzL9DKJoZUfBWyo
-        pYS2kTHCsOaFo3CQ3ixW3UZn54+T9e6KbtRmSba3Lu/7ozTuaoRBIBiSWnMEQwRD8C7Y2pPVHLYG
-        WwPvQjyHZYJ3QVAQFBmCutLVkREewrt4XrxnFy+BEN4lRONd7d/c1XG94BrcpqJ6s2XdzNb7+6ox
-        6LK5YbZoNQfyqJFpUEZ2Ps02pJ3ItlJNe7lsbMDHYCgIkqTWHEESQRJ8DLb2ZDWHrcHWwMcQ52GZ
-        4GMQFARFhqCudXUUH8LHBI67Z9cvkRA+JkbjY52Y14MNqlsp5C0zMXPaC6/PVTmKHfO5fLq+7iU3
-        dn7aE1qcuyjry+puuNwXW6OyEuD+RxgEgiGpNUcwRDAE74KtPVnNYWuwNfAuxHNYJngXBAVBkSGo
-        a10dpYfwLpGlhDt4l0QI75Ki8a5uzLwrt6cSq/3KszfpkjPz0m2V0g3Gn1QX8l5em2E1X2R7+6Bo
-        bZplM6kozLic3e3Au2AQCIaE1hzBEMEQvAu29mQ1h63B1sC7EM9hmeBdEBQERYagrnV1lB/CuyRa
-        vGd/e5kQ3iVH4129mHnXeLUsj8Ml77UKSadrLXcr1VEaZt+oiJlS0awapa46VTxfYtLFtJbccuK6
-        PNyDd70bBBpgnAwCvc+IqTl6n10+A3qf/S3kBZXB2ciqOZwNzgbqhZAO10RXRwgKgiJGUFe6OrK0
-        HzyAesmSfMeuXyxNBvVi6WjUaxAz9UpUi8OStCuKqVVrxU/nRl8ceUm1oHgVcyysm5tdK5dgebY7
-        SVFbqzJMd+amj128gMWxHILUmv87lkMw7xffb8+G4i3LIeRfHzWGv+GocTccNYa55ajR8k1HjX1s
-        MJR/GQzZWJEXJAZbI6vmsDXYGngX4jksE6u8ICgIigxBXenqeMRdydAMD/+JEXiJFCUKt2/jJVFE
-        AC8pQUUEXsOYgdewV09UxXpjNZoqiQwz0xPrhF0LB9lhpSrrbZ2udH05Vc9rzW3Ocdig22gMXNzW
-        CIdAMiS15rj/B/f/AHjB1p6s5rA12BqAF/I5LBPAC4KCoMgQ1LW2jo7+EOBFC8zt+3hJFEMI8GKi
-        Aa/Rb+7rmPIKzcw4ue/2ufosXEl0nalv2ZKwVxpZodmreHZW2KdaTitTHkw5em7znqQAkMFRkCRJ
-        rTmSJJIkABls7clqDluDrQGQIc/DMgHIICgIigxBXenryHqPAWQMJ9++8ZdEsYQAMjYSIDvyoVhX
-        hG31Qm44KKtaIVVVh2wuW1xMBaW8KJqSIKw71WSpa1Y73d6Ebhcnky4TOoE4wcZfcAgkQ1JrjmSI
-        ZAjgBVt7sprD1mBrAF7I57BMAC8ICoIiQ1BXGjtywfQhwItlee4O4MURAry4aMCLjhl4BatZjUrI
-        zZKeMvfZWrCnB44iDtJ9X614Sa9Zq3XzXcbb1YqVQqq44PjeusIBeMEhkAxJrTmSIZIhgBds7clq
-        DluDrQF4IZ/DMgG8ICgIigxBXensyD8IeHEMffsm9xLFEwK8+GjAi4kZeAmenVKFZkNMcdlyZpNh
-        dFZkR+PBzGkl+cl20m/mc0WHNnWtp5a6E30hbCfyFsALDoFkSGjNkQyRDAG8YGtPVnPYGmwNwAv5
-        HJYJ4AVBQVBkCOpKU0fxQcCLl7l79vwSCQFeYjTgxcUMvGoqQ7WkhM1vHc1p+3p2msklZbpoVhmr
-        nOw0Bvai2m/5utvssu46OzbK7UUFe3jBIZAMSa05kiGSIYAXbO3Jag5bg60BeCGfwzIBvCAoCIoM
-        QV3p6ig9CHgJEn3PHl4SIcBLiga8+LiBF7PIl/ez7SDcZTMrZs3JZVMSatOOspgtKp3pstBOddNV
-        2uWzbKlXkzdjZ8LjlkY4BJIhqTVHMkQyBPCCrT1ZzWFrsDUAL+RzWCaAFwQFQZEhqCtdHeUHAS9R
-        EO/Zw0smBHjJ0YCX8Ju7OiYGqa05rbsje9zP+DMjLaTc+rxfq/O96cwf7sJmrVhrjrquWFqmJk3G
-        plpV7PkFR0GSJLbmSJJIkgBksLUnqzlsDbYGQIY8D8sEIIOgICgyBHWlqyNNPYiQSTx7x6ZfNEUG
-        IaOpaIRMjHlJWDg0AzXdEY3uZrvZtmzOq2dNx9LcIp/khUyd1YfjsifPF9MKm252TcVgh53Nn0m8
-        vmu7QNMPOiNljmLuOCNpQs5IOtoZKcV8RsrD7t6o2cGALyd3WkK3wznvh/1SfjlqKgyj0/O52yy1
-        9wMqqISthcbNB5XUH7oN3Xf7ItLMY85ImmKEO+4Tp5lHnZGnx+84JZlop6Qc8ylZn9Cd0pzOqFSx
-        WfQ7TLGwnbR77YyhzPOVarWjD7jpauX4XVqp7jiPKg5EWvpDbxT/tHOBGhxOSfZBpyRNs3es5KYf
-        1o353lMyYjvmZNzf215LqXemzZwetAeZYSGV2tvZajLXHwwHYq7bac7F/mqglRrVem3obTP11qrB
-        /aHf27hSBaT7P6DmQLpAurhSBVt7sprD1mBruFIFsA7LxJUqCAqCIkNQVzbrpB/Uj5mmZfmOtdw0
-        If2Y6Yj9mFMxE69kfVSR5HyRb+rbVTqfWpfKLUXbbW1hs0r3UwOxMix4zbQxYsueEQRbZTCUUn88
-        hD3tpkE/qGESzUj8PddOCWmYREdsmJSO+YzsrLZyTxB7g8Ss1dFKrTVb9NM0V05V2s3GPhEszG6o
-        OC1/GBTDWs+cVIZKdvyH3i3w3e0utPCgM5IVmXuunQqEnJFCtDMy85vvd9lnhazc7aRnkwJd3c1G
-        wXK37QmVieunuFmTnTQS7W6hL+qDgbSTOtviOuxq4z/eU8/rUR60JzfN8dI911oJ2ZObjrgndzZm
-        T/VS9US9Xhw0u7rOUftxUZ6sOxVpuGnJQ0rvL+wGnS5LPhvmfW66TlQ0o5P/U69rfb8e5UGbZtE8
-        x99zqZWQTbPoiJtm5WI+IzMMv/HbbWNkl3k63fK1MJvsGKmWl1uoNXZPidvkolrvuROVH1edTdtg
-        V3Tnz/mW/xIewYJyeg+25QeXo32ImJ6hXt5j/xAt3386P3D6Xdm14e02U8MzLhPO72BsmeHyjNnP
-        cfvzwKt2DPSnV7IPJ6HrJML5IY69D54fP71Q5fT45cHzS2u2evwIp/+c5wfTw3l2fAOfxi6PX6T1
-        zePnlzkc/YV6JJynl3tbAvBp6PVw9h5ypjI3dm+/4cvrl0+Dr4fz5TL17ZnvI9+83se8n7zk3NL9
-        n7/s+YNcHv9m7GPKeeGQurDs3adJ50/45eP3fnkrGq4k4UrSn1zzf8uVpPcrG7dfSeJuOGqfrhL9
-        vStJ1C1XkrhbjtqNV5KoW48a86ArSRQukMPWnrjmsDXYGi6Q43oeLBMXyCEoCIoMQX1WkeaGTuBd
-        TpgTrvk88P7wiTx0nSPceykfXld3Fx9TL/zGswJLUzxjbRkb5fJOLqfcTx86I8rz4TYc/Q+CpnHR
-        zS8/rcD5Zz9QveCHmjD0oRjJw+G04yyJQDMCe/v6BY758b7GayXhEszNNyB++bEEZyh9Oh9r3U66
-        lUyXs603Vn0+Tc//Pl9VV4NgamxeUm7oOcZ/+C+1w8fxVG1ueP/77Unnev0V+j7/yz6c5e4Hgvw8
-        eJlxeHtB6H+1rfX745ehtwnv3Pn885EDf/WtxdI2Dp/28I6Ct+edHrnMCpe+cXCXT8D2/B6zP77H
-        v3rvx/Fy9/P4l5+8tmm4x+qrX19t9fBNEx4KydP/OrjI+4+vtuuY538mqH8d1wh8DLx++Xj+8cLA
-        4Vv6CJr906WAbwaOFPXob5/uyLr8eIo6PyLxH0ZPf17/ZN73o6+OYeiHo7s8nDfh4TvleC6d3s/P
-        xi+TQ089fr9+mvY2cp7wmaif3v4Po6/Hb7szTU/TrReuUzsY8dvQGxrWDyU/zlbmi3M8+Mn4qz91
-        N2dcf/o4p1/33dirfzivtcvlBGN7OHUOsf74cp+G3+acbePw+Et75wfG4mVkeO771LMIDqdFeHla
-        O5mpZFvtfrZSaR/+IPl44DLpcuegbhveQVb9w4nkv027gOnL5YXzufbkf5/91YfUXNs2tOB8jexw
-        dLbBx9jpp7KxewmmnnG8bvF5/MdZrnN9Tmdq+S+H//nuwng5/A1mOS/H8e+f8+Vnb+nss6eLR5e3
-        fvh69kM7+Pr/AdSCuXFgdwcA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['14154']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:24 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/ValidEventTests.test_performances_is_list.yaml
+++ b/tests/interface_objects/cassettes/ValidEventTests.test_performances_is_list.yaml
@@ -1,388 +1,309 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:26 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:34 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+NklG
+      PC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxjcnlwdG9fYmxvY2s+Y18tLTYt
+      YnNqV09qbFJncmUtc0RiSlI5T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZ
+      YzY4Q3U1TEJQYWhVU1BSOV9Dc1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgy
+      YWlmOWwzZDVmeWJoTTVRNU1ObDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6
+      emxlZD48L2RhdGVfdGltZV9vcHRpb25zPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['310']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+2d2ZKqyrrv789TVKyLvS/OYhZJz9q1awf2fQeKekOAIKA0SiPi6+w3OU92sKlR
+        NZrpGhIaQyBnVMxRJgkIX5b/Xybf9/ftf/a29bLTPN90nf/+B/gL/ceL5ixc1XT0//7HWKghzD/+
+        5/3/vKlyoEmBaWuSuwmSrr7kaX5oBe9vfqiori2bjhT6mieZvqTI6rvjvr3+esvbwos3gSsplrtY
+        vyMoglCI4q/E/soa6YNI7gur8cLa4rqAY/Ux0p5tR7Ppsru0qvzaKAcHtrqwexrSwVR8qFe2cUAP
+        tnN0TdU6LsJxB9frS8s98DCgThpOmei5sWHwe6wjrVpqnwWhxKOat13YQ3HHKBMtbLfUsG7RbX22
+        8coK6e7avmXWmX24KseA8yY46fPioLEhNQ0nkdnb63fv/83RNFVStY3sBaGnScf7dLr4X7W/GbIv
+        bTRvKTmyrfnvsea/vf7Q9hb6ya0/t1imn9xgbac5n//IniZLSXy096r49vr56rxB1fzFezUJZxwZ
+        mqddOpxa3xZmEJ/7Wq6jug4SrpOL+dZ43n7q2jltv2y87GzJvn/559w/ubDk3X9puGw89eeSjS//
+        Idub/3opJ6MkPL6VL5vfkrFwGhjnw57uw/dNb74mewtDWmvx6UyvyXD6bDkOuku/j92+tXx3sM9+
+        Px5PlZ2F9uuDni/no8N3jZ99TtdRki1LCy4XWvlhh/OVvn6+hdePm+j6geTJjp4cz5b3yZFtxXQ0
+        9Z3E/kLfXr9rOnVI3mSw8cyF9k7QHz0+285dwuQyZC85JPmtx7emN/t4Xz8OiYFTj69Npw6fRwTM
+        R4+vZzndzo9D4t96fJ7FcaXj2LW0483K5yVuQ9kJjn8Vl0/B97edbJmq9NH+Dt5ef2j5sQf2b3vg
+        /7YH8W97kP+2B/Vzj9efL+8UQ2kRel6iCkmXj9/Ofw66sklG9XdNnz2W8iJwvXeAol/6XBo/ezmh
+        rWjeO4NRX3pdGj97bSx5kXw4Yl/6XJq+9DmOOT+2Fdd6/dqcfPqeW9//3/9+3f+z/e31x8t8/Zux
+        DONfkPh/DfrCDZ3Au1zfSTS/NnzbfPq8HztmoKkv7WTsJOzz2fWiop4ZmIsEnXamFh01fnHU9PMd
+        +uWmM3ed353mqJfXp4MJRvjPF+AHL7y2CbTj/XrBUJDcxc8u595hsJDc5dLXgnecOp7qx9bPbr62
+        SKTffwcEjdEk8X3vj43n7nHyn22ryWdtclKURcGl57f2RJldhkLBCX0k2VFP+HjqjqAsggIBsP/C
+        0X+h6P9Fwb+OZ/r1Dpfj/ngPzq/9IBHzn+4KGRgvXTm+5/2gMILG0d++HyRK3nQ/yOQnzf24XP+J
+        Dc/DsTcWyiOu3K6O3l6/NF+6nG5DVw4CQ4teSm7oOdp/+i+95HI8ebFOhpBQ5YWPHc/37Py7qb5T
+        zdrHluTVpd1KBrr7nhxODo6M97Xx0mMjB8b7a7IzYp/Piyin8yI+4nw7LxJofvD6sf9pl8vuyRUG
+        of9umbtvh780fXRIZhlyIL9+vA7ijfbum/bGOk5YkoMHH/udtlx6hRtfs6yvhH2+xOrPl5j81m2g
+        X9tff3EMXXOPgZLf3yw5+QgNk3tOgr9IjKUAwOm312+tbwl96+dfEfQvgCYRJqnkg+2z+e3182DH
+        2UGiRcfpgH+aV3zXcKTfI78kfPOBvZeXJ2LyQsc5TiZO4wZgF2j6rvXEPL/o92PrbfOcc2PoyUcV
+        +dLto+Xc4XgNrmcfsfn89n9qfTt+pp8nO2UweiGE3tvrt6YPpFeT+3/sLa3td/TIbL9of/MNNzpP
+        qk6XczrdD21vfjIuk+6ng2v7ZLwkY/J4uC/NH33O86x9oHmObL0ISceX0nEgO+rL5x7nv5/T3PdX
+        n/i/2vCWDKzwci6eq3SqI16sdjp8otWfGy6dTofnZdXSvORvWEyGov/R7TL1uEwZCwctHxf+3VBa
+        yAsjGV4fEwv/eKyf2uDcLLuXWLhhXlQ2h3OzYsf/a9AzQf5/h9CnpV/XtS7i87kc/Nl2JDzLtI+T
+        yhNHfXl5twnFCYHO7w7h0FaCWJeGyxZf2pm+qVgXbPqx8dzrE8PPROUmMPS+RhAEZ53uzDfLKy7S
+        GkOzrcZVPkC1EuULW1/3osoqMAdrWd5RDoO2/RVdIsYdYUnoU62moz17djnj+YiXoyckf1kEn3xs
+        /tb09jPOfo+yp8cYp2FB/4WjL4Pu2+tn03mrYdi2n0SfPUf+a9v5fJ+EChkDMgbUmLxpDGSMYsf/
+        14xR88x/vlCPYAySZIkbGIN6Esag0jFG+86MoYynQ7PCMdXNpjFgRb26GJXLCNZq6eJWPrQFtNIx
+        x4xTZScSwfeWI2JgGeURZIzsCTBkDKgxedEYyBjFjv+vGYMPnX++MI9gDBrHsBsYg3kSxmDSMUb3
+        zowR7uJo2C31ZnLHqxs6U8E7XtzyaanU6E4GFWVG7WN2sY4lJKzN9y0W4earLWSMDAowZAyoMXnR
+        GMgYxY7/rxmj6yaMwT6CMRjA/H7WGImyT8IYbDrG6N2ZMdC6uEMUHizNlRMZe8GacQK+x70hOWPK
+        ZW7e3dmdba+/G/fWbbt8wERaMoIhZIzsCTBkDKgxedEYyBjFjv/f5GOE2j9fAPoIyGATcvh9yADo
+        c0AGQNNBRj8dZBzLCd+bzsIKj7WcL4q8WL/4gaxrLxvZ/9jr1OnfQInVXC9L09VoMtrWkU3FQkbm
+        di0dKHy7tmY1t9Wo0ao/R+bRci1zSrgPPccbQyjJoGJDKIGilBdRglBS7Pj/GkpETU2gBDwESlhw
+        QwYH+Lle7s9AyW+X4X0PJYM7r3xQ/KzGzimAaCjLdPe6uxtrcbfHz+eb0cCvWDXbwqptyjPra9OQ
+        ZDToMBgKISODCgwhA4pMXkQGQkax43+lEgVgD4AMHKVp5gbIwJ4EMrB0kDG8M2TstxWybaxwubXd
+        uHOtaUTrSJ0EeknRReWw21XUhmWMe9qctKezbr1rGpSHwVKUDCowhAwoMnkRGQgZxY7/lVIUgD8C
+        MgBF3JAnCvAngQw8HWSM7gwZo/bINFuEuLQHvoRam313X8GMw6DXZ8oDFsQdnBqGEd+teNzB7ZZH
+        THNf3vEQMrKnwBAyoMjkRWQgZBQ7/ldqUcAjTDVwHKdvyeF4ElMNkNJUQ7gzZPB7e8/Fa5wxmKkH
+        8GbJEhfTcOR4woISZ+3lrBqPcCVa1iuLJL4R4y4ndQBXMjKowBAyoMjkRWQgZBQ7/leKUcAjXDVw
+        AsNvycl4ElcNkNJVY3xnyKjGNWwT19Thwa+pkWm4BjAGrBtwE9AyurWGb5N7FKCYO5ZaQ3lWwZgF
+        K0PIyKACQ8iAIpMXkYGQUez4X6tGoR8BGSTK3pKTQT8JZNDpIGPyh6tRvE17vAh4du33yTqL2TMb
+        GO6yU4kPfXFDqEifGdoSa4yRSsvEKZs+DMmmDm04MqjYEEqgKOVFlCCUFDv+16pRHuH1hZMsdUsO
+        x5N4fYGUXl/inVc+5m2/G+ITeVVrl+bKQNfbwtzfIaJmcK7UilbL0p4iPTMstbd2syGarlTRUAgZ
+        GVRgCBlQZPIiMhAyih3/a9UojzD7wqnkDtwAGU9i9gVSmn1N7wwZwcKbMcNtadhpr6VNa1zltjNz
+        a3VM1O7XV+hswxs2V2Gn3X68rkw6jNdcVrrw8UoGFRhCBhSZvIgMhIxix/9KNQr2CLMvnKbYGxJF
+        MfQ5IANLafY1uzNkxGhjsG8bOk4gm8aaVGe2tFbxmmBVp/HK9VtaxO1Nd7ZX5+hw7QYLdCX2mnAl
+        I4MKDCEDikxeRAZCRrHjf6UaBcMc9f6QwRLghhwO7El8NbB0vhpHQ9S7Qga5IaLZfCpVnLmmkouR
+        SOGHmrvjDnLyElDTmCYoU9rsB5pa6w/Jw6I8LnOw5DWDCgwhA4pMXkQGQkax43+lGgXDvftDBoFi
+        zA05GdiT+Gpg6Xw1jgand4WMDjbAUAkXuv5sq1tyIBmDqRI5odtwPWCXNma43fUVdqeODqIWrEBJ
+        EbU+XMnIoAJDyIAikxeRgZBR7PhfqUbBiAc8LiFA8r8bIIN4Esgg0kEG9oerUUTNLTdHG7a50OWS
+        tl6IvSmYCHHPAGN/W1a6YAuEieiT4dCtlvr9ObrcVjdw5SODig2hBIpSXkQJQkmx43+lGgV7hNkX
+        kRzslhyOJzH7wtKZfR0NUe+68kFIk159PyOJfXXmuE2VkaqON5ooaIcXgtpC6JDEZh2ORLrbrdU3
+        K4b2lsYEQkYGFRhCBhSZvIgMhIxix/9KNQr2CLMvAmPoG8y+sCcx+8LSmX0B4s6Qga83Ea7gVcMS
+        W7TiMB5VOcyWVWfvc83auj0GWFQzrGiLhGYdDzi+TjY1BT5eyaACQ8iAIpMXkYGQUez4X6tGeYTZ
+        F4HT+C2Jok9i9oWlM/s6uq7fFTKi0dIqL9qVfrBZiX15wLSc+pipB1WthvXo/mEir/q+Afoa0ncH
+        FkOLgl2fwpLXDCowhAwoMnkRGQgZxY7/tWqUR/hqECRB3ZLD8SS+Glg6X42jIepdISOszjrB5kAa
+        pFJp+fXhxpqN5hRNxU1+JEfIellnnE65zWH+hue0+TLYjZUehIwMKjCEDCgyeREZCBnFjv+VahT8
+        Eb4ax69guyEnA0efAzLwdL4aR4PTu0JGf7RzJpsDUSZQT6wrTs3x3NkItEe7GA8PblvkxNZBxb24
+        xR0OcbDvthS9DnMyMqjAEDKgyORFZCBkFDv+V6pRcOAH94cMGrA35GTg4EkgA6SDDPYPV6OUe/1G
+        vNNrvjov4TYd7tiy3m9TB1fBrai1arhDNRbtYZ1HDiFPrLnScBRu4cpHBhUbQgkUpbyIEoSSYsf/
+        2nejJEzSCh3tvlDCoOTv53Akov8MUJL8pIQS7s4rH1a1DDxjPhVAya1MaL3Odkd0EEleFDZdYqaq
+        S5fHmb0x15FBYz8n+yLmOUMIGdlTYAgZUGTyIjIQMood/2vVKI76CMhgsd83+6LQp3AUTX5SOoqW
+        7gwZQzIkKTnaKtqhP2e5ilTih3OOZNtUhShtpQZF1ym+p4JFv9YumaYnkjHJw2qUDCowhAwoMnkR
+        GQgZxY7/lWqUo6Ho/SGDpZnfTxSl0KdwFE1+UjqKlu8MGV1kHRKTuLKNgdSiDaCYYtNcT+djfY12
+        9I05dpashEuy4Pj9zcGdIcAUFLiSkUEFhpABRSYvIgMho9jxv1KNcvTuujtkkIAEv5/DQaFPYd51
+        TONIBxnVO0OGPovrC7NjGFtmt+pilfGh3DLm7THH9IBRm4QobnUZXmTbOlsZjNFabeuLG5iTkUEF
+        hpABRSYvIgMho9jxv1KNQj0EMjCcviUn4ynMu44/6SCjdmfImPCLplVGtwdT6fbaitpjbE9iaHXM
+        dJX9oDncjknKpdY2vaj1Varnd2ZDyoLVKBlUYAgZUGTyIjIQMood/yvVKPRDIAPHiFtyMp7CvCv5
+        SWneVf/D1SilrYq3MMXvBA3B80d0qy+ELlbebeymGlFlYs5EDbe0LnvbLRLuq42Ks2nLEEoyqNgQ
+        SqAo5UWUIJQUO/5XqlGYh0AJAdBbcjiYJ4ESJh2UNO688mHuo7YtMcstijPcNO40tNYAXShRr24P
+        yuZmOsKGh2adU0KkjWmcvEAUYkdAyMigAkPIgCKTF5GBkFHs+F+pRmEfAxks/ftmXxT6FI6iyU9K
+        R9HmnSFDq28HnoDiZBMJsNGK0zo9dbEpOagyZScisjQiaTMmo4AdhAbeqx1KK2RTgtUoGVRgCBlQ
+        ZPIiMhAyih3/K9UoAH0IZZAMfkOmKECfgzJASkvR1p0po+cs516FkSu7PTc3gpLDtptd2dYYlG7v
+        uY7rDhb6oWeXSL3V5vc+0lfXdB9SRgYlGFIGVJm8qAykjGLH/0o5CsAeQhk0Sd2QxQGexFkDpHTW
+        6NyZMkB9ZfkBtWrNuCXfs4ZGy/f46kxdoLHvrqMyyottZZM02uHGsJUSN6/odViPkkEJhpQBVSYv
+        KgMpo9jxv1KPAvCHUAZDYDekZYAnsdYAKa01unemjM4GXYVdWfWXeM0FYCUjS7XMx8SupevbHT21
+        VUbm46lSovjqgto07bExbELKyKAEQ8qAKpMXlYGUUez4XylIAcRDKIPF2BvyMgDxJJRBpKOM3h+u
+        SLGrGGj01/X+rM2hDlEbmeW4PLVMj9WqcrcONusDE9DtXVNU1KFZMfqcRWLQ8CuDkg2pBKpSXlQJ
+        Ukmx43/t+1Ee4viV6Dh5Sx7Hkzh+gZSOX/07r32II6w+o1FlxlO74SSq9xiiNTmwnjAWKNFfLIOW
+        IYmMsUbEiaJODx7Yrk0KUkYGJRhSBlSZvKgMpIxix/9KSQp4iOUXBVBwg+XXtxP/acpIafk1uDNl
+        2MSsO1AJMR6Y2lCdtmsLt9Vr7IwQkeaDVq+n031Vqc6EeLW0OuvJqtYvjVX4hCWDEgwpA6pMXlQG
+        Ukax43+tJuUhnl8UYJhbskWfxPMLpPT8Gt6ZMmZBKPA2sxcpZyeHwO+qIlfFLbS2i2xxUDP6+thX
+        +LYkNeSleKgFmEF1REgZGZRgSBlQZfKiMpAyih3/azUpD/HXoHAK3JLH8ST+GiClvwZ/Z8pYlq1Z
+        iaO2u76OhyWWxhuqPdjHK/5Qn/a40r5WmXf7XTzuDiMS3/OOLNkLF1a+ZlCCIWVAlcmLykDKKHb8
+        r9SkYA/x16AIgr4hLwNDn4MysJT+GsLdK18dSkLq400btNgaHQxZr7MKpd6guTeddQOpmmy4XM6m
+        qtzYMSI6GTWHJgrzMjIowZAyoMrkRWUgZRQ7/ldqUjDgBw+gDBLHb8jLwMCTUAZIRxnjP1yTglR0
+        wz2M26Ml2h6tbObQKmFUZzDqdVweWLvVciiMKQUxuPFwHrChaXKzYQ0amGdQsiGVQFXKiypBKil2
+        /K/UpGCYoz6ASigMvSGPA3sS1y8spevX5M5rH8NQ1Ea8ND8sy/yY5dvjkHRHo0kX7Scf3nFYqcy4
+        XVNsA3txmM7Xc03mWssGzOPIoARDyoAqkxeVgZRR7PhfqUnBcO8RlEGj1A2uX9iTuH5hKV2/xDtT
+        BtfjXb1Z8yLZoxRnT7Rryt7VK7axnRBzZiIFk2FpUbOWB6sJ+oephQ+V3QE+YcmgBEPKgCqTF5WB
+        lFHs+F+pScEe4vpF0Ret+U3KeBLXLyyl69f0zpQxIPjq0t6RAxSZVRRrZQ62bSts65W+5SHthmdV
+        EbXTISpYzdUofzWVZqg2g5SRQQmGlAFVJi8qAymj2PG/UpOCPcZfg6XIW/I4nsRfA0vprzG/M2Uw
+        Q2fW5BugIvlA6NAdd9GlCGG4w62aRMds7dDfxgrB7PpAniD8pIZXeiH8npQsSjCkDKgyeVEZSBnF
+        jv+1mpSH+GvQKIndkpfxJP4aWDp/jaMo35UyVNr3GgrKj5sVUDqYnBbYW37oxttuD9iHRciOxZkk
+        Okhkx3tRmA2tEOcbMPszgxIMKQOqTF5UBlJGseN/rSaFeQhlAJy5JS+DeRLKYNJRBvjDNSmu2W4p
+        k3656mDiNGaX+2VrtIqrk6kcrOLpyuw367JZqw9kPxhylcpsvWdkBPpxZFCyIZVAVcqLKkEqKXb8
+        r9WkPMT1i8Yw8pY8jidx/cLSuX4dS2ruuvZB0x3T6xuLiBkbg91SqzTIyvKgNmj0QMpTb6iouumN
+        2BggLH0YKG1RZ2IdPmHJoARDyoAqkxeVgZRR7PhfqUnBH+L6ReMA3OD6haPPQRl4OtevY0nNfZ+w
+        lLl+2/KaPLqwBpuRuVltdmXPq/crey1qzfx+ODMptX8Qep5G8CI37lHUAmaLZlCCIWVAlcmLykDK
+        KHb8r31Pysn0y4rvDBks/fvJojT6FKZfNIKmM/06VtTcFTImuoohwsbVd5yr7vVlcyy6OuJJI3XY
+        ZISFU7ZlnFgrobdF0N08GFqzWguFaRwZVGAIGVBk8iIyEDKKHf8rJSlnd417QwZJo7+fxUGjT+Gu
+        kUBGOneNY7DvChkeOdmXOaEarN3OXuwEsdDnSth8qKKoQHmr6a7uq+2GjlPN8hQv7b2xgdh7CBkZ
+        VGAIGVBk8iIyEDKKHf8rFSlnc417QwaVUMYNkPEU5hoJZKQz1zjW09wVMvZaVV1o69IYm4wCq4lP
+        J2ZggpVx8IWZd/A8jpVGmEZtg0pEx5uGGpJRxYKpnxlUYAgZUGTyIjIQMood/ysFKeRDIIMm8N/P
+        yaBR8kkgg0wHGcwfrkcJ9WBd2q0c26gxy9Y+OgwVNqAnBNpxxeFiy/EYKa9riLgbdw2wsSMhanRb
+        MIcjg4oNoQSKUl5ECUJJseN/pR6FegiUMBh7Sw7HUxh+JVCSzvDrWE1z15UPe+IYyx09tHUMcTr1
+        Bkt1cGwCkIk0DgS6vhsujQPR0kiCcMWx0BrE/a6GQcjIoAJDyIAikxeRgZBR7PhfKUehHwIZLKB+
+        3++LRp/C7yuBjJR+X9ydIQMjybrnBITYFxAjCKUGGdeb4npUGtP2YTqo6H6p2u5a7IpWUWm0mOAb
+        vdyGNa8ZVGAIGVBk8iIyEDKKHf8r1SjMIyCDQVHslkTRp7D7SiAjpd1X6c6QEW8bNUpsRG1kJetd
+        v7TfudUAHwYzUKtODqRhBq2tXW8y7RI7WVl0FdHnZQ7mcGRQgSFkQJHJi8hAyCh2/K9UowD0IZQB
+        aPKGJA6APgdlgJTGGpU7U4ZkjSfa1GkcBqpXYjel0kie7SNpOpv1KhVyJQmOFa4G0zU/l4eiamxn
+        40oLhUsZGZRgSBlQZfKiMpAyih3/K+UoADyEMjAK3JCVAZ7EWQOkdNao3psyRh2tIrfnOGtRFT+c
+        BVtRpcJwyfcMQe1Nh72agBCGRLcmMr5GDKFS9REFrmVkUIIhZUCVyYvKQMoodvyv1KMA7CGUgRPM
+        DWkZAHsSysDSUUbtDxekKCjtKA1UQ4DabyyikUgoiBqvKuu95Y4iv9d1YnLjNp2ypyhoGxVWOyXC
+        4NpHBiUbUglUpbyoEqSSYsf/SkEKwB9CJQRO3JDHAZ7E8AukNPyq33nto1arq/Mhv9rKhrNlrO14
+        VRnKjdqyWR1vJ8NZB6/rnEAdzHV9R0ohOoxHnD+Aax8ZlGBIGVBl8qIykDKKHf8rFSngIY5fDImB
+        Gxy/wJM4foGUjl+NO1PGjol4Zkj1rC0Vm/3xsLOxKgRh1Gq7g9VyGjTtiw3fxDVy4jpbJxovQ7YR
+        wbWMDEowpAyoMnlRGUgZxY7/tS9IeYjlVyLM9C3Zok9i+QVSWn4170wZrjfshygYOGh5HFY0s1nl
+        J9FOpfzKQBoEbXs+UhWBH6ox2u63Tbo0OSjkHK5lZFCCIWVAlcmLykDKKHb8r9WkPMReg6EZ9JY8
+        jiex1wAp7TXad6aMQdseldr61jQPdpNx+2qtTvtTsdNeCq5RRiSmPpYrGzIcrbaTw5J3OWSARpAy
+        MijBkDKgyuRFZSBlFDv+12pSHuOvwVDULXkZT+KvAVL6a3TuTBmOFwXCwdsMyrvGAEOGlGJXMPOA
+        yKhWEteIE1XnB3XQoNZgUk+YgmmueGIKv4gtgxIMKQOqTF5UBlJGseN/rSaFfQhlsCR+S14G+ySU
+        waajjO4frklpdFudkYgSvqjgnRkSKWPCWwjUUhQxljwwOMksHCZeL0BFW7fLbi2Ug94a+pdnULIh
+        lUBVyosqQSopdvyv1KRgD3H9YlGcvSGPA0Ofg0qwlK5fvTuvfVTGzZW4ZqdlXDXMiV4agjpAh3Os
+        Rw5B7dAWDojsb8bMkgIDoPvUTlFVh4KUkUEJhpQBVSYvKgMpo9jxv1KTggE/eABlAIy8wfULexLX
+        Lyyl61f/3t/FJnIBUEcI1Yl2znZani50xG20LaGni1UZXcR2iTo0pJLEudVpZVirqcsNrHzNogRD
+        yoAqkxeVgZRR7PhfqUnBMEd9AGVgALshWxR7EtcvLKXr1+DOlKFwBIIa5miosnTgHPYGt5noC9sp
+        bdS4mryRHmeAyGX1Sk02qAqhTObzlg7XMjIowZAyoMrkRWUgZRQ7/ldqUrCH+GuwOEPekMeBPYm/
+        BpbSX2N0Z8qY1/p8A93svUYg0M6iGU0jBJfbCIUvYhyJNXsA1KZBH+TqeFiXnSXeiKcbuJaRQQmG
+        lAFVJi8qAymj2PG/UpOCPcRfgyVocEtexpP4a2Ap/TX4O1PG0mIFa9a1SdR0GXcRW7jQiVB160yD
+        mBww9aATEzWzqe9xn7Y9bRb6I2kLa1IyKMGQMqDK5EVlIGUUO/5XalIw6iGUQZL0LXkZ1JNQBpWO
+        MoQ/XJPibr2gzY0XZa1n1XpLkcE7WrWsGFJbN0ql+RCpBc6mH6u90pxng1G0n83VJfQWzaBkQyqB
+        qpQXVYJUUuz4X6tJeYjrF0sRxC15HE/i+oWldP0a33ntY0qRm4UdBvVDb0mpNop7u144oYhJg2zr
+        1rgmxjEynQssP1XR5c5Zhc0a6EHKyKAEQ8qAKpMXlYGUUez4X6tJeYjrF0vj6A2uX9iTuH5hKV2/
+        JvfO45B24qG1Y8j92N/zNLOrNmVTamqDmlA2xPm8vliyPjtRJXoxZha7cWNvlwz4hCWDEgwpA6pM
+        XlQGUkax43+tJuUhrl8sA+hbskWfxPULS+n6Jd6ZMvia7iiu6K0Zca7Ly41H7MvWshYNx0Fbdc39
+        YRxNBXbWDlh6Wsf8TY+19BJcy8igBEPKgCqTF5WBlFHs+F+pScEf46/BMuwNeRz4k/hr4Cn9NWZ3
+        pozmVGxPmszSnJCDvjJQ6n2v4e6Wsy7JqfhiuJ5o09ZC7+m1jWWudFDx40gMYeVrBiUYUgZUmbyo
+        DKSMYsf/2vekJJDBhXqY/HNHzKBRlKZ+PzGDQZ8CMxgETYkZ8ztjxiQgO/KGsx2kotRxbl8Rmq6C
+        DmmZF1CcSNRZICgmQOLmgRJDgLkrrq/u4SOTDGowxAwoM3mRGYgZxY7/taIUR30IZgAK+/3MDAZ9
+        Ch+vBDPS+Xjh6B+uSiHEubGqAM6OGkBnVP6wdMQ9eSBmO0eMiDIXRfISK4OBgfX08bzVVahGpwaf
+        sWRQsyGWQFnKiyxBLCl2/K9UpeDeY7AEI9jfT+VgUPxJsARPhyXgzqsf2ojoVdblnYhtG6OtsFdo
+        Qq/0MU5quwO5yvZK+6q9bTKczW9dXVe1w6w+r8LVjwxqMMQMKDN5kRmIGcWO/5WylKO76CMwA8fJ
+        33f+YtCn8BdNMCOdvyiO3RkzmD0gkL4wWTUXVVRsxk5NtOYC6PGOK7S0nRPjS3ei2LNo3omYbas7
+        WcWxBP1FM6jBEDOgzORFZiBmFDv+V+pSyAdhBoGB308ZZdCnMBhNMCOdwSiO3xkzasRmojsDlCFW
+        3pwANuISXbo5Km9GTjxp98dkLS4r1DZuxxioVudaGAWYCx+aZFCDIWZAmcmLzEDMKHb8rxSm0A/C
+        DJIlbsnleAovrwQz0nl54eSdMaO/RbAKF85nC0BEItvTp+poMTRKA0HjW/ZuNq8fFo1ux4qnwp7n
+        LbLO9ZEmXM3IoAZDzIAykxeZgZhR7PhfqUxhHoQZFANuyc14CjOvBDPSmXnh1J0xQyS62LRLslXa
+        ZufzCthbgWLVg5JBK8bE4hywXx6kroJWJXnRHytsgK9ZEmJGBjUYYgaUmbzIDMSMYsf/SmUK+yDM
+        oCn6ltyMp3DzSjAjnZsXTv/hyhR9X1pZNsdVB4HTKi2Bbpq1hjvEWHqESnwHx7aEqTDN0nrGzEtM
+        0OvvdRJ+X0oWNRtiCZSlvMgSxJJix/9KZQpAH8QlDInfkMwB0OfgEoCm4xLmzssfCU/gFtHd1OtG
+        bzoSuvhQPuhkPZQbHObNBJEl1dHQHO/GwXztdFeb4aTaCODyRwZFGHIG1Jm86AzkjGLH/0ppCgAP
+        4gyWQG8wAANPYgAG0hmA4eydOcMrLexZDfWiZlTlekZ/N++zlbZUqW03oTWoz3zaW5dDXyt1qYbO
+        c47K+ksPlsBmUIQhZ0CdyYvOQM4odvyv1KYA7DGcAVCMuiFrFDyJAxhI6QDG3ZszOlSvyprBYem0
+        3XZUqnDrvn/gYp7ybX7bZIbW2lpMWruxO2U3dMPh8diqwvWMDIow5AyoM3nRGcgZxY7/leIU8CCv
+        DQBY9oZ8DvAkXhsgpddG+d5eG66waVYGM6LdbawMRnUSvdbKrLxbbVVp2WizNTWc9CpVAbQ1pdff
+        eVGnj8P8jAyKMOQMqDN50RnIGcWO/7XvTXmQ2QbAGPKW/IwnMdsAKc02KnfmDLcuzMxye1vD8F4b
+        EyPGaTle0yT26sgvDQ/znloSWp3eurXnvdHAr5rrepWAz00yKMKQM6DO5EVnIGcUO/5XylMA9SDO
+        wGnslvwM6kk4g0rHGdU/XJ8y5g4hsdRjbdZsDirKqDNpHbb7ir+Sy+6UNyXBUbQOxyCdgdrbRcNW
+        MJwe4HOWLIo25BKoS3nRJcglxY7/tfqUB7mAAYJkbsnneBIXMJDSBax25/UPHCOj3dy3zf3IkgRy
+        aUgaNvajVtPTOoHTGNI+oOnxlg8izGNFRqfFdjyGz1kyKMKQM6DO5EVnIGcUO/7X6lMeZAMGSIK8
+        wQYMPIkNGEhpA1a/M2eENXS2qggHXBh1xKHfWI4a/aGAVNmlTvasIIyI2k5ujxairdc76LhLNA/b
+        LXzOkkERhpwBdSYvOgM5o9jxv1af8iAfMEDh4Ja80SfxAQMpfcAad+YMnUJw3ljOdaDjVEeyps5+
+        tx2wfJkN+7NuZxkajcifrkb2qFRqkSao1cDOGELOyJ4IQ86AOpMXnYGcUez4X6lPwUACGI/gDAYl
+        bsjnwJ7EbwNL6bfRujNnBPrKIZna/qCMhNF0F1dW0YpsNBa1Zg1Uq7vNalTqUbXNcLmiepau6R0a
+        Z2XIGRkUYcgZUGfyojOQM4od/yv1KRjmqI/hDBa9IT8DexK/DSyl30b7zpxBWdPI62Puml5P0eFu
+        wB/q0ZwIlvokGg4jRrZFpx4ccJpeM8NuP0a1arU1gM9NMijCkDOgzuRFZyBnFDv+V+pTMNx7DGew
+        NH1DfgaGPwln4Ok4o/OH61OW+lguV/HKSp4ND8NSfd/zGbJXd1mGiPh4FY7MYYCuwmmz1qD9iPB7
+        am8QwvWPDIo25BKoS3nRJcglxY7/lfoU7EE+YBhK4Tfkc2BP4gOGpfQB6955/YPD5e1G39d9MuJ9
+        bSn37KXbnjZjry+QfaLH+Bs6uaBIDzqaTkttltWlDg/XPzIowpAzoM7kRWcgZxQ7/lfqU7AH+YBh
+        gGBv8AHDnsQHDEvpA9a7t9/oRJ6pgx7Xnw5EbLA3wE5rWfs9mki/rCwNjFttI8QRGgdhEKg7udOZ
+        GYcF9NvIoAhDzoA6kxedgZxR7PhfqU/BHuQDhmE4dUve6JP4gGEpfcD6d+aMqDyzGsMB3dwBuWks
+        V0JYIziuhAhrA6+V9XqH7hjW1MfF6WLW2bU7kSVMJtBvI4MiDDkD6kxedAZyRrHjf60+5UF+GxiB
+        srfkczyJ3waW0m9jeGfOEJYx64FyuFAxYWuBYDuuVvkwCMb61F8Jiu45ddYxp1KvEpDC1uHCBd4f
+        Qc7IoAhDzoA6kxedgZxR7Phfq095kN8GRrDkLfkZT+K3gaX02xjdmTPUw1gxR/Nk8PYDtzuwRuZa
+        XVYooJZ7woZnw/JyWiZodDI0VgQ4VOe7TgXZwjzQDIow5AyoM3nRGcgZxY7/lfoUHH0QZ5AMuCE/
+        A0efgzNwNB1n8H+4PgXX8f2gF7PIqstYHQ64M7YSRq1FYAkbvam4S+swqXHmblKxqMHe5VR55uwz
+        ms/xQyYz/iDHGIyimBue/OFP4hiDp3SMEe5MyhYhGd0wqjnTbhBqfOCR9KBzaPPyUgeMya/mHafb
+        wYlp8nbtcl2hQmS3QjKayfxDzttxQPLaJtCOn/v3HZM0Sfy+uwCLPsWYZBE05Zgc33lMKgNCMxbz
+        EVXGVK3bQkC30abX036FwUZb15l1vI1vIyUxriOMyGkzq9e1sezM3l7DI+VJp/dgmX5wifb7m+xp
+        8uU9im+vn6/OG07nqu40L44MzdMuHc7vYHHkp1NfKxlmroOE6wQnvjWet5+6dk7bLxsvO1vy8U2e
+        /jn3l70gidqXhsvGU38u2fjyH7K9+a+XcmgF4fGtfNl8HH62fJwFnQ57iv/3TW/JOE0mN9Jai09n
+        en17/dLylgyLS7+P3b61fHewz34/Hk893udfH/R8OR8dvmv87HO6jpJsWVpwudDKDzucr/T18y28
+        ftzEnM5B4TQbTrPyMs2C0+xix/9r0Bdu6ATe5fpOovm14dvm0+f92DlC1Es7GTuqa392vaioZwbm
+        QvK0nalFR3FfHDX9fId+uemMgud3pzlqpvD0Xhz5+st7cH6dTLC94Ke7cqxT6crxPe8HhRE0/vtJ
+        HST6c5HKtftBJj9p7sfl+s/sfxqOvbFQHnHldnX0MSU4j9Lz7+eHUnIQGFr0UnJDz9H+03/pJZfj
+        yYt1MoSEKi987Hi+Z383yzj/ZiUD3X1PDicHR8b72njpsZED4/31OAmwz+dFlNN5ER9xvp0XCTQ/
+        eP3Y/7TLZffkCoPQf7fM3bfDX5o+OnybIZxfH4n93TftjaUlNyw5ePCx32nLpVe48TXL+orW50us
+        /nyJyW/dBvq1/fUXx9A19xgo+f3NkpOP0DC55yT4i8RYCgCcfnv91vqW0Ld+/hVB/wJoEmGSSj7Y
+        PpvfXj8Pdpy3JVp0nAf4p5nadw1H+j3yS8I3H9h7eXkipp9nLD+1npjnF/1+bH1zNE1NRsQmGW8J
+        zZ/G5On9/Kr90jn05KOKfOn20XLu8HXCc3r7P7W+HT/Tz5OdMhi9EMKxduqj6QPp1eT+H3tLa/sd
+        PTLbL9rffMONzrOp0+WcTvdD25ufjMvFZban7ZPxkozJ4+G+NH/0Oc+z9oHmObL1IiQdX0rHgeyo
+        L597nP9+Ql/zfvmJ/6sNb8nACi/n4rlKpzrixWqnwyda/bnh0umcyCarluYlf8NiMhT9j26Xqcdl
+        yngerTlHl7+7yPOn5WmmfWlL7rmfzEnf/z9OhiWt1ngDAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:26 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['11263']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:36 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['330']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+2d15bi2pql7/spos9NXfThpLypEZU18N57bjSEJIRASCCDe51+k36yxoVJs0nQ
-        FidXUrPGGbUzFgsCfmlOYn5aWv/rf28X9sva8HzLdf7rH/S/qH+8GI7m6pZj/tc/up1cQvrHf3/9
-        X6+6GhhKYC0MxV0Gh6m+4hl+aAdfX/1wrLsL1XKU0Dc8xfKVsap/3Rn+65efP/Sqebtl4Cpj29Xm
-        X30lkZAnZTqYr6xM2t5rfqYr0/yWThiLrrGvJrvJakdx7NKwqex285rBa0OJXku1VXmkyzN+ve83
-        jA0fbMdbRxfp6XCXK0zmI6NfdgvVDCOqGypjs7VsqZwQ602nY4WlwEpwtdFO8sxNPpFKzpeWtzKm
-        YVdNDns5Lt/bb+rZ6n5QF8azlDVa8uPR65dv3vOrYxi6ohtL1QtCz1COxfnquK9ffjb+OlV9ZWl4
-        E8VRF4Z/rsx3Y6+hf6j3ecS2/ENVjbXhfPxH9QxVORwU42u2//rl46fzA7rha1+zh2O420wNz7hM
-        OI2+ji0zXCpr1Q6NrzRFvX75PPCqWcHu/Eq26+iukwjnh4/6Pnh+/PRCldPjlwfPL63Zqu9f/nOe
-        H0wNNTi+gU9jl8dPT+l8+/j5ZQ5nxekUOb/cqTrfDr36huppU2Vu7N5+w5fDufUxeDwFL1Pfnvk+
-        8s3rfcz7yUvOLd3/+cueP8jl8W/GPqacPktOXVj27tOk8yf88vF7v7wVzfUDxVMd8/AaY+Pw79MB
-        UdzJxPAOR3Xsu3Z4EJyvrg/nxVea/dfhyH0/+joJbfvwPhZjyzH0rzxznPTt2HnK4TMFS8/SjK+c
-        +D7nY/AyKTx8btU7vCH+Y8772OvpnX28MCsfJ303eJn08cos/zHr0++7DLy/OPdp1sdvPIhBO5z8
-        qvn+gRn+9cuPo4dT+ocCLtTt9+/1m6HThPPzUfNINf+xgKeR797Gt2PnKd++hW+HXhdH1b99Nvo8
-        4/PQZcLheP/FYeNuOGq09Ouj9mnOXx816oajRnO3HLXPs64cNerWo8b8xVH7rnrHn79/E9+Onad8
-        +wa+HXp1XOX47WUbvgJbg6390TWHrcHWLr9+FapOcPxr9xJ4vr4etGjpytv4V/r1y3cj389gfjmD
-        /eUM7pcz+F/OEH6c8eXHj3fybUULPe8QAA9T3v51/lPXHC8Pf71+M/QxY6JqgeudA8b3gx+znHAx
-        PhweiRE+zboMfsxa2qp2iETMpzmXoU9zjgfb3y3Grv3l8/Ahc51Hv/6///v5+R/jr1++/5iBu1RO
-        JwUsM5Jl/lC/L3/xBwEEBUFBUFEE9VlFmhs6gXc5YU645vPA+8Mn8tB1rMDQX8qH19XdxcfUC7/x
-        rMDSFM9YW8ZGubyTyyn304fOEPB8uA1Hv/x8ITvhP19oKZi+JEMz9IMXhqIPJ+XHhPPcMNCOH8o3
-        gq+scPxF349+TPMNzXV0//DtLdI8x1PfzH578Dx9d/i/xULXvx5/KSXR0mXm+/ir5buSQNEnIKeo
-        jn4imafpCUpK0FKHlv+Tpf6Tov4PRf/n8Tf9/AmX1/2+Auef/UD1gh9qwtCHYiQPh9OOsyQCzQgs
-        d3NJOIa+qyRcgqGjlORSghO0PJ+PtW4n3Uqmy9nW65dPw5cppzJU1SCYGpuXlBt6jvEf/kvt8HE8
-        VZsb3v9+e9K5Xud/W/pXoZh7e+Tw02XcPpzl7geC/Dx4mXF4e0Hof7Wt9fvjl6G3CeH48GnUL28/
-        B7ul8dW3Fkv7yL4P7yh4e97pkcuscOkbB3f5xG3P7zH743v8q/d+HC93P49/+clrm4Z7rL769dVW
-        D9804aGQPP2vg4u8//hqu455/meC+hd9fOh94PXLx/OP+PnwLX3kzf4JXH8zcKSoR38z9Hd8evnx
-        FHW80HGOAel0/Gnmkna+GT39ef2Ted+P3gfSz4Ohpx6/Xz9Nexs5Tzh+BtdbqM7Bm09v/4fR1+O3
-        3Zmmp+nWC9epHYz4begNDeuHkh9nK/PFOR78ZPzVn7qbM7U/fZzzRY9vx179w3l9mH56cWN7OHUO
-        sf74cp+G3+acbePw+Et75wfG4mVkeO771LMIDqdFeHlaO5mpZFvtfrZSaR/+IPl44DLp9IS2qtuG
-        d5BV/3Ai+W/TLmD6cnnhf9xfZm8f/JuzQlO16eFMeQv3/vG1fhgDuQfi+rNr/m9BXML9iIu/4agx
-        dEyIi70FcQkxIi7m1qPGPQhxMSD3sLUnrjlsDbYGcg/QCMsEuYegICgyBPVZRX8KGf4rVHlas+q6
-        9oWEfKxj/Rg7kkPbWhyvOpz43KcfYwPOJ7R2fneJpHz+u+I0cHnEV9aWb43tC477fvA864P0nkmd
-        Ozecr/NEIjHhOoJqDeVZsVYuie2i6KzSm+46k3Yyer5hWq0m7YW5FufnDVGslafjRqJa3snNTq7O
-        dvnifnj5jedXvLz6bnkBc9ne28PvQ68/YtJvEelp0fXptBD/xVIvjerhPHsfOj86nS4W/uHoy+zp
-        MsnnsfPv+yCfAF5Ihv/Dao5kiGQI4AVbe7Kaw9ZgawBeyOewTAAvCAqCIkNQPwdeOc/65wvDOPoj
-        gBfLydIdwIshBHgx0YAXHzPwotTynjcHnVl95o58gQl3boJtJrdGqt1nqwU/x5b3I2/vO7TG1Vvi
-        VteLleQewAsOgWRIaM2RDJEMAbxga09Wc9gabA3AC/kclgngBUFBUGQI6ufAqx06/3xhuOP90PED
-        L55hhDuAF0cI8OKiAS8xZuDVTpqd2kooVMJ5V6iWJsHO4TraMLEoGIlqt+NbVX4nBzndZ+vmoNdq
-        B4ZZ9DcAXnAIJENCa45kiGQI4AVbe7Kaw9ZgawBeyOewTAAvCAqCIkNQPwdeVfcIvPjHAC+Bkm/f
-        /487fhQigBcfDXhJca/wUnKCVa5PttUen9qKc75VlCo1IQiXvXZC6Sp8l6mLrL5Pr/ldZTqqrur1
-        ZgorvOAQSIak1hzJEMkQwAu29mQ1h63B1gC8kM9hmQBeEBQERYag/mIPr9D45wsjPAh4yfw9e3gJ
-        hAAvIRrwkqMBr2Pr3K9FR7PDY7Pil7GqzV/848F8War+27NOk34ByKpmQivXN+KmN2CFdrLAG8Na
-        nZq4cycnCa3apEQ7JXVEG0aimRk08+tdc6oWtgBkcBQkSUJrjiSJJAlABlt7sprD1mBrAGTI87BM
-        ADIICoIiQ1A/B2R9Q//nCyM+BpCJEn3Pnl8iIYBMjAbIkjGvCFtsRvtOq5AaDZuWO8zU99ZkpRs9
-        X92w0xKv5KWG5mTyVbq7oWf1sJioj+RmF7dAwiGQDEmtOZIhkiGAF2ztyWoOW4OtAXghn8MyAbwg
-        KAiKDEFd6+ooPQZ4SYLE3AG8JEKAlxQNeKViBl5Bb9p2JmV3xqzl7FoaOZNRceea+wUj7lR+6FHF
-        bNscJ8pyIc+NpXp5Ost3m1jhBYdAMiS15kiGSIYAXrC1J6s5bA22BuCFfA7LBPCCoCAoMgR1rauj
-        /BjgJfPcPZvcy4QALzka8ErHDLwa/Gy3ZlaMUDBX1VTdLKZ4XS0IPcrQ2/pkkCh3Ro3KeDZL7gOp
-        wO7no2TgiFjhBYdAMiS15v+OZMi855Dbk6F4SzKUf33UGP6Go8bdcNQY5pajRss3HTX2sclQ/mUy
-        ZAG8YGtPXHPYGmwNwAv5HJYJ4AVBQVBkCOpKV0faD16q6i5W2sXQjHj7hl88RZNAu/gERUejXdmY
-        aZeQdKe5ui1Xs/y8TTdalYG4K4s8NaglmFrWbG35klBXrFKrEDpUGNIqMyqLO9Cud3tgbrCHT9L/
-        e/ZA3WIPfIz2QN1qD0K0WPieUO6Khaj5tZrHEAupX66DeL8uf3ss5G44ap/WOPy9dRC3HLXPKxz+
-        9jqIm48a86B1EFSstAsSg62RVXPYGmwNtAvhHJZ5s2WCdkFQENRDBXWtpaOjx0+7GJq9ffcunmII
-        oV1MNNqVi5l2GaG0rK/3Xn5RnhphRnflaWXWG3teYsKHglgYp8f8cO20tGC519oVnw/FYIibGWEP
-        iIWk1hyxELEQtAu29mQ1h63B1kC7EM5hmaBdEBQERYagrvRzZL0H0C6Wom7fuounWEJoFxuNduV/
-        czPHpCN7fGtoyrNdX1sVrLklC5pmhUJhyxjb+dyppruFvJwxM3PBmeqLjMtmO6BjWCqKW4RIrTn2
-        xHm7YeZXMfLp98TBnY+wtWepOWwNtgY6hjAPy7zZMkHHICgI6qGCutLMkQumD6BjknD7Pl88xRFC
-        x7hodKwQ81owc9wZt8XUJN/329yI4Tm6ti7MJrm6LLbYFFVQEjllMt4E44moTDOCujHElAvaBXtA
-        LCS15oiFiIWgXbC1J6s5bA22BtqFcA7LBO2CoCAoMgR1pZMj/wjaxYln5nEj7eIJoV18NNpVjJl2
-        0RbNddrz5GY0LfYzcqDX1Roz30v1cmkmTf3eor2R5TbH54qZ0njRmLl1bc1jV3ssFcUtQqTWHLcI
-        4RYh3PkIW3uymsPWYGugXQjnsMybLRO0C4KCoB4qqCttHIVH0C6el+/Z1V4ghHYJ0WhXKWbatUwV
-        GqleeWb0A2ayc1P1VNHK1hOlUi2vbAbNw4/Zpbir9WvGiFpPvWXBaHSme9Au2ANiIaE1RyxELATt
-        gq09Wc1ha7A10C6Ec1gmaBcEBUGRIagrPRylR9AukWXu2edLIoR2SdFoVyVm2iVZsrZf7ZajUC2b
-        Za5aTEyWZqkj0vxkwDe1YqqhL1tML3Dqe39oDVZVdlPM4k5G2ANiIak1RyxELATtgq09Wc1ha7A1
-        0C6Ec1gmaBcEBUGRIagrPRzlR9AuiZbu2bdLJoR2ydFoVzVm2lXYbLozvd9W7HmvkcgWgr2ZmXlV
-        tTHKdFsszUu1dtDYCXlrXh+pu/FmO8qwCaztwo3O2OCG1JpjgxsTG9z8XdoFicHWyKo5bA22BtqF
-        cA7LvNkyQbsgKAjqoYK60sORph6Bu2SKv2PjLpoiA3fRVDTcVfvNTRzrfHGu7YecNhoORNZrpXkv
-        uQ6X+wGjGb1Cpr3sWKORpIlsbr4bpDPjtDRXKzvgMfgJciShNUeORI4EHoOtPVnNYWuwNeAxpHlY
-        JvAYBAVBkSGoK00cafoheEym79jpi6YJwWN0NDxWj3k1WJgph8MiM3QVe7wthrYbMJbWbBgSp5eV
-        sFzPDPrWwJ0lpzLV2jTtoucPsgXgLvgDciGpNUcuRC4E7oKtPVnNYWuwNeAupHNYJnAXBAVBkSGo
-        K10caeYBuIulRFG6A3cxhOAuJhruasSMu5SSvKoGRivVac83A6q6aWSCaaHAp/KDRruZ9I20qPB2
-        cTnW5Wa9VTV2dXXWws2P8AfkQlJrjlyIXAjcBVt7sprD1mBrwF1I57BM4C4ICoIiQ1BX2jjS7CNw
-        Fy1wd+xsT7OE4C42Gu5qxoy71t2MTmk7fu74reZ+WdumW53qdnRQpqiMt2yj1Ov42UyukDR6w85+
-        tN8N+gkFO9t/+AO2Ajz5A7aAJqbm2AL6xqP2/FtAY2d72Nqz1By2BlsD7kI6h2XebJnAXRAUBPVQ
-        QV3p40jzj8BdLCves9cXTwju4qPhrnbMuGvW141ib624OZ4rdGcFLmdkerO+tK4Y41aeShlzc6+t
-        zLq76FWl5WK+o2YZBTczwh+QC0mtOXIhciFwF2ztyWoOW4OtAXchncMygbsgKAiKDEFdaeRIC4/A
-        XRzD3rN3l0AI7hKi4a5O3Lhrvpmoo3yiV0naOS6hjVqJbXrAVnRnkUqMRsPVoN5YU11NXJrr0At6
-        vCOnfeAu+ANyIak1Ry5ELgTugq09Wc1ha7A14C6kc1gmcBcEBUGRIahrnRzFR+AunpLv2btLJAR3
-        idFwV/c3d3JcT2luPZc1Z1FbsKlBcTeuytqoVhWb4x6lbvXVpNXPDjV3U9m6rSybHFedxhB7fcFP
-        kCNJrTlyJHIk8Bhs7clqDluDrQGPIc3DMoHHICgIigxBXevkKD0Ej8nCPXt9SYTgMSkaHuvFvBpM
-        EdZ+pmSJ7YbeSbQpa9Xrr4N+eerJC0lPBd0OVR5ORsF6lBzq5ZJpT3xmTwN3wR+QC0mtOXIhciFw
-        F2ztyWoOW4OtAXchncMygbsgKAiKDEFd6+QoPwJ3CYdT6g7cJROCu+RouKsfM+7KN/bLada1WyV9
-        NZ9uZXFfG9WzRsuwl+KSNxdra7PYdc1SbtcrDPIbva8OBQq4C/6AXEhqzZELkQuBu2BrT1Zz2Bps
-        DbgL6RyWCdwFQUFQZAjqSidHhnoE7hIF+Y6t7RmKDNzFUNFw1yBm3GUMd2orvdu7K3cy6BXdmllK
-        s1ohtefmblbK+Io4sdKjoFPJdRq0Ke1ZJz9xNsBd8AfkQkJrjlyIXAjcBVt7sprD1mBrwF1I57BM
-        4C4ICoIiQ1BXOjkyjKPHj7tkjr5jr6/j1zIRuIuJhrtGMeOuVccpm8Mkr/TFVKW5WyYLA0ZhakGt
-        NaQ1s083k/bI1stsyMvybp41s/WGWcfW9vAH5EJSa45ciFwI3AVbe7Kaw9Zga8BdSOewTOAuCAqC
-        IkNQVzo5MqwXP+7iKEa6Y+8uhiUEd7FRcFfqOC9W3MVx676dVctaRRxN69uh6Ni0nhTVcW/YKgXz
-        gjQx+E2zWFX24Xo1aHMJUZeULXAX/AG5kNCak5sLee6WYHicFUsyfH8h0qIhB+L1x6sMzgZng7P9
-        TmdDRkdGh2sCekFQEBSR0OvUz5HhHnBLI0cf/t8d0IsjBHpx0aAX/Zv7OU6cTX0400bjwSa5VQKF
-        FdtLfSTp23Y+XZXaqyI/bitjYeuOegO3WtDzTLCvYscv+AmiJKk1JzdKYvEE1oQ9hcRga7A12BrW
-        hCHNI80TbJnAYxAUBPUb8NipnyPDPwKPHV7snh2/eELwGB8NjzExrwnLFKQJxxe2VrDcZtmMVAtZ
-        rZor+ny7VM4bbMdnLCEzLpRYc1ST1/1drqKXeOAu+ANyIak1JzcXYuUE1oQ9i8rgbHA2OBvWhCGj
-        I6OT7ZqAXhAUBPU71oQduzoywkOglyRyd0AvgRDoJUSDXmzM0Et10u1qrsyzwySXWY9H+nBd3sy7
-        XS5Uw7RXzSue39gwFiNsw3nFHIn8apqYYpv7D39gb/AHnonJH/hb/EGO0R+4W/2BjxYN5UjREDW/
-        VvMYoiH3y2go3B8N+RuOGkPHtBiCvWUxhBBjLmR+dy5kYiVekBhsjayaw9Zga8BdSOewzJstE7gL
-        goKgHiqoa10dxUfgLlZk79nmXiQEd4nRcBcX975f7dIinVslxYXSVXfVRlhyqmG9rI/sVaU0G00k
-        ebRiu5Q7rtSqw1KpM09MxhVscw9/QC4ktebIhciFwF2wtSerOWwNtgbchXQOywTugqAgKDIEda2r
-        o/wI3MVzwj07fsmE4C45Gu4S4r6lsVEp+KnRPtineo1Fflag93prVEvbnWJ52/bKA1/vSWpd2ivJ
-        5rir96tZazoB7sLqT9z4Q2rNyb3x59dHDVvd4H7GP0BisDXYGmwNO3ghnePeK4ItE7gLgoKgHiqo
-        K10dWeoRuEtg2Tt28GIpMnAXS0XDXWLMuKsmGuupu89QzVbWHYh5VaC2UsZZMws9W6mX0psuJ3O1
-        1a6y7+byIsWHO03BhvXA4VgGQWzNsQwCyyCwugu29mQ1h63B1oC7kM5hmVjdBUFBUGQI6ko/R5b2
-        g/hxl0jLd+zdxdKE4C46Gu6SfnM/R98ZTDq2upLHTMFNN6j0umsPE8NKf0Illm5O2hW2Y5ebhGkv
-        aC9MZTFxnHawBR4DPseyCUJr/m9ZNiHfnyOFW3Ik/+uj9mnO31w2cdM37+dZcRy1aDnyvd5YDUaA
-        xGBrsDXY2m+zNaR5pHlYJlaDQVAQFJGrwU79HI90rBQ6Rrx4TKL42/f6Eigi8NjhfxHxmBzzajC/
-        KNfUUsaqFdR6YdPLO1uz19yZ20FmNxD6a6HVZxVzXu+k5Pl2WleH3KIjtrG1PfwBuZDUmuMuIdwl
-        BNwFW3uymsPWYGvAXUjnsEzgLggKgiJDUNc6OTr6I3CXzDB34C6GENzFRMNdybhxV3czykzZet2d
-        5UWu00lO2zpXHpUSfNvfzrWFOVg03DDJrKjdZKSkV0M2m+kDd8EfkAtJrTlyIXIhcBds7clqDluD
-        rQF3IZ3DMoG7ICgIigxBXenkyHqPwF2yKN2+tb1AsYTgLjYa7krFjLtafkaoCPX0puc26s3efDfp
-        WXXfS5Tm7VV9vayp6wTXUbiRyk+3W0qfSnqK6uJmRvgDciGpNUcuRC4E7oKtPVnNYWuwNeAupHNY
-        JnAXBAVBkSGoK50c+WAaP+7iaZ6+fa8vgeIJwV18NNyViRl3bTRNV9LtdWWWDPopd7cw9lRYpYb5
-        0qLTm/Xs4TrZ9EuZpe016yG7FAfZ1XwO3AV/QC4ktebIhciFwF2wtSerOWwNtgbchXQOywTugqAg
-        KDIEdaWTo/AQ3MWw4j17dwmE4C4hGu7Kxoy7RMFO2s1QTgzyXXPUVoY9qtyqZ6zcnpVW+VCoFCxX
-        n6ykeludLfN0217S2TJuZoQ/IBeSWnPkQuRC4C7Y2pPVHLYGWwPuQjqHZQJ3QVAQFBmCutLJUXwI
-        7mIZ7p69u0RCcJcYDXflfnMnR2s2MM3VwNTHS32RkfOBk81xdNMvSPneMsUmk5tSwUuMsrVhXxD0
-        xr4+KZgLrAaDnyBHklpz5EjkSOAx2NqT1Ry2BlsDHkOah2UCj0FQEBQZgrrSyVF6CB7jaOqevb4k
-        QvCYFA2P5WNeDZbo1zPdqVbQ0jlTKC2nVG9hNwLdY7i51QqGfjigqXxaKO6WtXow14p8dZTS98Bd
-        8AfkQkJrjlyIXAjcBVt7sprD1mBrwF1I57BM4C4ICoIiQ1BXOjnKj8FdskjdgbtkQnCXHA13FWLG
-        XaVRpduu9mblRLmeCWf7TT0pZrVsKcMvrbKXXk+pfiZP2+1ccbeajsSsMq97PlZ3wR+QC0mtOXIh
-        ciFwF2ztyWoOW4OtAXchncMygbsgKAiKDEFd6eRIUw/hXbzE3rG3PU2RwbtoKhrvKsbMu6rDzMbZ
-        7y0tUy+PgkW7XqYSQyE7n2WnOZOShD4VBn1VWal9tRp4w162QHn5HXgXDALBkNCaIxgiGIJ3wdae
-        rOawNdgaeBfiOSwTvAuCgqDIENSVVo408xDeJfLCHbt90QwhvIuJxrvKMfOuvqkYfseuGkMmu9tl
-        siIrb3r+iA5EU0sVW3s+4Xb42ZgzZ9Vqa7aVDHGs5bG+68Mg2BsMgmdiMgj+FoOQYzQI7laD4KMF
-        QzlSMETNr9U8hmDI/TIYCvcHQ/6Go8bQMQVD9pZgKMQYDJlbjxr3oGDIxMq7IDHYGlk1h63B1sC7
-        EM9hmTdbJngXBAVBPVRQV3o50uxDeJfEMXds30WzhPAuNhrvqsTMuzbdUjqzrSU7a8Ga7nSv6tqc
-        LsjjToNrDdMszy+DVX3iFdy8QOWNWj+99ZMMtu+CQSAYklpzBEMEQ/Au2NqT1Ry2BlsD70I8h2WC
-        d0FQEBQZgrrSzJHmHsK7ZEa+Y/8umiOEd3HReFf1N3dzXLCzga4xw3xQ4x2jkej6pe1gwbnVTt9P
-        m74zlgqzeXJaCie1UodyCkt13srg/kcYCoIkqTVHkESQBB+DrT1ZzWFrsDXwMcR5WCb4GAQFQZEh
-        qCvdHGn+EXxMoGj+nv2+eEL4GB+Nj9ViXg+W6Y2X+41WWLJZzanb4taaTJdtebOX2HQtmxl6LT5M
-        iZ3FXkmrEs+0jd5gXMZ6MBgEgiGpNUcwRDAE74KtPVnNYWuwNfAuxHNYJngXBAVBkSGoK+0caeEh
-        vIumaOkO3iUQwruEaLyrHjPv6u3p9kagO7y+YhvGMMX5S708YOjZwNDTC8qfhK15vtdfUUOpXMpR
-        azaf3TlY3wWDQDAkteYIhgiG4F2wtSerOWwNtgbehXgOywTvgqAgKDIEda2fo/gY3iVJ9+xvLxLC
-        u8RovKsRM+9qraVWYrP0zOx0vZ9nBqVJJVGdSe3Uel1WkgWqkJAbEkvVJgl/m6aW/tRkJo0NeNe7
-        QaABxskg0PiMmJqj8dmNR+35G5+hnyNs7VlqDluDrYF3IZ7DMm+2TPAuCAqCeqigrvVzlB/Cu1iB
-        vme/L5kQ3iVH412tmHlXY8TWGolypxLqbUtw+72lo5mdDl2ecRvRbKRogxPH0yJjzWfFzaKiNArS
-        qIx+jgDiWAhBas2xEAILIbC+C7b2ZDWHrcHWwLsQz2GZWN8FQUFQZAjqSj9HhnoI7+I48Y79uxiK
-        DN7FUNF4Vztm3jUQG9NRp1i2fEos7GWluNN2w+5Y3ZYajbYzHWZ6diIQG75AF3pZi5kyHZ0a4n5G
-        GASCIak1RzBEMATvgq09Wc1ha7A18C7Ec1gmeBcEBUGRIagr/RwZ2g8ewLt4lr1j/y6GJoR30dF4
-        V+c393Oc9YLJIliGGi+HTnpLtYdmwrH8lbk0Emvf9Kx0Rm1VsmtlMe23GXuSC1PKBvvbw1AQJEmt
-        OYIkgiT4GGztyWoOW4OtgY8hzsMywccgKAiKDEFd6efIMI7+AD4mMNQd+30d9yUggo8x0fhYN+b1
-        YHVhlWjv8m1T45bZIJHVlsWdkcptgwyV5fZ1NZdPLUW6sZhTKtem/W6+b1by4F0wCARDUmuOYIhg
-        CN4FW3uymsPWYGvgXYjnsEzwLggKgiJDUFf6OTKs9wjeJVKCcAfvYgnhXWw03tWLmXe109VFqrLq
-        W+G0OsqP2b6YajHpJJXISeXkmvbDuWabWYmjmCSb9zSrQXnlDva3h0EgGJJacwRDBEPwLtjak9Uc
-        tgZbA+9CPIdlgndBUBAUGYK60s+R4R6y35d4oR438i6OEN7FReNd/Zh5V19cJbJhscxJ6XV97UtB
-        fVxt+ktJqaqazg/3ZiJsjYXEZGTMp4bYLXdYTexhv68Pg0ADjJNBoPEZMTVH47Mbj9rzNz5DP0fY
-        2rPUHLYGWwPvQjyHZd5smeBdEBQE9VBBXennyAgP4V2ywN+z35dACO8SovGuYcy8K8ePq66dK0+n
-        +0orVdOkjjWZsb637wjZ7FCppkr+cDdZaMW5Rc1nhd124vVwPyOAOBZCEFtzLITAQgis74KtPVnN
-        YWuwNfAuxHNYJtZ3QVAQFBmCutbPUXwE7xIpnrln/y6REN4lRuNdo5h5V2IwE/yWxEy4SrJQFpR2
-        Ye7qs1q21WTN3FbfTPvtZrXUrnB5exUybK1nBM1gC94Fg0AwJLTmCIYIhuBdsLUnqzlsDbYG3oV4
-        DssE74KgICgyBHWtn6P0EN5Fs9I9+3dJhPAuKRLvoqnf3M+xIbsbZzOxq5lZ3mTS++xqxi/XGjdM
-        rNj0PBtWKibLpfTyTkoxdLJdaFXTnoP7H2EoCJKk1hxBEkESfAy29mQ1h63B1sDHEOdhmeBjEBQE
-        RYagrvVzlB/CxxiGv2e/L5kQPiZH42N0zOvBtowr24OqOaoMhotGd1vvaopSLpt0qb+vZCtTke5W
-        tnOxyEt2m6a5VFLoyNjfHgaBYEhszREMEQzBu2BrT1Zz2BpsDbwL8RyWCd4FQUFQZAjqSj9HlnoI
-        72Jpmrudd7EUGbyLpaLxLiZm3jVlRrM618lRlf3CFHwzqaTkbTvpuRRjacrOKvZm00bBX1R2nBfY
-        Db6wTgUJ3P8Ig0AwJLXm/45gyLzHkNuDoXhLMJR/fdQY/oajxt1w1BjmlqNGyzcdNfaxwVD+ZTBk
-        wbtga09cc9gabA28C/EclgneBUFBUGQI6ko/R9oPXkqhvYsZd8ni7dvbixRNAu4SExQdDXexMeMu
-        e9HotlrWZqwkByw36AY1xxRMJicmZqwrCuV6QWgpm5YyKXSXgtNqZ+dsq4LlXR/+gP4XJ39A3zNi
-        ak5u3zOeu6Xx2XFWDCshqI8XurIU4re0PnvUUgh0dISzPXPN4WxwNkAvZHS4Jpo6QlAQFDGCutLU
-        kfX0B0AvXqRu3/NLpFhCoBcbDXrxMUOvAeUuXDYReItWwrXESVDRwlEh2QrpTLJEN9eePGvx1fnE
-        morZZqacXc031BZ7eAGKYzEEqTXHzT+4+QdrvGBrT1Zz2BpsDbgL6RyWiTVeEBQERYagrvR05E63
-        NMaNuwRevH0LL5HiCMFdXDTcJcSMu4rpkm1O69Ua283stP5qpW38mtoWChWmpzP0bNFdSju1JTpF
-        mykzPCPsRkICa7zgD8iFpNYcuRC5ELgLtvZkNYetwdaAu5DOYZnAXRAUBEWGoK60dOQfgrtEjr19
-        By+R4gnBXXw03CX+5o6O2qyda/fHjXyp2thu9qOiNRushglvuRdCZp3ZsJyg7pV9IaUu1emyoHO0
-        TllYDQY/QY4ktebIkciRwGOwtSerOWwNtgY8hjQPywQeg6AgKDIEdaWjo/AQPCYx8j07fgmE4DEh
-        Gh6TYl4NNhrM9qVBLjFOrXr+Pq/YzT3VCBhRSO1T/lJuz9dtxhqNlEmqbs0600ngG2kFG9zDH5AL
-        Sa05ciFyIXAXbO3Jag5bg60BdyGdwzKBuyAoCIoMQV1p6Cg+BHfJtMDcgbtEQnCXGA13yTHjLm9P
-        W2Glse+si0I6te9uujNO363mqS0/UGRJaYjVbSHXrtpLoU1TQz9YrjY2cBf8AbmQ1JojFyIXAnfB
-        1p6s5rA12BpwF9I5LBO4C4KCoMgQ1JV+jtIjcJdEUcw9W9tLhOAuKRruSsaMu9jJQEglGrLeGWa9
-        xHhcLTADeZOjk9PiqMLIVtdVS6w56Cyn/Zxeq7qNpV1bA3d9+ANaX5z8AV3PiKk5up5dPgO6nv0t
-        4gWVwdnIqjmcDc4G6IWMDtdEP0cICoIiRlBX+jnS1EOoFy3yd2z5RVNkUC+aika90jFTr0y9VG1N
-        ih2xPUk7M0t3EpxvlwwhO2FqymKR5fRepWFUi+xM9z2lx264wdrZg3qBimM1BKE1x2oIrIbAIi/Y
-        2pPVHLYGWwPvQjyHZWKRFwQFQZEhqCsNHWn6IbyLEeg79vCiaUJ4Fx2Nd2Vi5l0zK+M4Q3W/0/pN
-        pmVzBVYNK3UvUe6VvHxzWxGHw0mmm1zrQVhUaiOpllE1Gh0dYRAIhqTWHMEQwRC8C7b2ZDWHrcHW
-        wLsQz2GZ4F0QFARFhqCudHSkmYfwLpaT7tjEi2YI4V1MNN6V/c0tHblZOVPnmzstJXBSUKvuWJVO
-        mco8dNILf1xiuuZitE7zvTnt7FpDeVq20sk91oPBUBAkSa05giSCJPgYbO3Jag5bg62BjyHOwzLB
-        xyAoCIoMQV1p6UizD+FjHMvdsesXzRLCx9hofCwX83qwsLrz8/V1azxwB5W6VjIrpcVAmg/znSHv
-        JPTqTOxUVdZap8zNxGovDidKKbnCrl8wCARDUmuOYIhgCN4FW3uymsPWYGvgXYjnsEzwLggKgiJD
-        UFd6OtLcQ3gXz9DUHbyLI4R3cdF4Vz5m3jXUtOJosR+vc5UF0y3SbdOUNjm+Xe73+lXebBXV5LLH
-        trYjSpbkeYVPm47igXfBIBAMSa05giGCIXgXbO3Jag5bg62BdyGewzLBuyAoCIoMQV1p6kjzD+Fd
-        AiXes789Twjv4qPxrkLc+33l2ovAq3TrbYVfWaOMtt43llp+sRc7o+Gw1trsm6muUJ30U4OkV8xa
-        pljM98C7PgwCDTBOBoHeZ8TUHL3PLp8Bvc/+FvKCyuBsZNUczgZnA/VCSIdroqsjBAVBESOoa10d
-        xYdQL1Gi7tn1SySEeonRqFcpZurFat2hVl9nU7nNfpYIKsld3xY6s4FD7Y1td1sShFGtY6Qm7K6s
-        l8psXxdzTQPUC1gcyyFIrTmWQ2A5BFZ5wdaerOawNdgaeBfiOSwTq7wgKAiKDEFd6+ooPYR3SYJw
-        zy5eEiG8S4rGu8ox865WcrlXBzkqN9z3C2a9M2uYycNZoCy01ohaB0zoL3f+TqtRVCal+PPiTB0J
-        S+xaD4NAMCS15giGCIbgXbC1J6s5bA22Bt6FeA7LBO+CoCAoMgR1rauj/BDeJfPsPbt4yYTwLjka
-        76r85q6OyTwvB/ViZRHQlV0ntZ7o9ppnzG2+kqh6ZcrvufrQtKRRo6eUR351sG2t5mPwMRgKgiSp
-        NUeQRJAEH4OtPVnNYWuwNfAxxHlYJvgYBAVBkSGoK10dGeoRfEymWPmOXb8Yigw+xlDR+Fg15vVg
-        88pk1fdqQ2u1llfZ2jgr1WV12TezhW0tLW5KmWyBKneXZoGeamurJe2WglkF74JBIBiSWnMEQwRD
-        8C7Y2pPVHLYGWwPvQjyHZYJ3QVAQFBmCutLVkaH94AG8i2Z46Q7eRRPCu+hovKsWM+/K1PTtqF9s
-        7cZpocqud11uu0iM2Vm3P3ITRUNUJpX1pKbL2W51oyRrXorf2tsNeBcMAsGQ0JojGCIYgnfB1p6s
-        5rA12Bp4F+I5LBO8C4KCoMgQ1JWujgzj6A/gXQzN3LG/PcMQwruYaLyrHjPvapbt6XiSnxs7e+bm
-        +51w27IVa1EbdAt8trHv2FzPNa1pa7ys+41Zys/nWnsG+9t/GAQaYJwMAr3PiKk5ep9dPgN6n/0t
-        5AWVwdnIqjmcDc4G6oWQDtdEV0cICoIiRlBXujoy3EPuamQl/o5dv47fy0RQLy4a9WrGTL1qIutY
-        qeGiUj0cNLebyGfpZHG+XLQkp1zql8fZETXKbux90N9sMiWqNvT3/BbUC1gcyyFIrTmWQ2A5BFZ5
-        wdaerOawNdgaeBfiOSwTq7wgKAiKDEFd6erI8A/hXZxI37OLF08I7+Kj8a5WzLzL9DKJoZUfBWyo
-        pYS2kTHCsOaFo3CQ3ixW3UZn54+T9e6KbtRmSba3Lu/7ozTuaoRBIBiSWnMEQwRD8C7Y2pPVHLYG
-        WwPvQjyHZYJ3QVAQFBmCutLVkREewrt4XrxnFy+BEN4lRONd7d/c1XG94BrcpqJ6s2XdzNb7+6ox
-        6LK5YbZoNQfyqJFpUEZ2Ps02pJ3ItlJNe7lsbMDHYCgIkqTWHEESQRJ8DLb2ZDWHrcHWwMcQ52GZ
-        4GMQFARFhqCudXUUH8LHBI67Z9cvkRA+JkbjY52Y14MNqlsp5C0zMXPaC6/PVTmKHfO5fLq+7iU3
-        dn7aE1qcuyjry+puuNwXW6OyEuD+RxgEgiGpNUcwRDAE74KtPVnNYWuwNfAuxHNYJngXBAVBkSGo
-        a10dpYfwLpGlhDt4l0QI75Ki8a5uzLwrt6cSq/3KszfpkjPz0m2V0g3Gn1QX8l5em2E1X2R7+6Bo
-        bZplM6kozLic3e3Au2AQCIaE1hzBEMEQvAu29mQ1h63B1sC7EM9hmeBdEBQERYagrnV1lB/CuyRa
-        vGd/e5kQ3iVH4129mHnXeLUsj8Ml77UKSadrLXcr1VEaZt+oiJlS0awapa46VTxfYtLFtJbccuK6
-        PNyDd70bBBpgnAwCvc+IqTl6n10+A3qf/S3kBZXB2ciqOZwNzgbqhZAO10RXRwgKgiJGUFe6OrK0
-        HzyAesmSfMeuXyxNBvVi6WjUaxAz9UpUi8OStCuKqVVrxU/nRl8ceUm1oHgVcyysm5tdK5dgebY7
-        SVFbqzJMd+amj128gMWxHILUmv87lkMw7xffb8+G4i3LIeRfHzWGv+GocTccNYa55ajR8k1HjX1s
-        MJR/GQzZWJEXJAZbI6vmsDXYGngX4jksE6u8ICgIigxBXenqeMRdydAMD/+JEXiJFCUKt2/jJVFE
-        AC8pQUUEXsOYgdewV09UxXpjNZoqiQwz0xPrhF0LB9lhpSrrbZ2udH05Vc9rzW3Ocdig22gMXNzW
-        CIdAMiS15rj/B/f/AHjB1p6s5rA12BqAF/I5LBPAC4KCoMgQ1LW2jo7+EOBFC8zt+3hJFEMI8GKi
-        Aa/Rb+7rmPIKzcw4ue/2ufosXEl0nalv2ZKwVxpZodmreHZW2KdaTitTHkw5em7znqQAkMFRkCRJ
-        rTmSJJIkABls7clqDluDrQGQIc/DMgHIICgIigxBXenryHqPAWQMJ9++8ZdEsYQAMjYSIDvyoVhX
-        hG31Qm44KKtaIVVVh2wuW1xMBaW8KJqSIKw71WSpa1Y73d6Ebhcnky4TOoE4wcZfcAgkQ1JrjmSI
-        ZAjgBVt7sprD1mBrAF7I57BMAC8ICoIiQ1BXGjtywfQhwItlee4O4MURAry4aMCLjhl4BatZjUrI
-        zZKeMvfZWrCnB44iDtJ9X614Sa9Zq3XzXcbb1YqVQqq44PjeusIBeMEhkAxJrTmSIZIhgBds7clq
-        DluDrQF4IZ/DMgG8ICgIigxBXensyD8IeHEMffsm9xLFEwK8+GjAi4kZeAmenVKFZkNMcdlyZpNh
-        dFZkR+PBzGkl+cl20m/mc0WHNnWtp5a6E30hbCfyFsALDoFkSGjNkQyRDAG8YGtPVnPYGmwNwAv5
-        HJYJ4AVBQVBkCOpKU0fxQcCLl7l79vwSCQFeYjTgxcUMvGoqQ7WkhM1vHc1p+3p2msklZbpoVhmr
-        nOw0Bvai2m/5utvssu46OzbK7UUFe3jBIZAMSa05kiGSIYAXbO3Jag5bg60BeCGfwzIBvCAoCIoM
-        QV3p6ig9CHgJEn3PHl4SIcBLiga8+LiBF7PIl/ez7SDcZTMrZs3JZVMSatOOspgtKp3pstBOddNV
-        2uWzbKlXkzdjZ8LjlkY4BJIhqTVHMkQyBPCCrT1ZzWFrsDUAL+RzWCaAFwQFQZEhqCtdHeUHAS9R
-        EO/Zw0smBHjJ0YCX8Ju7OiYGqa05rbsje9zP+DMjLaTc+rxfq/O96cwf7sJmrVhrjrquWFqmJk3G
-        plpV7PkFR0GSJLbmSJJIkgBksLUnqzlsDbYGQIY8D8sEIIOgICgyBHWlqyNNPYiQSTx7x6ZfNEUG
-        IaOpaIRMjHlJWDg0AzXdEY3uZrvZtmzOq2dNx9LcIp/khUyd1YfjsifPF9MKm252TcVgh53Nn0m8
-        vmu7QNMPOiNljmLuOCNpQs5IOtoZKcV8RsrD7t6o2cGALyd3WkK3wznvh/1SfjlqKgyj0/O52yy1
-        9wMqqISthcbNB5XUH7oN3Xf7ItLMY85ImmKEO+4Tp5lHnZGnx+84JZlop6Qc8ylZn9Cd0pzOqFSx
-        WfQ7TLGwnbR77YyhzPOVarWjD7jpauX4XVqp7jiPKg5EWvpDbxT/tHOBGhxOSfZBpyRNs3es5KYf
-        1o353lMyYjvmZNzf215LqXemzZwetAeZYSGV2tvZajLXHwwHYq7bac7F/mqglRrVem3obTP11qrB
-        /aHf27hSBaT7P6DmQLpAurhSBVt7sprD1mBruFIFsA7LxJUqCAqCIkNQVzbrpB/Uj5mmZfmOtdw0
-        If2Y6Yj9mFMxE69kfVSR5HyRb+rbVTqfWpfKLUXbbW1hs0r3UwOxMix4zbQxYsueEQRbZTCUUn88
-        hD3tpkE/qGESzUj8PddOCWmYREdsmJSO+YzsrLZyTxB7g8Ss1dFKrTVb9NM0V05V2s3GPhEszG6o
-        OC1/GBTDWs+cVIZKdvyH3i3w3e0utPCgM5IVmXuunQqEnJFCtDMy85vvd9lnhazc7aRnkwJd3c1G
-        wXK37QmVieunuFmTnTQS7W6hL+qDgbSTOtviOuxq4z/eU8/rUR60JzfN8dI911oJ2ZObjrgndzZm
-        T/VS9US9Xhw0u7rOUftxUZ6sOxVpuGnJQ0rvL+wGnS5LPhvmfW66TlQ0o5P/U69rfb8e5UGbZtE8
-        x99zqZWQTbPoiJtm5WI+IzMMv/HbbWNkl3k63fK1MJvsGKmWl1uoNXZPidvkolrvuROVH1edTdtg
-        V3Tnz/mW/xIewYJyeg+25QeXo32ImJ6hXt5j/xAt3386P3D6Xdm14e02U8MzLhPO72BsmeHyjNnP
-        cfvzwKt2DPSnV7IPJ6HrJML5IY69D54fP71Q5fT45cHzS2u2evwIp/+c5wfTw3l2fAOfxi6PX6T1
-        zePnlzkc/YV6JJynl3tbAvBp6PVw9h5ypjI3dm+/4cvrl0+Dr4fz5TL17ZnvI9+83se8n7zk3NL9
-        n7/s+YNcHv9m7GPKeeGQurDs3adJ50/45eP3fnkrGq4k4UrSn1zzf8uVpPcrG7dfSeJuOGqfrhL9
-        vStJ1C1XkrhbjtqNV5KoW48a86ArSRQukMPWnrjmsDXYGi6Q43oeLBMXyCEoCIoMQX1WkeaGTuBd
-        TpgTrvk88P7wiTx0nSPceykfXld3Fx9TL/zGswJLUzxjbRkb5fJOLqfcTx86I8rz4TYc/Q+CpnHR
-        zS8/rcD5Zz9QveCHmjD0oRjJw+G04yyJQDMCe/v6BY758b7GayXhEszNNyB++bEEZyh9Oh9r3U66
-        lUyXs603Vn0+Tc//Pl9VV4NgamxeUm7oOcZ/+C+1w8fxVG1ueP/77Unnev0V+j7/yz6c5e4Hgvw8
-        eJlxeHtB6H+1rfX745ehtwnv3Pn885EDf/WtxdI2Dp/28I6Ct+edHrnMCpe+cXCXT8D2/B6zP77H
-        v3rvx/Fy9/P4l5+8tmm4x+qrX19t9fBNEx4KydP/OrjI+4+vtuuY538mqH8d1wh8DLx++Xj+8cLA
-        4Vv6CJr906WAbwaOFPXob5/uyLr8eIo6PyLxH0ZPf17/ZN73o6+OYeiHo7s8nDfh4TvleC6d3s/P
-        xi+TQ089fr9+mvY2cp7wmaif3v4Po6/Hb7szTU/TrReuUzsY8dvQGxrWDyU/zlbmi3M8+Mn4qz91
-        N2dcf/o4p1/33dirfzivtcvlBGN7OHUOsf74cp+G3+acbePw+Et75wfG4mVkeO771LMIDqdFeHla
-        O5mpZFvtfrZSaR/+IPl44DLpcuegbhveQVb9w4nkv027gOnL5YXzufbkf5/91YfUXNs2tOB8jexw
-        dLbBx9jpp7KxewmmnnG8bvF5/MdZrnN9Tmdq+S+H//nuwng5/A1mOS/H8e+f8+Vnb+nss6eLR5e3
-        fvh69kM7+Pr/AdSCuXFgdwcA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['14154']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:27 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/ValidEventTests.test_performances_one_week.yaml
+++ b/tests/interface_objects/cassettes/ValidEventTests.test_performances_one_week.yaml
@@ -1,182 +1,148 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3Jl
+      cXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNjYXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBs
+      ZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVl
+      c3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9mb3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1
+      ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJx
+      dWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVxdWVzdF9tZWRpYT48cHV6emxlZD55ZXM8
+      L3B1enpsZWQ+PHJlcXVlc3RfY3VzdG9tX2ZpZWxkcyAvPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48
+      dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZXZlbnRfc2VhcmNoPg==
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['607']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+1a3XLbNha+36fQ5KK96MoE/8mUZSdynLaJ7aaWstn2hgMCoMWYBBkCtKW+zr7J
+        PlkPQVKkZO1aSuqdbNIMMxY/fDw4OPgAHgIIvl/l2eSWVSIt+HdP9BP0ZMI4KWjKr7978mbxYuo9
+        +T78W8BuGZeRYLgiy6hios5kGIg6pkWOUx7VglVRKqIY05AXgba/JCDVupRFFGcFuQlJNJ0601i8
+        e/vzu+zqumJT8Tx+eeX/PCOJt3zlrN7PL5Mf5OX89ex17OgZWj9L4/LF4lrO4vfxr8TxTmv7fPYa
+        L9/MX1/50an45z9+W4nfxbx+7iyM0jJ4XMZXdy9/mb08e/nb6gdrfXqzXBo4TfzMpHayjpcX9i/2
+        xWWGypk1/TXQtvwLaCok5oSJCFcsusVZ2jZuH94GKAwAwRGEj4VnbwNtuGsLKBMkPINor++WrGId
+        QaEBSeW65WYFpwWf1jfg0AZsyxX1XJV3hd3DGRai+9PycSUFUAagK1T8Z1A4+Qrn5beTU+jJunFl
+        VBxAf6nOa82uGVjahoJOCTdsrWrSoMsHpBFGx+sf2yBbxgberj3aBHi/0bY5PWELHDiqHTOcZUx2
+        DX2+80DbUm1wQeuDWAgZVZhfg70cr8ByHqec0dA2TlCgbUGKAE7KskoJCy23ZwxYS6mhGbgCk/aG
+        sYGCvIlrb9LQFWMMKcJgUfd6xrgWFc7epLlhDLXwIhIwqjPWBOvzbOL7GnPZjIqilDCfQWeq0Rn1
+        eKgH2g6yyzAeZJgPMqwHGfaDDOc+Q7vfPNWHEamrCiZtoPS/2uFwHZeg6i1oYCSYyKIKdYRGnA4c
+        WLzOY1aFnuGMWB04sMoMw3TYxG4XGnEazYl1HheZNoZhCm3R8N//Gj8/4IG220ztP2j5r/7/Qvp/
+        3OmkqLmsuvapl+YY2BSr+f4NTyWjk1egHchPBmr3Fq1SmRJIb25TdheVrCLNO72N0N6igGLJWj8i
+        xml3r4wtlvXfJ7qQkzkrJWviNTGQDlEcKC27liQqkkQwGZpOU9UuOtAEI/DqF6FuuYZrW9vsvrCl
+        r+FfnlOYa6FS5CO9Y25weDMXnoP0SMGY00imOVP0KfKnSF/o/lMTPUXoG6Q/bWra/0BndzcG7T3k
+        SZW8FxVbLicXeP1nxsMxLNdEB8fDRvZR8bDh+pB4dO1vk2clx8s3i9OrZ6evzq4CbQR3FBWGCyzl
+        kt1NZkVdcfa1mFxCcypMbkBCi7P5on+wjVn7GzJQ56cXfckmH40yEHoRgjksmxxvDHaMnNEUg/Sx
+        mlJgZC5haIVUv1tZd6ZdxzlNVyckK2qaVAWXJ5zJQFOcIOUQY8gdm7d4CYkWxL3KwqWUpXiqaf/V
+        hCbgjc2oNvIBhlhRwsDSfBMugqw4QdSwWGJSZDMvYYkVY9dFPk2QZVoM6yY5eVdeQ0fs9SPgGLoj
+        g44R0DhovLoPSiyX4Z9avbIYfBqh2BsIUZdlAUl11PjTfZ6NkW1Cl6LvYIG2JZdPVTsugwtZHnFs
+        O3F9qmOGdEv3iW9YBvIcnSa67cSemRygnRxX72t2uHKOrvwRlXO0L5+Bcj4iXpFiaoYPl2sx23N9
+        F8Og83XXNmLXpNj0EWZO4iXYYZbnGA/Lp/lygZm2yYT4oRr6UD8eT0kf6tEBerqvlk9MUB81Am0G
+        F0JWYtixjXHsJJZpEOoyxzP9GCZvy6AethPdjQ/QEqT+1eEz0dF1P+JMdLQvX+hMxFYykkxIpH0j
+        1gI+GaIBaRqSpaw6QCgd80GpHF7dI2jj8Mq/+Gkk8eHCGDI+yAMt1yUmMqnrxcTWkUsIgu9AmniW
+        g4n3sDpklTZQlKS3h08mR3vwiJPJ0b58BpPJJygf+DL9Sz7/J/L5+NwPMbgM26ZW4jsxRUaMsRsn
+        1DDgP8Gxj4iXOIRR0zpcQwU/eAb6UDcePSk+2qPP4W328WEjAGCDWrbnY8+3PGTrFnxRQGZIGPGw
+        7xmObRgeQr55uJ7kXXGkno5249H1dLRH/2M9tYF1fnoxzds1ymms1iinYso3a5TTJo3T+ufbmHWn
+        BySWtQgzlXxsQT2hjimWWOvvZXHD+HhhswX60nUJ+W7aND2SKVQtN7SmpGPVpWBZFmWpkFuLpWf3
+        F0vh18WPaIxre2xcs6JZ8oWgZPB9L2vKQls/sQ3f0XXTDbQNGmQFv25/TtGJjhyk244BhA0caIOx
+        JRYRL5qdhUSod8oW0OyjN+sJjG420Ltbtfda1Zw3Sw1qBVo3uu3XLVTtnu7h7aIBZ4xGlJW4as4F
+        qNVt5c8+vCPXFW4mmBGtR1pC04aiypsN+Nb9e2jQ7A61xyZO9auJtbiE4dZD/eGA/txFdJOHqNn9
+        3YMHYlmo/ZmkbU6r7W0sEKBawtqV982HB9BGcM9pT2ysJKs4ziYLIE5mjcw5nQxPtCvx6qTLvr2j
+        fQUBCKvu6po/e35+djV/e3Z+Pg+0UUFHUubnmGas+lpM3oIURU/rDjF0h0/6QbV1SucPx79m++Ij
+        AAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:29 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['1883']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:36 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_cost_range
-      /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block></event_search>'
+    body: !!binary |
+      PGRhdGVfdGltZV9vcHRpb25zPjxjcnlwdG9fYmxvY2s+Y18tLTYtYnNqV09qbFJncmUtc0RiSlI5
+      T0JjZjhoSzZ4cVNOZkd0TlNQQlBiNjFsMHlBaWJwRlRndEJicWJZYzY4Q3U1TEJQYWhVU1BSOV9D
+      c1hWWnhzenNTdUQ2VDJwNDJuYnBiUndKUUJKRUpaeEc0eUNraGgyYWlmOWwzZDVmeWJoTTVRNU1O
+      bDBwQjQtWTwvY3J5cHRvX2Jsb2NrPjxwdXp6bGVkPnllczwvcHV6emxlZD48bGF0ZXN0X2RhdGU+
+      MjAxNjA1MTA8L2xhdGVzdF9kYXRlPjxyZXF1ZXN0X2Nvc3RfcmFuZ2UgLz48ZXZlbnRfdG9rZW4+
+      NklGPC9ldmVudF90b2tlbj48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjwvZGF0ZV90aW1lX29wdGlv
+      bnM+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['778']
+      Content-Length: ['345']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1a227jthZ971e489KHHlui7hqwKnImSTFIOtPmgkHOi0CRlK1Yt5BUHH/P+ZPz
-        ZYe6WZLt1HY6QdOpAwGxFhc3N/depCiK8OenJB49UsajLP3pHZio70Y0xRmJ0ulP725vzsfOu5+9
-        7yB9pKnwOUUMz3xGeRELD/IiIFmCotQvOGV+xP0AEW9JOVS2F0HMlrnI/CDO8Ny79cfjx3keuvMP
-        bn5rfg7GU5aFBIhfFvjTb3f3OsX8Xj+9A9b97/PP6t2X9PQxubmY8RM9959uH+yry/PlKTbHVwSE
-        1sVDWNx9fJienPPPV+li+YDUG2B9Nph/muiXH89+Xz6ws/sHx42Z9tvH1NVP54tpfAeVgU+QRFyg
-        FFPuI0b9RxRHxEszqGzD66h4UCLIlzGj3tkXqHR3dQGhHHtnMsTLxYwy2hAqFAbRtMhLawX1gKpC
-        pQ9AHIllbSnOUpKl42Iu3V2BdXll6LIqbwpr0zhGnDf/ar6YUSRKB3pYU15VuRmW12Zk5qo01uaq
-        3A4h2IhiTpdtC4rMfweWMmmobc0VMrDX8baYnEeEbzdbd6QpH2AdperLOUqieNkj1T1UunaVNmgZ
-        Fz5D6VTaCKj8XSXEz8KQMpnVgGdxIajP0aMcJh7QJzJz6ygMiziWfiRBlFLimVpJGmI1RfZJ5CzC
-        1DPsFacDG1Ih+42YdMjsOCsMVp51hnW3JK2BDamzrJsdq9deA6yMGz1W12JOGZbiR9NVhzUTKpuo
-        lPRGABP0tO7rAKoIdf1jzF8U880AVsiaG0OspgxdGEIwKUd92zdQM/pQQ5D5fiZtxh5ZA87urPU4
-        z2dN3SNrwNgna33WH2RN3Tdr2jNZW4teeb/uxBCrKUMHhhBMM59L8zHl/nFaO05rf+uYH6e147TW
-        NP9QoFSUq90sF/LVRS7aqjW53+IegMoass7QdjL0nQxjJ8PcybA2Gcpm96p528cFY/L9TFLaX/VS
-        dxrkcvU6gDpGiLDIWP2CsQ52rLRIApkeR7N6rAbsWHmM5EtQGbt1qMcpk82XSZDFSh+WL0416v3v
-        v/36HQ6V9W6KLPcrURynzBdNmRvxU55ZEBwH1HFAHQfUSwZUfxThrEgFawRTbdf0gVVxtfNwm0aC
-        ktGFtEuypKM2+zcsEhH2GX2M6MJvPGkkt7UIEiTTVaebpqS5b3Z2in+NgCNmo5NiWnAx0lQgRdkR
-        am4hcNkpToWnW2VD62hH4xRnKeHy6W0D0zDVAbstrOlL+ZckhHhlo6oDnIa5wmHEM8dSgV/BKCW+
-        iBJa0ceqMwbODXDf6+p7Vf1RBe/LlrZXaOyuR6C+5wIxsRETDchgnMh0xl8zJBbQLN3YOySGBg4K
-        iTHWwEtC0oSg3sqt9Pjp9ubD1cmHi7MrqPTghlKF4VckxIwuRv/OCpbSH/jok+wOQ3hO2fdtpTpe
-        9e+IeNbH87ZktUnqx1LlWbcF2QcbRkJJhKTuUTVBy3luJseVV6ETKfc5FXwRCTyb4HKwVIUwSmVg
-        CzndSSyPaRlsFnszIXL+XlG211W4HPOUKL1W5YjKcjmOFFeXF1aNIFSJZtBQJ6pJnZCGRoBsW3VJ
-        qBq6QRHQ8eQ+n8qwb3UApkgGP5Zp4LI7srvVPcyRmHlftfnKIvyLY7A1ArzI84wJ7peOVDvoQ2RI
-        4O1XgwEGlYEy3o5MbCov1XCwZZqh7RKAqAoM4GJXMzTVsQAJgWkFjh7uIZMEsYeC7i+Sgxt/DZEc
-        7MQ/TyQmlZeqGqFmBiZCgRUauoaJTS1HdwM5kAyNOMgMgR3sFgmX61e2v0YObvs1NHKwE29BIwQs
-        noyFbhZBQqKnCY6zgoQsS8UkpWK3VGSg/tDCtnjRJ+ELyoWq/MiXXNDE75CyI3FE2R4KaZg7NbJ/
-        c7tF8Yp93UMMm6n+e88YoSsvhOSDVj5+DdvGuqoT2wmwCVQbY9U2DRI6hoWws1sPgkUl5IfR4/7z
-        xsEevMa8cbATb2He+BaUIpf4R6V8i0+YJl5+xVRcU16BiwMDuU6I7MAERmAYlqG6NlIdOwwCO7AB
-        wBjtL54s3XuWeakbr/A4+pMevYln1F+uJ82Ul2qZxMUWQRq2LBvorry3bWQQw9At18LAdIl+gJ7E
-        jO3/TvRSR15dUQd79CYU9Q08y8QiOz7KvuKjjAskCu7F1WJyALWEIiBIIKW9F9mcpv2twBpoS5e5
-        fGOJStf9OkorWlnSsIqc0zj244iLwfbi2eb24nPbjiV+cdvHlS22pzQrN05lb2MkIlEQ6plgYkJl
-        dQvjLJ3WP8fqBJRFKwAqXf0Z4n6alXvyIa/iPwDKA5DlpwlKVicfm9vqlAIr0rQ821Bt3QKtOagw
-        QKsv41t46yhMKSU+oTliopRJuQ1c+bMNb8gFQ+Us0KO1SE0o+5CxpDwFW7u/gcLyQ1V9EPYDuBoZ
-        N5/kYGmh9lRne5LWnyf1l/0tOOSzrPqyEdbdqXU6xCCX61VM6y3r1VukpPXgllPv+Mvy0XX11jn6
-        D2XZilrvX0tZFE2165PTy7Or6y9nl5fXUOkVNKSqwjUiMWU/8NEXKSTe0pozpc3J4HaoDM5N/x8q
-        y80zdC0AAA==
+        H4sIAAAAAAAAA+1c23LiPBK+36dwzcXuxY5jGzCHWf/+ixCSTDgk4RCG3LiELcDgA0gyh7zOvsk+
+        2cqSjQ0hlZlUpmoSnEpV8KdPLXercX9Nomh/b1xHWEGEbd/764tyJn8RoGf6lu1N/vrS712K5S9/
+        6//QLECgQWwXGv6CUCo2EMSBQ3QNByPLd4HtGQGGyLCxMQKW7vmadHxEM9F2QXxj5PjmXBdlUSyK
+        Izwb3M6czuRuDW57s77pLPOTXj531Rcbw2Vn+GPcGjv17nxaI0+Vuum2odjMWfn7ycVyS0p3y0d5
+        Xrxs+mK1+uSjW2O8UVBOsR6uvVqh7W+n0+4m1zRmN9ZtRQmMrgzR0nTvB6vy6AEGjRsruHJKjclw
+        gWoj1V81sGNflTfBrLZVqughr+Lu4O56oUKYV8WhJu3dv+ZBaBkWXABEAgSNME7M+WO4NgXYWEA0
+        NjzgQqxvIdakA0wLMA09Rxwb0wDDFfSSHwBBYND9gXp9oEnJFR+wIDb1Ot3O7XoKEYwIDNVMm2w5
+        1/E9y/fEYE6d2YF8nFGbbDwajCY7AOPoB+dTx+jdp4BokPGrdFD4J3AX/xFqNEuC8FZSwxrNBZYY
+        3CyLwz6kYQiQOTXmcMtWkmg6JUiYdBEvnrZD9owlvEN7FvBMeNwodycm7IEJh/lxDhwHksjRi4MJ
+        3FMpuQUpDqKPiYGAN6H2XLChlt2R7UFLV3NnsibtQYxAb5IskG1CvVCKGQnGKQF1AyBqUt0xdpDm
+        hnGNTeYUxkhDjJBYVMoxI70KC2dsMr9jJKt4vhHmrgPDYH1OF5cB8Ej4roiegrq2Ao5tGTGuK5p0
+        gBwycq8y8q8yCq8y1FcZxecM6bl7bA8NM0CIVgVKiV/xt8NktKBZvQcljDEwiY90RZZTnAhMWF7g
+        jiDSy7liihWBCWvhAJM+HHMpTgSlOGHO4a078h0pDdOnL0f1//03PT/BNenQTemFXM72/0T2P73p
+        ph94BEX+saKZBnbD7Hnf92wCLaFBc4dqn4QaVVFkE9uk0mllw3VY482wpvMIHR3iuovfHfSs6JoZ
+        602Dr4KCidCFCwLDeAk5WaFRTCicHRDT8MdjDImeL4ZLHaIJDUOTln6sK4VSrqQW9tnxIKdv6Zfr
+        WvRZSxeVK7ISMXc4rcx+uSgrTPoYwLOYfGR0Ua6IstJTKt/y8jdZ/resfAtXOj4hsnsYA36NCS3m
+        z6KikqnQAtv3jEcxVyjl5Z+OhyqrvxQPlX6/JR6R/0wb8nRs93u1TrXWqHc0KQVHFBaGFiBkCtfC
+        uR8gD/4LC23qDgLmnKZQr97txRN5zPhr29KL3y/jEXoV4Q5NdF+n5gAJNV4ajBgLQKa6RCeLLl9X
+        HLF1RSx6u3VFAjGR4vlsSjSdekgCrDv2amc+gmIC7TIAAVJ8TbYLqGPbXThhw0KNk3geG4lYwQJD
+        x0krbO5i/bmL9FXrWk7j0hEbE+iHGwV0zQH0ERrQmKvKmZqrFBUlX9KkHapR9T3hL0X5TJHpDqtF
+        +mBLYE1KjIXdAa1FYTuAWV+xB4TqN9QvVN/Esje6ZIoJBZ4XNhMsb5RcJJr2UKZ5jvAO0V/rczgY
+        IBBWkRQtRjgh9MFHbiib+e0/Q7Xwmc6bnZrSEQq9tibtoFjSWzT+IduYu7ocarYjuIan/po3Vcwd
+        ttwBpmGal5TOjMMNzReak6G5FBxzeJ+1IRB5wBF6lCich4nsWUIyg79/WO977Il/bECjiRVEa3Wr
+        F816pzuoN5tdWquTgYjEzHeB5UBE38MDmoo4pkWtR9QynpxoiR3fSyUTmFOaXnFjgUNbz7CsN/u4
+        Lp5cmp+qNs96s9Pe//Smfwjl/5KEZh/9+r4TFZ/k4+AECxWeY7thU8l0VOry3RoKJoH43YlV+YZK
+        rAiIRrCxsrE9ciLZdAhyViLDuaLyqRjS56Io5itea4jt2qy6htf3dsPa1rtEhudF3FviCVpfzIh9
+        NwdgVfTKcgPPSueFfrM3Lkx+wMuJ3HaH0YrcYmSdKvnoQ/CHeHgHac/l7L6UZb/GYGlROsvLwl1L
+        kxKIj06nrovp7lf4zqcxvl6iUDONkWmMrMZ8thqTaYzT3v/jGuMS2V+F4u/QGKpaKfyCxij+IRqj
+        +DaN0XhnjTHq/7i3L6rl+mJxfVcZTOpmp1YTczc3k8ESPDV68kXT7pe9euXBKHTb407hzpnWOpnG
+        +HgFONMYWY35LDUm0xinvf/HNUY38L4K5d+hMUr5XO4XNEb5D9EY5bdpjNY7a4xgtV3ft87bQ9BE
+        V9NJ+SLfRNsbXDLOr1sPdxejYXGzrZjzrSEGl4+bm4pYfZwtM43xAQtwpjGyGvNZakymMU57/49r
+        jJZPNUbld2iMslL++b8aU+XKH6IxKm/TGO131hjy1WAljrrK2J556+mm5wyrvfwmj+7VYblWqz62
+        Vm5z2b5d9dvzhlt7yg1KxpTcZxrj4xXgTGNkNeaz1JhMY5z2/r/w9xgB/Coo8u8QGRWqHH5eZCjy
+        nyEyFPltIuP2bSIjPE6of/dMJwjPcgojYM4FTMAECguA41mM9Ioocb7Px+c/Zp2HzvJKXFw4Ysde
+        zo2nYn45d4aX/s31ZcnCj+LjejwH1VGwCZCH+h9HlEgvHbjMTlpmJy3/UGmVqcdMPXwW9ZCpx9Pe
+        /+ykZXbSMjtpmZ20zE5aZictP/pJS56tn1y6vOSk9OL/iPo/lEgdpmVKAAA=
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['1945']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:29 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['2039']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:37 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <date_time_options><request_cost_range /><latest_date>20160426</latest_date><user_id>whitelabel-testuser</user_id><event_token>6IF</event_token><crypto_block>U_--vkpf9kC9pU5Ob-grofd1tGwcNPYj3ecsj3DY16jQkO0YWnDvmTKhsA3p_xUq7RLFyDc5-Rd1f6KqfuYIqgAFsORnwyqa0T16O4r_Dm3LIEQyqrEjq89lr2PIn93DkwglY</crypto_block></date_time_options>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['365']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1dW3OiyhZ+P7+CMy/n4QyjIKBOsdllLk4So06i5vZCIbTKyMXQoOLfOf/k/LLT
-        0I3gJTuXSk452WsqVZGvP5rutXotWB9OWv1z6TrcHAXY9r0/vgjfyl845Jm+ZXvjP74M+k2+9uVP
-        7R+qZYRID20X6f4sJFSsBwhHTqipOBpavmvYnh5hFOg21oeGpcUIq6X9TaoZxLPQ14eOb041rPN8
-        fdQSwumjfXLsrEx8MqgL8lLgkTtAq3Zj0Gj3dc+5uL/S43jaQbJ5XxPmtc5j68Gq/5Lnq9ufaCGH
-        y+HSs6rC5D5uno2mD+i25Z+1T8SqsSifOJXO6UWLr3avvL4dXYQ2L3Ue4lowXvzgjxrTmR08okk0
-        MBr3N03px81q0T1tr+66yvDXkf0wk4cPamljzKqHkKVbaGYEYRQgPTGO5vlqaR+uTgysz1Aw0j3D
-        RZhaZgtTI0zsTRHHxsSqaI68/JcRIEMnTkHa6a1ayo9og4WwqZ0SH8aLCQoQI6SoOrTH0UyfG06E
-        NKFcVktFQDXtMKY9Ob5n+R4fTclU1yBtTzu6TNtZI+3adAyM2S/KDyfICJMBFDDWnp7S32yn3ZBV
-        kS4R2l1qnU1IxcgIzIk+RXF2hRJZWzmYLEFGzc5cIxv95bw9XU5tC+/vlk6EtW9gOSWdS9NwbScu
-        kOgMS/l1S5nRfBzqgeGNSR9DRD6nDtH90QgFxKtD7DsRCThszMm60ITKN+K5bVQdRY5DxuEObQ9Z
-        miwmpE2MUsicwllgm0iTqmtODjJSROZtBGRAcs5ZY2o6srzjSj0hbYGMlPdckXNW4XoMWHcuFVj5
-        FUkwmGTxG+P1hEVZLe2iZEnvGNA1lttj3YBSAj0fbP4mm+8aMEW2hrGJUcrmEDYh1U2iPpubQBlF
-        iBGIv59wm/QCrwm1571W4DzttfILvCZIL/FakfUXXiu/1GviE17bsl5yvD2ITYxSNgewCameryd3
-        LwdhHdIapLXf2uaQ1iCtscs/RoYXJk+7rODRVBKLtqVnuCaopS1kmyE+y6g8y5CeZcjPMpRdRml3
-        emne1s0oCEgBSCjZJ/qoOx7OyNPrBpQzRoYZ+gEtMLbBnOVF7pC4pyYqBRYDc9bMMUxSEokFDoMK
-        nMTZOHaHvlMqwqTmoqj23/8Uz89xtbQ9zdCf6emigJT5ppS5Y7/SEw8EEFAQUBBQbwmoYhSZfuSF
-        AVswqVxTBNbNqfIw8OwQWVyL9Gv5bk5l+k1gh7apB2huo4XORsKW3N4mKgJSdyPPYsdM2Ym+ckIt
-        nHCNaBzhkBPLAlmUOYFyo9BMJoVRqFWU5ELbaE7DyPQ9C5O7d1WQJbm8wc4aKT0m/1zXsrTkouWa
-        UGPMNa7a2K8pZSEV5HTDs1IlM6Xz5Rov1PpC/Xul/L1c/ndZ+J5caf8JrN9tC9BjHBpBuGMTUSDG
-        aBB3Ou9pEkUQlYr0YpNIovAqk0i8KLzFJMwEqWhJ12Nn0D++bhy3Tq/VUgFmlNQMbSMMJ2jBHflR
-        4KF/Ya5DphMY5hQF/8xOovain21LU86bWQs5YrhDVrmfS5BFkDHI8MIIa449X7czKCNEQzIbo5Qd
-        h/EMadh2Z06ifZMRhdl5aQtjRTOMSHYp6LZ0jKe7Y3xq7AneGhTx0p6+x8hPrG9oqmOQO01EDCkL
-        30gWWR+qju+N6Ue+/E1ImtaAWsrPT+RncpdO9GacCtcbQKKiJvkNWWv5lB2mpU4QeV5SIKX+F0RW
-        7Wyg6eP1Ht42+johnYJRYCT31wItQyghmYMfuIZHcnM6/B1UTe52VE0/Fq45qd8hiTiDMmnYIiZP
-        2PrUpeXBHlzFE39BVft0OvSlxyamYrKuCT3tHC3J0iFlfdJdAc44NG2Qdq4X4xC53AMK/DWVBgFZ
-        FhE7rdc4uTy97t2eXl72yANJ3sBI6Qk9w3JQQMLqliwknNGYMM1eL/ztnsyyiW+sCtMwJ2SlZMU9
-        TvrawUC5B4nr97b5/0XiUl4vcckv8JoovJPEVXmJxKW8o8QlvtRr0gdJXCIo95DWPrHNIa1BWgPl
-        HoRGSJmg3ENAQUAdRkAVo+h3UYafkirT76z6vsOUkPx7rDmWKIeO7SZvHVJ9rnD4boJzKq3R0fGN
-        On2uSAHWgvW5je2hw+S4bZCycqWXKnX+FHnalOf5kdRXDPu+/uu807qo9s6r3uPxYjA/OfZOrB8/
-        x/b1lRBEzWsJ/0DVaqc1Gf7k2624ftVvdisD+Xx1z65Ie2S9xzMmzJ3eZM1rSN2VSTcl0vRL1+my
-        qH6rlLmfbbLO1hBtnUxcFxPv1yvpa5IiRq+XK58geEFl+DezOVSGUBmC4AVp7ZPZHNIapDUQvKA+
-        h5QJghcEFATUYQTUfsGrGdhfOVH0rI8QvCpSvfYKwUs8EMFLfJvgJb+z4FU2Wit5fNf/1f3lP2BF
-        jGKfr1w1luiod1tpn+FmpbV6CFbYE0ype11dWtb5ZWMFghdkCKgMD9TmUBlCZQiCF6S1T2ZzSGuQ
-        1kDwgvocUiYIXhBQEFCHEVD7Ba9e5H3lRCn5/9DvL3jJoqi8QvCSDkTwkt4meFXfWfDqNcb9zqNy
-        dhlNB0r7YhTGntQ373n3DPHtQR/bbTmuh00LV7rju5vrXojG53gBghdkCKgMD9TmUBlCZQiCF6S1
-        T2ZzSGuQ1kDwgvocUiYIXhBQEFCHEVD7Ba+2nwhe8scIXkq5/vK//yclUzkIwUt+m+BVe+9veOlN
-        xW51R8v2jXy0rE7l6/PaZUcJo9lNj9cHujwQu9WKtTqey/Hl5KH92O1eHcE3vCBDQGV4qDaHyhAq
-        QxC8IK19MptDWoO0BoIX1OeQMkHwgoCCgDqMgHrib3hF6CsnKh8keNXl1/wNL+VABC/lbYJX/W2C
-        V7J1rnbumU6UbFbMDQ1zyuHEmdzMwNlZKekZgaw95s1Wd1Fd3NxVlF7jTEb3nW555E+9Zk257owu
-        BO/CeBAQ4q9O7q5+zOOriXG2/G0EstJTmwvDrsKwqzDcCEAAOBybw/abY9h+E3RNSGufy+aQ1iCt
-        ga4JMgykTNA1IaAgoA4joGBXYdhVGHYVhl2FYVdh2FX4I3YVpmvtkz+fPTVJ03ccZIb0nRrxzjLM
-        sfSohWIunAQoeW9RxHdZvvfXnP7Exhz5wb6LOPIMZntcgm+fU9o3JJpn05dHbOjk9owjJ9T+B55+
-        RjsZlAAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['2400']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:29 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/ValidEventTests.test_string_properties.yaml
+++ b/tests/interface_objects/cassettes/ValidEventTests.test_string_properties.yaml
@@ -1,137 +1,114 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF92aWRlb19pZnJhbWUgLz48
+      cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNj
+      YXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21l
+      ZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9m
+      b3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlh
+      PnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVx
+      dWVzdF9tZWRpYT48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHJlcXVlc3RfcmV2aWV3cyAvPjxyZXF1
+      ZXN0X2N1c3RvbV9maWVsZHMgLz48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxtaW1lX3RleHRfdHlw
+      ZT5odG1sPC9taW1lX3RleHRfdHlwZT48cmVxdWVzdF9tZXRhX2NvbXBvbmVudHMgLz48cmVxdWVz
+      dF9leHRyYV9pbmZvIC8+PHJlcXVlc3Rfc291cmNlX2luZm8gLz48cmVxdWVzdF9jb3N0X3Jhbmdl
+      IC8+PC9ldmVudF9zZWFyY2g+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['759']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+077XbbuLH/8xTI3nM27aklkhKpj0TV1nacNF9Oaiubtn94QBIUGZOAQoCWta/T
+        P32Oe1/szgCkRMqyLSebnnQ3OUxCDgaYDwwGA8xo8tNVnpFLVshU8D//4HTtHwjjoYhSPv/zD+9n
+        zzqjH36aPpiwS8aVLxktwsQvmCwzNZ3IMohETlPul5IVfir9gEZTLibW7pZJWKwWSvhBJsKLaeh3
+        OoNOID9+ePsxO5sXrCOfBi/Pxm+PwniUvBpcfTo/jZ+r0/N3R++CgZPZq8M0WDybzdVR8Cn4RzgY
+        HZfe66N3NHl//u5s7B/Lv//8zyv5izwvnw5mvYXb48EiOFu+/NvRy5OX/7x67q6OL5KkR9N4nPUj
+        L14FyRvvb96b08xeHLmdf0ysFn+TKJWK8pBJnxbMv6RZaoTbBTcKmk4AQn1QH5uefJhYmy/TEDEZ
+        Tk9A26tlwgpWIWjoJEzVyuBmgkeCd8oLYGgNNO0a9bVurxqrzhmVsvrP4NNCSUDZAKpGjX8IjeRH
+        mi+e/E9/9IQcw2yWyE4DZQJzpifQDL1iMFobNKms4YKtNDULpn0DQeOo8Opua0hrsA3e9ngRKnn3
+        oEakGqEF3OBoOY5oljFlhCVPtzoYSa0NC1atSCGVX1A+h/FyegUj50HKWTT1el17YrVAGgGYVIsi
+        DdnUHdYYG5hBKUEMWsCQ3hpjDZrkqNd6yJ6jMZogjbAZ0RnVGE0qWp31kP01xoYKF76ElZ0xVNZv
+        U8RPJeUKV4ZYKPBpMJl6hfo1fOpMrC3INkbvToz+nRjunRjenRiD6xjWdfH0HPphWRTguAGlfjPL
+        YR4swKpboA1GTEMliqlj2w2cCrjB4mUesGI66g0aWBVwg7XIKLhE1N02qIGDNidXeSAyqwkGN2qg
+        0//9V7P/Bj6xtsW0brDl7/P/O5n/5qSHouSqqOTTG2cTsG7W/v49TxWLyCuwHYhRNqjVTlqkKg0h
+        xLlM2dJfsCLEfd1oaGfTJKKKGT58xqPqWw82S8oD4khFztlCMdQX6dkOaHGDYrBLFfoijiVT0/4A
+        SW1DN2iShbD9y6njDntDz21j140GfQV/8jwCXwtE7bHtVJhrOOzMYjSwHV+DKY98leZMo3fsccd2
+        Zs74cd9+bNt/sp3HSGl3h2rcbR2Yb4iVCnVNK55KyBu6+jX1Mei5w769tz4827uXPjx4Pkcflfwm
+        gNbmePp+dnx2ePzq5GxiNcAVilbDG6pUwpbkSJQFZ48kOQVxChpegAnNTs5ndUejM/MOUejgxbO6
+        ZR2T+imPxfTHTD2J0ssf5+oJvi7w5RoRqUrOYVmQRSGiMkT/QkTcoP2QFAwiRS5JymHq7BFRgpzT
+        KGMFdP/AskyShF7iEEEhLhgnEH2RQFzBMDHs39A9FEUkSVQWiATBliIriO+QOPTuiFLBC5WCd5FN
+        S/P5YM3xLEkliZlU6SUjCmJnRRBQAhHgExtVQSOW0+IChFllDMHLVB2QBVWJkASmiIDMVEE0QTOS
+        03kadlsCxiLLxFKS44wWFNj6qJWzInEhckJJkDF6QY6TAs4AOZUEgnkCXDwtuk8LIeUj8rZYJJTT
+        OTsAQoUo5wn0kkma50yLDFroyAuq8H0JxsmKDJnSjAnkjcgFCxUNS2CAhABfIU8XKMn5kjGVMuyw
+        Uz1vM9BLQeiSFlFnmZq5BBNJ5xzAhxxUwFfkA7RqejMImdILcSkvViBoXoZJJxOX4BolTBIjdVyG
+        CkyITH/5JcPxwgQaxbygi2RF5iVoiSsGs5GAGm4x24c4UxTUyGRyQLJ00ZE5NMCIBzDjhbYZEBHn
+        L0XDg9nZaDmGc9JOidsEwfaARpikDKUIBLANaw/GSEMtMEgEsxCmMLYsQ9iapJENDSdFW+BUWxaH
+        EasjsUSm9KFAG0ygTxOyS17Xlqs7v8vAlX2AodB+P2gLz8EOYeIKPaVnYgWdT2kl2ExbIFgILAeW
+        Iq9qKQjOXorzhNNnTBWGlqBula3QOAJcP5eI39CFfqtW9gOtmMTF96dlocnpdgN6sMsJHJLnIotS
+        PPHqZak7kQ7hAg5NgMRyxFJC6IHMF4ETKkzbrSia7wPysQQ9oQqKdJ4oQnPcbPVEg6PcQ4wPCTiR
+        Y8rJC+DzpzuF4Sscl6xECSZ2wR6SQ6mZJWAYCo/cj6RejmJJwMV092MA1kIkgIH53QzMrrlDNB8w
+        Tske7kOLqupUPn4iyQseZmXEojup6hsFleASQsk528tCngsBPkCQV1ws76IAPgOdyUPyBqYDfD8S
+        hCnEKdX/yj3onZepouA/yTNYFcdJmkUQyd1F+LzEdaKtCMwfPZv26WhRFFYXy2GHA4PFJbQvH8d4
+        CZBlxtDfiSwNVzdwcSpgwcUlRBAEWGZX4C9hRwcLuqRppkWhsYIVu9CnT1nZc01yvRPj/lvtxehB
+        xdTsQKxGMMAKI2dRSiEMpTq8hygZti01jZzllbvse2WQR+lVN8xEGcGOxFWXMzWxNM4k5RDvgL7w
+        RL0ANwUxUJFNE6UW8rFl3TqEJeH0zCKrwQOEu2IBQa417sMT2m4Q21HPZXE/sj02ilnsBnQ4tMdR
+        bLt9l1GnH3Y/LuYQFO3kY8IphEa4d0kQDoTX3xPcmKe/Knk94uTbUMVORchysQDnKH3kp7oubULa
+        CNV12RZsYrXM5Vu1nSGDx3ZH4cDz4uE4ciizHdcZh+Oe27NHAyeKHW8QjPrxHrYDYd2nku1vOfcm
+        /hUt5968/AYs5wv05WtMqzeGZ+gybzQcDyksurEz9HrBsB/R/timbBCPYjpg7mjQu9t88BYRPC3e
+        SvB9behz+fh6lvS5HO1hT9et5RszqC9agR6Dx7bduOcFHqXBIHb7vTAassGoPw7Aebu9aES92BkG
+        e9jSJzj47O+J7k37K3qie/PyO/VE7Er5ikllW3+SK6lY7m8gKEgGZ7U9DKXCvNNU9if3FWxjf+K/
+        ezcSj+GhFCI+iAPd4TDs2/1oOApCz7GHYWgPPTeKR+6AhqO7rUMVKYL8GA71ezuTe3PwFZ3JvXn5
+        DTiTb9B8RHm3g/luPt+G+Xx57GczeHqeF7nxeBBEdi+gdBjEUa8Hf0MajO1wFA9CFvXd/W1I8L09
+        0Oey8dWD4ntz9FvYzb5cbSEAaC9yvdGYjsbuyPYcF04UEBmGLBzR8ag38Hq9kW2P+/vbk1qKe9rT
+        vdn46vZ0b47+w/ZkFDt48ayTmzxIJ9B5kI7s8HXipYNhnFX3NzqrqvkUVaWcZjr4aIFqhDKIqKJW
+        /a0wpddMMhpA3bpaQLyboui+SoG0WqNhS4VVLjDR52epVK3E5cmOxGU0ffNXuwm3dowxZwLTr6AU
+        vNJVZcSmntP1euOB4/SHE2sNnWAiwLx27K5jD2zHG/QAYQ2eWJvBEip9LjDLH0u9p7QAWNOG9wks
+        WhezVZ+6DqoweVSTDXZ6VSlUC6ormXbgbUMneJvvR2xBC6zR05lmzc8ueIVcZXEaaDXEIKAMosjx
+        Htywfw06wUoNU8Z47JwRd3YKy60GTUwFhKxftDZ0nWf1jXS3QBWqT0uViGI6SxiZgXhAu91Q4wUi
+        Wk2PKcccEyaN85zp1K3JiC0J45hafbjurvHrzo1ag5IdEGeoEnIqLtcVGN66W6PwoAlpVgp4juMM
+        2x02BQMVNKN8PmV8jaW/60ZRpJhZzNAbWGsoTq6h7Nhd2yaHb9a9N00t5CTJcymxFEUXOexo2qCr
+        jE3f8zyVEtMUDxvY2DLBmgS/0NdhWIbU/KxRb5zc2t5vmV3MypLDLFsUTN4+w5jxqhJyDzEtSoBl
+        1mG8I8P/+zdnmADVOXqaHeicTyv5DI0mgx6XVbNUolhVnXiKFQdcVTl/IVmdIup2ScpDcP0p6KZL
+        XjzCGgVGgnKFGTTjumSVu63tjc5pyvVQ+u1Ou8Mal94I7O6wnGPyCgzJvY/VufaoN/pvtDpYs48U
+        mTN1bYnex/astYupqn/rmmv/Ip/aWPW5Az7BmdJuzLhOs4+2YRMJO2TITMXN+pID0BrgGsdUa18p
+        VuikPSCSI9xSwQg2PYzGGh8+VorAQDxO53v1bnWoR2L8U5kWKZM+y2maTc21jPwLqAkXleiGoot1
+        bjeg18OgzwYboFFUTDH/ysjQOyA/p1jhl1KsWwjBQWKmeonZ4HNVMKYOyBHLYixwOJo5PeI9+/ua
+        TnO8mkZ1Y2Qqp2uVrnu0WusuStdKhVPMBIMf0dl5VBBuvUTwbNV9AM4AGwpGzBYAOtSbvymMoHxF
+        wMmwfAEAJdYZWJKilkyxjlm81e0VWaZmlYcm+1uVtWC9BowPjqK75rhmDiy1KEPcXKMqhxs2Mseg
+        CswcV1HvjpxyHf1e0qxkFtYr7urd2JkRu67aaHWefmvFGrostdR1bmv252A/EA/6F1wsK2GaBQY3
+        CHSfuoIN1TYt2NgL4zU0ibfV5w0Uvxe9fS96+1709l9e9LZxBZvFjz8QwVNTxBTsgLJy2doHvDNN
+        pGoi2AQHnVsc7ZEQFyRYkb6NIRwMnWmxGkekapNxbPKyBE47+FbFeijEAnTDgXsYBynHYCzgV9bx
+        5C5Rdgsgq6opHwj7YVU1Vcm1s6LqBom+oJBqw+INzCxhGSC/plytYu6mYrYb+Lu9hm3DwjatZcK4
+        Dx7DT/25WJNuFg3etJd+fq1gk5sWdf2rPj8SW8w0CghvYGa/usEW3SYh61qo0jidtX/EsKthAoFV
+        yUxUdwYHJTgmwzZ8qKFIPSiIpV3QC4neUJmq0jXU/B6xBXr/CnjdDFoR0NH1+eHT1ydn5x9OXr8+
+        r5FM2G3edUDdVkaNZmJt867FnJ0d/nzyukW59XEKvgrjyve45cxhY+LRY9gS5iwjfzgFFwNa5DD5
+        nP3x7jHOYFE+1r8agX0St72tIdBZ6aFvGYuQWYnoLIawqtShleEG790w8NAOWw+uwzBBI9xo9ckX
+        oQgwJ9NzRV6KhFcRe5dsTxt6Ue1w6mBO+3z8rIoPCQ2QA7AJkjP4hvBELHmrT7fWuzGpyzRiYHBx
+        YQy48eVvbrRb4IThMNM+XrjsatjCxovu5XLZhRWpyoDBESff7qfvwlsgcweKVzuR9dx5uTj56/P0
+        lwt3q6O59myBrmeNbmm+pWt1X3sbQrs3HMh97Tfqa/T1dfWW8HdKdX2kGyj9WnR2UlmmESjXxdvL
+        HfA2sL7CXV/ltn9R/v+e+0Ywjj4AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:29 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3898']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:38 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_extra_info /><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_video_iframe
-      /><request_reviews /><request_cost_range /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><request_source_info
-      /><mime_text_type>html</mime_text_type></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['903']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1b63LbNhb+n6dAujPtj9oiKVG3hlXXtZ1sNmmS2s5ms384IAmKjEhCBkAr6uvs
-        m+yT7TkASZGSfMsm07TrjCYmDz6cO248pPfTxzwjV0zIlBc/fuP07G8IK0IepcX8x2/eXjw9nHzz
-        0+yRx65YoXzJqAgTXzBZZmrmyTKIeE7Twi8lE34q/YBGszWTnrW/yQvFeqm4H2Q8XMze+oeHV4tl
-        PF0cT5dvh6+Dw7ngceSoZ6vw1Zv3HwYslB8GJ++d0YdfF6/t9++Kk6v84kUijwZL/+Pby/HZy6fr
-        k3B4eBY58ejFZVy+f345P3oqX58Vq/UltS+c0WtX+Cf54OXz01/Xl+L0w+Vkmon+m+fFdHCyWM2z
-        957V0cmLUqloETLpU8H8K5ql0azgnrWPbrwy84BCffAZm52+86zNnWmImAxnp+Di9SphglUATfWC
-        dF4ukVvJZo5te1ab4IWpWhtOGS8iXhyWC1C3IZp2zeilbq8aDeswo1JWfwxeJYwqVKBFq9p1l4tu
-        u2EDkdNhNOx0bLskr0qKBVvXEiyI/4aIaVJB654NpcNvg9vDcpFGcj9bY0jV3qFtINqWpzRPs3UL
-        ZCy0NnKt2mlcKl/QYg48AgbXOiA+j2MmIKqB5FmpmC/pFQyTmTPoQeS2qV5cZhnokQdpwaLZsI+g
-        Ls1AwCa1FGnIZu64wWyIFagEu6kAhYYbTEPztGYbxoMpgraIFWjDeTDcoFryKkLD3G2hNhKXTISQ
-        /HTeGNwfetYuFVJ6x4E5/bita4ekAab/g88/yee7DtSULTW6NAPpqtAleTmO+to2xyDapAoA8b4m
-        bO4douZMbo9aC3N91Ow7RM1x7xK1NuqGqNl3jVr/mqhteQ/vt5Xo0gykq0CX5BXcl8A+Y9J/mNYe
-        prU/tM8fprWHaa0Sf1nSQuFuly8VHF1g06b35H5NnzmetUXZRvRvRQxuRbi3Ioa3Ika7CGvXPD1v
-        +2EpBJzPAFJfma3uPFjC7rVD2iBiGiouzAFjm7hBFWUeQHgm/VELVRE3qGVG4RCEvtsmtTAYbLnO
-        A55ZbTIcnAx19p9/t/tv6J61babiS18nxcOU+UlT5o7/rGs2BA8D6mFAPQyoTxlQ7VEU8rJQokoY
-        /bimTWia9ZOHt0WqWEReAN+I5xto9fxGpCoNfcGuUrbyK02qlNvb5EUUwmXCzYqouq+e7JQHxJmo
-        hByV81Iq0rcdSMoNwGBLFaJRkqnZYISCtqkbmGQhLyIJq/fYGbpDu4OuGw18Df/yPIpmKNSeOJMK
-        2dC9VPLJyHZ8TaZF5Ks0Zxp+aE8OncmFM/1hYP9g29/bzg8oaX+Hiu+2B8y9VFSoHZ/0HXDGEYQz
-        +5wuGTn90cC9s0vcvnMvl7iHfedTXFK5wDzK1fn46u3F8dnR8YvTM89qkSuIdsMvVKmErcjPvBQF
-        +06SV2COoOGCicd1J+Mvc51Gs9Hzp3VL85DUT4uYz77N1JMovfp2rp50+X5L8+WTvwymTySRqiwK
-        GBJkKXhUhjhZEx63xRLBFHSSJC0gavaEKE7OaZQx0WLzjmWZJIketSQQfMEKQrOMBPwjsIth/AKb
-        kItIkqgUCMoo5MKa0TYXCVwOeanggkpe9NCAQBALLXjUublIUkliOBOmV4woAfMPQQJMbKg9NipB
-        I5ZTsQAT1xlD8ipVB2RJVcIlgZgR87AzDWlGcjpPw17H7JhnGV9JcpxRQVtKftAuXJNY8JxQEmSM
-        LshxIlKpcirJKSgE2pyI3ongUjYdyWuxTGgBk9sBCBa8nCfQWyZpnjPtEPDRoVxQhdcryF4mMlRS
-        K8pRVyKXLFQ0LEEhEgJ9jTou0LLzFWMqZdjhBqe9zsBbgtAVFdHhKjVxh2xK5wWQjwpwTLEm76BV
-        S72A2Tpd8Cu5WLfMz8swOcz4FUylEgLKSL1EoHsTItPffsuQb5hAI58LukzWZF6CDwvFIFYJOOfa
-        bGz7H2JIwclMJgckS5eHMocG4HwA2SF0noHhGOUUkxZiuIlBTAW7wQ9d8ZC1IClMUoY2BRyMgIEL
-        nNJQuwHsgwiFKUiQZQg7BWksxSRLMW8KqrOwAI5VZUeiavrhtk6uAEYCU7JHXtY5rzu/ySh4G1hh
-        xr/TYyOHnIWgCh3uM76Gzq9oZV5VLzjAgcRS1FWtOMGYphg9DKpJa2AtwfkqW2PiBDjyrhCvPWJV
-        E8Ij7ZLExet3CYzWY1qQ5+QZ/0mjTMOj1gxyVKxxjiNrXkI4FuwxOZIk4xAGcJ/CUksrjpjYfEVg
-        CPdukgrZc8JvlIqXS7y4qCed7+rJBl0MAZTsse67rOH7ZVHVUu95EWZlxKLrpOrykUowx9Dcgt3g
-        vGecw1Dh5EXBV9ewgxGFQ+0x+QX8DLMocicqnSfK/C+vZX5eporCDEOeQk4cJ2kWwbbyGinnJSbH
-        B9xvQMxxkOtJDzOJQkqxHNYFyCTMmz1CmyUEF45qEcFxzDd1rDaxQuQsSilsnqje5cNmGaZWNdPU
-        HoyfBWQ9jJUw6YW449KNXlrA6gy64t5yCeMCVmyRzRKllvIHy9rf15KwcWSR1ZIK2zK+hM2YNR3A
-        L7TdILajvsviQWQP2SRmsRvQ8dieRrHtDlxGnUHY+7Ccw9q9VwGvoLCC4wwqwRwwV997uFzMPqt4
-        zdH7nX2w1wOyXC5h3pA+KqLLsF1KFyDr0nOH5lmdzPh60mTM4Ge7k3A0HMbjaeRQZjuuMw2nfbdv
-        T0ZOFDvDUTAZxHdIE9hXXJbs7klyb+FfIknurcT/X5IMGfxs2437w2BIaTCK3UE/jMZsNBlMAxhI
-        bj+a0GHsjIPbk0Rewq7n7jlyb9lfIkfurcTXkCORs/rorgbDMsij9GMvzHgZwe68UL2CqdtTBRx1
-        I4d9/mIfla/g+GFb38u1VCz3NxQ0JIM92R0ypELemiN3F3d7UnxBW++QDLuh/mPPGPEUfpTCQgvL
-        rzsehwN7EI0nQTh07HEY2uOhG8UTd0TDye35AIdRJPkxbNfvPG/cW4MvMW/cW4mvYd74M2QKnIAe
-        MuXPuMJU/vI10poO4RdMw8Cl00lMx8HQcQPXHbn2dEztyTgOgnEwdpwwpHdPHjgM3jV3PlWNL7Ac
-        /Y8afRVr1O+eT/0h/OzRMJqGo4j2w9Fo7AymcD8eUzdy3cFoOgqd4TQa3COfVCLufib6VEW+eEbd
-        W6OvIqP+BGuZWvGHpewzLmVSUVXKWaY3kx1SDSiDiCpq1fcKyzbtepIh1K3rJZxYUlTdN15qYNhS
-        ocolFnH8LJWqU6M63VOjuq52BfQXb9t0aw/vOeNYfQNrM6pSVUZsNnR6Q89qbj18Om0uD+2eg00N
-        wbM2/RMq/YJjYTeW2v8dAr5Fj/VtFjWvz1e3+lU3Ycpnpv7n9Ku33TpU/XrVHtw21cPnzH7EllQo
-        TBOsJWp99tErcCl0eaAFqykGgDZwkeOnFEb9HaqHbzuYrymOnTPiXryCwVKTPFP0lvWF9ob+xKS6
-        R7lbpArq01IlXOBnDuQCzAPZ3YYaF/BoPTumRcGVrhHmOdO1OVPGWBFWYK3scdNd4+vOrQJzyQ6I
-        M1YJecWvGL71gTXmYdOtVWpuU9q14aHjOONuh02JuKJmtJjPWNGg9H3dyEWK5aAMB7bVUDG4RvKw
-        15+SN780nTctHWyS5LmUM2fcn2KRfE/TBq4yNntb5KmUWCd43EJji4dFaF/ooiK+ydO+raHNxeZL
-        kPrrG3+Rm7cB99A9DI7OJJO9Zlrq0jwJxxOA01jh+x8UX4JiOU2zWVhKxXMmdCkvZPKvoJFgUnKY
-        c3v4Ise1PWueOj+bBxFNh+pLFHNjEgPaybl+cEH+xQRvoMbxrRsfS7rAoYjT+c3dOsiaBSsuy1Sk
-        97Zxu1/NLy3A9qIq//kx/Tj73nUhqQfEGYzHrtNvOOwi9/NYJrDl73Lp29dwMdiaT8bDirO9T4FN
-        c7eDYWLvk9YG1J1w3gEijSIxw9IXI+PhAflHim96pRQLpiEMciz/rbDqdq5gv6kOyM8si7Gy+vOF
-        0yfDp/9sZLT51TKqR1jm06M6f5oenda6i9JveIQzLMLBTKcLnpgduHwQXmTr3iOY5bBBMGKmMZoR
-        vWaZiiwt1oQqYLwEguJkqd+Egg5gYi7NmwRmwqsep5FVii9PMCzzh2BuVV3HQjHwh2TqNRrXysFQ
-        F2WIC0RUFfHQbIZm6D3Vkbmrd1jmm7emvHrGJQuwLHkEWuNM+lxioU/x4oCYr902RVb9uh9+MGc1
-        EuYQDtgt+IuCryp57bpoR6iFi28HD/O1MDORhr2ubnd6bXD4RhiumxFTMGJkZbCGvzFNpGoi2ARL
-        HWb1DsP9bGRVdPWhox9WRdeK+96C7A7fazisEqpQiCk+VxyvK03vMN3uvUpY4UN++Kk/5w2zdiV/
-        D4tOF/2BpB/xLQ6tqvw12XK3YvwmT7YEWTupqpPOjNN9xf/7ZOdWVbvFuZKiV4jzo5OXp2fn705f
-        vjyvQWbpMNd6bejaWMPMsmGum9estGhScSWaLXl+To7Im5dHx6cdn2w6eldpBLvQNBbGya07f3O8
-        65AThrX72QA3NvsattB4+FutVr01zBxlwMyRcBfS7WUOX7iFiqxnzt+Xp397lv62cLc6mgNVh7R7
-        krmh+Yau1RnnJkC3N2y3fJ3b9TGzOdRtGX+rVbucrpH0ueTslbJKI3CuXi330LvE+nTUnJK6X43/
-        F5UfhalyPgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3543']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:30 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/cassettes/ValidEventTests.test_unicode_properties.yaml
+++ b/tests/interface_objects/cassettes/ValidEventTests.test_unicode_properties.yaml
@@ -1,137 +1,114 @@
 interactions:
 - request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <start_session><user_id>whitelabel-testuser</user_id></start_session>'
+    body: !!binary |
+      PGV2ZW50X3NlYXJjaD48dXNlcl9wYXNzd2Q+ZGVtb3Bhc3M8L3VzZXJfcGFzc3dkPjxldmVudF90
+      b2tlbl9saXN0PjZJRjwvZXZlbnRfdG9rZW5fbGlzdD48cmVxdWVzdF92aWRlb19pZnJhbWUgLz48
+      cmVxdWVzdF9tZWRpYT5zcXVhcmU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+bGFuZHNj
+      YXBlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfb25lPC9yZXF1ZXN0X21l
+      ZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfdHdvPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21l
+      ZGlhPnRyaXBsZXRfdGhyZWU8L3JlcXVlc3RfbWVkaWE+PHJlcXVlc3RfbWVkaWE+dHJpcGxldF9m
+      b3VyPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlhPnRyaXBsZXRfZml2ZTwvcmVxdWVzdF9t
+      ZWRpYT48cmVxdWVzdF9tZWRpYT5tYXJxdWVlPC9yZXF1ZXN0X21lZGlhPjxyZXF1ZXN0X21lZGlh
+      PnNlYXRpbmdfcGxhbjwvcmVxdWVzdF9tZWRpYT48cmVxdWVzdF9tZWRpYT5zdXBwbGllcjwvcmVx
+      dWVzdF9tZWRpYT48cHV6emxlZD55ZXM8L3B1enpsZWQ+PHJlcXVlc3RfcmV2aWV3cyAvPjxyZXF1
+      ZXN0X2N1c3RvbV9maWVsZHMgLz48dXNlcl9pZD5kZW1vPC91c2VyX2lkPjxtaW1lX3RleHRfdHlw
+      ZT5odG1sPC9taW1lX3RleHRfdHlwZT48cmVxdWVzdF9tZXRhX2NvbXBvbmVudHMgLz48cmVxdWVz
+      dF9leHRyYV9pbmZvIC8+PHJlcXVlc3Rfc291cmNlX2luZm8gLz48cmVxdWVzdF9jb3N0X3Jhbmdl
+      IC8+PC9ldmVudF9zZWFyY2g+
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['108']
+      Content-Length: ['759']
       Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
+      User-Agent: [python-requests/2.9.1]
     method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe
+    uri: https://api.ticketswitch.com/tickets/xml_core.exe
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA21S21LbMBB971d48u6aTtOWzggxxG0TiiExxATzopGsjWssy44uJM7XVzIwTNo8
-        aW/aPWfPovNdI4JnULpq5dno08eTUQCyaHkly7NRtvwVno7O8QekDVWGaNC+jijQVhiMtGW8bWgl
-        idWgSKUJoxz3oFF0PIUK1XemJUy0RY0LEoarcbcvVw/P9u4xLdPPMJnnbHoNWTKOd3m6KRZpk/dS
-        TO+vNs3yYdzsXAd9Wadddc1Wi7az5b5fi5vp/tsu+x2vbuf8PqbfTyZfO5GTLyz/+XTa3PXbqU3m
-        T0kyi+vZcvOjMhNGF5ez9ELNJ0zp9UWiszh8RNEBPqSslG4RAwWMGC1qkJyUqrUdNnqLosMQKlpp
-        QJoXN8KIw5q6RZGitdKo3r0csK1RdDSBFFBBJG0AL0GbYPWnMhAklIEIMocARe8FXhADjR/GQReq
-        cqhV5MO9ANxZBU6CwfYikcGMXu1/fE/OmS8ycbz1U4UfGhqHwg6D35IOwsFK/iN2SOjN8xBxJl1j
-        Hly53+4y3kuHpEd75ML+Aoj0jp+fAgAA
+        H4sIAAAAAAAAA+077XbbuLH/8xTI3nM27aklkhKpj0TV1nacNF9Oaiubtn94QBIUGZOAQoCWta/T
+        P32Oe1/szgCkRMqyLSebnnQ3OUxCDgaYDwwGA8xo8tNVnpFLVshU8D//4HTtHwjjoYhSPv/zD+9n
+        zzqjH36aPpiwS8aVLxktwsQvmCwzNZ3IMohETlPul5IVfir9gEZTLibW7pZJWKwWSvhBJsKLaeh3
+        OoNOID9+ePsxO5sXrCOfBi/Pxm+PwniUvBpcfTo/jZ+r0/N3R++CgZPZq8M0WDybzdVR8Cn4RzgY
+        HZfe66N3NHl//u5s7B/Lv//8zyv5izwvnw5mvYXb48EiOFu+/NvRy5OX/7x67q6OL5KkR9N4nPUj
+        L14FyRvvb96b08xeHLmdf0ysFn+TKJWK8pBJnxbMv6RZaoTbBTcKmk4AQn1QH5uefJhYmy/TEDEZ
+        Tk9A26tlwgpWIWjoJEzVyuBmgkeCd8oLYGgNNO0a9bVurxqrzhmVsvrP4NNCSUDZAKpGjX8IjeRH
+        mi+e/E9/9IQcw2yWyE4DZQJzpifQDL1iMFobNKms4YKtNDULpn0DQeOo8Opua0hrsA3e9ngRKnn3
+        oEakGqEF3OBoOY5oljFlhCVPtzoYSa0NC1atSCGVX1A+h/FyegUj50HKWTT1el17YrVAGgGYVIsi
+        DdnUHdYYG5hBKUEMWsCQ3hpjDZrkqNd6yJ6jMZogjbAZ0RnVGE0qWp31kP01xoYKF76ElZ0xVNZv
+        U8RPJeUKV4ZYKPBpMJl6hfo1fOpMrC3INkbvToz+nRjunRjenRiD6xjWdfH0HPphWRTguAGlfjPL
+        YR4swKpboA1GTEMliqlj2w2cCrjB4mUesGI66g0aWBVwg7XIKLhE1N02qIGDNidXeSAyqwkGN2qg
+        0//9V7P/Bj6xtsW0brDl7/P/O5n/5qSHouSqqOTTG2cTsG7W/v49TxWLyCuwHYhRNqjVTlqkKg0h
+        xLlM2dJfsCLEfd1oaGfTJKKKGT58xqPqWw82S8oD4khFztlCMdQX6dkOaHGDYrBLFfoijiVT0/4A
+        SW1DN2iShbD9y6njDntDz21j140GfQV/8jwCXwtE7bHtVJhrOOzMYjSwHV+DKY98leZMo3fsccd2
+        Zs74cd9+bNt/sp3HSGl3h2rcbR2Yb4iVCnVNK55KyBu6+jX1Mei5w769tz4827uXPjx4Pkcflfwm
+        gNbmePp+dnx2ePzq5GxiNcAVilbDG6pUwpbkSJQFZ48kOQVxChpegAnNTs5ndUejM/MOUejgxbO6
+        ZR2T+imPxfTHTD2J0ssf5+oJvi7w5RoRqUrOYVmQRSGiMkT/QkTcoP2QFAwiRS5JymHq7BFRgpzT
+        KGMFdP/AskyShF7iEEEhLhgnEH2RQFzBMDHs39A9FEUkSVQWiATBliIriO+QOPTuiFLBC5WCd5FN
+        S/P5YM3xLEkliZlU6SUjCmJnRRBQAhHgExtVQSOW0+IChFllDMHLVB2QBVWJkASmiIDMVEE0QTOS
+        03kadlsCxiLLxFKS44wWFNj6qJWzInEhckJJkDF6QY6TAs4AOZUEgnkCXDwtuk8LIeUj8rZYJJTT
+        OTsAQoUo5wn0kkma50yLDFroyAuq8H0JxsmKDJnSjAnkjcgFCxUNS2CAhABfIU8XKMn5kjGVMuyw
+        Uz1vM9BLQeiSFlFnmZq5BBNJ5xzAhxxUwFfkA7RqejMImdILcSkvViBoXoZJJxOX4BolTBIjdVyG
+        CkyITH/5JcPxwgQaxbygi2RF5iVoiSsGs5GAGm4x24c4UxTUyGRyQLJ00ZE5NMCIBzDjhbYZEBHn
+        L0XDg9nZaDmGc9JOidsEwfaARpikDKUIBLANaw/GSEMtMEgEsxCmMLYsQ9iapJENDSdFW+BUWxaH
+        EasjsUSm9KFAG0ygTxOyS17Xlqs7v8vAlX2AodB+P2gLz8EOYeIKPaVnYgWdT2kl2ExbIFgILAeW
+        Iq9qKQjOXorzhNNnTBWGlqBula3QOAJcP5eI39CFfqtW9gOtmMTF96dlocnpdgN6sMsJHJLnIotS
+        PPHqZak7kQ7hAg5NgMRyxFJC6IHMF4ETKkzbrSia7wPysQQ9oQqKdJ4oQnPcbPVEg6PcQ4wPCTiR
+        Y8rJC+DzpzuF4Sscl6xECSZ2wR6SQ6mZJWAYCo/cj6RejmJJwMV092MA1kIkgIH53QzMrrlDNB8w
+        Tske7kOLqupUPn4iyQseZmXEojup6hsFleASQsk528tCngsBPkCQV1ws76IAPgOdyUPyBqYDfD8S
+        hCnEKdX/yj3onZepouA/yTNYFcdJmkUQyd1F+LzEdaKtCMwfPZv26WhRFFYXy2GHA4PFJbQvH8d4
+        CZBlxtDfiSwNVzdwcSpgwcUlRBAEWGZX4C9hRwcLuqRppkWhsYIVu9CnT1nZc01yvRPj/lvtxehB
+        xdTsQKxGMMAKI2dRSiEMpTq8hygZti01jZzllbvse2WQR+lVN8xEGcGOxFWXMzWxNM4k5RDvgL7w
+        RL0ANwUxUJFNE6UW8rFl3TqEJeH0zCKrwQOEu2IBQa417sMT2m4Q21HPZXE/sj02ilnsBnQ4tMdR
+        bLt9l1GnH3Y/LuYQFO3kY8IphEa4d0kQDoTX3xPcmKe/Knk94uTbUMVORchysQDnKH3kp7oubULa
+        CNV12RZsYrXM5Vu1nSGDx3ZH4cDz4uE4ciizHdcZh+Oe27NHAyeKHW8QjPrxHrYDYd2nku1vOfcm
+        /hUt5968/AYs5wv05WtMqzeGZ+gybzQcDyksurEz9HrBsB/R/timbBCPYjpg7mjQu9t88BYRPC3e
+        SvB9behz+fh6lvS5HO1hT9et5RszqC9agR6Dx7bduOcFHqXBIHb7vTAassGoPw7Aebu9aES92BkG
+        e9jSJzj47O+J7k37K3qie/PyO/VE7Er5ikllW3+SK6lY7m8gKEgGZ7U9DKXCvNNU9if3FWxjf+K/
+        ezcSj+GhFCI+iAPd4TDs2/1oOApCz7GHYWgPPTeKR+6AhqO7rUMVKYL8GA71ezuTe3PwFZ3JvXn5
+        DTiTb9B8RHm3g/luPt+G+Xx57GczeHqeF7nxeBBEdi+gdBjEUa8Hf0MajO1wFA9CFvXd/W1I8L09
+        0Oey8dWD4ntz9FvYzb5cbSEAaC9yvdGYjsbuyPYcF04UEBmGLBzR8ag38Hq9kW2P+/vbk1qKe9rT
+        vdn46vZ0b47+w/ZkFDt48ayTmzxIJ9B5kI7s8HXipYNhnFX3NzqrqvkUVaWcZjr4aIFqhDKIqKJW
+        /a0wpddMMhpA3bpaQLyboui+SoG0WqNhS4VVLjDR52epVK3E5cmOxGU0ffNXuwm3dowxZwLTr6AU
+        vNJVZcSmntP1euOB4/SHE2sNnWAiwLx27K5jD2zHG/QAYQ2eWJvBEip9LjDLH0u9p7QAWNOG9wks
+        WhezVZ+6DqoweVSTDXZ6VSlUC6ormXbgbUMneJvvR2xBC6zR05lmzc8ueIVcZXEaaDXEIKAMosjx
+        Htywfw06wUoNU8Z47JwRd3YKy60GTUwFhKxftDZ0nWf1jXS3QBWqT0uViGI6SxiZgXhAu91Q4wUi
+        Wk2PKcccEyaN85zp1K3JiC0J45hafbjurvHrzo1ag5IdEGeoEnIqLtcVGN66W6PwoAlpVgp4juMM
+        2x02BQMVNKN8PmV8jaW/60ZRpJhZzNAbWGsoTq6h7Nhd2yaHb9a9N00t5CTJcymxFEUXOexo2qCr
+        jE3f8zyVEtMUDxvY2DLBmgS/0NdhWIbU/KxRb5zc2t5vmV3MypLDLFsUTN4+w5jxqhJyDzEtSoBl
+        1mG8I8P/+zdnmADVOXqaHeicTyv5DI0mgx6XVbNUolhVnXiKFQdcVTl/IVmdIup2ScpDcP0p6KZL
+        XjzCGgVGgnKFGTTjumSVu63tjc5pyvVQ+u1Ou8Mal94I7O6wnGPyCgzJvY/VufaoN/pvtDpYs48U
+        mTN1bYnex/astYupqn/rmmv/Ip/aWPW5Az7BmdJuzLhOs4+2YRMJO2TITMXN+pID0BrgGsdUa18p
+        VuikPSCSI9xSwQg2PYzGGh8+VorAQDxO53v1bnWoR2L8U5kWKZM+y2maTc21jPwLqAkXleiGoot1
+        bjeg18OgzwYboFFUTDH/ysjQOyA/p1jhl1KsWwjBQWKmeonZ4HNVMKYOyBHLYixwOJo5PeI9+/ua
+        TnO8mkZ1Y2Qqp2uVrnu0WusuStdKhVPMBIMf0dl5VBBuvUTwbNV9AM4AGwpGzBYAOtSbvymMoHxF
+        wMmwfAEAJdYZWJKilkyxjlm81e0VWaZmlYcm+1uVtWC9BowPjqK75rhmDiy1KEPcXKMqhxs2Mseg
+        CswcV1HvjpxyHf1e0qxkFtYr7urd2JkRu67aaHWefmvFGrostdR1bmv252A/EA/6F1wsK2GaBQY3
+        CHSfuoIN1TYt2NgL4zU0ibfV5w0Uvxe9fS96+1709l9e9LZxBZvFjz8QwVNTxBTsgLJy2doHvDNN
+        pGoi2AQHnVsc7ZEQFyRYkb6NIRwMnWmxGkekapNxbPKyBE47+FbFeijEAnTDgXsYBynHYCzgV9bx
+        5C5Rdgsgq6opHwj7YVU1Vcm1s6LqBom+oJBqw+INzCxhGSC/plytYu6mYrYb+Lu9hm3DwjatZcK4
+        Dx7DT/25WJNuFg3etJd+fq1gk5sWdf2rPj8SW8w0CghvYGa/usEW3SYh61qo0jidtX/EsKthAoFV
+        yUxUdwYHJTgmwzZ8qKFIPSiIpV3QC4neUJmq0jXU/B6xBXr/CnjdDFoR0NH1+eHT1ydn5x9OXr8+
+        r5FM2G3edUDdVkaNZmJt867FnJ0d/nzyukW59XEKvgrjyve45cxhY+LRY9gS5iwjfzgFFwNa5DD5
+        nP3x7jHOYFE+1r8agX0St72tIdBZ6aFvGYuQWYnoLIawqtShleEG790w8NAOWw+uwzBBI9xo9ckX
+        oQgwJ9NzRV6KhFcRe5dsTxt6Ue1w6mBO+3z8rIoPCQ2QA7AJkjP4hvBELHmrT7fWuzGpyzRiYHBx
+        YQy48eVvbrRb4IThMNM+XrjsatjCxovu5XLZhRWpyoDBESff7qfvwlsgcweKVzuR9dx5uTj56/P0
+        lwt3q6O59myBrmeNbmm+pWt1X3sbQrs3HMh97Tfqa/T1dfWW8HdKdX2kGyj9WnR2UlmmESjXxdvL
+        HfA2sL7CXV/ltn9R/v+e+0Ywjj4AAA==
     headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['423']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:30 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
+      Cache-Control: ['max-age=3600, must-revalidate']
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['3898']
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 04 May 2016 17:06:39 GMT']
+      P3P: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
           IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
-    status: {code: 200, message: OK}
-- request:
-    body: '<?xml version=''1.0'' encoding=''UTF-8''?>
-
-      <event_search><request_extra_info /><request_media>square</request_media><request_media>landscape</request_media><request_media>triplet_one</request_media><request_media>triplet_two</request_media><request_media>triplet_three</request_media><request_media>triplet_four</request_media><request_media>triplet_five</request_media><request_media>marquee</request_media><request_media>seating_plan</request_media><request_media>supplier</request_media><user_id>whitelabel-testuser</user_id><event_token_list>6IF</event_token_list><request_video_iframe
-      /><request_reviews /><request_cost_range /><request_custom_fields /><crypto_block>c_--W4pzgWXvuSZQgQ3eBOYbGMeUL4CxYQqcPQmYynlGVKqmTX4mxcrysIkQpiMbWPopugzyflNGz7xUJCWROdVCa90B6plY_5bYEj8mSywGuLOjLLHCkHTqDitBbaPIHQArOBbrsfALsUC-Z</crypto_block><request_source_info
-      /><mime_text_type>html</mime_text_type></event_search>'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['903']
-      Content-Type: [text/xml]
-      User-Agent: [python-requests/2.8.1]
-    method: POST
-    uri: https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+1b63LbNhb+n6dAujPtj9oiKVG3hlXXtZ1sNmmS2s5ms384IAmKjEhCBkAr6uvs
-        m+yT7TkASZGSfMsm07TrjCYmDz6cO248pPfTxzwjV0zIlBc/fuP07G8IK0IepcX8x2/eXjw9nHzz
-        0+yRx65YoXzJqAgTXzBZZmrmyTKIeE7Twi8lE34q/YBGszWTnrW/yQvFeqm4H2Q8XMze+oeHV4tl
-        PF0cT5dvh6+Dw7ngceSoZ6vw1Zv3HwYslB8GJ++d0YdfF6/t9++Kk6v84kUijwZL/+Pby/HZy6fr
-        k3B4eBY58ejFZVy+f345P3oqX58Vq/UltS+c0WtX+Cf54OXz01/Xl+L0w+Vkmon+m+fFdHCyWM2z
-        957V0cmLUqloETLpU8H8K5ql0azgnrWPbrwy84BCffAZm52+86zNnWmImAxnp+Di9SphglUATfWC
-        dF4ukVvJZo5te1ab4IWpWhtOGS8iXhyWC1C3IZp2zeilbq8aDeswo1JWfwxeJYwqVKBFq9p1l4tu
-        u2EDkdNhNOx0bLskr0qKBVvXEiyI/4aIaVJB654NpcNvg9vDcpFGcj9bY0jV3qFtINqWpzRPs3UL
-        ZCy0NnKt2mlcKl/QYg48AgbXOiA+j2MmIKqB5FmpmC/pFQyTmTPoQeS2qV5cZhnokQdpwaLZsI+g
-        Ls1AwCa1FGnIZu64wWyIFagEu6kAhYYbTEPztGYbxoMpgraIFWjDeTDcoFryKkLD3G2hNhKXTISQ
-        /HTeGNwfetYuFVJ6x4E5/bita4ekAab/g88/yee7DtSULTW6NAPpqtAleTmO+to2xyDapAoA8b4m
-        bO4douZMbo9aC3N91Ow7RM1x7xK1NuqGqNl3jVr/mqhteQ/vt5Xo0gykq0CX5BXcl8A+Y9J/mNYe
-        prU/tM8fprWHaa0Sf1nSQuFuly8VHF1g06b35H5NnzmetUXZRvRvRQxuRbi3Ioa3Ika7CGvXPD1v
-        +2EpBJzPAFJfma3uPFjC7rVD2iBiGiouzAFjm7hBFWUeQHgm/VELVRE3qGVG4RCEvtsmtTAYbLnO
-        A55ZbTIcnAx19p9/t/tv6J61babiS18nxcOU+UlT5o7/rGs2BA8D6mFAPQyoTxlQ7VEU8rJQokoY
-        /bimTWia9ZOHt0WqWEReAN+I5xto9fxGpCoNfcGuUrbyK02qlNvb5EUUwmXCzYqouq+e7JQHxJmo
-        hByV81Iq0rcdSMoNwGBLFaJRkqnZYISCtqkbmGQhLyIJq/fYGbpDu4OuGw18Df/yPIpmKNSeOJMK
-        2dC9VPLJyHZ8TaZF5Ks0Zxp+aE8OncmFM/1hYP9g29/bzg8oaX+Hiu+2B8y9VFSoHZ/0HXDGEYQz
-        +5wuGTn90cC9s0vcvnMvl7iHfedTXFK5wDzK1fn46u3F8dnR8YvTM89qkSuIdsMvVKmErcjPvBQF
-        +06SV2COoOGCicd1J+Mvc51Gs9Hzp3VL85DUT4uYz77N1JMovfp2rp50+X5L8+WTvwymTySRqiwK
-        GBJkKXhUhjhZEx63xRLBFHSSJC0gavaEKE7OaZQx0WLzjmWZJIketSQQfMEKQrOMBPwjsIth/AKb
-        kItIkqgUCMoo5MKa0TYXCVwOeanggkpe9NCAQBALLXjUublIUkliOBOmV4woAfMPQQJMbKg9NipB
-        I5ZTsQAT1xlD8ipVB2RJVcIlgZgR87AzDWlGcjpPw17H7JhnGV9JcpxRQVtKftAuXJNY8JxQEmSM
-        LshxIlKpcirJKSgE2pyI3ongUjYdyWuxTGgBk9sBCBa8nCfQWyZpnjPtEPDRoVxQhdcryF4mMlRS
-        K8pRVyKXLFQ0LEEhEgJ9jTou0LLzFWMqZdjhBqe9zsBbgtAVFdHhKjVxh2xK5wWQjwpwTLEm76BV
-        S72A2Tpd8Cu5WLfMz8swOcz4FUylEgLKSL1EoHsTItPffsuQb5hAI58LukzWZF6CDwvFIFYJOOfa
-        bGz7H2JIwclMJgckS5eHMocG4HwA2SF0noHhGOUUkxZiuIlBTAW7wQ9d8ZC1IClMUoY2BRyMgIEL
-        nNJQuwHsgwiFKUiQZQg7BWksxSRLMW8KqrOwAI5VZUeiavrhtk6uAEYCU7JHXtY5rzu/ySh4G1hh
-        xr/TYyOHnIWgCh3uM76Gzq9oZV5VLzjAgcRS1FWtOMGYphg9DKpJa2AtwfkqW2PiBDjyrhCvPWJV
-        E8Ij7ZLExet3CYzWY1qQ5+QZ/0mjTMOj1gxyVKxxjiNrXkI4FuwxOZIk4xAGcJ/CUksrjpjYfEVg
-        CPdukgrZc8JvlIqXS7y4qCed7+rJBl0MAZTsse67rOH7ZVHVUu95EWZlxKLrpOrykUowx9Dcgt3g
-        vGecw1Dh5EXBV9ewgxGFQ+0x+QX8DLMocicqnSfK/C+vZX5eporCDEOeQk4cJ2kWwbbyGinnJSbH
-        B9xvQMxxkOtJDzOJQkqxHNYFyCTMmz1CmyUEF45qEcFxzDd1rDaxQuQsSilsnqje5cNmGaZWNdPU
-        HoyfBWQ9jJUw6YW449KNXlrA6gy64t5yCeMCVmyRzRKllvIHy9rf15KwcWSR1ZIK2zK+hM2YNR3A
-        L7TdILajvsviQWQP2SRmsRvQ8dieRrHtDlxGnUHY+7Ccw9q9VwGvoLCC4wwqwRwwV997uFzMPqt4
-        zdH7nX2w1wOyXC5h3pA+KqLLsF1KFyDr0nOH5lmdzPh60mTM4Ge7k3A0HMbjaeRQZjuuMw2nfbdv
-        T0ZOFDvDUTAZxHdIE9hXXJbs7klyb+FfIknurcT/X5IMGfxs2437w2BIaTCK3UE/jMZsNBlMAxhI
-        bj+a0GHsjIPbk0Rewq7n7jlyb9lfIkfurcTXkCORs/rorgbDMsij9GMvzHgZwe68UL2CqdtTBRx1
-        I4d9/mIfla/g+GFb38u1VCz3NxQ0JIM92R0ypELemiN3F3d7UnxBW++QDLuh/mPPGPEUfpTCQgvL
-        rzsehwN7EI0nQTh07HEY2uOhG8UTd0TDye35AIdRJPkxbNfvPG/cW4MvMW/cW4mvYd74M2QKnIAe
-        MuXPuMJU/vI10poO4RdMw8Cl00lMx8HQcQPXHbn2dEztyTgOgnEwdpwwpHdPHjgM3jV3PlWNL7Ac
-        /Y8afRVr1O+eT/0h/OzRMJqGo4j2w9Fo7AymcD8eUzdy3cFoOgqd4TQa3COfVCLufib6VEW+eEbd
-        W6OvIqP+BGuZWvGHpewzLmVSUVXKWaY3kx1SDSiDiCpq1fcKyzbtepIh1K3rJZxYUlTdN15qYNhS
-        ocolFnH8LJWqU6M63VOjuq52BfQXb9t0aw/vOeNYfQNrM6pSVUZsNnR6Q89qbj18Om0uD+2eg00N
-        wbM2/RMq/YJjYTeW2v8dAr5Fj/VtFjWvz1e3+lU3Ycpnpv7n9Ku33TpU/XrVHtw21cPnzH7EllQo
-        TBOsJWp99tErcCl0eaAFqykGgDZwkeOnFEb9HaqHbzuYrymOnTPiXryCwVKTPFP0lvWF9ob+xKS6
-        R7lbpArq01IlXOBnDuQCzAPZ3YYaF/BoPTumRcGVrhHmOdO1OVPGWBFWYK3scdNd4+vOrQJzyQ6I
-        M1YJecWvGL71gTXmYdOtVWpuU9q14aHjOONuh02JuKJmtJjPWNGg9H3dyEWK5aAMB7bVUDG4RvKw
-        15+SN780nTctHWyS5LmUM2fcn2KRfE/TBq4yNntb5KmUWCd43EJji4dFaF/ooiK+ydO+raHNxeZL
-        kPrrG3+Rm7cB99A9DI7OJJO9Zlrq0jwJxxOA01jh+x8UX4JiOU2zWVhKxXMmdCkvZPKvoJFgUnKY
-        c3v4Ise1PWueOj+bBxFNh+pLFHNjEgPaybl+cEH+xQRvoMbxrRsfS7rAoYjT+c3dOsiaBSsuy1Sk
-        97Zxu1/NLy3A9qIq//kx/Tj73nUhqQfEGYzHrtNvOOwi9/NYJrDl73Lp29dwMdiaT8bDirO9T4FN
-        c7eDYWLvk9YG1J1w3gEijSIxw9IXI+PhAflHim96pRQLpiEMciz/rbDqdq5gv6kOyM8si7Gy+vOF
-        0yfDp/9sZLT51TKqR1jm06M6f5oenda6i9JveIQzLMLBTKcLnpgduHwQXmTr3iOY5bBBMGKmMZoR
-        vWaZiiwt1oQqYLwEguJkqd+Egg5gYi7NmwRmwqsep5FVii9PMCzzh2BuVV3HQjHwh2TqNRrXysFQ
-        F2WIC0RUFfHQbIZm6D3Vkbmrd1jmm7emvHrGJQuwLHkEWuNM+lxioU/x4oCYr902RVb9uh9+MGc1
-        EuYQDtgt+IuCryp57bpoR6iFi28HD/O1MDORhr2ubnd6bXD4RhiumxFTMGJkZbCGvzFNpGoi2ARL
-        HWb1DsP9bGRVdPWhox9WRdeK+96C7A7fazisEqpQiCk+VxyvK03vMN3uvUpY4UN++Kk/5w2zdiV/
-        D4tOF/2BpB/xLQ6tqvw12XK3YvwmT7YEWTupqpPOjNN9xf/7ZOdWVbvFuZKiV4jzo5OXp2fn705f
-        vjyvQWbpMNd6bejaWMPMsmGum9estGhScSWaLXl+To7Im5dHx6cdn2w6eldpBLvQNBbGya07f3O8
-        65AThrX72QA3NvsattB4+FutVr01zBxlwMyRcBfS7WUOX7iFiqxnzt+Xp397lv62cLc6mgNVh7R7
-        krmh+Yau1RnnJkC3N2y3fJ3b9TGzOdRtGX+rVbucrpH0ueTslbJKI3CuXi330LvE+nTUnJK6X43/
-        F5UfhalyPgAA
-    headers:
-      cache-control: ['max-age=30, must-revalidate']
-      connection: [close]
-      content-encoding: [gzip]
-      content-length: ['3543']
-      content-type: [text/xml; charset=UTF-8]
-      date: ['Wed, 20 Apr 2016 11:18:30 GMT']
-      p3p: ['policyref="/w3c/p3p.xml", CP="NOI DSP COR LAW CURa ADMa DEVa OUR NOR
-          IND PHY ONL UNI PUR COM NAV DEM STA"']
-      server: [Apache]
-      vary: ['Accept-Encoding,Cookie,User-Agent']
-      x-clacks-overhead: [GNU Terry Pratchett]
-      x-robots-tag: [noindex]
-      x-ua-compatible: [IE=edge]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains;]
+      Vary: ['Accept-Encoding,Cookie,User-Agent']
+      X-Clacks-Overhead: [GNU Terry Pratchett]
+      X-UA-Compatible: [IE=edge]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/interface_objects/common.py
+++ b/tests/interface_objects/common.py
@@ -11,8 +11,6 @@ except ImportError:
     import xml.etree.ElementTree as xml
 
 
-
-
 def xml_matcher(r1, r2):
     """ Match requests by Core XML API method name """
     r1_xml = xml.fromstring(r1.body)
@@ -25,7 +23,6 @@ class InterfaceObjectTestCase(VCRTestCase):
         'username': settings.TEST_USERNAME,
         'password': settings.TEST_PASSWORD,
         'url': settings.API_URL,
-        'ext_start_session_url': settings.EXT_START_SESSION_URL
     }
 
     def _get_vcr(self):
@@ -40,5 +37,4 @@ class InterfaceObjectCreditUserTestCase(InterfaceObjectTestCase):
         'username': settings.TEST_CREDIT_USERNAME,
         'password': settings.TEST_CREDIT_PASSWORD,
         'url': settings.API_URL,
-        'ext_start_session_url': settings.EXT_START_SESSION_URL
     }

--- a/tests/interface_objects/test_event.py
+++ b/tests/interface_objects/test_event.py
@@ -62,12 +62,12 @@ class ValidEventTests(InterfaceObjectTestCase):
         found = False
 
         for c in self.event.categories:
-            if c.code == 'theatre':
+            if c.code == 'arts':
                 found = True
 
         self.assertTrue(
             found,
-            msg="'Theatre' category not found in event category list"
+            msg="'arts' category not found in event category list"
         )
 
     def test_float_properties(self):

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -3,11 +3,10 @@ from __future__ import absolute_import, division, print_function
 
 from pyticketswitch.settings import *
 
-API_URL = 'https://dogbex.ingresso.co.uk/cgi-bin/xml_core.exe'
-EXT_START_SESSION_URL = 'https://dogbex.ingresso.co.uk/cgi-bin/xml_start_session.exe'
+API_URL = 'https://api.ticketswitch.com/tickets/xml_core.exe'
 
-TEST_USERNAME = 'whitelabel-testuser'
-TEST_PASSWORD = ''
+TEST_USERNAME = 'demo'
+TEST_PASSWORD = 'demopass'
 
-TEST_CREDIT_USERNAME = 'credit-testuser'
-TEST_CREDIT_PASSWORD = 'testing123'
+TEST_CREDIT_USERNAME = 'demo-credit'
+TEST_CREDIT_PASSWORD = 'demopass'

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import pytest
 from pyticketswitch.interface import CoreAPI
 from pyticketswitch.core_objects import RunningUser

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,0 +1,83 @@
+import pytest
+from pyticketswitch.interface import CoreAPI
+from pyticketswitch.core_objects import RunningUser
+
+try:
+    import xml.etree.cElementTree as xml
+except ImportError:
+    import xml.etree.ElementTree as xml
+
+
+@pytest.fixture
+def valid_start_session_result():
+    raw = """<?xml version="1.0" encoding="UTF-8"?>
+        <start_session_result>
+          <subdomain_user_is_bad>no</subdomain_user_is_bad>
+          <crypto_block>abc123</crypto_block>
+          <running_user>
+            <backend_group>tsw</backend_group>
+            <default_country_code>uk</default_country_code>
+            <default_lang_code>en</default_lang_code>
+            <is_b2b>no</is_b2b>
+            <real_name>Demonstration User</real_name>
+            <style>pure</style>
+            <user_id>demo</user_id>
+          </running_user>
+          <country_code>uk</country_code>
+          <country_desc>United Kingdom</country_desc>
+        </start_session_result>
+    """
+    result = xml.fromstring(raw)
+    return result
+
+
+@pytest.fixture
+def core():
+    core = CoreAPI(
+        username='demo',
+        password='demopass',
+        url='http://api.ticketswitch.com/tickets/xml_core.exe',
+        remote_ip='123.123.123.123',
+        remote_site='demotickets.com',
+        accept_language='en',
+        api_request_timeout=10,
+    )
+    return core
+
+
+def test_core_api_start_session(core, monkeypatch, valid_start_session_result):
+
+    def fake_call(*args, **kwargs):
+        return valid_start_session_result
+
+    monkeypatch.setattr(core, '_create_xml_and_post', fake_call)
+
+    result = core.start_session()
+
+    assert result == 'abc123'
+    assert core.running_user is not None
+    assert core.running_user.user_id == 'demo'
+
+
+def test_core_api_start_session_with_custom_start_session_method(core):
+
+    def fake_start_session_method(remote_ip, remote_site):
+        assert remote_ip == '123.123.123.123'
+        assert remote_site == 'demotickets.com'
+        return {
+            'crypto_block': '123abc',
+            'user_id': 'demo',
+            'running_user': RunningUser(
+                user_id='demo',
+                style='pure',
+            )
+        }
+
+    core.custom_start_session = fake_start_session_method
+
+    result = core.start_session()
+
+    assert result == '123abc'
+    assert core.username == 'demo'
+    assert core.running_user is not None
+    assert core.running_user.user_id == 'demo'


### PR DESCRIPTION
Removes an internal and deprecated api call and provides a way to specify custom start session method.

Tests now run against the live api not a development server