### PR TITLE
Add sub_user support to authenticated calls

### DIFF
--- a/features/steps/step_reservation.py
+++ b/features/steps/step_reservation.py
@@ -253,16 +253,9 @@ def then_my_trolley_does_not_contain_tickets_for_event(context, event_id):
 @then('my trolley contains the requested seats')
 def then_my_trolley_contains_the_requested_seats(context):
     order = context.trolley.bundles[0].orders[0]
-    seat_ids = [seat.id for seat in order.requested_seats]
+    seat_ids = order.requested_seat_ids #[seat.id for seat in order.requested_seats]
 
     assert_that(seat_ids, has_items(*context.seats))
-
-
-@then('the trolley falls back to best available')
-def then_the_trolley_falls_back_to_best_available(context):
-    order = context.trolley.bundles[0].orders[0]
-
-    assert_that(order.requested_seats, is_(None))
 
 
 @then('my send method is the one I requested')

--- a/features/steps/step_reservation.py
+++ b/features/steps/step_reservation.py
@@ -287,7 +287,7 @@ def then_i_get_the_requested_seats(context):
     order = context.reservation.trolley.bundles[0].orders[0]
     seat_ids = [seat.id for seat in order.get_seats()]
 
-    assert_that(order.got_requested_seats, is_(True))
+    assert_that(order.seat_request_status, equal_to('got_all'))
     assert_that(seat_ids, has_items(*context.seats))
 
 
@@ -296,7 +296,7 @@ def then_i_get_different_seats_than_requested(context):
     order = context.reservation.trolley.bundles[0].orders[0]
     seat_ids = [seat.id for seat in order.get_seats()]
 
-    assert_that(order.got_requested_seats, is_(False))
+    assert_that(order.seat_request_status, is_not(equal_to('got_all')))
     assert_that(seat_ids, has_length(context.no_of_tickets))
 
 

--- a/features/steps/step_reservation.py
+++ b/features/steps/step_reservation.py
@@ -253,7 +253,7 @@ def then_my_trolley_does_not_contain_tickets_for_event(context, event_id):
 @then('my trolley contains the requested seats')
 def then_my_trolley_contains_the_requested_seats(context):
     order = context.trolley.bundles[0].orders[0]
-    seat_ids = order.requested_seat_ids #[seat.id for seat in order.requested_seats]
+    seat_ids = order.requested_seat_ids
 
     assert_that(seat_ids, has_items(*context.seats))
 

--- a/features/trolley.feature
+++ b/features/trolley.feature
@@ -21,19 +21,11 @@ Feature: add tickets to the trolley
 
     Scenario: create a trolley with seats
         Given an API client with valid credentials
-        And my customer wants tickets to "3CVF"
+        And my customer wants tickets to "7AB"
         And my customer is requesting specific seats
         When I add the tickets to the trolley
         Then I get a trolley token
         And my trolley contains the requested seats
-
-    Scenario: create a trolley with unavailble seats
-        Given an API client with valid credentials
-        And my customer wants tickets to "3CVF"
-        And my customer is requesting unavailable specific seats
-        When I add the tickets to the trolley
-        Then I get a trolley token
-        And the trolley falls back to best available
 
     Scenario: add item to an existing trolley
         Given an API client with valid credentials

--- a/features/trolley.feature
+++ b/features/trolley.feature
@@ -27,6 +27,14 @@ Feature: add tickets to the trolley
         Then I get a trolley token
         And my trolley contains the requested seats
 
+    Scenario: create a trolley with unavailble seats
+        Given an API client with valid credentials
+        And my customer wants tickets to "7AB"
+        And my customer is requesting unavailable specific seats
+        When I add the tickets to the trolley
+        Then I get a trolley token
+        And my trolley contains the requested seats
+
     Scenario: add item to an existing trolley
         Given an API client with valid credentials
         And I have an existing trolley with items from "6IF" in it

--- a/pyticketswitch/client.py
+++ b/pyticketswitch/client.py
@@ -87,7 +87,11 @@ class Client(object):
             dict: auth params that passed to requests
 
         """
-        return {'user_id': self.user, 'user_passwd': self.password}
+        if self.sub_user:
+            return {'user_id': self.user, 'user_passwd': self.password,
+                    'sub_user': self.sub_user}
+        else:
+            return {'user_id': self.user, 'user_passwd': self.password}
 
     def get_headers(self, headers):
         """Generate common headers to send with all requests

--- a/pyticketswitch/client.py
+++ b/pyticketswitch/client.py
@@ -90,8 +90,7 @@ class Client(object):
         if self.sub_user:
             return {'user_id': self.user, 'user_passwd': self.password,
                     'sub_user': self.sub_user}
