### PR TITLE
Handle empty trollies better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ invalid parameters had be given.
   objects.
 - an optional `raise_on_unavailable_order` argument to `get_trolley` and
   `make_reservation` that will raise an exception when the API reports that
-  the order that was be added to a trolley was unavailable.
+  the order that was be added to a trolley was unavailable. If the call
+  successfully reserved something the exception will also include the
+  reservation and any metadata.
 
 ## [2.3.2] - 2018-05-14
 ### Fixed

--- a/pyticketswitch/client.py
+++ b/pyticketswitch/client.py
@@ -1364,7 +1364,9 @@ class Client(object):
         if raise_on_unavailable_order:
             if reservation and reservation.input_contained_unavailable_order:
                 raise exceptions.OrderUnavailableError(
-                    "inputs contained unavailable order")
+                    "inputs contained unavailable order",
+                    reservation=reservation,
+                    meta=meta)
 
         return reservation, meta
 

--- a/pyticketswitch/exceptions.py
+++ b/pyticketswitch/exceptions.py
@@ -54,4 +54,8 @@ class CallbackGoneError(APIError):
 
 
 class OrderUnavailableError(PyticketswitchError):
-    pass
+
+    def __init__(self, msg, reservation=None, meta=None, *args, **kwargs):
+        super(OrderUnavailableError, self).__init__(msg, *args, **kwargs)
+        self.reservation = reservation
+        self.meta = meta


### PR DESCRIPTION
This is an edge case where a trolley is built using `get_trolley`
then the user attempts to add something additional to the trolley at
reservation time, the API is unable to find any available product that
matches the new addition, but continues to reserve the rest of the
trolley. In this situation if user was using the
`raise_on_unavailable_order` flag on `make_reservation` then the details
of the reserved orders would be lost.

This change attaches the reservation and meta data to the exception so
that the user is aware of them.