### PR TITLE
update need performance flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- a bug where `needs_performance` for all events was set to `False`.
 
 ## [2.4.1] - 2018-06-01
 ### Updated

--- a/docs/users/advanced.rst
+++ b/docs/users/advanced.rst
@@ -1148,8 +1148,8 @@ that will be set with each request performed by `make_request` method::
     >>> client.make_request('test.v1', {})
 
 This is useful when using a common id for tracking requests across the 
-whole infrastructure, and if set might prove very helpful
-when debugging failing queries.
+whole infrastructure, and if set might prove helpful when debugging failing
+queries.
 
 Additionally it's also possible to set a tracking id not only
 when instantiating the API Client but also using separate
@@ -1226,14 +1226,17 @@ This is indicated by the :attr:`Event.needs_performance
 While the customer may not need to provide you with any additional
 information, you still need to provide a valid performance id to a number of
 calls such as :meth:`Client.get_availability
-<pyticketswitch.Client.get_availability>`, :meth:`Client.get_send_methods
-<pyticketswitch.Client.get_send_methods>`, or :meth:`Client.make_reservation
-<pyticketswitch.Client.make_reservation>`.
+<pyticketswitch.client.Client.get_availability>`,
+:meth:`Client.get_send_methods
+<pyticketswitch.client.Client.get_send_methods>`, or
+:meth:`Client.make_reservation
+<pyticketswitch.client.Client.make_reservation>`.
 
 You should still fetch this in the normal way via
-:meth:`Client.list_performances <pyticketswitch.Client.list_performances>`,
-however only one :class:`Performance <pyticketswitch.performance.Performance>`
-will be returned. Additionally :attr:`PerformanceMeta.auto_select
+:meth:`Client.list_performances
+<pyticketswitch.client.Client.list_performances>`, however only one
+:class:`Performance <pyticketswitch.performance.Performance>` will be
+returned. Additionally :attr:`PerformanceMeta.auto_select
 <pyticketswitch.performance.PerformanceMeta.auto_select>` should be set to
 ``True``, indicating that this performance should be automatically selected
 for the customer::
@@ -1249,7 +1252,7 @@ for the customer::
 
 .. warning:: Auto-generated performances change every day, you should be
              calling :meth:`Client.list_performances
-             <pyticketswitch.Client.list_performances>` at least once a day in
-             order to ensure you have the correct performance ID.
+             <pyticketswitch.client.Client.list_performances>` at least once a
+             day in order to ensure you have the correct performance ID.
 
 .. _`stripe`: https://stripe.com/gb

--- a/docs/users/advanced.rst
+++ b/docs/users/advanced.rst
@@ -1234,8 +1234,7 @@ calls such as :meth:`Client.get_availability
 You should still fetch this in the normal way via
 :meth:`Client.list_performances <passport.Client.list_performances>`, however
 only one :class:`Performance <passport.performance.Performance>` will be
-returned, it will have todays date.
-Additionally :attr:`PerformanceMeta.auto_select
+returned. Additionally :attr:`PerformanceMeta.auto_select
 <passport.performance.PerformanceMeta.auto_select>` should be set to ``True``,
 indicating that this performance should be automatically selected for the
 customer::

