### PR TITLE
updated version of six

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.2.5] - 2018-04-25
+## Changed
+- updated dependencies - six to 1.11.0
+
 ## [2.2.4] - 2018-04-17
 ### Added
 - added `area_code`, `venue_code`, `lingo_code` and `venue_is_enforced` to the

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,3 +1,3 @@
 requests==2.9.1
-six==1.10.0
+six==1.11.0
 python-dateutil==2.5.3


### PR DESCRIPTION
I had to update these to because the test requirements are not pinned and latest want a later version on six.
I ran the tests with both py2 & 3.