### PR TITLE
Simplify version reading

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,8 @@ from __future__ import absolute_import, division, print_function
 
 from setuptools import setup
 import re
+from pyticketswitch import __version__ as version
 
-version = ''
-with open('pyticketswitch/__init__.py', 'r') as fd:
-    version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
-                        fd.read(), re.MULTILINE).group(1)
 
 if not version:
     raise RuntimeError('Cannot find version information')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, division, print_function
 
 from setuptools import setup
-import re
 from pyticketswitch import __version__ as version
 
 


### PR DESCRIPTION
I think this is a much more readable solution than using a regex. I tried the installation process (`pip2 install -e .`) after this change and it went well (no error was raised).