### PR TITLE
Use HTTP Basic Authentication instead of querystring

### DIFF
--- a/features/steps/step_test.py
+++ b/features/steps/step_test.py
@@ -3,7 +3,7 @@ from behave import when, then
 
 
 @when('the test method is called')
-@vcr.use_cassette('fixtures/cassettes/test.yaml', record_mode='new_episodes')
+@vcr.use_cassette('fixtures/cassettes/test.yaml', record_mode='new_episodes', match_on=['method', 'uri', 'headers'])
 def when_the_test_method_is_called(context):
     try:
         context.user = context.client.test()

--- a/pyticketswitch/client.py
+++ b/pyticketswitch/client.py
@@ -175,7 +175,9 @@ class Client(object):
 
         raw_headers = self.get_headers(headers)
 
-        auth = (self.user, self.password)
+        auth = None
+        if self.user and self.password:
+            auth = (self.user, self.password)
 
         session = self.get_session()
 

--- a/pyticketswitch/client.py
+++ b/pyticketswitch/client.py
@@ -78,8 +78,11 @@ class Client(object):
         )
         return url
 
+    @utils.deprecated
     def get_auth_params(self):
         """Get the authentication parameters for inclusion in requests.
+
+        **This method is deprecated** - please use `get_extra_params` instead.
 
         This this method is intended to be overwritten if
         additional/alternative auth params need to be provided
@@ -88,10 +91,29 @@ class Client(object):
             dict: auth params that passed to requests
 
         """
-        auth_params = {}
-        if self.sub_user:
-            auth_params.update(sub_id=self.sub_user)
-        return auth_params
+        return {}
+
+    def get_extra_params(self):
+        """Get additional parameters for inclusion in requests.
+
+        This method is intended to be overwritten if additional/alternative
+        parameters need to be provided in the query string or POST body.
+
+        Returns:
+            dict: parameters that will be included in the request
+        """
+        extra_params = {}
+        # Call the deprecated method if it has been overridden
+        if not hasattr(self.get_auth_params, 'is_deprecated'):
+            utils.deprecation_warning(
+                "Function get_auth_params() is deprecated and should not be used",
+                stacklevel=3
+            )
+            extra_params.update(self.get_auth_params())
+        elif self.sub_user:
+            extra_params.update(sub_id=self.sub_user)
+
+        return extra_params
 
     def get_auth_for_request(self):
         """Get the authentication parameter for the raw request
@@ -179,7 +201,7 @@ class Client(object):
         """
 
         url = self.get_url(endpoint)
-        params.update(self.get_auth_params())
+        params.update(self.get_extra_params())
         if not params.get('tsw_session_track_id'):
             params.update(self.get_tracking_params())
 

--- a/pyticketswitch/client.py
+++ b/pyticketswitch/client.py
@@ -88,10 +88,10 @@ class Client(object):
             dict: auth params that passed to requests
 
         """
+        auth_params = {}
         if self.sub_user:
-            return {'user_id': self.user, 'user_passwd': self.password,
-                    'sub_id': self.sub_user}
-        return {'user_id': self.user, 'user_passwd': self.password}
+            auth_params.update(sub_id=self.sub_user)
+        return auth_params
 
     def get_headers(self, headers):
         """Generate common headers to send with all requests
@@ -175,12 +175,14 @@ class Client(object):
 
         raw_headers = self.get_headers(headers)
 
+        auth = (self.user, self.password)
+
         session = self.get_session()
 
         if method == POST:
-            response = session.post(url, data=params, headers=raw_headers, timeout=timeout)
+            response = session.post(url, auth=auth, data=params, headers=raw_headers, timeout=timeout)
         else:
-            response = session.get(url, params=params, headers=raw_headers, timeout=timeout)
+            response = session.get(url, auth=auth, params=params, headers=raw_headers, timeout=timeout)
 
         logger.debug(six.u(response.content))
 

--- a/pyticketswitch/client.py
+++ b/pyticketswitch/client.py
@@ -93,6 +93,18 @@ class Client(object):
             auth_params.update(sub_id=self.sub_user)
         return auth_params
 
+    def get_auth_for_request(self):
+        """Get the authentication parameter for the raw request
+
+        This method is intended to be overwritten if required.
+
+        Returns:
+            :class:`requests.auth.AuthBase`: the authentication parameter
+                accepted by the `requests` module
+        """
+        if self.user and self.password:
+            return (self.user, self.password)
+
     def get_headers(self, headers):
         """Generate common headers to send with all requests
 
@@ -175,9 +187,7 @@ class Client(object):
 
         raw_headers = self.get_headers(headers)
 
-        auth = None
-        if self.user and self.password:
-            auth = (self.user, self.password)
+        auth = self.get_auth_for_request()
 
         session = self.get_session()
 

--- a/pyticketswitch/client.py
+++ b/pyticketswitch/client.py
@@ -115,7 +115,7 @@ class Client(object):
 
         return extra_params
 
-    def get_auth_for_request(self):
+    def get_auth(self):
         """Get the authentication parameter for the raw request
 
         This method is intended to be overwritten if required.
@@ -209,7 +209,7 @@ class Client(object):
 
         raw_headers = self.get_headers(headers)
 
-        auth = self.get_auth_for_request()
+        auth = self.get_auth()
 
         session = self.get_session()
 

--- a/pyticketswitch/utils.py
+++ b/pyticketswitch/utils.py
@@ -1,3 +1,6 @@
+import functools
+import warnings
+
 from datetime import date, datetime
 from dateutil import parser
 from pyticketswitch.exceptions import InvalidParametersError