--- a/docs/users/advanced.rst
+++ b/docs/users/advanced.rst
@@ -1211,8 +1211,7 @@ represented as an event on the API, but it doesn't need a performance, neither
 does a season pass, nor a voucher.
 
 This is indicated by the :attr:`Event.needs_performance
-<passport.event.Event.needs_performance>` flag on the :class:`Event
-<passport.event.Event>`::
+<pyticketswitch.event.Event.needs_performance>` flag::
 
     >>> from pyticketswitch import Client
     >>> client = Client('demo', 'demopass')
@@ -1227,17 +1226,17 @@ This is indicated by the :attr:`Event.needs_performance
 While the customer may not need to provide you with any additional
 information, you still need to provide a valid performance id to a number of
 calls such as :meth:`Client.get_availability
-<passport.Client.get_availability>`, :meth:`Client.get_send_methods
-<passport.Client.get_send_methods>`, or :meth:`Client.make_reservation
-<passport.Client.make_reservation>`.
+<pyticketswitch.Client.get_availability>`, :meth:`Client.get_send_methods
+<pyticketswitch.Client.get_send_methods>`, or :meth:`Client.make_reservation
+<pyticketswitch.Client.make_reservation>`.
 
 You should still fetch this in the normal way via
-:meth:`Client.list_performances <passport.Client.list_performances>`, however
-only one :class:`Performance <passport.performance.Performance>` will be
-returned. Additionally :attr:`PerformanceMeta.auto_select
-<passport.performance.PerformanceMeta.auto_select>` should be set to ``True``,
-indicating that this performance should be automatically selected for the
-customer::
+:meth:`Client.list_performances <pyticketswitch.Client.list_performances>`,
+however only one :class:`Performance <pyticketswitch.performance.Performance>`
+will be returned. Additionally :attr:`PerformanceMeta.auto_select
+<pyticketswitch.performance.PerformanceMeta.auto_select>` should be set to
+``True``, indicating that this performance should be automatically selected
+for the customer::
 
     >>> from pyticketswitch import Client
     >>> client = Client('demo', 'demopass')
@@ -1250,7 +1249,7 @@ customer::
 
 .. warning:: Auto-generated performances change every day, you should be
              calling :meth:`Client.list_performances
-             <passport.Client.list_performances>` at least once a day in order
-             to ensure you have the correct performance ID.
+             <pyticketswitch.Client.list_performances>` at least once a day in
+             order to ensure you have the correct performance ID.
 
 .. _`stripe`: https://stripe.com/gb

--- a/docs/users/advanced.rst
+++ b/docs/users/advanced.rst
@@ -1200,4 +1200,58 @@ you can determine how you should be capturing these details::
 You can then use the integration data to initialise a card details capture or
 similar front end integration.
 
+Events that don't need performance selection
+============================================
+
+.. _events_that_dont_need_performance_selection:
+
+Some events available via the API don't require the customer to specify a
+date/time on which they want to attend. For example a t-shirt might be
+represented as an event on the API, but it doesn't need a performance, neither
+does a season pass, nor a voucher.
+
+This is indicated by the :attr:`Event.needs_performance
+<passport.event.Event.needs_performance>` flag on the :class:`Event
+<passport.event.Event>`::
+
+    >>> from pyticketswitch import Client
+    >>> client = Client('demo', 'demopass')
+    >>> event, meta = client.get_event('7AA')
+    >>> event.needs_performance
+    True
+    >>> event, meta = client.get_event('6KS')
+    >>> event.needs_performance
+    False
+    >>> 
+
+While the customer may not need to provide you with any additional
+information, you still need to provide a valid performance id to a number of
+calls such as :meth:`Client.get_availability
+<passport.Client.get_availability>`, :meth:`Client.get_send_methods
+<passport.Client.get_send_methods>`, or :meth:`Client.make_reservation
+<passport.Client.make_reservation>`.
+
+You should still fetch this in the normal way via
+:meth:`Client.list_performances <passport.Client.list_performances>`, however
+only one :class:`Performance <passport.performance.Performance>` will be
+returned, it will have todays date.
+Additionally :attr:`PerformanceMeta.auto_select
+<passport.performance.PerformanceMeta.auto_select>` should be set to ``True``,
+indicating that this performance should be automatically selected for the
+customer::
+
+    >>> from pyticketswitch import Client
+    >>> client = Client('demo', 'demopass')
+    >>> perfs, meta = client.list_performances('6KS')
+    >>> perfs
+    [<Performance 6KS-E3L>]
+    >>> meta.auto_select
+    True
+    >>> 
+
+.. warning:: Auto-generated performances change every day, you should be
+             calling :meth:`Client.list_performances
+             <passport.Client.list_performances>` at least once a day in order
+             to ensure you have the correct performance ID.
+
 .. _`stripe`: https://stripe.com/gb

--- a/features/event-extras.feature
+++ b/features/event-extras.feature
@@ -73,8 +73,8 @@ Feature: add additional information to request
                 "name": "video",
                 "url": "https://www.youtube.com/embed/G1JpEHGizk4?rel=0",
                 "secure": true,