-        else:
-            return {'user_id': self.user, 'user_passwd': self.password}
+        return {'user_id': self.user, 'user_passwd': self.password}
 
     def get_headers(self, headers):
         """Generate common headers to send with all requests

--- a/pyticketswitch/order.py
+++ b/pyticketswitch/order.py
@@ -175,7 +175,7 @@ class Order(JSONMixin, object):
                  ticket_type_code=None, ticket_type_description=None,
                  ticket_orders=None, number_of_seats=None,
                  total_seatprice=None, total_surcharge=None,
-                 seat_request_status=None, requested_seats=None,
+                 seat_request_status=None, requested_seat_ids=None,
                  backend_purchase_reference=None, send_method=None):
 
         self.item = item
@@ -189,7 +189,7 @@ class Order(JSONMixin, object):
         self.total_seatprice = total_seatprice
         self.total_surcharge = total_surcharge
         self.seat_request_status = seat_request_status
-        self.requested_seats = requested_seats
+        self.requested_seat_ids = requested_seat_ids
         self.backend_purchase_reference = backend_purchase_reference
         self.send_method = send_method
 
@@ -214,6 +214,7 @@ class Order(JSONMixin, object):
             'ticket_type_code': data.get('ticket_type_code'),
             'ticket_type_description': data.get('ticket_type_desc'),
             'seat_request_status': data.get('seat_request_status'),
+            'requested_seat_ids': data.get('requested_seat_ids'),
             'backend_purchase_reference': data.get('backend_purchase_reference'),
         }
 
@@ -242,14 +243,6 @@ class Order(JSONMixin, object):
         raw_total_surcharge = data.get('total_sale_surcharge')
         if raw_total_surcharge is not None:
             kwargs.update(total_surcharge=float(raw_total_surcharge))
-
-        raw_requested_seats = data.get('requested_seats')
-        if raw_requested_seats:
-            requested_seats = [
-                Seat.from_api_data(seat)
-                for seat in raw_requested_seats
-            ]
-            kwargs.update(requested_seats=requested_seats)
 
         raw_send_method = data.get('send_method')
         if raw_send_method:
@@ -283,15 +276,6 @@ class Order(JSONMixin, object):
 
         """
         return [seat.id for seat in self.get_seats() if seat.id]
