### PR TITLE
Fix pytest warning from pytest 3.0+

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool:pytest]
 norecursedirs = logs
 testpaths = tests
 addopts = --cov=pyticketswitch --doctest-modules --doctest-glob='*.rst' --ignore=setup.py --ignore=docs/conf.py --ignore=example_usage.py


### PR DESCRIPTION
Prevent `WC1 None [pytest] section in setup.cfg files is deprecated, use [tool:pytest] instead.`, as per pytest-dev/pytest#567.