-                "width": 420,
-                "height": 315
+                "width": 400,
+                "height": 300
             }
         }
         """

--- a/features/steps/step_events.py
+++ b/features/steps/step_events.py
@@ -118,6 +118,12 @@ def when_get_events(context, event_ids):
     context.events, _ = context.client.get_events(event_ids)
 
 
+@when(u'I fetch event "{event_id}"')
+@vcr.use_cassette('fixtures/cassettes/get-events-single.yaml', record_mode='new_episodes')
+def when_get_event(context, event_id):
+    assert event_id
+    context.event, _ = context.client.get_event(event_id)
+
 @when(u'we attempt to fetch events with the ID\'s "{event_ids}" requesting availability')
 @vcr.use_cassette('fixtures/cassettes/get-events-single.yaml', record_mode='new_episodes')
 def when_get_events_with_availability(context, event_ids):
@@ -424,3 +430,13 @@ def then_the_upsells_do_not_contain_event(context, event_ids):
 
     upsell_event_ids = [event.id for event in context.event.upsell_events]
     assert set(upsell_event_ids).isdisjoint(set(event_ids))
+
+
+@then(u'the event needs a performance to be selected')
+def then_the_event_needs_a_performance_to_be_selected(context):
+    assert context.event.needs_performance
+
+
+@then(u'the event does not need a performance to be selected')
+def then_the_event_does_not_need_a_performance_to_be_selected(context):
+    assert context.event.needs_performance

--- a/pyticketswitch/event.py
+++ b/pyticketswitch/event.py
@@ -43,8 +43,11 @@ class Event(JSONMixin, object):
             event will require a departure date.
         needs_duration (bool): indicates that ticket purchases for this
             event will require a duration.
-        needs_performance (bool): indicates that ticket purchases for this
-            event will require a performance id.
+        needs_performance (bool): indicates that you should ask your customer
+            what date/time they want to attend this event on.
+            See :ref:`Events that don't need performance selection
+            <events_that_dont_need_performance_selection>` for more
+            information.
         upsell_list (list): list of event id's.
         cost_range (:class:`CostRange <pyticketswitch.cost_range.CostRange>`):
             pricing summary from cached availability. Only present when
@@ -303,9 +306,9 @@ class Event(JSONMixin, object):
             'has_performances': has_performances,
             'show_performance_time': data.get('show_perf_time', False),
             'is_seated': data.get('is_seated', False),
-            'needs_departure_date': data.get('needs_departure_date', False),
-            'needs_duration': data.get('needs_duration', False),
-            'needs_performance': data.get('needs_performance', False),
+            'needs_departure_date': data.get('need_departure_date', False),
+            'needs_duration': data.get('need_duration', False),
+            'needs_performance': data.get('need_performance', False),
 
             'upsell_list': data.get('event_upsell_list', {}).get('event_id', []),
 

--- a/pyticketswitch/performance.py
+++ b/pyticketswitch/performance.py
@@ -137,7 +137,10 @@ class PerformanceMeta(PaginationMixin, CurrencyMeta, object):
     Attributes:
         auto_select (bool): indicates that the performance list will contain
             only one performance and this performance should be automatically
-            selected for the customer.
+            selected for the customer. See :ref:`Events that don't need
+            performance selection
+            <events_that_dont_need_performance_selection>` for more
+            information.
         has_names: (bool): indicates that the related performances have names
     """
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -59,9 +59,9 @@ def data():
         'has_no_perfs': True,
         'show_perf_time': True,
         'is_seated': True,
-        'needs_departure_date': True,
-        'needs_duration': True,
-        'needs_performance': True,
+        'need_departure_date': True,
+        'need_duration': True,
+        'need_performance': True,
 
         'event_upsell_list': {
             'event_id': ['DEF2', 'GHI3', 'JKL4'],


### PR DESCRIPTION
The wrapper was incorrectly setting `needs_performance` to `False` for all events, additionally the documentation for the flag was incorrect and woefully inadequate. 