### PR TITLE
Add purchase_result information to each bundle

### DIFF
--- a/pyticketswitch/purchase_result.py
+++ b/pyticketswitch/purchase_result.py
@@ -12,17 +12,27 @@ class PurchaseResult(JSONMixin, object):
             verification number.
         error (string): error code for backend purchase failure. These are
             non uniform as they can come from a varitiy of sources.
+        failure_reason (string): description of the failure reason, if there
+            is one. Not for display to customers.
+        is_partial (bool): indicates if the success is only partial for multi-
+            bundle transactions where one may succeed and the other fail.
+        is_semi_credit (bool): Marks the purchase as provisionally completed but
+            requiring invoicing before sale is finally confirmed.
 
     """
 
     def __init__(self, success=False, failed_3d_secure=False, failed_avs=False,
-                 failed_cv_two=False, error=None):
+                 failed_cv_two=False, error=None, failure_reason=None,
+                 is_partial=False, is_semi_credit=False):
 
         self.success = success
         self.failed_3d_secure = failed_3d_secure
         self.failed_avs = failed_avs
         self.failed_cv_two = failed_cv_two
         self.error = error
+        self.failure_reason = failure_reason
+        self.is_partial = is_partial
+        self.is_semi_credit = is_semi_credit
 
     @classmethod
     def from_api_data(cls, data):
@@ -46,6 +56,9 @@ class PurchaseResult(JSONMixin, object):
             'failed_avs': data.get('failed_avs'),
             'failed_cv_two': data.get('failed_cv_two'),
             'error': data.get('purchase_error'),
+            'failure_reason': data.get('failure_reason'),
+            'is_partial': data.get('is_partial'),
+            'is_semi_credit': data.get('is_semi_credit'),
         }
 
         return cls(**kwargs)

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -2,6 +2,7 @@ from pyticketswitch.bundle import Bundle
 from pyticketswitch.event import Event
 from pyticketswitch.order import Order
 from pyticketswitch.debitor import Debitor
+from pyticketswitch.purchase_result import PurchaseResult
 
 
 class TestBundle(object):
@@ -23,6 +24,9 @@ class TestBundle(object):
                 "debitor_type": "dummy"
             },
             "source_t_and_c": 'some legal stuff',
+            "purchase_result": {
+                "success": True,
+            },
         }
 
         bundle = Bundle.from_api_data(data)
@@ -50,6 +54,9 @@ class TestBundle(object):
 
         assert isinstance(bundle.debitor, Debitor)
         assert bundle.debitor.type == 'dummy'
+
+        assert isinstance(bundle.purchase_result, PurchaseResult)
+        assert bundle.purchase_result.success
 
     def test_get_events(self):
 

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -99,6 +99,25 @@ class TestBundle(object):
 
         assert events == {'abc123', 'def456'}
 
+    def test_is_purchased(self):
+        pr = PurchaseResult(success=True)
+
+        bundle_orders = [Order(item=1, event=Event(id_='TEST'))]
+
+        bundle = Bundle(
+            'tests',
+            orders=bundle_orders,
+            purchase_result=pr,
+        )
+
+        no_pr_bundle = Bundle(
+            'tests',
+            orders=bundle_orders,
+        )
+
+        assert bundle.is_purchased()
+        assert not no_pr_bundle.is_purchased()
+
     def test_repr(self):
 
         bundle = Bundle('tests')

--- a/tests/test_purchase_result.py
+++ b/tests/test_purchase_result.py
@@ -10,7 +10,10 @@ class TestPurchaseResult:
             "failed_avs": True,
             "failed_cv_two": True,
             "purchase_error": "too much donk",
-            "success": True
+            "success": True,
+            "failure_reason": "unknown",
+            "is_partial": True,
+            "is_semi_credit": False,
         }
 
         purchase_result = PurchaseResult.from_api_data(data)
@@ -20,3 +23,6 @@ class TestPurchaseResult:
         assert purchase_result.failed_avs is True
         assert purchase_result.failed_cv_two is True
         assert purchase_result.error == 'too much donk'
+        assert purchase_result.failure_reason == 'unknown'
+        assert purchase_result.is_partial
+        assert not purchase_result.is_semi_credit


### PR DESCRIPTION
F13 attaches purchase_result information to each bundle, as well as the trolley as a whole. This adds support for a purchase result object to the bundle, and adds extra flags to the purchase result class to allow checking for partial success and semi credit status (which is useful for bundling and B2B, respectively). This captures useful data that would otherwise be thrown away.