### PR TITLE
add kwargs to the test.v1 method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-
+### Added
+- the `Client.test()` function will now take additional kwargs that are passed
+  directly to the API. This is useful for debugging purposes.
 
 ## [2.5.0] - 2018-08-14
 ### Added

--- a/pyticketswitch/client.py
+++ b/pyticketswitch/client.py
@@ -289,7 +289,7 @@ class Client(object):
 
         return contents
 
-    def test(self):
+    def test(self, **kwargs):
         """Test the connection
 
         Wraps `/f13/test.v1`_
@@ -300,13 +300,16 @@ class Client(object):
         This call is not required, but may be useful for validating auth
         credentials, or checking on the health of the ticketswitch API.
 
+        Args:
+            kwargs: miscellaneous parameters passed directly to the API.
+
         Returns:
             :obj:`pyticketswitch.user.User`: details about the user calling the API
 
         .. _`/f13/test.v1`: http://docs.ingresso.co.uk/#test
 
         """
-        response = self.make_request('test.v1', {})
+        response = self.make_request('test.v1', kwargs)
 
         user = User.from_api_data(response)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1570,6 +1570,22 @@ class TestClient:
         assert isinstance(user, User)
         assert user.id == 'foobar'
 
+    def test_test_with_kwargs(self, client, monkeypatch):
+        response = {'user_id': 'foobar'}
+
+        mock_make_request = Mock(return_value=response)
+        monkeypatch.setattr(client, 'make_request', mock_make_request)
+
+        user = client.test(foo='bar', lol='beans')
+
+        mock_make_request.assert_called_with('test.v1', {
+            'foo': 'bar',
+            'lol': 'beans'
+        })
+
+        assert isinstance(user, User)
+        assert user.id == 'foobar'
+
     def test_release_reservation(self, client, monkeypatch):
         response = {'released_ok': True}
 


### PR DESCRIPTION
this brings this method inline with the other client methods, and is useful for debugging purposes.