@@ -176,3 +179,36 @@ def filter_none_from_parameters(params):
         for key, value in params.items()
         if value is not None
     }
+
+
+def deprecation_warning(message, stacklevel=2):
+    warnings.simplefilter('always', DeprecationWarning)  # turn off filter
+    warnings.warn(message,
+                  category=DeprecationWarning,
+                  stacklevel=stacklevel)
+    warnings.simplefilter('default', DeprecationWarning)  # reset filter
+
+
+def deprecated(func):
+    """Mark a function as deprecated and raise a warning
+
+    This decorator is used to mark functions as deprecated. It will result in
+    a warning being emitted when the function is called.
+
+    Args:
+        func: the function to be wrapped
+
+    Returns:
+        the wrapped function that raises a warning
+    """
+
+    @functools.wraps(func)
+    def wrapped_func(*args, **kwargs):
+        deprecation_warning(
+            "Call to deprecated function {}".format(func.__name__)
+        )
+        return func(*args, **kwargs)
+
+    # Mark the function as deprecated
+    wrapped_func.is_deprecated = True
+    return wrapped_func

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,6 @@
 import pytest
 import json
 import requests
-import warnings
 from datetime import datetime
 from mock import Mock
 from pyticketswitch.client import Client, POST
@@ -69,6 +68,7 @@ def mock_make_request_for_trolley(client, monkeypatch):
     mock_make_request = Mock(return_value=response)
     monkeypatch.setattr(client, 'make_request', mock_make_request)
     return mock_make_request
+
 
 class FakeResponse(object):
 
@@ -244,6 +244,7 @@ class TestClient:
         client.add_optional_kwargs(params, tracking_id="123")
         response = client.make_request('events.v1', params)
 
+        assert response
         fake_get.assert_called_with(
             'https://api.ticketswitch.com/f13/events.v1/',
             auth=('user', 'pass'),
@@ -1899,4 +1900,15 @@ class TestClient:
                 'Accept-Language': 'en-GB',
             },
             timeout=None,
+        )
+
+    def test_get_auth_params_raises_deprecation_warning(self, client):
+        """Tests that get_auth_params raises deprecation warning"""
+
+        with pytest.warns(DeprecationWarning) as warning_list:
+            params = client.get_auth_params()
+
+        assert not params
+        assert warning_list[0].message.args[0] == (
+            'Call to deprecated function get_auth_params'
         )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -120,10 +120,9 @@ class TestClient:
         assert response == {'lol': 'beans'}
         fake_get.assert_called_with(
             'https://api.ticketswitch.com/f13/events.v1/',
+            auth=('bilbo', 'baggins'),
             params={
                 'foo': 'bar',
-                'user_id': 'bilbo',
-                'user_passwd': 'baggins',
             },
             headers={
                 'Accept-Language': 'en-GB',
@@ -147,17 +146,15 @@ class TestClient:
         assert response == {'lol': 'beans'}
         fake_get.assert_called_with(
             'https://api.ticketswitch.com/f13/events.v1/',
+            auth=('bilbo', 'baggins'),
             params={
                 'foo': 'bar',
-                'user_id': 'bilbo',
-                'user_passwd': 'baggins',
             },
             headers={
                 'Accept-Language': 'en-GB',
             },
             timeout=15
         )
-
 
     @pytest.mark.integration
     def test_make_request_with_post(self, client, monkeypatch):
@@ -175,10 +172,9 @@ class TestClient:
         assert response == {'lol': 'beans'}
         fake_post.assert_called_with(
             'https://api.ticketswitch.com/f13/events.v1/',
+            auth=('bilbo', 'baggins'),
             data={
                 'foo': 'bar',
-                'user_id': 'bilbo',
-                'user_passwd': 'baggins',
             },
             headers={
                 'Accept-Language': 'en-GB',
@@ -202,10 +198,9 @@ class TestClient:
         assert response == {'lol': 'beans'}
         fake_get.assert_called_with(
             'https://api.ticketswitch.com/f13/events.v1/',
+            auth=('beatles', 'lovemedo'),
             params={
                 'foo': 'bar',
-                'user_id': 'beatles',
-                'user_passwd': 'lovemedo',
                 'sub_id': 'ringo',
             },
             headers={
@@ -223,11 +218,11 @@ class TestClient:
         monkeypatch.setattr(client, 'get_session', Mock(return_value=session))
         client.language='en-GB'
         response = client.make_request('events.v1', {})
+        assert response
         fake_get.assert_called_with(
             'https://api.ticketswitch.com/f13/events.v1/',
+            auth=('user', 'pass'),
             params={
-                'user_id': 'user',
-                'user_passwd': 'pass',
                 'tsw_session_track_id': 'xyz'
             },
             headers={
@@ -250,9 +245,8 @@ class TestClient:
 
         fake_get.assert_called_with(
             'https://api.ticketswitch.com/f13/events.v1/',
+            auth=('user', 'pass'),
             params={
-                'user_id': 'user',
-                'user_passwd': 'pass',
                 'tsw_session_track_id': '123'
             },
             headers={
@@ -264,9 +258,8 @@ class TestClient:
         client.add_optional_kwargs(params, tracking_id="456")
         fake_get.assert_called_with(
             'https://api.ticketswitch.com/f13/events.v1/',
+            auth=('user', 'pass'),
             params={
-                'user_id': 'user',
-                'user_passwd': 'pass',
                 'tsw_session_track_id': '456'
             },
             headers={


### PR DESCRIPTION
This changes all authentication to use HTTP Basic auth headers (automatically handled by the requests library). For B2B users, the sub_user is still passed in the query string.