-
-    def get_requested_seat_ids(self):
-        """Get all seat ids from requested seats
-
-        Returns:
-            list: list of seat ids.
-        """
-
-        return [seat.id for seat in self.requested_seats]
 
     def unique_seat_text(self):
         """Get the unique seat text for all seats in an order

--- a/pyticketswitch/order.py
+++ b/pyticketswitch/order.py
@@ -158,9 +158,8 @@ class Order(JSONMixin, object):
             order.
         total_seatprice (float): total seat price of the order.
         total_surcharge (float): total additional surcharges for the order.
-        got_requested_seats (bool): indicates whether the chosen seats were
-            successfully reserved or alternatives were provided. If seats were
-            not specified this will always be :obj:`False`.
+        seat_request_status (str): the status of requested seats. Will be filled
+            after the order has been reserved, and :obj:`None` before.
         requested_seats (list): list of
             :class:`Seats <pyticketswitch.seat.Seat>` requested at reservation
             time.
@@ -176,7 +175,7 @@ class Order(JSONMixin, object):
                  ticket_type_code=None, ticket_type_description=None,
                  ticket_orders=None, number_of_seats=None,
                  total_seatprice=None, total_surcharge=None,
-                 got_requested_seats=False, requested_seats=None,
+                 seat_request_status=None, requested_seats=None,
                  backend_purchase_reference=None, send_method=None):
 
         self.item = item
@@ -189,7 +188,7 @@ class Order(JSONMixin, object):
         self.number_of_seats = number_of_seats
         self.total_seatprice = total_seatprice
         self.total_surcharge = total_surcharge
-        self.got_requested_seats = got_requested_seats
+        self.seat_request_status = seat_request_status
         self.requested_seats = requested_seats
         self.backend_purchase_reference = backend_purchase_reference
         self.send_method = send_method
@@ -214,7 +213,7 @@ class Order(JSONMixin, object):
             'price_band_code': data.get('price_band_code'),
             'ticket_type_code': data.get('ticket_type_code'),
             'ticket_type_description': data.get('ticket_type_desc'),
-            'got_requested_seats': data.get('got_requested_seats', False),
+            'seat_request_status': data.get('seat_request_status'),
             'backend_purchase_reference': data.get('backend_purchase_reference'),
         }
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,6 +20,12 @@ def client():
 
 
 @pytest.fixture
+def client_with_subuser():
+    client = Client(user="beatles", password="lovemedo", sub_user="ringo")
+    return client
+
+
+@pytest.fixture
 def fake_func():
     def wrapper(return_value):
         def fake(*args, **kwargs):
@@ -144,6 +150,30 @@ class TestClient:
                 'foo': 'bar',
                 'user_id': 'bilbo',
                 'user_passwd': 'baggins',
+            },
+            headers={
+                'Accept-Language': 'en-GB',
+            }
+        )
+
+    def test_make_request_with_subuser(self, monkeypatch):
+        client = client_with_subuser()
+        fake_response = FakeResponse(status_code=200, json={"lol": "beans"})
+        fake_get = Mock(return_value=fake_response)
+        monkeypatch.setattr('requests.get', fake_get)
+        params = {
+            'foo': 'bar',
+        }
+        client.language='en-GB'
+        response = client.make_request('events.v1', params)
+        assert response == {'lol': 'beans'}
+        fake_get.assert_called_with(
+            'https://api.ticketswitch.com/f13/events.v1/',
+            params={
+                'foo': 'bar',
+                'user_id': 'beatles',
+                'user_passwd': 'lovemedo',
+                'sub_user': 'ringo',
             },
             headers={
                 'Accept-Language': 'en-GB',

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,12 +20,6 @@ def client():
 
 
 @pytest.fixture
-def client_with_subuser():
-    client = Client(user="beatles", password="lovemedo", sub_user="ringo")
-    return client
-
-
-@pytest.fixture
 def fake_func():
     def wrapper(return_value):
         def fake(*args, **kwargs):
@@ -157,7 +151,7 @@ class TestClient:
         )
 
     def test_make_request_with_subuser(self, monkeypatch):
-        client = client_with_subuser()
+        client = Client(user="beatles", password="lovemedo", sub_user="ringo")
         fake_response = FakeResponse(status_code=200, json={"lol": "beans"})
         fake_get = Mock(return_value=fake_response)
         monkeypatch.setattr('requests.get', fake_get)

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -103,9 +103,9 @@ class TestOrder:
             "total_no_of_seats": 3,
             "total_sale_seatprice": 51,
             "total_sale_surcharge": 5.40,
-            "requested_seats": [
-                {'full_id': 'ABC123'},
-                {'full_id': 'DEF456'},
+            "requested_seat_ids": [
+                'ABC123',
+                'DEF456',
             ],
             'send_method': {
                 'send_code': 'POST',
@@ -148,9 +148,9 @@ class TestOrder:
         assert order.ticket_orders[0].code == 'ADULT'
         assert order.ticket_orders[1].code == 'CHILD'
 
-        assert len(order.requested_seats) == 2
-        assert order.requested_seats[0].id == 'ABC123'
-        assert order.requested_seats[1].id == 'DEF456'
+        assert len(order.requested_seat_ids) == 2
+        assert order.requested_seat_ids[0] == 'ABC123'
+        assert order.requested_seat_ids[1] == 'DEF456'
 
         assert order.total_including_send_cost() == (51 + 5.40 + 3.5)
 
@@ -229,10 +229,6 @@ class TestOrder:
     def test_get_seats_with_no_ticket_orders(self):
         order = Order(1, ticket_orders=[])
         assert order.get_seats() == []
-
-    def test_get_requested_seat_ids(self):
-        order = Order(1, requested_seats=[Seat('A1'), Seat('A2'), Seat('A3')])
-        assert order.get_requested_seat_ids() == ['A1', 'A2', 'A3']
 
     def test_repr(self):
         order = Order(1, ticket_orders=[])

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -91,7 +91,7 @@ class TestOrder:
                 "perf_id": "6IF-A7N",
             },
             "price_band_code": "C/pool",
-            "got_requested_seats": True,
+            "seat_request_status": "got_all",
             "ticket_orders": {
                 "ticket_order": [
                     {"discount_code": "ADULT"},
@@ -136,7 +136,7 @@ class TestOrder:
         assert order.number_of_seats == 3
         assert order.total_seatprice == 51
         assert order.total_surcharge == 5.40
-        assert order.got_requested_seats is True
+        assert order.seat_request_status == "got_all"
         assert order.backend_purchase_reference == 'GHI098'
 
         assert isinstance(order.event, Event)


### PR DESCRIPTION
`get_auth_params()` now checks if a sub user has been specified, and if so adds it to the parameters when making a request.

Updated tests to match