### PR TITLE
Add Cider Debitor support

### DIFF
--- a/pyticketswitch/payment_methods.py
+++ b/pyticketswitch/payment_methods.py
@@ -221,6 +221,33 @@ class StripeDetails(object):
         }
 
 
+class CiderDetails(object):
+    """For use with multiple payment tokens and details
+
+    Can be used to provide payment tokens and details directly to the API at
+    purchase time, avoiding a callout/callback cycle.
+
+    Implements
+    :class:`PaymentMethod <pyticketswitch.payment_methods.PaymentMethod>`.
+
+    Attributes:
+        data (dict): dictionary of payment tokens and details
+    """
+
+    def __init__(self, data):
+        self.data = data
+
+    def as_api_parameters(self):
+        """Generate API keyword args for these details.
+
+        Returns:
+            dict: the cider debitor details in the format the API can use.
+        """
+
+        return self.data
+
+
 PaymentMethod.register(CardDetails)
 PaymentMethod.register(RedirectionDetails)
 PaymentMethod.register(StripeDetails)
+PaymentMethod.register(CiderDetails)

--- a/pyticketswitch/payment_methods.py
+++ b/pyticketswitch/payment_methods.py
@@ -232,10 +232,12 @@ class CiderDetails(object):
 
     Attributes:
         data (dict): dictionary of payment tokens and details
+        system_codes (list): a list of systems for which payment is being made
     """
 
-    def __init__(self, data):
+    def __init__(self, data, system_codes):
         self.data = data
+        self.system_codes = system_codes
 
     def as_api_parameters(self):
         """Generate API keyword args for these details.
@@ -244,7 +246,13 @@ class CiderDetails(object):
             dict: the cider debitor details in the format the API can use.
         """
 
-        return self.data
+        data = {}
+        for system in self.system_codes:
+            data.update({
+                "{0}_callback/{1}".format(system, variable): self.data[variable]
+                for variable in self.data.keys()
+            })
+        return data
 
 
 PaymentMethod.register(CardDetails)

--- a/tests/test_payment_methods.py
+++ b/tests/test_payment_methods.py
@@ -213,10 +213,13 @@ class TestStripeDetails:
 class TestCiderDetails:
 
     def test_is_payment_method(self):
-        cider_details = CiderDetails({'beep': 'bop'})
+        cider_details = CiderDetails({'beep': 'bop'}, ["test"])
         assert isinstance(cider_details, PaymentMethod)
 
     def test_as_api_parameters(self):
-        cider_details = CiderDetails({'beep': 'boop'})
+        cider_details = CiderDetails({'beep': 'boop'}, ["test", "bip"])
         params = cider_details.as_api_parameters()
-        assert params == {'beep': 'boop'}
+        assert params == {
+            'test_callback/beep': 'boop',
+            'bip_callback/beep': 'boop',
+        }

--- a/tests/test_payment_methods.py
+++ b/tests/test_payment_methods.py
@@ -2,7 +2,7 @@ import pytest
 from pyticketswitch.exceptions import InvalidParametersError
 from pyticketswitch.address import Address
 from pyticketswitch.payment_methods import (
-    PaymentMethod, CardDetails, RedirectionDetails, StripeDetails,
+    PaymentMethod, CardDetails, RedirectionDetails, StripeDetails, CiderDetails
 )
 
 
@@ -208,3 +208,15 @@ class TestStripeDetails:
             'foo_callback/stripeToken': 'abc123',
             'bar_callback/stripeToken': 'def456',
         }
+
+
+class TestCiderDetails:
+
+    def test_is_payment_method(self):
+        cider_details = CiderDetails({'beep': 'bop'})
+        assert isinstance(cider_details, PaymentMethod)
+
+    def test_as_api_parameters(self):
+        cider_details = CiderDetails({'beep': 'boop'})
+        params = cider_details.as_api_parameters()
+        assert params == {'beep': 'boop'}


### PR DESCRIPTION
Add support for the Cider debitor.

This debitor can accept arbitrary parameters for different payment methods and aggregate payments for multiple bundles into a single transaction. This adds support for preintegration for this debitor by reformatting the parameters in the way that TicketSwitch expects.